### PR TITLE
feat: add Elixir and Bash language support

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -939,9 +939,11 @@ dependencies = [
  "thiserror",
  "toml",
  "tree-sitter",
+ "tree-sitter-bash",
  "tree-sitter-c",
  "tree-sitter-c-sharp",
  "tree-sitter-cpp",
+ "tree-sitter-elixir",
  "tree-sitter-fortran",
  "tree-sitter-go",
  "tree-sitter-java",
@@ -1373,6 +1375,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-bash"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "329a4d48623ac337d42b1df84e81a1c9dbb2946907c102ca72db158c1964a52e"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-c"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,6 +1409,16 @@ name = "tree-sitter-cpp"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df2196ea9d47b4ab4a31b9297eaa5a5d19a0b121dceb9f118f6790ad0ab94743"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-elixir"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66dd064a762ed95bfc29857fa3cb7403bb1e5cb88112de0f6341b7e47284ba40"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/crates/sem-core/Cargo.toml
+++ b/crates/sem-core/Cargo.toml
@@ -20,6 +20,8 @@ tree-sitter-c-sharp = "0.23"
 tree-sitter-php = "0.23"
 tree-sitter-fortran = "0.5"
 tree-sitter-swift = "0.7"
+tree-sitter-elixir = "0.3"
+tree-sitter-bash = "0.23"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
+++ b/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
@@ -32,6 +32,50 @@ fn visit_node(
 ) {
     let node_type = node.kind();
 
+    // Handle call-based entities (Elixir: def, defmodule, etc.)
+    if node_type == "call" && !config.call_entity_identifiers.is_empty() {
+        if let Some((name, entity_type)) = extract_call_entity(node, config, source) {
+            let content_str = node_text(node, source);
+            let content = content_str.to_string();
+            let struct_hash = structural_hash(node, source);
+            let entity = SemanticEntity {
+                id: build_entity_id(file_path, entity_type, &name, parent_id),
+                file_path: file_path.to_string(),
+                entity_type: entity_type.to_string(),
+                name: name.clone(),
+                parent_id: parent_id.map(String::from),
+                content_hash: content_hash(&content),
+                structural_hash: Some(struct_hash),
+                content,
+                start_line: node.start_position().row + 1,
+                end_line: node.end_position().row + 1,
+                metadata: None,
+            };
+
+            let entity_id = entity.id.clone();
+            entities.push(entity);
+
+            // Visit container children for nested entities (defs inside defmodule)
+            let mut cursor = node.walk();
+            for child in node.named_children(&mut cursor) {
+                if config.container_node_types.contains(&child.kind()) {
+                    let mut inner_cursor = child.walk();
+                    for nested in child.named_children(&mut inner_cursor) {
+                        visit_node(
+                            nested,
+                            file_path,
+                            config,
+                            entities,
+                            Some(&entity_id),
+                            source,
+                        );
+                    }
+                }
+            }
+            return;
+        }
+    }
+
     if config.entity_node_types.contains(&node_type) {
         if let Some(name) = extract_name(node, source) {
             let entity_type = if node_type == "decorated_definition" {
@@ -266,6 +310,120 @@ fn map_node_type<'a>(tree_sitter_type: &'a str) -> &'a str {
         "template_declaration" => "template",
         other => other,
     }
+}
+
+/// Extract entity info from a call node (Elixir macros like def, defmodule, etc.)
+fn extract_call_entity(node: Node, config: &LanguageConfig, source: &[u8]) -> Option<(String, &'static str)> {
+    let target = node.child_by_field_name("target")?;
+    if target.kind() != "identifier" {
+        return None;
+    }
+    let keyword = node_text(target, source);
+
+    if !config.call_entity_identifiers.contains(&keyword) {
+        return None;
+    }
+
+    let entity_type = match keyword {
+        "defmodule" => "module",
+        "def" | "defp" | "defdelegate" => "function",
+        "defmacro" | "defmacrop" => "macro",
+        "defguard" | "defguardp" => "guard",
+        "defprotocol" => "protocol",
+        "defimpl" => "impl",
+        "defstruct" => "struct",
+        "defexception" => "exception",
+        _ => return None,
+    };
+
+    // Get arguments node (child by kind, not field name)
+    let mut cursor = node.walk();
+    let args = node.named_children(&mut cursor)
+        .find(|c| c.kind() == "arguments")?;
+
+    let name = match keyword {
+        "defmodule" | "defprotocol" => {
+            extract_first_alias_or_identifier(args, source)?
+        }
+        "defimpl" => {
+            let base = extract_first_alias_or_identifier(args, source)?;
+            if let Some(target) = extract_keyword_value(args, "for", source) {
+                format!("{} for {}", base, target)
+            } else {
+                base
+            }
+        }
+        "defstruct" => "__struct__".to_string(),
+        "defexception" => "__exception__".to_string(),
+        _ => {
+            // def, defp, defmacro, defguard, defdelegate
+            // First arg is a call (fn with params), identifier (arity-0),
+            // or binary_operator (defguard with when clause)
+            let mut cursor = args.walk();
+            let first_arg = args.named_children(&mut cursor).next()?;
+            extract_fn_name_from_arg(first_arg, source)?
+        }
+    };
+
+    Some((name, entity_type))
+}
+
+/// Extract function name from a def/defp/defmacro/defguard argument.
+/// Handles: call (fn with params), identifier (arity-0), binary_operator (defguard when clause)
+fn extract_fn_name_from_arg(node: Node, source: &[u8]) -> Option<String> {
+    match node.kind() {
+        "call" => {
+            if let Some(fn_target) = node.child_by_field_name("target") {
+                Some(node_text(fn_target, source).to_string())
+            } else {
+                let mut c = node.walk();
+                let id = node.named_children(&mut c)
+                    .find(|n| n.kind() == "identifier")?;
+                Some(node_text(id, source).to_string())
+            }
+        }
+        "identifier" => Some(node_text(node, source).to_string()),
+        "binary_operator" => {
+            // defguard is_positive(x) when ... -> left side has the actual call/identifier
+            let left = node.child_by_field_name("left")?;
+            extract_fn_name_from_arg(left, source)
+        }
+        _ => None,
+    }
+}
+
+fn extract_first_alias_or_identifier(args: Node, source: &[u8]) -> Option<String> {
+    let mut cursor = args.walk();
+    for child in args.named_children(&mut cursor) {
+        match child.kind() {
+            "alias" => return Some(node_text(child, source).to_string()),
+            "identifier" => return Some(node_text(child, source).to_string()),
+            _ => {}
+        }
+    }
+    None
+}
+
+fn extract_keyword_value(args: Node, key: &str, source: &[u8]) -> Option<String> {
+    let mut cursor = args.walk();
+    for child in args.named_children(&mut cursor) {
+        if child.kind() == "keywords" {
+            let mut kw_cursor = child.walk();
+            for pair in child.named_children(&mut kw_cursor) {
+                if pair.kind() == "pair" {
+                    if let Some(pair_key) = pair.child_by_field_name("key") {
+                        let key_text = node_text(pair_key, source).trim();
+                        if key_text == format!("{}:", key) || key_text == key {
+                            if let Some(pair_value) = pair.child_by_field_name("value") {
+                                return Some(node_text(pair_value, source).to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
 }
 
 /// For Python decorated_definition, check the inner node to determine the real type.

--- a/crates/sem-core/src/parser/plugins/code/languages.rs
+++ b/crates/sem-core/src/parser/plugins/code/languages.rs
@@ -6,6 +6,7 @@ pub struct LanguageConfig {
     pub extensions: &'static [&'static str],
     pub entity_node_types: &'static [&'static str],
     pub container_node_types: &'static [&'static str],
+    pub call_entity_identifiers: &'static [&'static str],
     pub get_language: fn() -> Option<Language>,
 }
 
@@ -65,6 +66,14 @@ fn get_swift() -> Option<Language> {
     Some(tree_sitter_swift::LANGUAGE.into())
 }
 
+fn get_elixir() -> Option<Language> {
+    Some(tree_sitter_elixir::LANGUAGE.into())
+}
+
+fn get_bash() -> Option<Language> {
+    Some(tree_sitter_bash::LANGUAGE.into())
+}
+
 static TYPESCRIPT_CONFIG: LanguageConfig = LanguageConfig {
     id: "typescript",
     extensions: &[".ts"],
@@ -81,6 +90,7 @@ static TYPESCRIPT_CONFIG: LanguageConfig = LanguageConfig {
         "public_field_definition",
     ],
     container_node_types: &["class_body", "interface_body", "enum_body"],
+    call_entity_identifiers: &[],
     get_language: get_typescript,
 };
 
@@ -100,6 +110,7 @@ static TSX_CONFIG: LanguageConfig = LanguageConfig {
         "public_field_definition",
     ],
     container_node_types: &["class_body", "interface_body", "enum_body"],
+    call_entity_identifiers: &[],
     get_language: get_tsx,
 };
 
@@ -116,6 +127,7 @@ static JAVASCRIPT_CONFIG: LanguageConfig = LanguageConfig {
         "field_definition",
     ],
     container_node_types: &["class_body"],
+    call_entity_identifiers: &[],
     get_language: get_javascript,
 };
 
@@ -128,6 +140,7 @@ static PYTHON_CONFIG: LanguageConfig = LanguageConfig {
         "decorated_definition",
     ],
     container_node_types: &["block"],
+    call_entity_identifiers: &[],
     get_language: get_python,
 };
 
@@ -142,6 +155,7 @@ static GO_CONFIG: LanguageConfig = LanguageConfig {
         "const_declaration",
     ],
     container_node_types: &[],
+    call_entity_identifiers: &[],
     get_language: get_go,
 };
 
@@ -160,6 +174,7 @@ static RUST_CONFIG: LanguageConfig = LanguageConfig {
         "type_item",
     ],
     container_node_types: &["declaration_list"],
+    call_entity_identifiers: &[],
     get_language: get_rust,
 };
 
@@ -176,6 +191,7 @@ static JAVA_CONFIG: LanguageConfig = LanguageConfig {
         "annotation_type_declaration",
     ],
     container_node_types: &["class_body", "interface_body", "enum_body"],
+    call_entity_identifiers: &[],
     get_language: get_java,
 };
 
@@ -191,6 +207,7 @@ static C_CONFIG: LanguageConfig = LanguageConfig {
         "declaration",
     ],
     container_node_types: &[],
+    call_entity_identifiers: &[],
     get_language: get_c,
 };
 
@@ -208,6 +225,7 @@ static CPP_CONFIG: LanguageConfig = LanguageConfig {
         "type_definition",
     ],
     container_node_types: &["field_declaration_list", "declaration_list"],
+    call_entity_identifiers: &[],
     get_language: get_cpp,
 };
 
@@ -221,6 +239,7 @@ static RUBY_CONFIG: LanguageConfig = LanguageConfig {
         "module",
     ],
     container_node_types: &["body_statement"],
+    call_entity_identifiers: &[],
     get_language: get_ruby,
 };
 
@@ -239,6 +258,7 @@ static CSHARP_CONFIG: LanguageConfig = LanguageConfig {
         "field_declaration",
     ],
     container_node_types: &["declaration_list"],
+    call_entity_identifiers: &[],
     get_language: get_csharp,
 };
 
@@ -255,6 +275,7 @@ static PHP_CONFIG: LanguageConfig = LanguageConfig {
         "namespace_definition",
     ],
     container_node_types: &["declaration_list", "enum_declaration_list"],
+    call_entity_identifiers: &[],
     get_language: get_php,
 };
 
@@ -270,6 +291,7 @@ static FORTRAN_CONFIG: LanguageConfig = LanguageConfig {
         "type_declaration",
     ],
     container_node_types: &[],
+    call_entity_identifiers: &[],
     get_language: get_fortran,
 };
 
@@ -289,7 +311,30 @@ static SWIFT_CONFIG: LanguageConfig = LanguageConfig {
         "associatedtype_declaration",
     ],
     container_node_types: &["class_body", "protocol_body", "enum_class_body"],
+    call_entity_identifiers: &[],
     get_language: get_swift,
+};
+
+static ELIXIR_CONFIG: LanguageConfig = LanguageConfig {
+    id: "elixir",
+    extensions: &[".ex", ".exs"],
+    entity_node_types: &[],
+    container_node_types: &["do_block"],
+    call_entity_identifiers: &[
+        "defmodule", "def", "defp", "defmacro", "defmacrop",
+        "defguard", "defguardp", "defprotocol", "defimpl",
+        "defstruct", "defexception", "defdelegate",
+    ],
+    get_language: get_elixir,
+};
+
+static BASH_CONFIG: LanguageConfig = LanguageConfig {
+    id: "bash",
+    extensions: &[".sh"],
+    entity_node_types: &["function_definition"],
+    container_node_types: &[],
+    call_entity_identifiers: &[],
+    get_language: get_bash,
 };
 
 static ALL_CONFIGS: &[&LanguageConfig] = &[
@@ -307,6 +352,8 @@ static ALL_CONFIGS: &[&LanguageConfig] = &[
     &PHP_CONFIG,
     &FORTRAN_CONFIG,
     &SWIFT_CONFIG,
+    &ELIXIR_CONFIG,
+    &BASH_CONFIG,
 ];
 
 pub fn get_language_config(extension: &str) -> Option<&'static LanguageConfig> {
@@ -323,6 +370,8 @@ pub fn get_all_code_extensions() -> &'static [&'static str] {
         ".java", ".c", ".h", ".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx",
         ".rb", ".cs", ".php", ".f90", ".f95", ".f03", ".f08", ".f", ".for",
         ".swift",
+        ".ex", ".exs",
+        ".sh",
     ];
     EXTENSIONS
 }

--- a/crates/sem-core/src/parser/plugins/code/mod.rs
+++ b/crates/sem-core/src/parser/plugins/code/mod.rs
@@ -268,6 +268,81 @@ func helper(x: Int) -> Int {
     }
 
     #[test]
+    fn test_elixir_entity_extraction() {
+        let code = r#"
+defmodule MyApp.Accounts do
+  def create_user(attrs) do
+    %User{}
+    |> User.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  defp validate(attrs) do
+    # private helper
+    :ok
+  end
+
+  defmacro is_admin(user) do
+    quote do
+      unquote(user).role == :admin
+    end
+  end
+
+  defguard is_positive(x) when is_integer(x) and x > 0
+end
+
+defprotocol Printable do
+  def to_string(data)
+end
+
+defimpl Printable, for: Integer do
+  def to_string(i), do: Integer.to_string(i)
+end
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "accounts.ex");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+        let types: Vec<&str> = entities.iter().map(|e| e.entity_type.as_str()).collect();
+        eprintln!("Elixir entities: {:?}", names.iter().zip(types.iter()).collect::<Vec<_>>());
+
+        assert!(names.contains(&"MyApp.Accounts"), "Should find module, got: {:?}", names);
+        assert!(names.contains(&"create_user"), "Should find def, got: {:?}", names);
+        assert!(names.contains(&"validate"), "Should find defp, got: {:?}", names);
+        assert!(names.contains(&"is_admin"), "Should find defmacro, got: {:?}", names);
+        assert!(names.contains(&"Printable"), "Should find defprotocol, got: {:?}", names);
+
+        // Verify nesting: create_user should have MyApp.Accounts as parent
+        let create_user = entities.iter().find(|e| e.name == "create_user").unwrap();
+        assert!(create_user.parent_id.is_some(), "create_user should be nested under module");
+    }
+
+    #[test]
+    fn test_bash_entity_extraction() {
+        let code = r#"#!/bin/bash
+
+greet() {
+    echo "Hello, $1!"
+}
+
+function deploy {
+    echo "deploying..."
+}
+
+# not a function
+echo "main script"
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "deploy.sh");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+        let types: Vec<&str> = entities.iter().map(|e| e.entity_type.as_str()).collect();
+        eprintln!("Bash entities: {:?}", names.iter().zip(types.iter()).collect::<Vec<_>>());
+
+        assert!(names.contains(&"greet"), "Should find greet(), got: {:?}", names);
+        assert!(names.contains(&"deploy"), "Should find function deploy, got: {:?}", names);
+        assert_eq!(entities.len(), 2, "Should only find functions, got: {:?}", names);
+    }
+
+    #[test]
     fn test_typescript_entity_extraction() {
         // Existing language should still work
         let code = r#"


### PR DESCRIPTION
## Summary
- Adds Elixir (.ex/.exs) entity extraction using a new `call_entity_identifiers` mechanism on `LanguageConfig`, since Elixir's tree-sitter grammar represents `def`, `defmodule`, etc. as `call` nodes rather than dedicated AST types
- Supports defmodule, def, defp, defmacro, defmacrop, defguard, defguardp, defprotocol, defimpl (with `for:` target), defstruct, defexception, defdelegate
- Adds Bash (.sh) entity extraction for function definitions (both `greet() {}` and `function deploy {}` syntax)
- All 31 sem tests pass, all 121 weave tests pass

Closes #5

## Test plan
- [x] `test_elixir_entity_extraction`: verifies module, def, defp, defmacro, defguard, defprotocol, defimpl with `for:` target, and nesting
- [x] `test_bash_entity_extraction`: verifies both function syntaxes, only functions extracted
- [x] Full sem-core test suite (31 tests)
- [x] Full weave test suite (121 tests)