### PR TITLE
fix: remove non-existent sem-api from Cargo.toml

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["sem-core", "sem-cli", "sem-api"]
+members = ["sem-core", "sem-cli"]
 resolver = "2"
 
 [profile.release]


### PR DESCRIPTION
Something more complicated may be needed here, but removing this non-existent member allows a successful build.