### PR TITLE
feat: add HCL language support

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -644,6 +644,7 @@ dependencies = [
  "tree-sitter-elixir",
  "tree-sitter-fortran",
  "tree-sitter-go",
+ "tree-sitter-hcl",
  "tree-sitter-java",
  "tree-sitter-javascript",
  "tree-sitter-php",
@@ -936,6 +937,16 @@ name = "tree-sitter-go"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b13d476345220dbe600147dd444165c5791bf85ef53e28acbedd46112ee18431"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-hcl"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a7b2cc3d7121553b84309fab9d11b3ff3d420403eef9ae50f9fd1cd9d9cf012"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/crates/sem-core/Cargo.toml
+++ b/crates/sem-core/Cargo.toml
@@ -22,6 +22,7 @@ tree-sitter-fortran = "0.5"
 tree-sitter-swift = "0.7"
 tree-sitter-elixir = "0.3"
 tree-sitter-bash = "0.23"
+tree-sitter-hcl = "1.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
+++ b/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
@@ -18,6 +18,7 @@ pub fn extract_entities(
         &mut entities,
         None,
         source_code.as_bytes(),
+        None,
     );
     entities
 }
@@ -29,6 +30,7 @@ fn visit_node(
     entities: &mut Vec<SemanticEntity>,
     parent_id: Option<&str>,
     source: &[u8],
+    enclosing_entity_node_type: Option<&'static str>,
 ) {
     let node_type = node.kind();
 
@@ -68,6 +70,7 @@ fn visit_node(
                             entities,
                             Some(&entity_id),
                             source,
+                            enclosing_entity_node_type,
                         );
                     }
                 }
@@ -78,57 +81,63 @@ fn visit_node(
 
     if config.entity_node_types.contains(&node_type) {
         if let Some(name) = extract_name(node, source) {
+            let name = qualify_hcl_name(&name, node_type, parent_id, enclosing_entity_node_type);
             let entity_type = if node_type == "decorated_definition" {
                 map_decorated_type(node)
             } else {
                 map_node_type(node_type)
             };
-            let content_str = node_text(node, source);
-            let content = content_str.to_string();
+            let should_skip = should_skip_entity(config, enclosing_entity_node_type, node_type);
+            if !should_skip {
+                let content_str = node_text(node, source);
+                let content = content_str.to_string();
 
-            let struct_hash = structural_hash(node, source);
-            let entity = SemanticEntity {
-                id: build_entity_id(file_path, entity_type, &name, parent_id),
-                file_path: file_path.to_string(),
-                entity_type: entity_type.to_string(),
-                name: name.clone(),
-                parent_id: parent_id.map(String::from),
-                content_hash: content_hash(&content),
-                structural_hash: Some(struct_hash),
-                content,
-                start_line: node.start_position().row + 1,
-                end_line: node.end_position().row + 1,
-                metadata: None,
-            };
+                let struct_hash = structural_hash(node, source);
+                let entity = SemanticEntity {
+                    id: build_entity_id(file_path, entity_type, &name, parent_id),
+                    file_path: file_path.to_string(),
+                    entity_type: entity_type.to_string(),
+                    name: name.clone(),
+                    parent_id: parent_id.map(String::from),
+                    content_hash: content_hash(&content),
+                    structural_hash: Some(struct_hash),
+                    content,
+                    start_line: node.start_position().row + 1,
+                    end_line: node.end_position().row + 1,
+                    metadata: None,
+                };
 
-            let entity_id = entity.id.clone();
-            entities.push(entity);
+                let entity_id = entity.id.clone();
+                entities.push(entity);
 
-            // Visit children for nested entities (methods inside classes, etc.)
-            let mut cursor = node.walk();
-            for child in node.named_children(&mut cursor) {
-                if config.container_node_types.contains(&child.kind()) {
-                    let mut inner_cursor = child.walk();
-                    for nested in child.named_children(&mut inner_cursor) {
-                        visit_node(
-                            nested,
-                            file_path,
-                            config,
-                            entities,
-                            Some(&entity_id),
-                            source,
-                        );
+                // Visit children for nested entities (methods inside classes, etc.)
+                let next_enclosing_entity_node_type = Some(node_type);
+                let mut cursor = node.walk();
+                for child in node.named_children(&mut cursor) {
+                    if config.container_node_types.contains(&child.kind()) {
+                        let mut inner_cursor = child.walk();
+                        for nested in child.named_children(&mut inner_cursor) {
+                            visit_node(
+                                nested,
+                                file_path,
+                                config,
+                                entities,
+                                Some(&entity_id),
+                                source,
+                                next_enclosing_entity_node_type,
+                            );
+                        }
                     }
                 }
+                return;
             }
-            return;
         }
     }
 
     // For export statements, look inside for the actual declaration
     if node_type == "export_statement" {
         if let Some(declaration) = node.child_by_field_name("declaration") {
-            visit_node(declaration, file_path, config, entities, parent_id, source);
+            visit_node(declaration, file_path, config, entities, parent_id, source, enclosing_entity_node_type);
             return;
         }
     }
@@ -136,7 +145,15 @@ fn visit_node(
     // Recurse into top-level children
     let mut cursor = node.walk();
     for child in node.named_children(&mut cursor) {
-        visit_node(child, file_path, config, entities, parent_id, source);
+        visit_node(
+            child,
+            file_path,
+            config,
+            entities,
+            parent_id,
+            source,
+            enclosing_entity_node_type,
+        );
     }
 }
 
@@ -225,7 +242,10 @@ fn extract_name(node: Node, source: &[u8]) -> Option<String> {
     }
 
     // For C struct/enum/union specifiers, try the 'name' field
-    if node_type == "struct_specifier" || node_type == "enum_specifier" || node_type == "union_specifier" {
+    if node_type == "struct_specifier"
+        || node_type == "enum_specifier"
+        || node_type == "union_specifier"
+    {
         if let Some(name_node) = node.child_by_field_name("name") {
             return Some(node_text(name_node, source).to_string());
         }
@@ -235,6 +255,25 @@ fn extract_name(node: Node, source: &[u8]) -> Option<String> {
     if node_type == "type_definition" {
         if let Some(declarator) = node.child_by_field_name("declarator") {
             return extract_declarator_name(declarator, source);
+        }
+    }
+
+    // For HCL blocks, combine block type with labels (e.g., resource.cloudflare_record.dns)
+    if node_type == "block" {
+        let mut parts = Vec::new();
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            match child.kind() {
+                "identifier" => parts.push(node_text(child, source).to_string()),
+                "string_lit" => {
+                    let text = node_text(child, source);
+                    parts.push(text.trim_matches('"').to_string());
+                }
+                _ => break, // stop at body or other non-label nodes
+            }
+        }
+        if !parts.is_empty() {
+            return Some(parts.join("."));
         }
     }
 
@@ -249,6 +288,40 @@ fn extract_name(node: Node, source: &[u8]) -> Option<String> {
     None
 }
 
+// Prefix nested HCL block names with their parent entity name for flat output.
+fn qualify_hcl_name(
+    name: &str,
+    node_type: &str,
+    parent_id: Option<&str>,
+    enclosing_entity_node_type: Option<&'static str>,
+) -> String {
+    if node_type != "block" || enclosing_entity_node_type != Some("block") {
+        return name.to_string();
+    }
+
+    match parent_id.and_then(parent_entity_name_from_id) {
+        Some(parent_name) => format!("{parent_name}.{name}"),
+        None => name.to_string(),
+    }
+}
+
+// Extract the entity name portion from an entity id.
+fn parent_entity_name_from_id(parent_id: &str) -> Option<&str> {
+    parent_id.rsplit("::").next()
+}
+
+// Apply language-specific nested entity suppression rules from config.
+fn should_skip_entity(
+    config: &LanguageConfig,
+    enclosing_entity_node_type: Option<&'static str>,
+    node_type: &str,
+) -> bool {
+    config.suppressed_nested_entities.iter().any(|rule| {
+        enclosing_entity_node_type == Some(rule.parent_entity_node_type)
+            && node_type == rule.child_entity_node_type
+    })
+}
+
 /// Extract the name from a C declarator (handles pointer_declarator, function_declarator, etc.)
 fn extract_declarator_name(node: Node, source: &[u8]) -> Option<String> {
     match node.kind() {
@@ -257,12 +330,16 @@ fn extract_declarator_name(node: Node, source: &[u8]) -> Option<String> {
             // For C++ qualified names like ClassName::method, return the full qualified name
             Some(node_text(node, source).to_string())
         }
-        "pointer_declarator" | "function_declarator" | "array_declarator" | "parenthesized_declarator" => {
+        "pointer_declarator"
+        | "function_declarator"
+        | "array_declarator"
+        | "parenthesized_declarator" => {
             if let Some(inner) = node.child_by_field_name("declarator") {
                 extract_declarator_name(inner, source)
             } else {
                 let mut cursor = node.walk();
-                let result = node.named_children(&mut cursor)
+                let result = node
+                    .named_children(&mut cursor)
                     .find(|c| c.kind() == "identifier" || c.kind() == "type_identifier")
                     .map(|c| node_text(c, source).to_string());
                 result
@@ -273,7 +350,8 @@ fn extract_declarator_name(node: Node, source: &[u8]) -> Option<String> {
                 return Some(node_text(name, source).to_string());
             }
             let mut cursor = node.walk();
-            let result = node.named_children(&mut cursor)
+            let result = node
+                .named_children(&mut cursor)
                 .find(|c| c.kind() == "identifier" || c.kind() == "type_identifier")
                 .map(|c| node_text(c, source).to_string());
             result
@@ -338,13 +416,10 @@ fn extract_call_entity(node: Node, config: &LanguageConfig, source: &[u8]) -> Op
 
     // Get arguments node (child by kind, not field name)
     let mut cursor = node.walk();
-    let args = node.named_children(&mut cursor)
-        .find(|c| c.kind() == "arguments")?;
+    let args = node.named_children(&mut cursor).find(|c| c.kind() == "arguments")?;
 
     let name = match keyword {
-        "defmodule" | "defprotocol" => {
-            extract_first_alias_or_identifier(args, source)?
-        }
+        "defmodule" | "defprotocol" => extract_first_alias_or_identifier(args, source)?,
         "defimpl" => {
             let base = extract_first_alias_or_identifier(args, source)?;
             if let Some(target) = extract_keyword_value(args, "for", source) {

--- a/crates/sem-core/src/parser/plugins/code/languages.rs
+++ b/crates/sem-core/src/parser/plugins/code/languages.rs
@@ -1,5 +1,10 @@
 use tree_sitter::Language;
 
+pub struct SuppressedNestedEntity {
+    pub parent_entity_node_type: &'static str,
+    pub child_entity_node_type: &'static str,
+}
+
 #[allow(dead_code)]
 pub struct LanguageConfig {
     pub id: &'static str,
@@ -7,6 +12,7 @@ pub struct LanguageConfig {
     pub entity_node_types: &'static [&'static str],
     pub container_node_types: &'static [&'static str],
     pub call_entity_identifiers: &'static [&'static str],
+    pub suppressed_nested_entities: &'static [SuppressedNestedEntity],
     pub get_language: fn() -> Option<Language>,
 }
 
@@ -74,6 +80,10 @@ fn get_bash() -> Option<Language> {
     Some(tree_sitter_bash::LANGUAGE.into())
 }
 
+fn get_hcl() -> Option<Language> {
+    Some(tree_sitter_hcl::LANGUAGE.into())
+}
+
 static TYPESCRIPT_CONFIG: LanguageConfig = LanguageConfig {
     id: "typescript",
     extensions: &[".ts"],
@@ -91,6 +101,7 @@ static TYPESCRIPT_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["class_body", "interface_body", "enum_body", "statement_block"],
     call_entity_identifiers: &[],
+    suppressed_nested_entities: &[],
     get_language: get_typescript,
 };
 
@@ -111,6 +122,7 @@ static TSX_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["class_body", "interface_body", "enum_body", "statement_block"],
     call_entity_identifiers: &[],
+    suppressed_nested_entities: &[],
     get_language: get_tsx,
 };
 
@@ -128,6 +140,7 @@ static JAVASCRIPT_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["class_body", "statement_block"],
     call_entity_identifiers: &[],
+    suppressed_nested_entities: &[],
     get_language: get_javascript,
 };
 
@@ -141,6 +154,7 @@ static PYTHON_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["block"],
     call_entity_identifiers: &[],
+    suppressed_nested_entities: &[],
     get_language: get_python,
 };
 
@@ -156,6 +170,7 @@ static GO_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["block"],
     call_entity_identifiers: &[],
+    suppressed_nested_entities: &[],
     get_language: get_go,
 };
 
@@ -175,6 +190,7 @@ static RUST_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["declaration_list", "block"],
     call_entity_identifiers: &[],
+    suppressed_nested_entities: &[],
     get_language: get_rust,
 };
 
@@ -192,6 +208,7 @@ static JAVA_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["class_body", "interface_body", "enum_body", "block"],
     call_entity_identifiers: &[],
+    suppressed_nested_entities: &[],
     get_language: get_java,
 };
 
@@ -208,6 +225,7 @@ static C_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["compound_statement"],
     call_entity_identifiers: &[],
+    suppressed_nested_entities: &[],
     get_language: get_c,
 };
 
@@ -226,6 +244,7 @@ static CPP_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["field_declaration_list", "declaration_list", "compound_statement"],
     call_entity_identifiers: &[],
+    suppressed_nested_entities: &[],
     get_language: get_cpp,
 };
 
@@ -240,6 +259,7 @@ static RUBY_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["body_statement"],
     call_entity_identifiers: &[],
+    suppressed_nested_entities: &[],
     get_language: get_ruby,
 };
 
@@ -259,6 +279,7 @@ static CSHARP_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["declaration_list", "block"],
     call_entity_identifiers: &[],
+    suppressed_nested_entities: &[],
     get_language: get_csharp,
 };
 
@@ -276,6 +297,7 @@ static PHP_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["declaration_list", "enum_declaration_list", "compound_statement"],
     call_entity_identifiers: &[],
+    suppressed_nested_entities: &[],
     get_language: get_php,
 };
 
@@ -292,6 +314,7 @@ static FORTRAN_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &[],
     call_entity_identifiers: &[],
+    suppressed_nested_entities: &[],
     get_language: get_fortran,
 };
 
@@ -312,6 +335,7 @@ static SWIFT_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["class_body", "protocol_body", "enum_class_body", "function_body"],
     call_entity_identifiers: &[],
+    suppressed_nested_entities: &[],
     get_language: get_swift,
 };
 
@@ -325,6 +349,7 @@ static ELIXIR_CONFIG: LanguageConfig = LanguageConfig {
         "defguard", "defguardp", "defprotocol", "defimpl",
         "defstruct", "defexception", "defdelegate",
     ],
+    suppressed_nested_entities: &[],
     get_language: get_elixir,
 };
 
@@ -334,7 +359,21 @@ static BASH_CONFIG: LanguageConfig = LanguageConfig {
     entity_node_types: &["function_definition"],
     container_node_types: &["compound_statement"],
     call_entity_identifiers: &[],
+    suppressed_nested_entities: &[],
     get_language: get_bash,
+};
+
+static HCL_CONFIG: LanguageConfig = LanguageConfig {
+    id: "hcl",
+    extensions: &[".hcl", ".tf", ".tfvars"],
+    entity_node_types: &["block", "attribute"],
+    container_node_types: &["body"],
+    call_entity_identifiers: &[],
+    suppressed_nested_entities: &[SuppressedNestedEntity {
+        parent_entity_node_type: "block",
+        child_entity_node_type: "attribute",
+    }],
+    get_language: get_hcl,
 };
 
 static ALL_CONFIGS: &[&LanguageConfig] = &[
@@ -354,6 +393,7 @@ static ALL_CONFIGS: &[&LanguageConfig] = &[
     &SWIFT_CONFIG,
     &ELIXIR_CONFIG,
     &BASH_CONFIG,
+    &HCL_CONFIG,
 ];
 
 pub fn get_language_config(extension: &str) -> Option<&'static LanguageConfig> {
@@ -366,12 +406,9 @@ pub fn get_language_config(extension: &str) -> Option<&'static LanguageConfig> {
 pub fn get_all_code_extensions() -> &'static [&'static str] {
     // All unique extensions across all language configs
     static EXTENSIONS: &[&str] = &[
-        ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".py", ".go", ".rs",
-        ".java", ".c", ".h", ".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx",
-        ".rb", ".cs", ".php", ".f90", ".f95", ".f03", ".f08", ".f", ".for",
-        ".swift",
-        ".ex", ".exs",
-        ".sh",
+        ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".py", ".go", ".rs", ".java", ".c", ".h",
+        ".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx", ".rb", ".cs", ".php", ".f90", ".f95", ".f03",
+        ".f08", ".f", ".for", ".swift", ".ex", ".exs", ".sh", ".hcl", ".tf", ".tfvars",
     ];
     EXTENSIONS
 }

--- a/crates/sem-core/src/parser/plugins/code/mod.rs
+++ b/crates/sem-core/src/parser/plugins/code/mod.rs
@@ -423,4 +423,50 @@ function outer() {
 
         assert!(names.contains(&"outer"), "got: {:?}", names);
     }
+
+    #[test]
+    fn test_hcl_entity_extraction() {
+        let code = r#"
+region = "eu-west-1"
+
+variable "image_id" {
+  type = string
+}
+
+resource "aws_instance" "web" {
+  ami = var.image_id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "main.tf");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+        let types: Vec<&str> = entities.iter().map(|e| e.entity_type.as_str()).collect();
+        eprintln!("HCL entities: {:?}", entities.iter().map(|e| (&e.name, &e.entity_type, &e.parent_id)).collect::<Vec<_>>());
+
+        assert!(names.contains(&"region"), "Should find top-level attribute, got: {:?}", names);
+        assert!(names.contains(&"variable.image_id"), "Should find variable block, got: {:?}", names);
+        assert!(names.contains(&"resource.aws_instance.web"), "Should find resource block, got: {:?}", names);
+        assert!(
+            names.contains(&"resource.aws_instance.web.lifecycle"),
+            "Should find nested lifecycle block with qualified name, got: {:?}",
+            names
+        );
+        assert!(!names.contains(&"ami"), "Should skip nested attributes inside blocks, got: {:?}", names);
+        assert!(
+            !names.contains(&"create_before_destroy"),
+            "Should skip nested attributes inside nested blocks, got: {:?}",
+            names
+        );
+
+        let lifecycle = entities
+            .iter()
+            .find(|e| e.name == "resource.aws_instance.web.lifecycle")
+            .unwrap();
+        assert!(lifecycle.parent_id.is_some(), "lifecycle should be nested under resource");
+        assert!(types.contains(&"attribute"), "Should preserve attribute entity type for top-level attributes");
+    }
 }


### PR DESCRIPTION
Adds HCL/Terraform support to the Rust code parser.

Extracts top-level attributes and blocks, skips nested attributes inside blocks and qualifies nested block names with their parent path so nested entries are unambiguous in diff output. It also moves the nested-entity skip rule into language config and adds tests for the new HCL behavior.
