### PR TITLE
fix: Scope boundaries for JS/TS entity extraction

### DIFF
--- a/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
+++ b/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
@@ -30,7 +30,7 @@ fn visit_node(
     entities: &mut Vec<SemanticEntity>,
     parent_id: Option<&str>,
     source: &[u8],
-    enclosing_entity_node_type: Option<&'static str>,
+    suppression_context: Option<&str>,
 ) {
     let node_type = node.kind();
 
@@ -70,7 +70,7 @@ fn visit_node(
                             entities,
                             Some(&entity_id),
                             source,
-                            enclosing_entity_node_type,
+                            suppression_context,
                         );
                     }
                 }
@@ -81,13 +81,13 @@ fn visit_node(
 
     if config.entity_node_types.contains(&node_type) {
         if let Some(name) = extract_name(node, source) {
-            let name = qualify_hcl_name(&name, node_type, parent_id, enclosing_entity_node_type);
+            let name = qualify_hcl_name(&name, node_type, parent_id, suppression_context);
             let entity_type = if node_type == "decorated_definition" {
                 map_decorated_type(node)
             } else {
                 map_node_type(node_type)
             };
-            let should_skip = should_skip_entity(config, enclosing_entity_node_type, node_type);
+            let should_skip = should_skip_entity(config, suppression_context, node_type);
             if !should_skip {
                 let content_str = node_text(node, source);
                 let content = content_str.to_string();
@@ -111,7 +111,7 @@ fn visit_node(
                 entities.push(entity);
 
                 // Visit children for nested entities (methods inside classes, etc.)
-                let next_enclosing_entity_node_type = Some(node_type);
+                let next_suppression_context = Some(node_type);
                 let mut cursor = node.walk();
                 for child in node.named_children(&mut cursor) {
                     if config.container_node_types.contains(&child.kind()) {
@@ -124,11 +124,36 @@ fn visit_node(
                                 entities,
                                 Some(&entity_id),
                                 source,
-                                next_enclosing_entity_node_type,
+                                next_suppression_context,
                             );
                         }
                     }
                 }
+
+                // For variable declarations, also traverse into initializers
+                // that are scope boundaries (arrow functions, function expressions)
+                // so that inner class/function declarations are extracted.
+                if node_type == "lexical_declaration" || node_type == "variable_declaration" {
+                    let mut vd_cursor = node.walk();
+                    for child in node.named_children(&mut vd_cursor) {
+                        if child.kind() == "variable_declarator" {
+                            if let Some(value) = child.child_by_field_name("value") {
+                                if config.scope_boundary_types.contains(&value.kind()) {
+                                    visit_node(
+                                        value,
+                                        file_path,
+                                        config,
+                                        entities,
+                                        Some(&entity_id),
+                                        source,
+                                        Some(value.kind()),
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+
                 return;
             }
         }
@@ -137,14 +162,23 @@ fn visit_node(
     // For export statements, look inside for the actual declaration
     if node_type == "export_statement" {
         if let Some(declaration) = node.child_by_field_name("declaration") {
-            visit_node(declaration, file_path, config, entities, parent_id, source, enclosing_entity_node_type);
+            visit_node(declaration, file_path, config, entities, parent_id, source, suppression_context);
             return;
         }
     }
 
-    // Recurse into top-level children
+    // Recurse into children. When we enter a scope boundary (e.g. arrow
+    // functions, function expressions) we propagate the boundary's node type
+    // as the suppression context so that suppressed_nested_entities rules
+    // filter out local variable declarations while still allowing inner
+    // class/function declarations to be extracted.
     let mut cursor = node.walk();
     for child in node.named_children(&mut cursor) {
+        let child_enclosing = if config.scope_boundary_types.contains(&child.kind()) {
+            Some(child.kind())
+        } else {
+            suppression_context
+        };
         visit_node(
             child,
             file_path,
@@ -152,7 +186,7 @@ fn visit_node(
             entities,
             parent_id,
             source,
-            enclosing_entity_node_type,
+            child_enclosing,
         );
     }
 }
@@ -452,9 +486,9 @@ fn qualify_hcl_name(
     name: &str,
     node_type: &str,
     parent_id: Option<&str>,
-    enclosing_entity_node_type: Option<&'static str>,
+    suppression_context: Option<&str>,
 ) -> String {
-    if node_type != "block" || enclosing_entity_node_type != Some("block") {
+    if node_type != "block" || suppression_context != Some("block") {
         return name.to_string();
     }
 
@@ -472,11 +506,11 @@ fn parent_entity_name_from_id(parent_id: &str) -> Option<&str> {
 // Apply language-specific nested entity suppression rules from config.
 fn should_skip_entity(
     config: &LanguageConfig,
-    enclosing_entity_node_type: Option<&'static str>,
+    suppression_context: Option<&str>,
     node_type: &str,
 ) -> bool {
     config.suppressed_nested_entities.iter().any(|rule| {
-        enclosing_entity_node_type == Some(rule.parent_entity_node_type)
+        suppression_context == Some(rule.parent_entity_node_type)
             && node_type == rule.child_entity_node_type
     })
 }
@@ -522,7 +556,7 @@ fn node_text<'a>(node: Node, source: &'a [u8]) -> &'a str {
     node.utf8_text(source).unwrap_or("")
 }
 
-fn map_node_type<'a>(tree_sitter_type: &'a str) -> &'a str {
+fn map_node_type(tree_sitter_type: &str) -> &str {
     match tree_sitter_type {
         "function_declaration" | "function_definition" | "function_item" => "function",
         "method_declaration" | "method_definition" | "method" | "singleton_method" => "method",

--- a/crates/sem-core/src/parser/plugins/code/languages.rs
+++ b/crates/sem-core/src/parser/plugins/code/languages.rs
@@ -13,6 +13,10 @@ pub struct LanguageConfig {
     pub container_node_types: &'static [&'static str],
     pub call_entity_identifiers: &'static [&'static str],
     pub suppressed_nested_entities: &'static [SuppressedNestedEntity],
+    /// Node types that introduce a new scope. The general (non-container) recursion
+    /// in visit_node will not descend into these nodes, preventing local variables
+    /// inside function bodies from being extracted as top-level entities.
+    pub scope_boundary_types: &'static [&'static str],
     pub get_language: fn() -> Option<Language>,
 }
 
@@ -92,6 +96,69 @@ fn get_xml() -> Option<Language> {
     Some(tree_sitter_xml::LANGUAGE_XML.into())
 }
 
+/// Inside JS/TS function bodies, suppress variable declarations so that local
+/// variables are not extracted as nested entities. Inner function/class
+/// declarations are still extracted for diff granularity.
+const JS_TS_SUPPRESSED_NESTED: &[SuppressedNestedEntity] = &[
+    SuppressedNestedEntity {
+        parent_entity_node_type: "function_declaration",
+        child_entity_node_type: "lexical_declaration",
+    },
+    SuppressedNestedEntity {
+        parent_entity_node_type: "function_declaration",
+        child_entity_node_type: "variable_declaration",
+    },
+    SuppressedNestedEntity {
+        parent_entity_node_type: "generator_function_declaration",
+        child_entity_node_type: "lexical_declaration",
+    },
+    SuppressedNestedEntity {
+        parent_entity_node_type: "generator_function_declaration",
+        child_entity_node_type: "variable_declaration",
+    },
+    SuppressedNestedEntity {
+        parent_entity_node_type: "method_definition",
+        child_entity_node_type: "lexical_declaration",
+    },
+    SuppressedNestedEntity {
+        parent_entity_node_type: "method_definition",
+        child_entity_node_type: "variable_declaration",
+    },
+    // Scope boundaries: suppress local variables inside arrow functions,
+    // function expressions, and generator functions, while still allowing
+    // inner class/function declarations to be extracted.
+    SuppressedNestedEntity {
+        parent_entity_node_type: "arrow_function",
+        child_entity_node_type: "lexical_declaration",
+    },
+    SuppressedNestedEntity {
+        parent_entity_node_type: "arrow_function",
+        child_entity_node_type: "variable_declaration",
+    },
+    SuppressedNestedEntity {
+        parent_entity_node_type: "function_expression",
+        child_entity_node_type: "lexical_declaration",
+    },
+    SuppressedNestedEntity {
+        parent_entity_node_type: "function_expression",
+        child_entity_node_type: "variable_declaration",
+    },
+    SuppressedNestedEntity {
+        parent_entity_node_type: "generator_function",
+        child_entity_node_type: "lexical_declaration",
+    },
+    SuppressedNestedEntity {
+        parent_entity_node_type: "generator_function",
+        child_entity_node_type: "variable_declaration",
+    },
+];
+
+const JS_TS_SCOPE_BOUNDARIES: &[&str] = &[
+    "arrow_function",
+    "function_expression",
+    "generator_function",
+];
+
 static TYPESCRIPT_CONFIG: LanguageConfig = LanguageConfig {
     id: "typescript",
     extensions: &[".ts"],
@@ -109,7 +176,8 @@ static TYPESCRIPT_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["class_body", "interface_body", "enum_body", "statement_block"],
     call_entity_identifiers: &[],
-    suppressed_nested_entities: &[],
+    suppressed_nested_entities: JS_TS_SUPPRESSED_NESTED,
+    scope_boundary_types: JS_TS_SCOPE_BOUNDARIES,
     get_language: get_typescript,
 };
 
@@ -130,7 +198,8 @@ static TSX_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["class_body", "interface_body", "enum_body", "statement_block"],
     call_entity_identifiers: &[],
-    suppressed_nested_entities: &[],
+    suppressed_nested_entities: JS_TS_SUPPRESSED_NESTED,
+    scope_boundary_types: JS_TS_SCOPE_BOUNDARIES,
     get_language: get_tsx,
 };
 
@@ -148,7 +217,8 @@ static JAVASCRIPT_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["class_body", "statement_block"],
     call_entity_identifiers: &[],
-    suppressed_nested_entities: &[],
+    suppressed_nested_entities: JS_TS_SUPPRESSED_NESTED,
+    scope_boundary_types: JS_TS_SCOPE_BOUNDARIES,
     get_language: get_javascript,
 };
 
@@ -163,6 +233,7 @@ static PYTHON_CONFIG: LanguageConfig = LanguageConfig {
     container_node_types: &["block"],
     call_entity_identifiers: &[],
     suppressed_nested_entities: &[],
+    scope_boundary_types: &[],
     get_language: get_python,
 };
 
@@ -179,6 +250,7 @@ static GO_CONFIG: LanguageConfig = LanguageConfig {
     container_node_types: &["block"],
     call_entity_identifiers: &[],
     suppressed_nested_entities: &[],
+    scope_boundary_types: &[],
     get_language: get_go,
 };
 
@@ -199,6 +271,7 @@ static RUST_CONFIG: LanguageConfig = LanguageConfig {
     container_node_types: &["declaration_list", "block"],
     call_entity_identifiers: &[],
     suppressed_nested_entities: &[],
+    scope_boundary_types: &[],
     get_language: get_rust,
 };
 
@@ -217,6 +290,7 @@ static JAVA_CONFIG: LanguageConfig = LanguageConfig {
     container_node_types: &["class_body", "interface_body", "enum_body", "block"],
     call_entity_identifiers: &[],
     suppressed_nested_entities: &[],
+    scope_boundary_types: &[],
     get_language: get_java,
 };
 
@@ -234,6 +308,7 @@ static C_CONFIG: LanguageConfig = LanguageConfig {
     container_node_types: &["compound_statement"],
     call_entity_identifiers: &[],
     suppressed_nested_entities: &[],
+    scope_boundary_types: &[],
     get_language: get_c,
 };
 
@@ -253,6 +328,7 @@ static CPP_CONFIG: LanguageConfig = LanguageConfig {
     container_node_types: &["field_declaration_list", "declaration_list", "compound_statement"],
     call_entity_identifiers: &[],
     suppressed_nested_entities: &[],
+    scope_boundary_types: &[],
     get_language: get_cpp,
 };
 
@@ -268,6 +344,7 @@ static RUBY_CONFIG: LanguageConfig = LanguageConfig {
     container_node_types: &["body_statement"],
     call_entity_identifiers: &[],
     suppressed_nested_entities: &[],
+    scope_boundary_types: &[],
     get_language: get_ruby,
 };
 
@@ -288,6 +365,7 @@ static CSHARP_CONFIG: LanguageConfig = LanguageConfig {
     container_node_types: &["declaration_list", "block"],
     call_entity_identifiers: &[],
     suppressed_nested_entities: &[],
+    scope_boundary_types: &[],
     get_language: get_csharp,
 };
 
@@ -306,6 +384,7 @@ static PHP_CONFIG: LanguageConfig = LanguageConfig {
     container_node_types: &["declaration_list", "enum_declaration_list", "compound_statement"],
     call_entity_identifiers: &[],
     suppressed_nested_entities: &[],
+    scope_boundary_types: &[],
     get_language: get_php,
 };
 
@@ -323,6 +402,7 @@ static FORTRAN_CONFIG: LanguageConfig = LanguageConfig {
     container_node_types: &[],
     call_entity_identifiers: &[],
     suppressed_nested_entities: &[],
+    scope_boundary_types: &[],
     get_language: get_fortran,
 };
 
@@ -344,6 +424,7 @@ static SWIFT_CONFIG: LanguageConfig = LanguageConfig {
     container_node_types: &["class_body", "protocol_body", "enum_class_body", "function_body"],
     call_entity_identifiers: &[],
     suppressed_nested_entities: &[],
+    scope_boundary_types: &[],
     get_language: get_swift,
 };
 
@@ -358,6 +439,7 @@ static ELIXIR_CONFIG: LanguageConfig = LanguageConfig {
         "defstruct", "defexception", "defdelegate",
     ],
     suppressed_nested_entities: &[],
+    scope_boundary_types: &[],
     get_language: get_elixir,
 };
 
@@ -368,6 +450,7 @@ static BASH_CONFIG: LanguageConfig = LanguageConfig {
     container_node_types: &["compound_statement"],
     call_entity_identifiers: &[],
     suppressed_nested_entities: &[],
+    scope_boundary_types: &[],
     get_language: get_bash,
 };
 
@@ -381,6 +464,7 @@ static HCL_CONFIG: LanguageConfig = LanguageConfig {
         parent_entity_node_type: "block",
         child_entity_node_type: "attribute",
     }],
+    scope_boundary_types: &[],
     get_language: get_hcl,
 };
 
@@ -399,6 +483,7 @@ static KOTLIN_CONFIG: LanguageConfig = LanguageConfig {
     container_node_types: &["class_body", "enum_class_body"],
     call_entity_identifiers: &[],
     suppressed_nested_entities: &[],
+    scope_boundary_types: &[],
     get_language: get_kotlin,
 };
 
@@ -409,6 +494,7 @@ static XML_CONFIG: LanguageConfig = LanguageConfig {
     container_node_types: &["content"],
     call_entity_identifiers: &[],
     suppressed_nested_entities: &[],
+    scope_boundary_types: &[],
     get_language: get_xml,
 };
 

--- a/crates/sem-core/src/parser/plugins/code/mod.rs
+++ b/crates/sem-core/src/parser/plugins/code/mod.rs
@@ -599,4 +599,243 @@ fun topLevel(x: Int): Int = x * 2
         assert!(names.contains(&"dependencies"), "got: {:?}", names);
         assert!(names.contains(&"build"), "got: {:?}", names);
     }
+
+    #[test]
+    fn test_arrow_callback_scope_boundary_typescript() {
+        // Arrow function callbacks: locals are suppressed, but inner
+        // class/function declarations are still extracted. Nested callbacks
+        // also suppress their locals.
+        let code = r#"
+const activeQueues = [
+  { queue: queues.fooQueue, processor: foo.process },
+];
+
+activeQueues.forEach((handler: any) => {
+  const queue = handler.queue;
+  let retries = 0;
+
+  class QueueHandler {
+    handle() { return queue; }
+  }
+
+  function createHandler() {
+    return new QueueHandler();
+  }
+
+  queue.process((job) => {
+    const orderId = job.data.orderId;
+    return orderId;
+  });
+});
+
+function handleFailure(job: any, err: any) {
+  console.error('failed', err);
+}
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "process.ts");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+        let top_level: Vec<&str> = entities
+            .iter()
+            .filter(|e| e.parent_id.is_none())
+            .map(|e| e.name.as_str())
+            .collect();
+
+        // Top-level entities preserved
+        assert!(top_level.contains(&"activeQueues"), "got: {:?}", top_level);
+        assert!(top_level.contains(&"handleFailure"), "got: {:?}", top_level);
+
+        // Declarations inside callback extracted
+        assert!(names.contains(&"QueueHandler"), "got: {:?}", names);
+        assert!(names.contains(&"handle"), "got: {:?}", names);
+        assert!(names.contains(&"createHandler"), "got: {:?}", names);
+
+        // Locals inside callbacks suppressed
+        assert!(!names.contains(&"queue"), "got: {:?}", names);
+        assert!(!names.contains(&"retries"), "got: {:?}", names);
+        assert!(!names.contains(&"orderId"), "got: {:?}", names);
+    }
+
+    #[test]
+    fn test_top_level_iife_wrapper_still_extracts_typescript_entities() {
+        let code = r#"
+function factory() {
+  class Foo {
+    method(): number {
+      return 1;
+    }
+  }
+
+  function bar(): Foo {
+    return new Foo();
+  }
+}
+
+factory();
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "wrapped.ts");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+        assert!(
+            names.contains(&"factory"),
+            "Should find top-level wrapper function, got: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"Foo"),
+            "Should find class inside top-level wrapper, got: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"bar"),
+            "Should find function inside top-level wrapper, got: {:?}",
+            names
+        );
+    }
+
+    #[test]
+    fn test_top_level_iife_still_extracts_typescript_entities() {
+        let code = r#"
+(() => {
+  class Foo {
+    method(): number {
+      return 1;
+    }
+  }
+
+  function bar(): Foo {
+    return new Foo();
+  }
+})();
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "iife.ts");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+        assert!(
+            names.contains(&"Foo"),
+            "Should find class inside top-level IIFE, got: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"bar"),
+            "Should find function inside top-level IIFE, got: {:?}",
+            names
+        );
+    }
+
+    #[test]
+    fn test_function_locals_not_extracted_as_nested_entities_typescript() {
+        let code = r#"
+export default function foo() {
+  const x = 1;
+  return x;
+}
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "default-export.ts");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+        assert!(
+            names.contains(&"foo"),
+            "Should find exported function, got: {:?}",
+            names
+        );
+        assert!(
+            !names.contains(&"x"),
+            "Local inside function should not be extracted as an entity, got: {:?}",
+            names
+        );
+    }
+
+    #[test]
+    fn test_function_expression_scope_boundary_typescript() {
+        // Function expressions: assigned to variables, or used as callback
+        // arguments. Locals are suppressed in all cases.
+        let code = r#"
+const foo = function namedExpr(x: number) {
+  const inner = x + 1;
+  return inner;
+};
+
+const bar = function(y: number) {
+  const local = y * 2;
+  return local;
+};
+
+const items = [1, 2, 3];
+
+items.forEach(function process(item) {
+  const doubled = item * 2;
+  console.log(doubled);
+});
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "funexpr.ts");
+        let top_level: Vec<&str> = entities
+            .iter()
+            .filter(|e| e.parent_id.is_none())
+            .map(|e| e.name.as_str())
+            .collect();
+        let all_names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+
+        // Top-level variable declarations preserved
+        assert!(top_level.contains(&"foo"), "got: {:?}", top_level);
+        assert!(top_level.contains(&"bar"), "got: {:?}", top_level);
+        assert!(top_level.contains(&"items"), "got: {:?}", top_level);
+
+        // Locals inside function expressions suppressed
+        assert!(!all_names.contains(&"inner"), "got: {:?}", all_names);
+        assert!(!all_names.contains(&"local"), "got: {:?}", all_names);
+        assert!(!all_names.contains(&"doubled"), "got: {:?}", all_names);
+
+        // Named function expression used as callback argument not extracted
+        assert!(!top_level.contains(&"process"), "got: {:?}", top_level);
+    }
+
+    #[test]
+    fn test_variable_assigned_arrow_extracts_inner_entities() {
+        // Arrow function assigned to a variable: inner class/function
+        // declarations should be extracted, locals should be suppressed.
+        let code = r#"
+const handler = () => {
+  class Inner {
+    run() { return 1; }
+  }
+
+  function make() {
+    return new Inner();
+  }
+
+  const local = 42;
+};
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "assigned.ts");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+
+        assert!(names.contains(&"handler"), "got: {:?}", names);
+        assert!(names.contains(&"Inner"), "got: {:?}", names);
+        assert!(names.contains(&"run"), "got: {:?}", names);
+        assert!(names.contains(&"make"), "got: {:?}", names);
+        assert!(!names.contains(&"local"), "got: {:?}", names);
+    }
+
+    #[test]
+    fn test_variable_assigned_function_expression_extracts_inner_entities() {
+        // Function expression assigned to a variable: same behavior.
+        let code = r#"
+const handler = function() {
+  class Inner {}
+  function make() { return new Inner(); }
+  const local = 42;
+};
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "funexpr-inner.ts");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+
+        assert!(names.contains(&"handler"), "got: {:?}", names);
+        assert!(names.contains(&"Inner"), "got: {:?}", names);
+        assert!(names.contains(&"make"), "got: {:?}", names);
+        assert!(!names.contains(&"local"), "got: {:?}", names);
+    }
 }


### PR DESCRIPTION
The entity extractor recursed into JS/TS function expression bodies (arrow functions, function expressions, generator functions) and extracted local variables (const, let, var) as top-level entities. These spurious entities are unstable and small structural changes to surrounding code could cause different locals to be extracted, producing different entity sets from logically equivalent code.

Downstream consumers such as weave would interpret the instability as intentional additions or deletions, which could cause code to be silently dropped or mangled during merge conflict resolution.

Scope boundaries are now selectively transparent: local variable declarations inside function expression bodies are suppressed, but inner class and function declarations are still extracted as entities.

This keeps entity extraction stable across versions while preserving granularity for real semantic units.

Implementation uses two mechanisms configured through LanguageConfig:

1. scope_boundary_types When the general recursion in visit_node encounters one of these node types, it propagates the boundary as the suppression_context rather than skipping the subtree entirely.

2. suppressed_nested_entities Rules keyed on suppression_context filter out lexical_declaration and variable_declaration inside scope boundary types and named function/method bodies.

Both are configured through LanguageConfig fields and currently only apply to JavaScript/TypeScript.