### PR TITLE
Feature/typescript-and-javascript parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ sem unsetup
 
 | Language | Extensions | Entities |
 |----------|-----------|----------|
-| TypeScript | `.ts` `.tsx` | functions, classes, interfaces, types, enums, exports |
+| TypeScript | `.ts` `.tsx` `.mts` `.cts`  | functions, classes, interfaces, types, enums, exports |
 | JavaScript | `.js` `.jsx` `.mjs` `.cjs` | functions, classes, variables, exports |
 | Python | `.py` | functions, classes, decorated definitions |
 | Go | `.go` | functions, methods, types, vars, consts |

--- a/crates/sem-api/src/main.rs
+++ b/crates/sem-api/src/main.rs
@@ -73,7 +73,7 @@ struct SearchReq {
 // ── Repo management ──────────────────────────────────────────────
 
 const SUPPORTED_EXT: &[&str] = &[
-    "ts", "tsx", "js", "jsx", "py", "go", "rs", "java",
+    "ts", "tsx", "mts", "cts", "js", "jsx", "py", "go", "rs", "java",
     "c", "cpp", "cc", "h", "hpp", "rb", "cs", "php",
 ];
 

--- a/crates/sem-core/src/parser/plugins/code/languages.rs
+++ b/crates/sem-core/src/parser/plugins/code/languages.rs
@@ -161,7 +161,7 @@ const JS_TS_SCOPE_BOUNDARIES: &[&str] = &[
 
 static TYPESCRIPT_CONFIG: LanguageConfig = LanguageConfig {
     id: "typescript",
-    extensions: &[".ts"],
+    extensions: &[".ts", ".mts", ".cts"],
     entity_node_types: &[
         "function_declaration",
         "class_declaration",
@@ -530,7 +530,7 @@ pub fn get_language_config(extension: &str) -> Option<&'static LanguageConfig> {
 pub fn get_all_code_extensions() -> &'static [&'static str] {
     // All unique extensions across all language configs
     static EXTENSIONS: &[&str] = &[
-        ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".py", ".go", ".rs", ".java", ".c", ".h",
+        ".ts",".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".py", ".go", ".rs", ".java", ".c", ".h",
         ".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx", ".rb", ".cs", ".php", ".f90", ".f95", ".f03",
         ".f08", ".f", ".for", ".swift", ".ex", ".exs", ".sh", ".hcl", ".tf", ".tfvars",
         ".kt", ".kts",

--- a/crates/sem-core/src/parser/plugins/code/mod.rs
+++ b/crates/sem-core/src/parser/plugins/code/mod.rs
@@ -364,6 +364,37 @@ export class Greeter {
     }
 
     #[test]
+    fn test_module_typescript_entity_extraction() {
+        let code = r#"
+export function hello(): string {
+    return "hello";
+}
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "test.mts");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+
+        assert!(names.contains(&"hello"), "Should find hello function");
+    }
+
+    #[test]
+    fn test_commonjs_typescript_entity_extraction() {
+        let code = r#"
+export class Greeter {
+    greet(name: string): string {
+        return `Hello, ${name}!`;
+    }
+}
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "test.cts");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+
+        assert!(names.contains(&"Greeter"), "Should find Greeter class");
+        assert!(names.contains(&"greet"), "Should find greet method");
+    }
+
+    #[test]
     fn test_nested_functions_typescript() {
         let code = r#"
 function outer() {

--- a/crates/sem-core/src/parser/registry.rs
+++ b/crates/sem-core/src/parser/registry.rs
@@ -105,4 +105,24 @@ mod tests {
 
         assert_eq!(plugin.id(), "svelte");
     }
+
+    #[test]
+    fn test_registry_matches_typescript_module_suffix() {
+        let registry = create_default_registry();
+        let plugin = registry
+            .get_plugin("src/lib/index.mts")
+            .expect("plugin should exist");
+
+        assert_eq!(plugin.id(), "code");
+    }
+
+    #[test]
+    fn test_registry_matches_typescript_commonjs_suffix() {
+        let registry = create_default_registry();
+        let plugin = registry
+            .get_plugin("src/lib/index.cts")
+            .expect("plugin should exist");
+
+        assert_eq!(plugin.id(), "code");
+    }
 }

--- a/docs/details.html
+++ b/docs/details.html
@@ -549,7 +549,7 @@
           <tr><th>Format</th><th>Extensions</th><th>Entities</th></tr>
         </thead>
         <tbody>
-          <tr><td>TypeScript</td><td>.ts .tsx</td><td>functions, classes, interfaces, types, enums, exports</td></tr>
+          <tr><td>TypeScript</td><td>.ts .tsx .mts .cts</td><td>functions, classes, interfaces, types, enums, exports</td></tr>
           <tr><td>JavaScript</td><td>.js .jsx .mjs .cjs</td><td>functions, classes, variables, exports</td></tr>
           <tr><td>Python</td><td>.py</td><td>functions, classes, decorated definitions</td></tr>
           <tr><td>Go</td><td>.go</td><td>functions, methods, types, vars, consts</td></tr>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -86,7 +86,7 @@ sem impact validateToken --file-exts .py
 
 | Language | Extensions | Entity Types |
 |----------|-----------|--------------|
-| TypeScript | .ts .tsx | functions, classes, interfaces, types, enums, exports |
+| TypeScript | .ts .tsx .mts .cts | functions, classes, interfaces, types, enums, exports |
 | JavaScript | .js .jsx .mjs .cjs | functions, classes, variables, exports |
 | Python | .py | functions, classes, decorated definitions |
 | Go | .go | functions, methods, types, vars, consts |


### PR DESCRIPTION
JS supported JS, JSX, MJS and CJS.
TS only supported TS, TSX. After this PR, it supports MTS and CTS.