### PR TITLE
Fix panic on multi-byte UTF-8 chars in graph and verify

### DIFF
--- a/crates/sem-core/src/parser/graph.rs
+++ b/crates/sem-core/src/parser/graph.rs
@@ -672,7 +672,11 @@ fn infer_ref_type(content: &str, ref_name: &str) -> RefType {
                 return RefType::Calls;
             }
         }
+        // Advance past pos to the next char boundary to avoid slicing inside a multi-byte UTF-8 char.
         search_start = pos + 1;
+        while search_start < content.len() && !content.is_char_boundary(search_start) {
+            search_start += 1;
+        }
     }
 
     // Check if it's in an import/use statement (line-level, not substring)
@@ -930,6 +934,24 @@ mod tests {
     fn test_infer_ref_type_type() {
         assert_eq!(
             infer_ref_type("let x: MyType = something", "MyType"),
+            RefType::TypeRef,
+        );
+    }
+
+    #[test]
+    fn test_infer_ref_type_multibyte_utf8() {
+        // Ensure no panic when content contains multi-byte UTF-8 characters
+        assert_eq!(
+            infer_ref_type("let café = foo(x)", "foo"),
+            RefType::Calls,
+        );
+        assert_eq!(
+            infer_ref_type("class HandicapfrPublicationFieldsEnum:\n    É = 1\n    bar()", "bar"),
+            RefType::Calls,
+        );
+        // No match should not panic either
+        assert_eq!(
+            infer_ref_type("// 日本語コメント\nlet x = 1", "missing"),
             RefType::TypeRef,
         );
     }

--- a/crates/sem-core/src/parser/verify.rs
+++ b/crates/sem-core/src/parser/verify.rs
@@ -243,6 +243,9 @@ fn count_call_args(content: &str, callee_name: &str) -> Option<usize> {
         }
 
         search_start = pos + 1;
+        while search_start < content.len() && !content.is_char_boundary(search_start) {
+            search_start += 1;
+        }
     }
 
     None
@@ -304,5 +307,13 @@ mod tests {
         assert_eq!(count_call_args("foo()", "foo"), Some(0));
         assert_eq!(count_call_args("bar(1)", "foo"), None);
         assert_eq!(count_call_args("foo(a, b)", "foo"), Some(2));
+    }
+
+    #[test]
+    fn test_count_call_args_multibyte_utf8() {
+        // Ensure no panic when content contains multi-byte UTF-8 characters before the call site
+        assert_eq!(count_call_args("let café = foo(1, 2);", "foo"), Some(2));
+        assert_eq!(count_call_args("let É = 1; bar(x)", "bar"), Some(1));
+        assert_eq!(count_call_args("// 日本語コメント\nfoo(a, b, c)", "foo"), Some(3));
     }
 }


### PR DESCRIPTION
 Fixes a panic when processing files containing multi-byte UTF-8 characters (e.g. É):

```
  thread '<unnamed>' (10009) panicked at sem-core/src/parser/graph.rs:661:38:
  byte index 29732 is not a char boundary; it is inside 'É' (bytes 29731..29733) of `class                  
  HandicapfrPublicationFieldsEnum:                                                                          
```
                                                                                                      
In `infer_ref_type()` and `count_call_args()`, `content[search_start..]` could slice inside a multi-byte character when advancing `search_start by +1` byte. The fix advances to the next char boundary using `is_char_boundary()`.                                                                                       
                                                            
## Disclaimer

I'm not a Rust developer — I only know the basics. This fix was vibe-coded with AI assistance. That said,  the change is minimal and straightforward, so I'm comfortable proposing it.