### PR TITLE
Add .pyi file extension support to Python language config

### DIFF
--- a/crates/sem-core/src/parser/plugins/code/languages.rs
+++ b/crates/sem-core/src/parser/plugins/code/languages.rs
@@ -224,7 +224,7 @@ static JAVASCRIPT_CONFIG: LanguageConfig = LanguageConfig {
 
 static PYTHON_CONFIG: LanguageConfig = LanguageConfig {
     id: "python",
-    extensions: &[".py"],
+    extensions: &[".py", ".pyi"],
     entity_node_types: &[
         "function_definition",
         "class_definition",
@@ -530,7 +530,7 @@ pub fn get_language_config(extension: &str) -> Option<&'static LanguageConfig> {
 pub fn get_all_code_extensions() -> &'static [&'static str] {
     // All unique extensions across all language configs
     static EXTENSIONS: &[&str] = &[
-        ".ts",".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".py", ".go", ".rs", ".java", ".c", ".h",
+        ".ts",".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".py", ".pyi", ".go", ".rs", ".java", ".c", ".h",
         ".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx", ".rb", ".cs", ".php", ".f90", ".f95", ".f03",
         ".f08", ".f", ".for", ".swift", ".ex", ".exs", ".sh", ".hcl", ".tf", ".tfvars",
         ".kt", ".kts",


### PR DESCRIPTION
Python stub files (.pyi) use the same grammar as .py files. This adds .pyi to both the Python LanguageConfig extensions and the global code extensions list.

https://claude.ai/code/session_01XpULqUKdMPwrKthvZ1CSGm