### PR TITLE
feat: Promote JS/TS const function expressions to functions

### DIFF
--- a/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
+++ b/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
@@ -142,13 +142,7 @@ fn visit_node(
     if config.entity_node_types.contains(&node_type) {
         if let Some(name) = extract_name(node, source) {
             let name = qualify_hcl_name(&name, node_type, parent_id, suppression_context);
-            let entity_type = if node_type == "decorated_definition" {
-                map_decorated_type(node)
-            } else if node_type == "class_member" {
-                map_class_member_type(node)
-            } else {
-                map_node_type(node_type)
-            };
+            let entity_type = map_entity_type(node, config);
             let should_skip = should_skip_entity(config, suppression_context, node_type);
             if !should_skip {
                 // Dart top-level signatures are split from their body node.
@@ -1032,6 +1026,38 @@ fn map_class_member_type(node: Node) -> &'static str {
         }
     }
     "member"
+}
+
+fn map_entity_type(node: Node, config: &LanguageConfig) -> &'static str {
+    match node.kind() {
+        "decorated_definition" => map_decorated_type(node),
+        "class_member" => map_class_member_type(node),
+        _ => promote_js_ts_const_function(node, config).unwrap_or_else(|| map_node_type(node.kind())),
+    }
+}
+
+fn promote_js_ts_const_function(node: Node, config: &LanguageConfig) -> Option<&'static str> {
+    if !matches!(config.id, "typescript" | "tsx" | "javascript") {
+        return None;
+    }
+
+    if node.kind() != "lexical_declaration" {
+        return None;
+    }
+
+    let declaration_kind = node.child_by_field_name("kind")?;
+    if declaration_kind.kind() != "const" {
+        return None;
+    }
+
+    let mut cursor = node.walk();
+    let declarator = node.named_children(&mut cursor).find(|child| child.kind() == "variable_declarator")?;
+    let value = declarator.child_by_field_name("value")?;
+
+    match value.kind() {
+        "arrow_function" | "function_expression" | "generator_function" => Some("function"),
+        _ => None,
+    }
 }
 
 /// Dart constructor signatures use `field("name", seq(identifier, optional(".", identifier)))`,

--- a/crates/sem-core/src/parser/plugins/code/mod.rs
+++ b/crates/sem-core/src/parser/plugins/code/mod.rs
@@ -806,12 +806,17 @@ items.forEach(function process(item) {
             .filter(|e| e.parent_id.is_none())
             .map(|e| e.name.as_str())
             .collect();
+        let find = |name: &str| entities.iter().find(|e| e.name == name).unwrap();
         let all_names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
 
-        // Top-level variable declarations preserved
+        // Top-level declarations preserved, and const-assigned function
+        // expressions are promoted from variable to function.
         assert!(top_level.contains(&"foo"), "got: {:?}", top_level);
         assert!(top_level.contains(&"bar"), "got: {:?}", top_level);
         assert!(top_level.contains(&"items"), "got: {:?}", top_level);
+        assert_eq!(find("foo").entity_type, "function");
+        assert_eq!(find("bar").entity_type, "function");
+        assert_eq!(find("items").entity_type, "variable");
 
         // Locals inside function expressions suppressed
         assert!(!all_names.contains(&"inner"), "got: {:?}", all_names);
@@ -841,8 +846,10 @@ const handler = () => {
 "#;
         let plugin = CodeParserPlugin;
         let entities = plugin.extract_entities(code, "assigned.ts");
+        let handler = entities.iter().find(|e| e.name == "handler").unwrap();
         let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
 
+        assert_eq!(handler.entity_type, "function");
         assert!(names.contains(&"handler"), "got: {:?}", names);
         assert!(names.contains(&"Inner"), "got: {:?}", names);
         assert!(names.contains(&"run"), "got: {:?}", names);
@@ -862,12 +869,42 @@ const handler = function() {
 "#;
         let plugin = CodeParserPlugin;
         let entities = plugin.extract_entities(code, "funexpr-inner.ts");
+        let handler = entities.iter().find(|e| e.name == "handler").unwrap();
         let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
 
+        assert_eq!(handler.entity_type, "function");
         assert!(names.contains(&"handler"), "got: {:?}", names);
         assert!(names.contains(&"Inner"), "got: {:?}", names);
         assert!(names.contains(&"make"), "got: {:?}", names);
         assert!(!names.contains(&"local"), "got: {:?}", names);
+    }
+
+    #[test]
+    fn test_let_assigned_arrow_stays_variable_typescript() {
+        let code = r#"
+let handler = () => {
+  return 42;
+};
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "let-assigned.ts");
+        let handler = entities.iter().find(|e| e.name == "handler").unwrap();
+
+        assert_eq!(handler.entity_type, "variable");
+    }
+
+    #[test]
+    fn test_const_assigned_arrow_promoted_to_function_javascript() {
+        let code = r#"
+const handler = () => {
+  return 42;
+};
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "handler.js");
+        let handler = entities.iter().find(|e| e.name == "handler").unwrap();
+
+        assert_eq!(handler.entity_type, "function");
     }
 
     #[test]


### PR DESCRIPTION
Classify const declarations with function-like initializers as function entities in the code extractor. Add focused tests covering const promotion and let remaining variable-typed.

This is a rust version of a PR I had opened a few weeks back.