### PR TITLE
critical fix(sem-core): detect JS/TS named generator declarations in entity diffs

### DIFF
--- a/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
+++ b/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
@@ -831,7 +831,11 @@ fn node_text<'a>(node: Node, source: &'a [u8]) -> &'a str {
 
 fn map_node_type(tree_sitter_type: &str) -> &str {
     match tree_sitter_type {
-        "function_declaration" | "function_definition" | "function_item" | "function_signature"
+        "function_declaration"
+        | "generator_function_declaration"
+        | "function_definition"
+        | "function_item"
+        | "function_signature"
         | "subroutine_declaration_statement" => "function",
         "method_declaration" | "method_definition" | "method" | "singleton_method" => "method",
         "class_declaration" | "class_definition" | "class_specifier" => "class",

--- a/crates/sem-core/src/parser/plugins/code/languages.rs
+++ b/crates/sem-core/src/parser/plugins/code/languages.rs
@@ -180,6 +180,7 @@ static TYPESCRIPT_CONFIG: LanguageConfig = LanguageConfig {
     extensions: &[".ts", ".mts", ".cts"],
     entity_node_types: &[
         "function_declaration",
+        "generator_function_declaration",
         "class_declaration",
         "interface_declaration",
         "type_alias_declaration",
@@ -202,6 +203,7 @@ static TSX_CONFIG: LanguageConfig = LanguageConfig {
     extensions: &[".tsx"],
     entity_node_types: &[
         "function_declaration",
+        "generator_function_declaration",
         "class_declaration",
         "interface_declaration",
         "type_alias_declaration",
@@ -224,6 +226,7 @@ static JAVASCRIPT_CONFIG: LanguageConfig = LanguageConfig {
     extensions: &[".js", ".jsx", ".mjs", ".cjs", ".es6"],
     entity_node_types: &[
         "function_declaration",
+        "generator_function_declaration",
         "class_declaration",
         "export_statement",
         "lexical_declaration",

--- a/crates/sem-core/src/parser/plugins/code/mod.rs
+++ b/crates/sem-core/src/parser/plugins/code/mod.rs
@@ -395,6 +395,37 @@ export class Greeter {
     }
 
     #[test]
+    fn test_typescript_generator_function_entity_extraction() {
+        let code = r#"
+export async function* streamUsers(): AsyncGenerator<string> {
+    yield "alice";
+}
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "stream.ts");
+        let stream = entities.iter().find(|e| e.name == "streamUsers");
+
+        assert!(stream.is_some(), "Should find generator function, got: {:?}", entities.iter().map(|e| (&e.name, &e.entity_type)).collect::<Vec<_>>());
+        assert_eq!(stream.unwrap().entity_type, "function");
+    }
+
+    #[test]
+    fn test_javascript_generator_function_entity_extraction() {
+        let code = r#"
+export function* ids() {
+    yield 1;
+    yield 2;
+}
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "ids.js");
+        let ids = entities.iter().find(|e| e.name == "ids");
+
+        assert!(ids.is_some(), "Should find generator function, got: {:?}", entities.iter().map(|e| (&e.name, &e.entity_type)).collect::<Vec<_>>());
+        assert_eq!(ids.unwrap().entity_type, "function");
+    }
+
+    #[test]
     fn test_nested_functions_typescript() {
         let code = r#"
 function outer() {


### PR DESCRIPTION
• This fixes a gap in JS/TS entity extraction where named generator declarations were invisible to semantic diff.

Before this change, function* foo() {} and async function* foo() {} were not recognized as entities in JavaScript, TypeScript, or TSX, so additions, deletions, and modifications to those declarations could be missed by sem diff. This PR adds generator_function_declaration to the JS/TS extractor configs, maps it to the existing function entity type, and adds regression tests covering both JS and TS generator declarations.

Tests:

cargo test -p sem-core generator_function_entity_extraction
cargo test -p sem-core nested_functions_typescript