### PR TITLE
feat: add npm wrapper package (requires NPM_TOKEN secret)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,7 @@ jobs:
         shell: pwsh
         run: |
           Compress-Archive -Path target/${{ matrix.target }}/release/sem.exe -DestinationPath ${{ matrix.name }}.zip
+          tar -czf ${{ matrix.name }}.tar.gz -C target/${{ matrix.target }}/release sem.exe
 
       - uses: actions/upload-artifact@v4
         with:
@@ -133,6 +134,32 @@ jobs:
           files: |
             *.tar.gz
             *.zip
+
+  publish-npm:
+    needs: [check-version, release]
+    if: needs.check-version.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Sync npm package version
+        run: node ./scripts/sync-package-version.mjs "${{ needs.check-version.outputs.version }}"
+
+      - name: Check npm package contents
+        run: npm pack --dry-run
+
+      - name: Publish npm package
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-crates:
     needs: [check-version, create-tag]

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ target/
 .sem/
 *.db
 .DS_Store
+node_modules/
+.npm-cache/
+vendor/
 
 # Nixos artifacts
 .envrc

--- a/README.md
+++ b/README.md
@@ -37,6 +37,19 @@ It works in any Git repo with no setup.
 brew install sem-cli
 ```
 
+Or install the npm wrapper into `node_modules`:
+
+```bash
+npm install --save-dev @ataraxy-labs/sem
+```
+
+With Bun, trust the package so its `postinstall` script can download the binary:
+
+```bash
+bun add -d @ataraxy-labs/sem
+bun pm trust @ataraxy-labs/sem
+```
+
 Or build from source (requires Rust):
 
 ```bash

--- a/bin/sem.js
+++ b/bin/sem.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { getInstalledBinaryPath } from '../scripts/package-meta.mjs';
+
+const binaryPath = getInstalledBinaryPath();
+
+if (!existsSync(binaryPath)) {
+  console.error(
+    [
+      'sem is not installed yet.',
+      'Reinstall @ataraxy-labs/sem to download the binary.',
+      'If you use Bun, trust the package first so its postinstall script can run.',
+    ].join(' '),
+  );
+  process.exit(1);
+}
+
+const child = spawn(binaryPath, process.argv.slice(2), {
+  stdio: 'inherit',
+});
+
+child.on('error', (error) => {
+  console.error(`Failed to launch sem: ${error.message}`);
+  process.exit(1);
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 1);
+});
+
+for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
+  process.on(signal, () => {
+    if (!child.killed) {
+      child.kill(signal);
+    }
+  });
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@ataraxy-labs/sem",
+  "version": "0.3.14",
+  "description": "npm wrapper for the sem CLI. Downloads the matching release binary and exposes the sem command in node_modules/.bin.",
+  "license": "MIT OR Apache-2.0",
+  "type": "module",
+  "bin": {
+    "sem": "./bin/sem.js"
+  },
+  "files": [
+    "bin/sem.js",
+    "scripts/package-meta.mjs",
+    "scripts/postinstall.mjs",
+    "scripts/sync-package-version.mjs",
+    "README.md",
+    "LICENSE-APACHE",
+    "LICENSE-MIT"
+  ],
+  "keywords": [
+    "sem",
+    "diff",
+    "semantic",
+    "git",
+    "cli"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Ataraxy-Labs/sem.git"
+  },
+  "homepage": "https://github.com/Ataraxy-Labs/sem",
+  "bugs": {
+    "url": "https://github.com/Ataraxy-Labs/sem/issues"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "preferUnplugged": true,
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "postinstall": "node ./scripts/postinstall.mjs",
+    "prepack": "node ./scripts/sync-package-version.mjs",
+    "test": "node ./scripts/package-meta.test.mjs"
+  }
+}

--- a/scripts/package-meta.mjs
+++ b/scripts/package-meta.mjs
@@ -1,0 +1,102 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptsDirectory = path.dirname(fileURLToPath(import.meta.url));
+
+export const PACKAGE_ROOT = path.resolve(scriptsDirectory, '..');
+
+export function getBinaryName(platform = process.platform) {
+  return platform === 'win32' ? 'sem.exe' : 'sem';
+}
+
+export function getVendorDirectory(packageRoot = PACKAGE_ROOT) {
+  return path.join(packageRoot, 'vendor');
+}
+
+export function getInstalledBinaryPath({
+  packageRoot = PACKAGE_ROOT,
+  platform = process.platform,
+} = {}) {
+  return path.join(getVendorDirectory(packageRoot), getBinaryName(platform));
+}
+
+export function resolveReleaseArtifact({
+  platform = process.platform,
+  arch = process.arch,
+} = {}) {
+  const key = `${platform}:${arch}`;
+
+  switch (key) {
+    case 'linux:x64':
+      return 'sem-linux-x86_64.tar.gz';
+    case 'linux:arm64':
+      return 'sem-linux-arm64.tar.gz';
+    case 'darwin:arm64':
+      return 'sem-darwin-arm64.tar.gz';
+    case 'win32:x64':
+      return 'sem-windows-x86_64.tar.gz';
+    default:
+      throw new Error(
+        `Unsupported platform ${key}. Supported targets: linux/x64, linux/arm64, darwin/arm64, win32/x64.`,
+      );
+  }
+}
+
+export function getReleaseBaseUrl(version, env = process.env) {
+  const override = env.SEM_RELEASE_BASE_URL?.trim();
+  if (override) {
+    return override.replace(/\/+$/, '');
+  }
+
+  return `https://github.com/Ataraxy-Labs/sem/releases/download/v${version}`;
+}
+
+export function getReleaseDownloadUrl(version, options = {}) {
+  const baseUrl = getReleaseBaseUrl(version, options.env);
+  const artifact = resolveReleaseArtifact(options);
+  return `${baseUrl}/${artifact}`;
+}
+
+export async function readPackageVersion(packageRoot = PACKAGE_ROOT) {
+  const packageJsonPath = path.join(packageRoot, 'package.json');
+  const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
+  return packageJson.version;
+}
+
+export async function readCargoPackageVersion(
+  manifestPath = path.join(PACKAGE_ROOT, 'crates', 'sem-cli', 'Cargo.toml'),
+) {
+  const cargoToml = await fs.readFile(manifestPath, 'utf8');
+  const versionMatch = cargoToml.match(/^version\s*=\s*"([^"]+)"/m);
+
+  if (!versionMatch) {
+    throw new Error(`Could not find version in ${manifestPath}`);
+  }
+
+  return versionMatch[1];
+}
+
+export async function syncPackageVersion({
+  packageRoot = PACKAGE_ROOT,
+  version,
+} = {}) {
+  const resolvedVersion = version ?? (await readCargoPackageVersion());
+  const packageJsonPath = path.join(packageRoot, 'package.json');
+  const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
+  const changed = packageJson.version !== resolvedVersion;
+
+  if (changed) {
+    packageJson.version = resolvedVersion;
+    await fs.writeFile(
+      packageJsonPath,
+      `${JSON.stringify(packageJson, null, 2)}\n`,
+      'utf8',
+    );
+  }
+
+  return {
+    changed,
+    version: resolvedVersion,
+  };
+}

--- a/scripts/package-meta.test.mjs
+++ b/scripts/package-meta.test.mjs
@@ -1,0 +1,73 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { getReleaseDownloadUrl, resolveReleaseArtifact, syncPackageVersion } from './package-meta.mjs';
+
+test('resolveReleaseArtifact maps supported targets to release assets', () => {
+  assert.equal(
+    resolveReleaseArtifact({ platform: 'linux', arch: 'x64' }),
+    'sem-linux-x86_64.tar.gz',
+  );
+  assert.equal(
+    resolveReleaseArtifact({ platform: 'linux', arch: 'arm64' }),
+    'sem-linux-arm64.tar.gz',
+  );
+  assert.equal(
+    resolveReleaseArtifact({ platform: 'darwin', arch: 'arm64' }),
+    'sem-darwin-arm64.tar.gz',
+  );
+  assert.equal(
+    resolveReleaseArtifact({ platform: 'win32', arch: 'x64' }),
+    'sem-windows-x86_64.tar.gz',
+  );
+});
+
+test('getReleaseDownloadUrl respects a custom base url', () => {
+  const url = getReleaseDownloadUrl('0.3.14', {
+    platform: 'linux',
+    arch: 'x64',
+    env: {
+      SEM_RELEASE_BASE_URL: 'https://example.com/releases/v0.3.14/',
+    },
+  });
+
+  assert.equal(url, 'https://example.com/releases/v0.3.14/sem-linux-x86_64.tar.gz');
+});
+
+test('syncPackageVersion rewrites only the version field', async () => {
+  const tempDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'sem-package-test-'));
+  const packageJsonPath = path.join(tempDirectory, 'package.json');
+
+  try {
+    await fs.writeFile(
+      packageJsonPath,
+      `${JSON.stringify(
+        {
+          name: '@ataraxy-labs/sem',
+          version: '0.0.0',
+          private: true,
+        },
+        null,
+        2,
+      )}\n`,
+      'utf8',
+    );
+
+    const result = await syncPackageVersion({
+      packageRoot: tempDirectory,
+      version: '1.2.3',
+    });
+
+    const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
+
+    assert.equal(result.changed, true);
+    assert.equal(result.version, '1.2.3');
+    assert.equal(packageJson.version, '1.2.3');
+    assert.equal(packageJson.name, '@ataraxy-labs/sem');
+    assert.equal(packageJson.private, true);
+  } finally {
+    await fs.rm(tempDirectory, { recursive: true, force: true });
+  }
+});

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,0 +1,107 @@
+import fs from 'node:fs/promises';
+import { createWriteStream } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import {
+  getBinaryName,
+  getInstalledBinaryPath,
+  getReleaseDownloadUrl,
+  readPackageVersion,
+  resolveReleaseArtifact,
+} from './package-meta.mjs';
+
+async function downloadFile(url, destinationPath) {
+  const response = await fetch(url, {
+    headers: {
+      'user-agent': '@ataraxy-labs/sem npm installer',
+    },
+    redirect: 'follow',
+  });
+
+  if (!response.ok) {
+    throw new Error(`Download failed with ${response.status} ${response.statusText}`);
+  }
+
+  if (!response.body) {
+    throw new Error('Download response did not include a body');
+  }
+
+  await pipeline(
+    Readable.fromWeb(response.body),
+    createWriteStream(destinationPath),
+  );
+}
+
+function extractArchive(archivePath, outputDirectory) {
+  const result = spawnSync('tar', ['-xzf', archivePath, '-C', outputDirectory], {
+    stdio: 'pipe',
+  });
+
+  if (result.error) {
+    throw new Error(`Failed to extract archive: ${result.error.message}`);
+  }
+
+  if (result.status !== 0) {
+    const stderr = result.stderr?.toString('utf8').trim();
+    throw new Error(
+      `Failed to extract archive with tar${stderr ? `: ${stderr}` : ''}`,
+    );
+  }
+}
+
+async function installFromBinary(sourceBinaryPath, destinationBinaryPath) {
+  await fs.mkdir(path.dirname(destinationBinaryPath), { recursive: true });
+  await fs.copyFile(sourceBinaryPath, destinationBinaryPath);
+
+  if (process.platform !== 'win32') {
+    await fs.chmod(destinationBinaryPath, 0o755);
+  }
+}
+
+async function installFromRelease(destinationBinaryPath) {
+  const version = await readPackageVersion();
+  const releaseUrl = getReleaseDownloadUrl(version);
+  const archiveName = resolveReleaseArtifact();
+  const temporaryDirectory = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'sem-install-'),
+  );
+
+  try {
+    const archivePath = path.join(temporaryDirectory, archiveName);
+    await downloadFile(releaseUrl, archivePath);
+    extractArchive(archivePath, temporaryDirectory);
+    await installFromBinary(
+      path.join(temporaryDirectory, getBinaryName()),
+      destinationBinaryPath,
+    );
+  } finally {
+    await fs.rm(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  if (process.env.SEM_SKIP_DOWNLOAD === '1') {
+    console.log('Skipping sem binary download because SEM_SKIP_DOWNLOAD=1.');
+    return;
+  }
+
+  const destinationBinaryPath = getInstalledBinaryPath();
+  await fs.rm(destinationBinaryPath, { force: true });
+
+  if (process.env.SEM_BINARY_PATH) {
+    await installFromBinary(process.env.SEM_BINARY_PATH, destinationBinaryPath);
+    console.log(`Installed sem from local binary ${process.env.SEM_BINARY_PATH}.`);
+    return;
+  }
+
+  await installFromRelease(destinationBinaryPath);
+  console.log(`Installed sem binary to ${destinationBinaryPath}.`);
+}
+
+main().catch((error) => {
+  console.error(`Failed to install sem: ${error.message}`);
+  process.exit(1);
+});

--- a/scripts/sync-package-version.mjs
+++ b/scripts/sync-package-version.mjs
@@ -1,0 +1,12 @@
+import { syncPackageVersion } from './package-meta.mjs';
+
+const requestedVersion = process.argv[2]?.trim();
+const result = await syncPackageVersion({
+  version: requestedVersion || undefined,
+});
+
+if (result.changed) {
+  console.log(`Updated package.json version to ${result.version}.`);
+} else {
+  console.log(`package.json already matches version ${result.version}.`);
+}


### PR DESCRIPTION
Creates an npm package wrapper around sem so that users may install into their javascript/typescript/tsx projects and rely on sem without each dev having to individually install. May be useful for ci and/or precommit hooks and/or agent rules where a user may want the agent to be aware of differences more simply