### PR TITLE
Add graph-backed sem grep command and document it across the CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,30 @@ echo '[{"filePath":"src/main.rs","status":"modified","beforeContent":"...","afte
 sem diff --file-exts .py .rs
 ```
 
+### sem grep
+
+Graph-backed entity search for discovery, migrations, and review narrowing.
+
+```bash
+# Find entities by name
+sem grep auth
+
+# Search inside entity bodies too
+sem grep exec --content
+
+# Filter by entity type and path
+sem grep authenticate --type function --path src/auth
+
+# Find direct callers of an entity
+sem grep --depends-on exec --ref-kind calls
+
+# Narrow to test code only
+sem grep --tests --depends-on authenticateUser
+
+# Rank likely hotspots
+sem grep --min-dependents 20 --json
+```
+
 ### sem impact
 
 Cross-file dependency graph shows what breaks if an entity changes.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ Graph-backed entity search for discovery, migrations, and review narrowing.
 # Find entities by name
 sem grep auth
 
+# Default matching ignores case plus _/- identifier style differences
+sem grep auth-user
+
+# Require literal case and identifier separators
+sem grep AuthUser --case-sensitive
+
 # Search inside entity bodies too
 sem grep exec --content
 

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ This means sem detects renames and moves, not just additions and deletions. Stru
 
 ## MCP Server
 
-sem includes an MCP server with 6 tools for AI agents: `sem_entities`, `sem_diff`, `sem_blame`, `sem_impact`, `sem_log`, `sem_context`. These mirror the CLI commands exactly.
+sem includes an MCP server with 7 tools for AI agents: `sem_entities`, `sem_diff`, `sem_blame`, `sem_impact`, `sem_log`, `sem_grep`, `sem_context`. These mirror the CLI commands exactly.
 
 ```json
 {

--- a/SKILL.md
+++ b/SKILL.md
@@ -6,7 +6,7 @@ Semantic version control CLI. Entity-level diffs for Git (functions, classes, me
 
 Cargo workspace at `crates/`:
 - `sem-core` — entity extraction engine, tree-sitter parsers, dependency graph
-- `sem-cli` — CLI binary (`sem diff`, `sem graph`, `sem impact`, `sem blame`)
+- `sem-cli` — CLI binary (`sem diff`, `sem graph`, `sem impact`, `sem blame`, `sem grep`)
 
 ## Build & Test
 

--- a/crates/sem-cli/src/commands/graph.rs
+++ b/crates/sem-cli/src/commands/graph.rs
@@ -8,9 +8,7 @@ use crate::cache::DiskCache;
 
 /// Normalize extension strings: ensure each starts with '.'
 pub fn normalize_exts(exts: &[String]) -> Vec<String> {
-    exts.iter().map(|e| {
-        if e.starts_with('.') { e.clone() } else { format!(".{}", e) }
-    }).collect()
+    sem_core::utils::paths::normalize_file_exts(exts)
 }
 
 /// Find all supported files in the repo (public for use by other commands).

--- a/crates/sem-cli/src/commands/grep.rs
+++ b/crates/sem-cli/src/commands/grep.rs
@@ -11,7 +11,7 @@ pub struct GrepOptions {
     pub cwd: String,
     pub pattern: Option<String>,
     pub content: bool,
-    pub ignore_case: bool,
+    pub case_sensitive: bool,
     pub entity_types: Vec<String>,
     pub path_substring: Option<String>,
     pub tests: bool,
@@ -140,15 +140,15 @@ fn find_matches(
             &source.content,
             opts.pattern.as_deref(),
             opts.content,
-            opts.ignore_case,
+            opts.case_sensitive,
         ) {
             continue;
         }
-        if !matches_type(&entity.entity_type, &opts.entity_types, opts.ignore_case) {
+        if !matches_type(&entity.entity_type, &opts.entity_types, opts.case_sensitive) {
             continue;
         }
         if let Some(path_substring) = opts.path_substring.as_deref() {
-            if !matches_text(&entity.file_path, path_substring, opts.ignore_case) {
+            if !matches_text(&entity.file_path, path_substring, opts.case_sensitive) {
                 continue;
             }
         }
@@ -182,7 +182,7 @@ fn find_matches(
                 &outgoing_edges,
                 &opts.depends_on,
                 opts.ref_kind,
-                opts.ignore_case,
+                opts.case_sensitive,
             )
         };
 
@@ -231,7 +231,7 @@ fn find_matching_dependencies(
     outgoing_edges: &HashMap<&str, Vec<&EntityRef>>,
     depends_on: &[String],
     ref_kind: Option<RefKind>,
-    ignore_case: bool,
+    case_sensitive: bool,
 ) -> Vec<String> {
     let mut matched: HashSet<String> = HashSet::new();
 
@@ -250,7 +250,7 @@ fn find_matching_dependencies(
 
             if depends_on
                 .iter()
-                .any(|pattern| matches_text(&target.name, pattern, ignore_case))
+                .any(|pattern| matches_text(&target.name, pattern, case_sensitive))
             {
                 matched.insert(target.name.clone());
             }
@@ -267,33 +267,51 @@ fn matches_pattern(
     content: &str,
     pattern: Option<&str>,
     search_content: bool,
-    ignore_case: bool,
+    case_sensitive: bool,
 ) -> bool {
     let Some(pattern) = pattern else {
         return true;
     };
 
-    matches_text(&entity.name, pattern, ignore_case)
-        || (search_content && matches_text(content, pattern, ignore_case))
+    matches_text(&entity.name, pattern, case_sensitive)
+        || (search_content && matches_text(content, pattern, case_sensitive))
 }
 
-fn matches_type(value: &str, filters: &[String], ignore_case: bool) -> bool {
+fn matches_type(value: &str, filters: &[String], case_sensitive: bool) -> bool {
     filters.is_empty()
         || filters.iter().any(|filter| {
-            if ignore_case {
-                value.eq_ignore_ascii_case(filter)
-            } else {
+            if case_sensitive {
                 value == filter
+            } else {
+                value.eq_ignore_ascii_case(filter)
             }
         })
 }
 
-fn matches_text(haystack: &str, needle: &str, ignore_case: bool) -> bool {
-    if ignore_case {
-        haystack.to_lowercase().contains(&needle.to_lowercase())
-    } else {
-        haystack.contains(needle)
+fn matches_text(haystack: &str, needle: &str, case_sensitive: bool) -> bool {
+    if case_sensitive {
+        return haystack.contains(needle);
     }
+
+    let needle_lower = needle.to_lowercase();
+    if haystack.to_lowercase().contains(&needle_lower) {
+        return true;
+    }
+
+    let normalized_needle = normalize_identifier_text(needle);
+    !normalized_needle.is_empty()
+        && normalize_identifier_text(haystack).contains(&normalized_needle)
+}
+
+fn normalize_identifier_text(value: &str) -> String {
+    let mut normalized = String::with_capacity(value.len());
+    for ch in value.chars() {
+        if matches!(ch, '_' | '-') {
+            continue;
+        }
+        normalized.extend(ch.to_lowercase());
+    }
+    normalized
 }
 
 fn print_terminal(matches: &[GrepMatch], opts: &GrepOptions) {
@@ -370,7 +388,7 @@ fn print_json(matches: &[GrepMatch], opts: &GrepOptions) {
             "matches": matches.len(),
             "pattern": opts.pattern.as_deref(),
             "content": opts.content,
-            "ignoreCase": opts.ignore_case,
+            "caseSensitive": opts.case_sensitive,
             "types": &opts.entity_types,
             "path": opts.path_substring.as_deref(),
             "tests": opts.tests,
@@ -402,7 +420,7 @@ mod tests {
     use sem_core::model::entity::SemanticEntity;
     use sem_core::parser::graph::{EntityGraph, EntityInfo, EntityRef, RefType};
 
-    use super::{find_matches, GrepOptions, RefKind};
+    use super::{find_matches, matches_text, GrepOptions, RefKind};
 
     fn entity_info(
         id: &str,
@@ -443,7 +461,7 @@ mod tests {
             cwd: ".".to_string(),
             pattern: None,
             content: false,
-            ignore_case: false,
+            case_sensitive: false,
             entity_types: Vec::new(),
             path_substring: None,
             tests: false,
@@ -559,6 +577,47 @@ mod tests {
             .map(|entry| entry.name.as_str())
             .collect();
         assert_eq!(names, vec!["exec", "runShell"]);
+    }
+
+    #[test]
+    fn grep_matches_common_identifier_styles_by_default() {
+        let (graph, entities) = fixture_graph();
+        let mut opts = test_options();
+
+        opts.pattern = Some("auth-controller".to_string());
+        let kebab_to_pascal = find_matches(&graph, &entities, &opts);
+        assert_eq!(kebab_to_pascal.len(), 1);
+        assert_eq!(kebab_to_pascal[0].name, "AuthController");
+
+        opts.pattern = Some("RUN_SHELL".to_string());
+        let screaming_to_camel = find_matches(&graph, &entities, &opts);
+        assert_eq!(screaming_to_camel.len(), 1);
+        assert_eq!(screaming_to_camel[0].name, "runShell");
+    }
+
+    #[test]
+    fn grep_case_sensitive_requires_literal_text() {
+        let (graph, entities) = fixture_graph();
+        let mut opts = test_options();
+        opts.case_sensitive = true;
+        opts.pattern = Some("RUN_SHELL".to_string());
+
+        let matches = find_matches(&graph, &entities, &opts);
+        assert!(matches.is_empty());
+
+        opts.pattern = Some("runShell".to_string());
+        let matches = find_matches(&graph, &entities, &opts);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].name, "runShell");
+    }
+
+    #[test]
+    fn smart_text_matching_is_not_sparse() {
+        assert!(matches_text("authenticate_user", "authenticateUser", false));
+        assert!(matches_text("AUTHENTICATE-USER", "authenticate_user", false));
+        assert!(!matches_text("authenticate user", "authenticateUser", false));
+        assert!(!matches_text("handle_mouse_event", "hm", false));
+        assert!(!matches_text("authenticate_user", "authenticateUser", true));
     }
 
     #[test]

--- a/crates/sem-cli/src/commands/grep.rs
+++ b/crates/sem-cli/src/commands/grep.rs
@@ -1,0 +1,603 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::Path;
+
+use clap::ValueEnum;
+use colored::Colorize;
+use sem_core::model::entity::SemanticEntity;
+use sem_core::parser::graph::{EntityGraph, EntityInfo, EntityRef, RefType};
+use sem_core::parser::plugins::create_default_registry;
+
+pub struct GrepOptions {
+    pub cwd: String,
+    pub pattern: Option<String>,
+    pub content: bool,
+    pub ignore_case: bool,
+    pub entity_types: Vec<String>,
+    pub path_substring: Option<String>,
+    pub tests: bool,
+    pub depends_on: Vec<String>,
+    pub ref_kind: Option<RefKind>,
+    pub min_dependencies: Option<usize>,
+    pub min_dependents: Option<usize>,
+    pub json: bool,
+    pub file_exts: Vec<String>,
+    pub no_cache: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum RefKind {
+    Calls,
+    Imports,
+    Type,
+}
+
+impl RefKind {
+    fn matches(self, ref_type: &RefType) -> bool {
+        match self {
+            Self::Calls => *ref_type == RefType::Calls,
+            Self::Imports => *ref_type == RefType::Imports,
+            Self::Type => *ref_type == RefType::TypeRef,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Calls => "calls",
+            Self::Imports => "imports",
+            Self::Type => "type",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GrepMatch {
+    name: String,
+    entity_type: String,
+    file_path: String,
+    start_line: usize,
+    end_line: usize,
+    parent_id: Option<String>,
+    dependency_count: usize,
+    dependent_count: usize,
+    is_test: bool,
+    matched_dependencies: Vec<String>,
+}
+
+pub fn grep_command(opts: GrepOptions) {
+    validate_options(&opts);
+
+    let root = Path::new(&opts.cwd);
+    let registry = create_default_registry();
+    let ext_filter = super::graph::normalize_exts(&opts.file_exts);
+    let file_paths = super::graph::find_supported_files_public(root, &registry, &ext_filter);
+    let (graph, all_entities) =
+        super::graph::get_or_build_graph(root, &file_paths, &registry, opts.no_cache);
+    let matches = find_matches(&graph, &all_entities, &opts);
+
+    if opts.json {
+        print_json(&matches, &opts);
+    } else {
+        print_terminal(&matches, &opts);
+    }
+}
+
+fn validate_options(opts: &GrepOptions) {
+    let has_selector = opts.pattern.is_some()
+        || !opts.entity_types.is_empty()
+        || opts.path_substring.is_some()
+        || opts.tests
+        || !opts.depends_on.is_empty()
+        || opts.min_dependencies.is_some()
+        || opts.min_dependents.is_some();
+
+    if !has_selector {
+        eprintln!(
+            "{} Provide a pattern or at least one filter (`--type`, `--path`, `--tests`, `--depends-on`, `--min-dependencies`, `--min-dependents`)",
+            "error:".red().bold(),
+        );
+        std::process::exit(1);
+    }
+
+    if opts.content && opts.pattern.is_none() {
+        eprintln!("{} `--content` requires a pattern", "error:".red().bold(),);
+        std::process::exit(1);
+    }
+
+    if opts.ref_kind.is_some() && opts.depends_on.is_empty() {
+        eprintln!(
+            "{} `--ref-kind` requires at least one `--depends-on` filter",
+            "error:".red().bold(),
+        );
+        std::process::exit(1);
+    }
+}
+
+fn find_matches(
+    graph: &EntityGraph,
+    all_entities: &[SemanticEntity],
+    opts: &GrepOptions,
+) -> Vec<GrepMatch> {
+    let entities_by_id: HashMap<&str, &SemanticEntity> = all_entities
+        .iter()
+        .map(|entity| (entity.id.as_str(), entity))
+        .collect();
+    let test_ids = if opts.tests {
+        graph.filter_test_entities(all_entities)
+    } else {
+        HashSet::new()
+    };
+    let outgoing_edges = build_outgoing_edges(&graph.edges);
+    let mut matches = Vec::new();
+
+    for entity in graph.entities.values() {
+        let source = match entities_by_id.get(entity.id.as_str()) {
+            Some(source) => *source,
+            None => continue,
+        };
+
+        if !matches_pattern(
+            entity,
+            &source.content,
+            opts.pattern.as_deref(),
+            opts.content,
+            opts.ignore_case,
+        ) {
+            continue;
+        }
+        if !matches_type(&entity.entity_type, &opts.entity_types, opts.ignore_case) {
+            continue;
+        }
+        if let Some(path_substring) = opts.path_substring.as_deref() {
+            if !matches_text(&entity.file_path, path_substring, opts.ignore_case) {
+                continue;
+            }
+        }
+        if opts.tests && !test_ids.contains(&entity.id) {
+            continue;
+        }
+
+        let dependency_count = graph
+            .dependencies
+            .get(entity.id.as_str())
+            .map_or(0, Vec::len);
+        let dependent_count = graph.dependents.get(entity.id.as_str()).map_or(0, Vec::len);
+
+        if let Some(min_dependencies) = opts.min_dependencies {
+            if dependency_count < min_dependencies {
+                continue;
+            }
+        }
+        if let Some(min_dependents) = opts.min_dependents {
+            if dependent_count < min_dependents {
+                continue;
+            }
+        }
+
+        let matched_dependencies = if opts.depends_on.is_empty() {
+            Vec::new()
+        } else {
+            find_matching_dependencies(
+                graph,
+                entity,
+                &outgoing_edges,
+                &opts.depends_on,
+                opts.ref_kind,
+                opts.ignore_case,
+            )
+        };
+
+        if !opts.depends_on.is_empty() && matched_dependencies.is_empty() {
+            continue;
+        }
+
+        matches.push(GrepMatch {
+            name: entity.name.clone(),
+            entity_type: entity.entity_type.clone(),
+            file_path: entity.file_path.clone(),
+            start_line: entity.start_line,
+            end_line: entity.end_line,
+            parent_id: entity.parent_id.clone(),
+            dependency_count,
+            dependent_count,
+            is_test: test_ids.contains(&entity.id),
+            matched_dependencies,
+        });
+    }
+
+    matches.sort_by(|left, right| {
+        left.file_path
+            .cmp(&right.file_path)
+            .then(left.start_line.cmp(&right.start_line))
+            .then(left.end_line.cmp(&right.end_line))
+            .then(left.name.cmp(&right.name))
+    });
+    matches
+}
+
+fn build_outgoing_edges<'a>(edges: &'a [EntityRef]) -> HashMap<&'a str, Vec<&'a EntityRef>> {
+    let mut outgoing: HashMap<&str, Vec<&EntityRef>> = HashMap::new();
+    for edge in edges {
+        outgoing
+            .entry(edge.from_entity.as_str())
+            .or_default()
+            .push(edge);
+    }
+    outgoing
+}
+
+fn find_matching_dependencies(
+    graph: &EntityGraph,
+    entity: &EntityInfo,
+    outgoing_edges: &HashMap<&str, Vec<&EntityRef>>,
+    depends_on: &[String],
+    ref_kind: Option<RefKind>,
+    ignore_case: bool,
+) -> Vec<String> {
+    let mut matched: HashSet<String> = HashSet::new();
+
+    if let Some(edges) = outgoing_edges.get(entity.id.as_str()) {
+        for edge in edges {
+            if let Some(kind) = ref_kind {
+                if !kind.matches(&edge.ref_type) {
+                    continue;
+                }
+            }
+
+            let target = match graph.entities.get(edge.to_entity.as_str()) {
+                Some(target) => target,
+                None => continue,
+            };
+
+            if depends_on
+                .iter()
+                .any(|pattern| matches_text(&target.name, pattern, ignore_case))
+            {
+                matched.insert(target.name.clone());
+            }
+        }
+    }
+
+    let mut matched: Vec<_> = matched.into_iter().collect();
+    matched.sort();
+    matched
+}
+
+fn matches_pattern(
+    entity: &EntityInfo,
+    content: &str,
+    pattern: Option<&str>,
+    search_content: bool,
+    ignore_case: bool,
+) -> bool {
+    let Some(pattern) = pattern else {
+        return true;
+    };
+
+    matches_text(&entity.name, pattern, ignore_case)
+        || (search_content && matches_text(content, pattern, ignore_case))
+}
+
+fn matches_type(value: &str, filters: &[String], ignore_case: bool) -> bool {
+    filters.is_empty()
+        || filters.iter().any(|filter| {
+            if ignore_case {
+                value.eq_ignore_ascii_case(filter)
+            } else {
+                value == filter
+            }
+        })
+}
+
+fn matches_text(haystack: &str, needle: &str, ignore_case: bool) -> bool {
+    if ignore_case {
+        haystack.to_lowercase().contains(&needle.to_lowercase())
+    } else {
+        haystack.contains(needle)
+    }
+}
+
+fn print_terminal(matches: &[GrepMatch], opts: &GrepOptions) {
+    if matches.is_empty() {
+        println!("{} {}", "grep:".green().bold(), "no matches".dimmed());
+        return;
+    }
+
+    println!(
+        "{} {}",
+        "grep:".green().bold(),
+        format!("{} matches", matches.len()).bold(),
+    );
+
+    if let Some(pattern) = opts.pattern.as_deref() {
+        println!("  {} {}", "pattern".dimmed(), pattern.bold());
+    }
+    if !opts.entity_types.is_empty() {
+        println!(
+            "  {} {}",
+            "types".dimmed(),
+            opts.entity_types.join(", ").bold()
+        );
+    }
+    if let Some(path_substring) = opts.path_substring.as_deref() {
+        println!("  {} {}", "path".dimmed(), path_substring.bold());
+    }
+    if !opts.depends_on.is_empty() {
+        let relation = opts.ref_kind.map_or("any ref", RefKind::as_str);
+        println!(
+            "  {} {} ({})",
+            "depends on".dimmed(),
+            opts.depends_on.join(", ").bold(),
+            relation.dimmed(),
+        );
+    }
+    println!();
+
+    let mut by_file: BTreeMap<&str, Vec<&GrepMatch>> = BTreeMap::new();
+    for matched in matches {
+        by_file
+            .entry(matched.file_path.as_str())
+            .or_default()
+            .push(matched);
+    }
+
+    for (file, entries) in by_file {
+        println!("  {}", file.bold());
+        for entry in entries {
+            let mut suffix = format!(
+                "L{}-{}, deps: {}, dependents: {}",
+                entry.start_line, entry.end_line, entry.dependency_count, entry.dependent_count,
+            );
+            if entry.is_test {
+                suffix.push_str(", test");
+            }
+            if !entry.matched_dependencies.is_empty() {
+                suffix.push_str(&format!(", via: {}", entry.matched_dependencies.join(", ")));
+            }
+
+            println!(
+                "    {} {} ({})",
+                entry.entity_type.dimmed(),
+                entry.name.bold(),
+                suffix.dimmed(),
+            );
+        }
+    }
+}
+
+fn print_json(matches: &[GrepMatch], opts: &GrepOptions) {
+    let output = serde_json::json!({
+        "summary": {
+            "matches": matches.len(),
+            "pattern": opts.pattern.as_deref(),
+            "content": opts.content,
+            "ignoreCase": opts.ignore_case,
+            "types": &opts.entity_types,
+            "path": opts.path_substring.as_deref(),
+            "tests": opts.tests,
+            "dependsOn": &opts.depends_on,
+            "refKind": opts.ref_kind.map(RefKind::as_str),
+            "minDependencies": opts.min_dependencies,
+            "minDependents": opts.min_dependents,
+        },
+        "matches": matches.iter().map(|entry| serde_json::json!({
+            "name": &entry.name,
+            "type": &entry.entity_type,
+            "file": &entry.file_path,
+            "lines": [entry.start_line, entry.end_line],
+            "parentId": &entry.parent_id,
+            "dependencyCount": entry.dependency_count,
+            "dependentCount": entry.dependent_count,
+            "isTest": entry.is_test,
+            "matchedDependencies": &entry.matched_dependencies,
+        })).collect::<Vec<_>>(),
+    });
+
+    println!("{}", serde_json::to_string(&output).unwrap());
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use sem_core::model::entity::SemanticEntity;
+    use sem_core::parser::graph::{EntityGraph, EntityInfo, EntityRef, RefType};
+
+    use super::{find_matches, GrepOptions, RefKind};
+
+    fn entity_info(
+        id: &str,
+        name: &str,
+        entity_type: &str,
+        file_path: &str,
+        start_line: usize,
+    ) -> EntityInfo {
+        EntityInfo {
+            id: id.to_string(),
+            name: name.to_string(),
+            entity_type: entity_type.to_string(),
+            file_path: file_path.to_string(),
+            parent_id: None,
+            start_line,
+            end_line: start_line + 2,
+        }
+    }
+
+    fn semantic_entity(info: &EntityInfo, content: &str) -> SemanticEntity {
+        SemanticEntity {
+            id: info.id.clone(),
+            file_path: info.file_path.clone(),
+            entity_type: info.entity_type.clone(),
+            name: info.name.clone(),
+            parent_id: info.parent_id.clone(),
+            content: content.to_string(),
+            content_hash: format!("hash-{}", info.id),
+            structural_hash: None,
+            start_line: info.start_line,
+            end_line: info.end_line,
+            metadata: None,
+        }
+    }
+
+    fn test_options() -> GrepOptions {
+        GrepOptions {
+            cwd: ".".to_string(),
+            pattern: None,
+            content: false,
+            ignore_case: false,
+            entity_types: Vec::new(),
+            path_substring: None,
+            tests: false,
+            depends_on: Vec::new(),
+            ref_kind: None,
+            min_dependencies: None,
+            min_dependents: None,
+            json: false,
+            file_exts: Vec::new(),
+            no_cache: false,
+        }
+    }
+
+    fn fixture_graph() -> (EntityGraph, Vec<SemanticEntity>) {
+        let exec = entity_info(
+            "src/process.ts::function::exec",
+            "exec",
+            "function",
+            "src/process.ts",
+            1,
+        );
+        let login = entity_info(
+            "src/auth.ts::function::login",
+            "login",
+            "function",
+            "src/auth.ts",
+            10,
+        );
+        let run_shell = entity_info(
+            "src/shell.ts::function::runShell",
+            "runShell",
+            "function",
+            "src/shell.ts",
+            20,
+        );
+        let auth_controller = entity_info(
+            "src/auth_controller.ts::class::AuthController",
+            "AuthController",
+            "class",
+            "src/auth_controller.ts",
+            5,
+        );
+        let login_test = entity_info(
+            "tests/auth_test.rs::function::test_login",
+            "test_login",
+            "function",
+            "tests/auth_test.rs",
+            3,
+        );
+
+        let graph = EntityGraph::from_parts(
+            HashMap::from([
+                (exec.id.clone(), exec.clone()),
+                (login.id.clone(), login.clone()),
+                (run_shell.id.clone(), run_shell.clone()),
+                (auth_controller.id.clone(), auth_controller.clone()),
+                (login_test.id.clone(), login_test.clone()),
+            ]),
+            vec![
+                EntityRef {
+                    from_entity: run_shell.id.clone(),
+                    to_entity: exec.id.clone(),
+                    ref_type: RefType::Calls,
+                },
+                EntityRef {
+                    from_entity: auth_controller.id.clone(),
+                    to_entity: login.id.clone(),
+                    ref_type: RefType::TypeRef,
+                },
+                EntityRef {
+                    from_entity: login_test.id.clone(),
+                    to_entity: login.id.clone(),
+                    ref_type: RefType::Calls,
+                },
+            ],
+        );
+
+        let entities = vec![
+            semantic_entity(&exec, "export function exec(command) { return command; }"),
+            semantic_entity(
+                &login,
+                "pub fn login(user: &str) -> bool { !user.is_empty() }",
+            ),
+            semantic_entity(&run_shell, "function runShell() { return exec(\"ls\"); }"),
+            semantic_entity(
+                &auth_controller,
+                "class AuthController extends login { handle() { return true; } }",
+            ),
+            semantic_entity(
+                &login_test,
+                "#[test]\nfn test_login() {\n    assert!(login(\"alice\"));\n}",
+            ),
+        ];
+
+        (graph, entities)
+    }
+
+    #[test]
+    fn grep_matches_name_by_default_and_content_when_requested() {
+        let (graph, entities) = fixture_graph();
+
+        let mut opts = test_options();
+        opts.pattern = Some("exec".to_string());
+
+        let name_only = find_matches(&graph, &entities, &opts);
+        assert_eq!(name_only.len(), 1);
+        assert_eq!(name_only[0].name, "exec");
+
+        opts.content = true;
+        let with_content = find_matches(&graph, &entities, &opts);
+        let names: Vec<_> = with_content
+            .iter()
+            .map(|entry| entry.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["exec", "runShell"]);
+    }
+
+    #[test]
+    fn grep_filters_by_dependency_name_and_reference_kind() {
+        let (graph, entities) = fixture_graph();
+        let mut opts = test_options();
+        opts.depends_on = vec!["login".to_string()];
+
+        let any_ref = find_matches(&graph, &entities, &opts);
+        let names: Vec<_> = any_ref.iter().map(|entry| entry.name.as_str()).collect();
+        assert_eq!(names, vec!["AuthController", "test_login"]);
+
+        opts.ref_kind = Some(RefKind::Calls);
+        let calls_only = find_matches(&graph, &entities, &opts);
+        assert_eq!(calls_only.len(), 1);
+        assert_eq!(calls_only[0].name, "test_login");
+        assert_eq!(calls_only[0].matched_dependencies, vec!["login"]);
+    }
+
+    #[test]
+    fn grep_combines_test_and_graph_threshold_filters() {
+        let (graph, entities) = fixture_graph();
+        let mut opts = test_options();
+        opts.tests = true;
+        opts.depends_on = vec!["login".to_string()];
+        opts.min_dependencies = Some(1);
+
+        let matches = find_matches(&graph, &entities, &opts);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].name, "test_login");
+        assert!(matches[0].is_test);
+
+        opts.tests = false;
+        opts.depends_on.clear();
+        opts.min_dependencies = None;
+        opts.min_dependents = Some(2);
+
+        let high_fan_in = find_matches(&graph, &entities, &opts);
+        assert_eq!(high_fan_in.len(), 1);
+        assert_eq!(high_fan_in[0].name, "login");
+    }
+}

--- a/crates/sem-cli/src/commands/grep.rs
+++ b/crates/sem-cli/src/commands/grep.rs
@@ -1,24 +1,14 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::BTreeMap;
 use std::path::Path;
 
 use clap::ValueEnum;
 use colored::Colorize;
-use sem_core::model::entity::SemanticEntity;
-use sem_core::parser::graph::{EntityGraph, EntityInfo, EntityRef, RefType};
+use sem_core::parser::grep::{find_matches, result_json, GrepMatch, GrepQuery, GrepRefKind};
 use sem_core::parser::plugins::create_default_registry;
 
 pub struct GrepOptions {
     pub cwd: String,
-    pub pattern: Option<String>,
-    pub content: bool,
-    pub case_sensitive: bool,
-    pub entity_types: Vec<String>,
-    pub path_substring: Option<String>,
-    pub tests: bool,
-    pub depends_on: Vec<String>,
-    pub ref_kind: Option<RefKind>,
-    pub min_dependencies: Option<usize>,
-    pub min_dependents: Option<usize>,
+    pub query: GrepQuery,
     pub json: bool,
     pub file_exts: Vec<String>,
     pub no_cache: bool,
@@ -31,290 +21,36 @@ pub enum RefKind {
     Type,
 }
 
-impl RefKind {
-    fn matches(self, ref_type: &RefType) -> bool {
-        match self {
-            Self::Calls => *ref_type == RefType::Calls,
-            Self::Imports => *ref_type == RefType::Imports,
-            Self::Type => *ref_type == RefType::TypeRef,
+impl From<RefKind> for GrepRefKind {
+    fn from(value: RefKind) -> Self {
+        match value {
+            RefKind::Calls => Self::Calls,
+            RefKind::Imports => Self::Imports,
+            RefKind::Type => Self::Type,
         }
     }
-
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Calls => "calls",
-            Self::Imports => "imports",
-            Self::Type => "type",
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct GrepMatch {
-    name: String,
-    entity_type: String,
-    file_path: String,
-    start_line: usize,
-    end_line: usize,
-    parent_id: Option<String>,
-    dependency_count: usize,
-    dependent_count: usize,
-    is_test: bool,
-    matched_dependencies: Vec<String>,
 }
 
 pub fn grep_command(opts: GrepOptions) {
-    validate_options(&opts);
-
     let root = Path::new(&opts.cwd);
     let registry = create_default_registry();
     let ext_filter = super::graph::normalize_exts(&opts.file_exts);
     let file_paths = super::graph::find_supported_files_public(root, &registry, &ext_filter);
     let (graph, all_entities) =
         super::graph::get_or_build_graph(root, &file_paths, &registry, opts.no_cache);
-    let matches = find_matches(&graph, &all_entities, &opts);
+    let matches = find_matches(&graph, &all_entities, &opts.query).unwrap_or_else(|err| {
+        eprintln!("{} {}", "error:".red().bold(), err);
+        std::process::exit(1);
+    });
 
     if opts.json {
-        print_json(&matches, &opts);
+        print_json(&matches, &opts.query);
     } else {
-        print_terminal(&matches, &opts);
+        print_terminal(&matches, &opts.query);
     }
 }
 
-fn validate_options(opts: &GrepOptions) {
-    let has_selector = opts.pattern.is_some()
-        || !opts.entity_types.is_empty()
-        || opts.path_substring.is_some()
-        || opts.tests
-        || !opts.depends_on.is_empty()
-        || opts.min_dependencies.is_some()
-        || opts.min_dependents.is_some();
-
-    if !has_selector {
-        eprintln!(
-            "{} Provide a pattern or at least one filter (`--type`, `--path`, `--tests`, `--depends-on`, `--min-dependencies`, `--min-dependents`)",
-            "error:".red().bold(),
-        );
-        std::process::exit(1);
-    }
-
-    if opts.content && opts.pattern.is_none() {
-        eprintln!("{} `--content` requires a pattern", "error:".red().bold(),);
-        std::process::exit(1);
-    }
-
-    if opts.ref_kind.is_some() && opts.depends_on.is_empty() {
-        eprintln!(
-            "{} `--ref-kind` requires at least one `--depends-on` filter",
-            "error:".red().bold(),
-        );
-        std::process::exit(1);
-    }
-}
-
-fn find_matches(
-    graph: &EntityGraph,
-    all_entities: &[SemanticEntity],
-    opts: &GrepOptions,
-) -> Vec<GrepMatch> {
-    let entities_by_id: HashMap<&str, &SemanticEntity> = all_entities
-        .iter()
-        .map(|entity| (entity.id.as_str(), entity))
-        .collect();
-    let test_ids = if opts.tests {
-        graph.filter_test_entities(all_entities)
-    } else {
-        HashSet::new()
-    };
-    let outgoing_edges = build_outgoing_edges(&graph.edges);
-    let mut matches = Vec::new();
-
-    for entity in graph.entities.values() {
-        let source = match entities_by_id.get(entity.id.as_str()) {
-            Some(source) => *source,
-            None => continue,
-        };
-
-        if !matches_pattern(
-            entity,
-            &source.content,
-            opts.pattern.as_deref(),
-            opts.content,
-            opts.case_sensitive,
-        ) {
-            continue;
-        }
-        if !matches_type(&entity.entity_type, &opts.entity_types, opts.case_sensitive) {
-            continue;
-        }
-        if let Some(path_substring) = opts.path_substring.as_deref() {
-            if !matches_text(&entity.file_path, path_substring, opts.case_sensitive) {
-                continue;
-            }
-        }
-        if opts.tests && !test_ids.contains(&entity.id) {
-            continue;
-        }
-
-        let dependency_count = graph
-            .dependencies
-            .get(entity.id.as_str())
-            .map_or(0, Vec::len);
-        let dependent_count = graph.dependents.get(entity.id.as_str()).map_or(0, Vec::len);
-
-        if let Some(min_dependencies) = opts.min_dependencies {
-            if dependency_count < min_dependencies {
-                continue;
-            }
-        }
-        if let Some(min_dependents) = opts.min_dependents {
-            if dependent_count < min_dependents {
-                continue;
-            }
-        }
-
-        let matched_dependencies = if opts.depends_on.is_empty() {
-            Vec::new()
-        } else {
-            find_matching_dependencies(
-                graph,
-                entity,
-                &outgoing_edges,
-                &opts.depends_on,
-                opts.ref_kind,
-                opts.case_sensitive,
-            )
-        };
-
-        if !opts.depends_on.is_empty() && matched_dependencies.is_empty() {
-            continue;
-        }
-
-        matches.push(GrepMatch {
-            name: entity.name.clone(),
-            entity_type: entity.entity_type.clone(),
-            file_path: entity.file_path.clone(),
-            start_line: entity.start_line,
-            end_line: entity.end_line,
-            parent_id: entity.parent_id.clone(),
-            dependency_count,
-            dependent_count,
-            is_test: test_ids.contains(&entity.id),
-            matched_dependencies,
-        });
-    }
-
-    matches.sort_by(|left, right| {
-        left.file_path
-            .cmp(&right.file_path)
-            .then(left.start_line.cmp(&right.start_line))
-            .then(left.end_line.cmp(&right.end_line))
-            .then(left.name.cmp(&right.name))
-    });
-    matches
-}
-
-fn build_outgoing_edges<'a>(edges: &'a [EntityRef]) -> HashMap<&'a str, Vec<&'a EntityRef>> {
-    let mut outgoing: HashMap<&str, Vec<&EntityRef>> = HashMap::new();
-    for edge in edges {
-        outgoing
-            .entry(edge.from_entity.as_str())
-            .or_default()
-            .push(edge);
-    }
-    outgoing
-}
-
-fn find_matching_dependencies(
-    graph: &EntityGraph,
-    entity: &EntityInfo,
-    outgoing_edges: &HashMap<&str, Vec<&EntityRef>>,
-    depends_on: &[String],
-    ref_kind: Option<RefKind>,
-    case_sensitive: bool,
-) -> Vec<String> {
-    let mut matched: HashSet<String> = HashSet::new();
-
-    if let Some(edges) = outgoing_edges.get(entity.id.as_str()) {
-        for edge in edges {
-            if let Some(kind) = ref_kind {
-                if !kind.matches(&edge.ref_type) {
-                    continue;
-                }
-            }
-
-            let target = match graph.entities.get(edge.to_entity.as_str()) {
-                Some(target) => target,
-                None => continue,
-            };
-
-            if depends_on
-                .iter()
-                .any(|pattern| matches_text(&target.name, pattern, case_sensitive))
-            {
-                matched.insert(target.name.clone());
-            }
-        }
-    }
-
-    let mut matched: Vec<_> = matched.into_iter().collect();
-    matched.sort();
-    matched
-}
-
-fn matches_pattern(
-    entity: &EntityInfo,
-    content: &str,
-    pattern: Option<&str>,
-    search_content: bool,
-    case_sensitive: bool,
-) -> bool {
-    let Some(pattern) = pattern else {
-        return true;
-    };
-
-    matches_text(&entity.name, pattern, case_sensitive)
-        || (search_content && matches_text(content, pattern, case_sensitive))
-}
-
-fn matches_type(value: &str, filters: &[String], case_sensitive: bool) -> bool {
-    filters.is_empty()
-        || filters.iter().any(|filter| {
-            if case_sensitive {
-                value == filter
-            } else {
-                value.eq_ignore_ascii_case(filter)
-            }
-        })
-}
-
-fn matches_text(haystack: &str, needle: &str, case_sensitive: bool) -> bool {
-    if case_sensitive {
-        return haystack.contains(needle);
-    }
-
-    let needle_lower = needle.to_lowercase();
-    if haystack.to_lowercase().contains(&needle_lower) {
-        return true;
-    }
-
-    let normalized_needle = normalize_identifier_text(needle);
-    !normalized_needle.is_empty()
-        && normalize_identifier_text(haystack).contains(&normalized_needle)
-}
-
-fn normalize_identifier_text(value: &str) -> String {
-    let mut normalized = String::with_capacity(value.len());
-    for ch in value.chars() {
-        if matches!(ch, '_' | '-') {
-            continue;
-        }
-        normalized.extend(ch.to_lowercase());
-    }
-    normalized
-}
-
-fn print_terminal(matches: &[GrepMatch], opts: &GrepOptions) {
+fn print_terminal(matches: &[GrepMatch], query: &GrepQuery) {
     if matches.is_empty() {
         println!("{} {}", "grep:".green().bold(), "no matches".dimmed());
         return;
@@ -326,25 +62,25 @@ fn print_terminal(matches: &[GrepMatch], opts: &GrepOptions) {
         format!("{} matches", matches.len()).bold(),
     );
 
-    if let Some(pattern) = opts.pattern.as_deref() {
+    if let Some(pattern) = query.pattern.as_deref() {
         println!("  {} {}", "pattern".dimmed(), pattern.bold());
     }
-    if !opts.entity_types.is_empty() {
+    if !query.entity_types.is_empty() {
         println!(
             "  {} {}",
             "types".dimmed(),
-            opts.entity_types.join(", ").bold()
+            query.entity_types.join(", ").bold()
         );
     }
-    if let Some(path_substring) = opts.path_substring.as_deref() {
+    if let Some(path_substring) = query.path_substring.as_deref() {
         println!("  {} {}", "path".dimmed(), path_substring.bold());
     }
-    if !opts.depends_on.is_empty() {
-        let relation = opts.ref_kind.map_or("any ref", RefKind::as_str);
+    if !query.depends_on.is_empty() {
+        let relation = query.ref_kind.map_or("any ref", GrepRefKind::as_str);
         println!(
             "  {} {} ({})",
             "depends on".dimmed(),
-            opts.depends_on.join(", ").bold(),
+            query.depends_on.join(", ").bold(),
             relation.dimmed(),
         );
     }
@@ -382,281 +118,6 @@ fn print_terminal(matches: &[GrepMatch], opts: &GrepOptions) {
     }
 }
 
-fn print_json(matches: &[GrepMatch], opts: &GrepOptions) {
-    let output = serde_json::json!({
-        "summary": {
-            "matches": matches.len(),
-            "pattern": opts.pattern.as_deref(),
-            "content": opts.content,
-            "caseSensitive": opts.case_sensitive,
-            "types": &opts.entity_types,
-            "path": opts.path_substring.as_deref(),
-            "tests": opts.tests,
-            "dependsOn": &opts.depends_on,
-            "refKind": opts.ref_kind.map(RefKind::as_str),
-            "minDependencies": opts.min_dependencies,
-            "minDependents": opts.min_dependents,
-        },
-        "matches": matches.iter().map(|entry| serde_json::json!({
-            "name": &entry.name,
-            "type": &entry.entity_type,
-            "file": &entry.file_path,
-            "lines": [entry.start_line, entry.end_line],
-            "parentId": &entry.parent_id,
-            "dependencyCount": entry.dependency_count,
-            "dependentCount": entry.dependent_count,
-            "isTest": entry.is_test,
-            "matchedDependencies": &entry.matched_dependencies,
-        })).collect::<Vec<_>>(),
-    });
-
-    println!("{}", serde_json::to_string(&output).unwrap());
-}
-
-#[cfg(test)]
-mod tests {
-    use std::collections::HashMap;
-
-    use sem_core::model::entity::SemanticEntity;
-    use sem_core::parser::graph::{EntityGraph, EntityInfo, EntityRef, RefType};
-
-    use super::{find_matches, matches_text, GrepOptions, RefKind};
-
-    fn entity_info(
-        id: &str,
-        name: &str,
-        entity_type: &str,
-        file_path: &str,
-        start_line: usize,
-    ) -> EntityInfo {
-        EntityInfo {
-            id: id.to_string(),
-            name: name.to_string(),
-            entity_type: entity_type.to_string(),
-            file_path: file_path.to_string(),
-            parent_id: None,
-            start_line,
-            end_line: start_line + 2,
-        }
-    }
-
-    fn semantic_entity(info: &EntityInfo, content: &str) -> SemanticEntity {
-        SemanticEntity {
-            id: info.id.clone(),
-            file_path: info.file_path.clone(),
-            entity_type: info.entity_type.clone(),
-            name: info.name.clone(),
-            parent_id: info.parent_id.clone(),
-            content: content.to_string(),
-            content_hash: format!("hash-{}", info.id),
-            structural_hash: None,
-            start_line: info.start_line,
-            end_line: info.end_line,
-            metadata: None,
-        }
-    }
-
-    fn test_options() -> GrepOptions {
-        GrepOptions {
-            cwd: ".".to_string(),
-            pattern: None,
-            content: false,
-            case_sensitive: false,
-            entity_types: Vec::new(),
-            path_substring: None,
-            tests: false,
-            depends_on: Vec::new(),
-            ref_kind: None,
-            min_dependencies: None,
-            min_dependents: None,
-            json: false,
-            file_exts: Vec::new(),
-            no_cache: false,
-        }
-    }
-
-    fn fixture_graph() -> (EntityGraph, Vec<SemanticEntity>) {
-        let exec = entity_info(
-            "src/process.ts::function::exec",
-            "exec",
-            "function",
-            "src/process.ts",
-            1,
-        );
-        let login = entity_info(
-            "src/auth.ts::function::login",
-            "login",
-            "function",
-            "src/auth.ts",
-            10,
-        );
-        let run_shell = entity_info(
-            "src/shell.ts::function::runShell",
-            "runShell",
-            "function",
-            "src/shell.ts",
-            20,
-        );
-        let auth_controller = entity_info(
-            "src/auth_controller.ts::class::AuthController",
-            "AuthController",
-            "class",
-            "src/auth_controller.ts",
-            5,
-        );
-        let login_test = entity_info(
-            "tests/auth_test.rs::function::test_login",
-            "test_login",
-            "function",
-            "tests/auth_test.rs",
-            3,
-        );
-
-        let graph = EntityGraph::from_parts(
-            HashMap::from([
-                (exec.id.clone(), exec.clone()),
-                (login.id.clone(), login.clone()),
-                (run_shell.id.clone(), run_shell.clone()),
-                (auth_controller.id.clone(), auth_controller.clone()),
-                (login_test.id.clone(), login_test.clone()),
-            ]),
-            vec![
-                EntityRef {
-                    from_entity: run_shell.id.clone(),
-                    to_entity: exec.id.clone(),
-                    ref_type: RefType::Calls,
-                },
-                EntityRef {
-                    from_entity: auth_controller.id.clone(),
-                    to_entity: login.id.clone(),
-                    ref_type: RefType::TypeRef,
-                },
-                EntityRef {
-                    from_entity: login_test.id.clone(),
-                    to_entity: login.id.clone(),
-                    ref_type: RefType::Calls,
-                },
-            ],
-        );
-
-        let entities = vec![
-            semantic_entity(&exec, "export function exec(command) { return command; }"),
-            semantic_entity(
-                &login,
-                "pub fn login(user: &str) -> bool { !user.is_empty() }",
-            ),
-            semantic_entity(&run_shell, "function runShell() { return exec(\"ls\"); }"),
-            semantic_entity(
-                &auth_controller,
-                "class AuthController extends login { handle() { return true; } }",
-            ),
-            semantic_entity(
-                &login_test,
-                "#[test]\nfn test_login() {\n    assert!(login(\"alice\"));\n}",
-            ),
-        ];
-
-        (graph, entities)
-    }
-
-    #[test]
-    fn grep_matches_name_by_default_and_content_when_requested() {
-        let (graph, entities) = fixture_graph();
-
-        let mut opts = test_options();
-        opts.pattern = Some("exec".to_string());
-
-        let name_only = find_matches(&graph, &entities, &opts);
-        assert_eq!(name_only.len(), 1);
-        assert_eq!(name_only[0].name, "exec");
-
-        opts.content = true;
-        let with_content = find_matches(&graph, &entities, &opts);
-        let names: Vec<_> = with_content
-            .iter()
-            .map(|entry| entry.name.as_str())
-            .collect();
-        assert_eq!(names, vec!["exec", "runShell"]);
-    }
-
-    #[test]
-    fn grep_matches_common_identifier_styles_by_default() {
-        let (graph, entities) = fixture_graph();
-        let mut opts = test_options();
-
-        opts.pattern = Some("auth-controller".to_string());
-        let kebab_to_pascal = find_matches(&graph, &entities, &opts);
-        assert_eq!(kebab_to_pascal.len(), 1);
-        assert_eq!(kebab_to_pascal[0].name, "AuthController");
-
-        opts.pattern = Some("RUN_SHELL".to_string());
-        let screaming_to_camel = find_matches(&graph, &entities, &opts);
-        assert_eq!(screaming_to_camel.len(), 1);
-        assert_eq!(screaming_to_camel[0].name, "runShell");
-    }
-
-    #[test]
-    fn grep_case_sensitive_requires_literal_text() {
-        let (graph, entities) = fixture_graph();
-        let mut opts = test_options();
-        opts.case_sensitive = true;
-        opts.pattern = Some("RUN_SHELL".to_string());
-
-        let matches = find_matches(&graph, &entities, &opts);
-        assert!(matches.is_empty());
-
-        opts.pattern = Some("runShell".to_string());
-        let matches = find_matches(&graph, &entities, &opts);
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].name, "runShell");
-    }
-
-    #[test]
-    fn smart_text_matching_is_not_sparse() {
-        assert!(matches_text("authenticate_user", "authenticateUser", false));
-        assert!(matches_text("AUTHENTICATE-USER", "authenticate_user", false));
-        assert!(!matches_text("authenticate user", "authenticateUser", false));
-        assert!(!matches_text("handle_mouse_event", "hm", false));
-        assert!(!matches_text("authenticate_user", "authenticateUser", true));
-    }
-
-    #[test]
-    fn grep_filters_by_dependency_name_and_reference_kind() {
-        let (graph, entities) = fixture_graph();
-        let mut opts = test_options();
-        opts.depends_on = vec!["login".to_string()];
-
-        let any_ref = find_matches(&graph, &entities, &opts);
-        let names: Vec<_> = any_ref.iter().map(|entry| entry.name.as_str()).collect();
-        assert_eq!(names, vec!["AuthController", "test_login"]);
-
-        opts.ref_kind = Some(RefKind::Calls);
-        let calls_only = find_matches(&graph, &entities, &opts);
-        assert_eq!(calls_only.len(), 1);
-        assert_eq!(calls_only[0].name, "test_login");
-        assert_eq!(calls_only[0].matched_dependencies, vec!["login"]);
-    }
-
-    #[test]
-    fn grep_combines_test_and_graph_threshold_filters() {
-        let (graph, entities) = fixture_graph();
-        let mut opts = test_options();
-        opts.tests = true;
-        opts.depends_on = vec!["login".to_string()];
-        opts.min_dependencies = Some(1);
-
-        let matches = find_matches(&graph, &entities, &opts);
-        assert_eq!(matches.len(), 1);
-        assert_eq!(matches[0].name, "test_login");
-        assert!(matches[0].is_test);
-
-        opts.tests = false;
-        opts.depends_on.clear();
-        opts.min_dependencies = None;
-        opts.min_dependents = Some(2);
-
-        let high_fan_in = find_matches(&graph, &entities, &opts);
-        assert_eq!(high_fan_in.len(), 1);
-        assert_eq!(high_fan_in[0].name, "login");
-    }
+fn print_json(matches: &[GrepMatch], query: &GrepQuery) {
+    println!("{}", result_json(matches, query));
 }

--- a/crates/sem-cli/src/commands/mod.rs
+++ b/crates/sem-cli/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod context;
 pub mod diff;
 pub mod entities;
 pub mod graph;
+pub mod grep;
 pub mod impact;
 pub mod log;
 pub mod setup;

--- a/crates/sem-cli/src/main.rs
+++ b/crates/sem-cli/src/main.rs
@@ -170,9 +170,9 @@ enum Commands {
         #[arg(long, short = 'c')]
         content: bool,
 
-        /// Match text filters case-insensitively
-        #[arg(long, short = 'i')]
-        ignore_case: bool,
+        /// Match text filters literally, including case and identifier separators
+        #[arg(long)]
+        case_sensitive: bool,
 
         /// Only include these entity types (e.g. --type function --type class)
         #[arg(long = "type", num_args = 1..)]
@@ -382,7 +382,7 @@ fn main() {
         Some(Commands::Grep {
             pattern,
             content,
-            ignore_case,
+            case_sensitive,
             entity_types,
             path,
             tests,
@@ -401,7 +401,7 @@ fn main() {
                     .to_string(),
                 pattern,
                 content,
-                ignore_case,
+                case_sensitive,
                 entity_types,
                 path_substring: path,
                 tests,

--- a/crates/sem-cli/src/main.rs
+++ b/crates/sem-cli/src/main.rs
@@ -13,6 +13,7 @@ use commands::entities::{entities_command, EntitiesOptions};
 use commands::grep::{grep_command, GrepOptions, RefKind};
 use commands::impact::{impact_command, ImpactMode, ImpactOptions};
 use commands::log::{log_command, LogOptions};
+use sem_core::parser::grep::GrepQuery;
 
 #[derive(Parser)]
 #[command(name = "sem", version = env!("CARGO_PKG_VERSION"), about = "Semantic version control")]
@@ -399,16 +400,18 @@ fn main() {
                     .unwrap_or_default()
                     .to_string_lossy()
                     .to_string(),
-                pattern,
-                content,
-                case_sensitive,
-                entity_types,
-                path_substring: path,
-                tests,
-                depends_on,
-                ref_kind,
-                min_dependencies,
-                min_dependents,
+                query: GrepQuery {
+                    pattern,
+                    content,
+                    case_sensitive,
+                    entity_types,
+                    path_substring: path,
+                    tests,
+                    depends_on,
+                    ref_kind: ref_kind.map(Into::into),
+                    min_dependencies,
+                    min_dependents,
+                },
                 json,
                 file_exts,
                 no_cache,

--- a/crates/sem-cli/src/main.rs
+++ b/crates/sem-cli/src/main.rs
@@ -10,6 +10,7 @@ use commands::blame::{blame_command, BlameOptions};
 use commands::context::{context_command, ContextOptions};
 use commands::diff::{diff_command, DiffOptions, OutputFormat};
 use commands::entities::{entities_command, EntitiesOptions};
+use commands::grep::{grep_command, GrepOptions, RefKind};
 use commands::impact::{impact_command, ImpactMode, ImpactOptions};
 use commands::log::{log_command, LogOptions};
 
@@ -158,6 +159,60 @@ enum Commands {
         /// Output as JSON
         #[arg(long)]
         json: bool,
+    },
+    /// Search semantic entities across the repo
+    Grep {
+        /// Entity name pattern
+        #[arg()]
+        pattern: Option<String>,
+
+        /// Also search inside entity content
+        #[arg(long, short = 'c')]
+        content: bool,
+
+        /// Match text filters case-insensitively
+        #[arg(long, short = 'i')]
+        ignore_case: bool,
+
+        /// Only include these entity types (e.g. --type function --type class)
+        #[arg(long = "type", num_args = 1..)]
+        entity_types: Vec<String>,
+
+        /// Only include entities whose file path contains this substring
+        #[arg(long)]
+        path: Option<String>,
+
+        /// Only include entities that look like tests
+        #[arg(long)]
+        tests: bool,
+
+        /// Only include entities that directly depend on a matching entity name
+        #[arg(long, num_args = 1..)]
+        depends_on: Vec<String>,
+
+        /// Restrict --depends-on matches to a specific reference kind
+        #[arg(long, value_enum)]
+        ref_kind: Option<RefKind>,
+
+        /// Only include entities with at least this many direct dependencies
+        #[arg(long)]
+        min_dependencies: Option<usize>,
+
+        /// Only include entities with at least this many direct dependents
+        #[arg(long)]
+        min_dependents: Option<usize>,
+
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+
+        /// Only include files with these extensions (e.g. --file-exts .py .rs)
+        #[arg(long, num_args = 1..)]
+        file_exts: Vec<String>,
+
+        /// Skip the SQLite entity cache (rebuild from scratch)
+        #[arg(long)]
+        no_cache: bool,
     },
     /// Show token-budgeted context for an entity
     Context {
@@ -322,6 +377,41 @@ fn main() {
                     .to_string(),
                 file_path: file,
                 json,
+            });
+        }
+        Some(Commands::Grep {
+            pattern,
+            content,
+            ignore_case,
+            entity_types,
+            path,
+            tests,
+            depends_on,
+            ref_kind,
+            min_dependencies,
+            min_dependents,
+            json,
+            file_exts,
+            no_cache,
+        }) => {
+            grep_command(GrepOptions {
+                cwd: std::env::current_dir()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string(),
+                pattern,
+                content,
+                ignore_case,
+                entity_types,
+                path_substring: path,
+                tests,
+                depends_on,
+                ref_kind,
+                min_dependencies,
+                min_dependents,
+                json,
+                file_exts,
+                no_cache,
             });
         }
         Some(Commands::Context {

--- a/crates/sem-core/src/parser/grep.rs
+++ b/crates/sem-core/src/parser/grep.rs
@@ -1,0 +1,618 @@
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::str::FromStr;
+
+use serde_json::json;
+
+use crate::model::entity::SemanticEntity;
+use crate::parser::graph::{EntityGraph, EntityInfo, EntityRef, RefType};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GrepRefKind {
+    Calls,
+    Imports,
+    Type,
+}
+
+impl GrepRefKind {
+    pub fn matches(self, ref_type: &RefType) -> bool {
+        match self {
+            Self::Calls => *ref_type == RefType::Calls,
+            Self::Imports => *ref_type == RefType::Imports,
+            Self::Type => *ref_type == RefType::TypeRef,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Calls => "calls",
+            Self::Imports => "imports",
+            Self::Type => "type",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct ParseGrepRefKindError;
+
+impl fmt::Display for ParseGrepRefKindError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("ref_kind must be one of: calls, imports, type")
+    }
+}
+
+impl std::error::Error for ParseGrepRefKindError {}
+
+impl FromStr for GrepRefKind {
+    type Err = ParseGrepRefKindError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "calls" => Ok(Self::Calls),
+            "imports" => Ok(Self::Imports),
+            "type" => Ok(Self::Type),
+            _ => Err(ParseGrepRefKindError),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
+pub struct GrepQuery {
+    pub pattern: Option<String>,
+    pub content: bool,
+    pub case_sensitive: bool,
+    pub entity_types: Vec<String>,
+    pub path_substring: Option<String>,
+    pub tests: bool,
+    pub depends_on: Vec<String>,
+    pub ref_kind: Option<GrepRefKind>,
+    pub min_dependencies: Option<usize>,
+    pub min_dependents: Option<usize>,
+}
+
+impl GrepQuery {
+    pub fn validate(&self) -> Result<(), GrepValidationError> {
+        if !self.has_selector() {
+            return Err(GrepValidationError::MissingSelector);
+        }
+        if self.content && self.pattern.is_none() {
+            return Err(GrepValidationError::ContentRequiresPattern);
+        }
+        if self.ref_kind.is_some() && self.depends_on.is_empty() {
+            return Err(GrepValidationError::RefKindRequiresDependsOn);
+        }
+        Ok(())
+    }
+
+    fn has_selector(&self) -> bool {
+        self.pattern.is_some()
+            || !self.entity_types.is_empty()
+            || self.path_substring.is_some()
+            || self.tests
+            || !self.depends_on.is_empty()
+            || self.min_dependencies.is_some()
+            || self.min_dependents.is_some()
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum GrepValidationError {
+    MissingSelector,
+    ContentRequiresPattern,
+    RefKindRequiresDependsOn,
+}
+
+impl fmt::Display for GrepValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingSelector => f.write_str(
+                "provide a pattern or at least one filter (`--type`, `--path`, `--tests`, `--depends-on`, `--min-dependencies`, `--min-dependents`)",
+            ),
+            Self::ContentRequiresPattern => f.write_str("`--content` requires a pattern"),
+            Self::RefKindRequiresDependsOn => {
+                f.write_str("`--ref-kind` requires at least one `--depends-on` filter")
+            }
+        }
+    }
+}
+
+impl std::error::Error for GrepValidationError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GrepMatch {
+    pub name: String,
+    pub entity_type: String,
+    pub file_path: String,
+    pub start_line: usize,
+    pub end_line: usize,
+    pub parent_id: Option<String>,
+    pub dependency_count: usize,
+    pub dependent_count: usize,
+    pub is_test: bool,
+    pub matched_dependencies: Vec<String>,
+}
+
+pub fn find_matches(
+    graph: &EntityGraph,
+    all_entities: &[SemanticEntity],
+    query: &GrepQuery,
+) -> Result<Vec<GrepMatch>, GrepValidationError> {
+    query.validate()?;
+
+    let entities_by_id: HashMap<&str, &SemanticEntity> = all_entities
+        .iter()
+        .map(|entity| (entity.id.as_str(), entity))
+        .collect();
+    let test_ids = if query.tests {
+        graph.filter_test_entities(all_entities)
+    } else {
+        HashSet::new()
+    };
+    let outgoing_edges = build_outgoing_edges(&graph.edges);
+    let mut matches = Vec::new();
+
+    for entity in graph.entities.values() {
+        let source = match entities_by_id.get(entity.id.as_str()) {
+            Some(source) => *source,
+            None => continue,
+        };
+
+        if !matches_pattern(
+            entity,
+            &source.content,
+            query.pattern.as_deref(),
+            query.content,
+            query.case_sensitive,
+        ) {
+            continue;
+        }
+        if !matches_type(&entity.entity_type, &query.entity_types, query.case_sensitive) {
+            continue;
+        }
+        if let Some(path_substring) = query.path_substring.as_deref() {
+            if !matches_text(&entity.file_path, path_substring, query.case_sensitive) {
+                continue;
+            }
+        }
+        if query.tests && !test_ids.contains(&entity.id) {
+            continue;
+        }
+
+        let dependency_count = graph
+            .dependencies
+            .get(entity.id.as_str())
+            .map_or(0, Vec::len);
+        let dependent_count = graph.dependents.get(entity.id.as_str()).map_or(0, Vec::len);
+
+        if let Some(min_dependencies) = query.min_dependencies {
+            if dependency_count < min_dependencies {
+                continue;
+            }
+        }
+        if let Some(min_dependents) = query.min_dependents {
+            if dependent_count < min_dependents {
+                continue;
+            }
+        }
+
+        let matched_dependencies = if query.depends_on.is_empty() {
+            Vec::new()
+        } else {
+            find_matching_dependencies(
+                graph,
+                entity,
+                &outgoing_edges,
+                &query.depends_on,
+                query.ref_kind,
+                query.case_sensitive,
+            )
+        };
+
+        if !query.depends_on.is_empty() && matched_dependencies.is_empty() {
+            continue;
+        }
+
+        matches.push(GrepMatch {
+            name: entity.name.clone(),
+            entity_type: entity.entity_type.clone(),
+            file_path: entity.file_path.clone(),
+            start_line: entity.start_line,
+            end_line: entity.end_line,
+            parent_id: entity.parent_id.clone(),
+            dependency_count,
+            dependent_count,
+            is_test: test_ids.contains(&entity.id),
+            matched_dependencies,
+        });
+    }
+
+    matches.sort_by(|left, right| {
+        left.file_path
+            .cmp(&right.file_path)
+            .then(left.start_line.cmp(&right.start_line))
+            .then(left.end_line.cmp(&right.end_line))
+            .then(left.name.cmp(&right.name))
+    });
+    Ok(matches)
+}
+
+pub fn result_json(matches: &[GrepMatch], query: &GrepQuery) -> serde_json::Value {
+    json!({
+        "summary": {
+            "matches": matches.len(),
+            "pattern": query.pattern.as_deref(),
+            "content": query.content,
+            "caseSensitive": query.case_sensitive,
+            "types": &query.entity_types,
+            "path": query.path_substring.as_deref(),
+            "tests": query.tests,
+            "dependsOn": &query.depends_on,
+            "refKind": query.ref_kind.map(GrepRefKind::as_str),
+            "minDependencies": query.min_dependencies,
+            "minDependents": query.min_dependents,
+        },
+        "matches": matches.iter().map(|entry| json!({
+            "name": &entry.name,
+            "type": &entry.entity_type,
+            "file": &entry.file_path,
+            "lines": [entry.start_line, entry.end_line],
+            "parentId": &entry.parent_id,
+            "dependencyCount": entry.dependency_count,
+            "dependentCount": entry.dependent_count,
+            "isTest": entry.is_test,
+            "matchedDependencies": &entry.matched_dependencies,
+        })).collect::<Vec<_>>(),
+    })
+}
+
+fn build_outgoing_edges<'a>(edges: &'a [EntityRef]) -> HashMap<&'a str, Vec<&'a EntityRef>> {
+    let mut outgoing: HashMap<&str, Vec<&EntityRef>> = HashMap::new();
+    for edge in edges {
+        outgoing
+            .entry(edge.from_entity.as_str())
+            .or_default()
+            .push(edge);
+    }
+    outgoing
+}
+
+fn find_matching_dependencies(
+    graph: &EntityGraph,
+    entity: &EntityInfo,
+    outgoing_edges: &HashMap<&str, Vec<&EntityRef>>,
+    depends_on: &[String],
+    ref_kind: Option<GrepRefKind>,
+    case_sensitive: bool,
+) -> Vec<String> {
+    let mut matched: HashSet<String> = HashSet::new();
+
+    if let Some(edges) = outgoing_edges.get(entity.id.as_str()) {
+        for edge in edges {
+            if let Some(kind) = ref_kind {
+                if !kind.matches(&edge.ref_type) {
+                    continue;
+                }
+            }
+
+            let target = match graph.entities.get(edge.to_entity.as_str()) {
+                Some(target) => target,
+                None => continue,
+            };
+
+            if depends_on
+                .iter()
+                .any(|pattern| matches_text(&target.name, pattern, case_sensitive))
+            {
+                matched.insert(target.name.clone());
+            }
+        }
+    }
+
+    let mut matched: Vec<_> = matched.into_iter().collect();
+    matched.sort();
+    matched
+}
+
+fn matches_pattern(
+    entity: &EntityInfo,
+    content: &str,
+    pattern: Option<&str>,
+    search_content: bool,
+    case_sensitive: bool,
+) -> bool {
+    let Some(pattern) = pattern else {
+        return true;
+    };
+
+    matches_text(&entity.name, pattern, case_sensitive)
+        || (search_content && matches_text(content, pattern, case_sensitive))
+}
+
+fn matches_type(value: &str, filters: &[String], case_sensitive: bool) -> bool {
+    filters.is_empty()
+        || filters.iter().any(|filter| {
+            if case_sensitive {
+                value == filter
+            } else {
+                value.eq_ignore_ascii_case(filter)
+            }
+        })
+}
+
+fn matches_text(haystack: &str, needle: &str, case_sensitive: bool) -> bool {
+    if case_sensitive {
+        return haystack.contains(needle);
+    }
+
+    let needle_lower = needle.to_lowercase();
+    if haystack.to_lowercase().contains(&needle_lower) {
+        return true;
+    }
+
+    let normalized_needle = normalize_identifier_text(needle);
+    !normalized_needle.is_empty()
+        && normalize_identifier_text(haystack).contains(&normalized_needle)
+}
+
+fn normalize_identifier_text(value: &str) -> String {
+    let mut normalized = String::with_capacity(value.len());
+    for ch in value.chars() {
+        if matches!(ch, '_' | '-') {
+            continue;
+        }
+        normalized.extend(ch.to_lowercase());
+    }
+    normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::model::entity::SemanticEntity;
+    use crate::parser::graph::{EntityGraph, EntityInfo, EntityRef, RefType};
+
+    use super::{find_matches, matches_text, GrepQuery, GrepRefKind};
+
+    fn entity_info(
+        id: &str,
+        name: &str,
+        entity_type: &str,
+        file_path: &str,
+        start_line: usize,
+    ) -> EntityInfo {
+        EntityInfo {
+            id: id.to_string(),
+            name: name.to_string(),
+            entity_type: entity_type.to_string(),
+            file_path: file_path.to_string(),
+            parent_id: None,
+            start_line,
+            end_line: start_line + 2,
+        }
+    }
+
+    fn semantic_entity(info: &EntityInfo, content: &str) -> SemanticEntity {
+        SemanticEntity {
+            id: info.id.clone(),
+            file_path: info.file_path.clone(),
+            entity_type: info.entity_type.clone(),
+            name: info.name.clone(),
+            parent_id: info.parent_id.clone(),
+            content: content.to_string(),
+            content_hash: format!("hash-{}", info.id),
+            structural_hash: None,
+            start_line: info.start_line,
+            end_line: info.end_line,
+            metadata: None,
+        }
+    }
+
+    fn test_query() -> GrepQuery {
+        GrepQuery {
+            pattern: None,
+            content: false,
+            case_sensitive: false,
+            entity_types: Vec::new(),
+            path_substring: None,
+            tests: false,
+            depends_on: Vec::new(),
+            ref_kind: None,
+            min_dependencies: None,
+            min_dependents: None,
+        }
+    }
+
+    fn fixture_graph() -> (EntityGraph, Vec<SemanticEntity>) {
+        let exec = entity_info(
+            "src/process.ts::function::exec",
+            "exec",
+            "function",
+            "src/process.ts",
+            1,
+        );
+        let login = entity_info(
+            "src/auth.ts::function::login",
+            "login",
+            "function",
+            "src/auth.ts",
+            10,
+        );
+        let run_shell = entity_info(
+            "src/shell.ts::function::runShell",
+            "runShell",
+            "function",
+            "src/shell.ts",
+            20,
+        );
+        let auth_controller = entity_info(
+            "src/auth_controller.ts::class::AuthController",
+            "AuthController",
+            "class",
+            "src/auth_controller.ts",
+            5,
+        );
+        let login_test = entity_info(
+            "tests/auth_test.rs::function::test_login",
+            "test_login",
+            "function",
+            "tests/auth_test.rs",
+            3,
+        );
+
+        let graph = EntityGraph::from_parts(
+            HashMap::from([
+                (exec.id.clone(), exec.clone()),
+                (login.id.clone(), login.clone()),
+                (run_shell.id.clone(), run_shell.clone()),
+                (auth_controller.id.clone(), auth_controller.clone()),
+                (login_test.id.clone(), login_test.clone()),
+            ]),
+            vec![
+                EntityRef {
+                    from_entity: run_shell.id.clone(),
+                    to_entity: exec.id.clone(),
+                    ref_type: RefType::Calls,
+                },
+                EntityRef {
+                    from_entity: auth_controller.id.clone(),
+                    to_entity: login.id.clone(),
+                    ref_type: RefType::TypeRef,
+                },
+                EntityRef {
+                    from_entity: login_test.id.clone(),
+                    to_entity: login.id.clone(),
+                    ref_type: RefType::Calls,
+                },
+            ],
+        );
+
+        let entities = vec![
+            semantic_entity(&exec, "export function exec(command) { return command; }"),
+            semantic_entity(
+                &login,
+                "pub fn login(user: &str) -> bool { !user.is_empty() }",
+            ),
+            semantic_entity(&run_shell, "function runShell() { return exec(\"ls\"); }"),
+            semantic_entity(
+                &auth_controller,
+                "class AuthController extends login { handle() { return true; } }",
+            ),
+            semantic_entity(
+                &login_test,
+                "#[test]\nfn test_login() {\n    assert!(login(\"alice\"));\n}",
+            ),
+        ];
+
+        (graph, entities)
+    }
+
+    #[test]
+    fn grep_matches_name_by_default_and_content_when_requested() {
+        let (graph, entities) = fixture_graph();
+
+        let mut query = test_query();
+        query.pattern = Some("exec".to_string());
+
+        let name_only = find_matches(&graph, &entities, &query).expect("valid grep query");
+        assert_eq!(name_only.len(), 1);
+        assert_eq!(name_only[0].name, "exec");
+
+        query.content = true;
+        let with_content = find_matches(&graph, &entities, &query).expect("valid grep query");
+        let names: Vec<_> = with_content
+            .iter()
+            .map(|entry| entry.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["exec", "runShell"]);
+    }
+
+    #[test]
+    fn grep_matches_common_identifier_styles_by_default() {
+        let (graph, entities) = fixture_graph();
+        let mut query = test_query();
+
+        query.pattern = Some("auth-controller".to_string());
+        let kebab_to_pascal = find_matches(&graph, &entities, &query).expect("valid grep query");
+        assert_eq!(kebab_to_pascal.len(), 1);
+        assert_eq!(kebab_to_pascal[0].name, "AuthController");
+
+        query.pattern = Some("RUN_SHELL".to_string());
+        let screaming_to_camel = find_matches(&graph, &entities, &query).expect("valid grep query");
+        assert_eq!(screaming_to_camel.len(), 1);
+        assert_eq!(screaming_to_camel[0].name, "runShell");
+    }
+
+    #[test]
+    fn grep_case_sensitive_requires_literal_text() {
+        let (graph, entities) = fixture_graph();
+        let mut query = test_query();
+        query.case_sensitive = true;
+        query.pattern = Some("RUN_SHELL".to_string());
+
+        let matches = find_matches(&graph, &entities, &query).expect("valid grep query");
+        assert!(matches.is_empty());
+
+        query.pattern = Some("runShell".to_string());
+        let matches = find_matches(&graph, &entities, &query).expect("valid grep query");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].name, "runShell");
+    }
+
+    #[test]
+    fn smart_text_matching_is_not_sparse() {
+        assert!(matches_text("authenticate_user", "authenticateUser", false));
+        assert!(matches_text("AUTHENTICATE-USER", "authenticate_user", false));
+        assert!(!matches_text("authenticate user", "authenticateUser", false));
+        assert!(!matches_text("handle_mouse_event", "hm", false));
+        assert!(!matches_text("authenticate_user", "authenticateUser", true));
+    }
+
+    #[test]
+    fn grep_filters_by_dependency_name_and_reference_kind() {
+        let (graph, entities) = fixture_graph();
+        let mut query = test_query();
+        query.depends_on = vec!["login".to_string()];
+
+        let any_ref = find_matches(&graph, &entities, &query).expect("valid grep query");
+        let names: Vec<_> = any_ref.iter().map(|entry| entry.name.as_str()).collect();
+        assert_eq!(names, vec!["AuthController", "test_login"]);
+
+        query.ref_kind = Some(GrepRefKind::Calls);
+        let calls_only = find_matches(&graph, &entities, &query).expect("valid grep query");
+        assert_eq!(calls_only.len(), 1);
+        assert_eq!(calls_only[0].name, "test_login");
+        assert_eq!(calls_only[0].matched_dependencies, vec!["login"]);
+    }
+
+    #[test]
+    fn grep_combines_test_and_graph_threshold_filters() {
+        let (graph, entities) = fixture_graph();
+        let mut query = test_query();
+        query.tests = true;
+        query.depends_on = vec!["login".to_string()];
+        query.min_dependencies = Some(1);
+
+        let matches = find_matches(&graph, &entities, &query).expect("valid grep query");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].name, "test_login");
+        assert!(matches[0].is_test);
+
+        query.tests = false;
+        query.depends_on.clear();
+        query.min_dependencies = None;
+        query.min_dependents = Some(2);
+
+        let high_fan_in = find_matches(&graph, &entities, &query).expect("valid grep query");
+        assert_eq!(high_fan_in.len(), 1);
+        assert_eq!(high_fan_in[0].name, "login");
+    }
+
+    #[test]
+    fn grep_rejects_filterless_queries() {
+        let (graph, entities) = fixture_graph();
+        let err = find_matches(&graph, &entities, &test_query())
+            .expect_err("filterless grep should fail");
+        assert_eq!(err.to_string(), "provide a pattern or at least one filter (`--type`, `--path`, `--tests`, `--depends-on`, `--min-dependencies`, `--min-dependents`)");
+    }
+}

--- a/crates/sem-core/src/parser/mod.rs
+++ b/crates/sem-core/src/parser/mod.rs
@@ -5,4 +5,5 @@ pub mod graph;
 pub mod plugins;
 pub mod verify;
 pub mod context;
+pub mod grep;
 pub mod hotspot;

--- a/crates/sem-core/src/utils/mod.rs
+++ b/crates/sem-core/src/utils/mod.rs
@@ -1,1 +1,2 @@
 pub mod hash;
+pub mod paths;

--- a/crates/sem-core/src/utils/paths.rs
+++ b/crates/sem-core/src/utils/paths.rs
@@ -1,0 +1,9 @@
+pub fn normalize_file_exts(exts: &[String]) -> Vec<String> {
+    exts.iter().map(|ext| {
+        if ext.starts_with('.') {
+            ext.clone()
+        } else {
+            format!(".{}", ext)
+        }
+    }).collect()
+}

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -13,9 +13,11 @@ use sem_core::git::bridge::GitBridge;
 use sem_core::git::types::DiffScope;
 use sem_core::model::entity::SemanticEntity;
 use sem_core::parser::differ::compute_semantic_diff;
+use sem_core::parser::grep::{find_matches, result_json, GrepQuery, GrepRefKind};
 use sem_core::parser::graph::EntityGraph;
 use sem_core::parser::plugins::create_default_registry;
 use sem_core::parser::registry::ParserRegistry;
+use sem_core::utils::paths::normalize_file_exts;
 use tokio::sync::Mutex;
 
 use crate::cache;
@@ -62,6 +64,9 @@ impl SemServer {
                 if let Ok(bridge) = GitBridge::open(search_dir) {
                     return Ok(bridge.repo_root().to_path_buf());
                 }
+                if let Some(root) = Self::find_git_root(search_dir) {
+                    return Ok(root);
+                }
             }
         }
 
@@ -78,6 +83,9 @@ impl SemServer {
             if let Ok(bridge) = GitBridge::open(&cwd) {
                 return Ok(bridge.repo_root().to_path_buf());
             }
+            if let Some(root) = Self::find_git_root(&cwd) {
+                return Ok(root);
+            }
         }
 
         Err(
@@ -87,6 +95,18 @@ impl SemServer {
              - Run sem-mcp from within a git repo"
                 .to_string(),
         )
+    }
+
+    fn find_git_root(start: &Path) -> Option<PathBuf> {
+        let mut dir = start.to_path_buf();
+        loop {
+            if dir.join(".git").exists() {
+                return Some(dir);
+            }
+            if !dir.pop() {
+                return None;
+            }
+        }
     }
 
     fn resolve_file_path(repo_root: &Path, file_path: &str) -> (String, PathBuf) {
@@ -768,7 +788,62 @@ impl SemServer {
         )]))
     }
 
-    // ── Tool 6: Context ──
+    // ── Tool 6: Grep ──
+
+    #[tool(description = "Graph-backed entity search for discovery, migrations, and review narrowing")]
+    async fn sem_grep(
+        &self,
+        Parameters(params): Parameters<GrepParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let GrepParams {
+            pattern,
+            content,
+            case_sensitive,
+            entity_types,
+            path,
+            tests,
+            depends_on,
+            ref_kind,
+            min_dependencies,
+            min_dependents,
+            file_exts,
+        } = params;
+
+        let ref_kind = ref_kind
+            .as_deref()
+            .map(|kind| kind.parse::<GrepRefKind>())
+            .transpose()
+            .map_err(internal_err)?;
+
+        let query = GrepQuery {
+            pattern,
+            content,
+            case_sensitive,
+            entity_types,
+            path_substring: path,
+            tests,
+            depends_on,
+            ref_kind,
+            min_dependencies,
+            min_dependents,
+        };
+
+        let repo_root = Self::discover_repo_root(None).map_err(internal_err)?;
+
+        let mut file_paths = Self::find_supported_files(&repo_root, &self.registry);
+        if !file_exts.is_empty() {
+            let ext_filter = normalize_file_exts(&file_exts);
+            file_paths.retain(|path| ext_filter.iter().any(|ext| path.ends_with(ext.as_str())));
+        }
+        let (graph, all_entities) = self.get_or_build_graph(&repo_root, &file_paths).await;
+        let matches = find_matches(&graph, &all_entities, &query).map_err(internal_err)?;
+
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&result_json(&matches, &query)).unwrap_or_default(),
+        )]))
+    }
+
+    // ── Tool 7: Context ──
 
     #[tool(description = "Pack optimal entity context into a token budget. Priority: target entity (full) > direct dependents (full) > transitive (signature only).")]
     async fn sem_context(
@@ -828,7 +903,7 @@ impl ServerHandler for SemServer {
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build()).with_instructions(
             "sem MCP server for entity-level semantic code intelligence. \
-             6 tools: entities, diff, blame, impact, log, context.",
+             7 tools: entities, diff, blame, impact, log, grep, context.",
         )
     }
 }

--- a/crates/sem-mcp/src/tools.rs
+++ b/crates/sem-mcp/src/tools.rs
@@ -45,6 +45,38 @@ pub struct LogParams {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct GrepParams {
+    #[schemars(description = "Entity name pattern. If omitted, provide at least one filter.")]
+    pub pattern: Option<String>,
+    #[serde(default)]
+    #[schemars(description = "Also search inside entity content. Requires pattern.")]
+    pub content: bool,
+    #[serde(default)]
+    #[schemars(description = "Match text filters literally, including case and identifier separators.")]
+    pub case_sensitive: bool,
+    #[serde(default, alias = "types", alias = "type")]
+    #[schemars(description = "Only include these entity types, such as function or class.")]
+    pub entity_types: Vec<String>,
+    #[schemars(description = "Only include entities whose file path contains this substring.")]
+    pub path: Option<String>,
+    #[serde(default)]
+    #[schemars(description = "Only include entities that look like tests.")]
+    pub tests: bool,
+    #[serde(default)]
+    #[schemars(description = "Only include entities that directly depend on a matching entity name.")]
+    pub depends_on: Vec<String>,
+    #[schemars(description = "Restrict depends_on matches to one reference kind: calls, imports, or type.")]
+    pub ref_kind: Option<String>,
+    #[schemars(description = "Only include entities with at least this many direct dependencies.")]
+    pub min_dependencies: Option<usize>,
+    #[schemars(description = "Only include entities with at least this many direct dependents.")]
+    pub min_dependents: Option<usize>,
+    #[serde(default)]
+    #[schemars(description = "Only include files with these extensions, such as .py or .rs.")]
+    pub file_exts: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ContextParams {
     #[schemars(description = "Path to the file containing the entity")]
     pub file_path: String,

--- a/docs/benchmarks.html
+++ b/docs/benchmarks.html
@@ -177,13 +177,13 @@
     <section id="hero">
       <h2>sem-mcp performance</h2>
       <p class="section-desc">
-        6 MCP tools. Entity-level intelligence for agents.<br>
+        7 MCP tools. Entity-level intelligence for agents.<br>
         Real numbers from sem's own codebase (48 Rust files).
       </p>
 
       <div class="speed-row" style="margin-top: 0;">
         <div class="speed-pill">
-          <span class="number">6</span>
+          <span class="number">7</span>
           <span class="label">MCP tools</span>
         </div>
         <div class="speed-pill">

--- a/docs/details.html
+++ b/docs/details.html
@@ -249,7 +249,7 @@
         <div class="cmd-doc-flags">
           <div class="flag"><code>[pattern]</code> <span>Entity name pattern</span></div>
           <div class="flag"><code>-c, --content</code> <span>Also search inside entity content</span></div>
-          <div class="flag"><code>-i, --ignore-case</code> <span>Case-insensitive matching for text filters</span></div>
+          <div class="flag"><code>--case-sensitive</code> <span>Require literal case and identifier separators</span></div>
           <div class="flag"><code>--type &lt;kind&gt;...</code> <span>Filter entity types such as function, class, or method</span></div>
           <div class="flag"><code>--path &lt;text&gt;</code> <span>Filter by file path substring</span></div>
           <div class="flag"><code>--depends-on &lt;entity&gt;...</code> <span>Only include entities that directly reference a matching entity</span></div>

--- a/docs/details.html
+++ b/docs/details.html
@@ -243,6 +243,27 @@
 
       <div class="cmd-doc">
         <div class="cmd-doc-header">
+          <span class="cmd-doc-name">sem grep</span>
+          <span class="cmd-doc-desc">Search semantic entities across the repo</span>
+        </div>
+        <div class="cmd-doc-flags">
+          <div class="flag"><code>[pattern]</code> <span>Entity name pattern</span></div>
+          <div class="flag"><code>-c, --content</code> <span>Also search inside entity content</span></div>
+          <div class="flag"><code>-i, --ignore-case</code> <span>Case-insensitive matching for text filters</span></div>
+          <div class="flag"><code>--type &lt;kind&gt;...</code> <span>Filter entity types such as function, class, or method</span></div>
+          <div class="flag"><code>--path &lt;text&gt;</code> <span>Filter by file path substring</span></div>
+          <div class="flag"><code>--depends-on &lt;entity&gt;...</code> <span>Only include entities that directly reference a matching entity</span></div>
+          <div class="flag"><code>--ref-kind &lt;kind&gt;</code> <span>Restrict dependency matches to calls, imports, or type refs</span></div>
+          <div class="flag"><code>--tests</code> <span>Only include entities that look like tests</span></div>
+          <div class="flag"><code>--min-dependencies &lt;n&gt;</code> <span>Minimum direct dependency count</span></div>
+          <div class="flag"><code>--min-dependents &lt;n&gt;</code> <span>Minimum direct dependent count</span></div>
+          <div class="flag"><code>--json</code> <span>Output as JSON</span></div>
+          <div class="flag"><code>--file-exts &lt;ext&gt;...</code> <span>Filter by extension</span></div>
+        </div>
+      </div>
+
+      <div class="cmd-doc">
+        <div class="cmd-doc-header">
           <span class="cmd-doc-name">sem impact</span>
           <span class="cmd-doc-desc">What breaks if this entity changes?</span>
         </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -379,7 +379,7 @@
 
     <!-- ═══ Capabilities ═══ -->
     <section class="fade-in" style="border-top: 1px solid var(--border);">
-      <h2>Six commands. One binary.</h2>
+      <h2>Seven commands. One binary.</h2>
       <p class="section-desc">
         Everything works in any Git repo. No config. No plugins.
       </p>
@@ -394,10 +394,12 @@
         </div>
 
         <div class="cmd-card">
-          <div class="cmd-name"><code>sem blame</code></div>
-          <div class="cmd-desc">Who changed it? Per-entity blame showing the last commit that touched each function, class, or method.</div>
-          <pre class="cmd-example"><span class="d">│</span>  <span class="g">⊕</span> <span class="w">render_inline_diff</span>  <span class="c">a1a6fbf</span>  <span class="d">Rohan  04-03</span>
-<span class="d">│</span>  <span class="g">⊕</span> <span class="w">format_terminal</span>     <span class="c">a1a6fbf</span>  <span class="d">Rohan  04-03</span></pre>
+          <div class="cmd-name"><code>sem grep</code></div>
+          <div class="cmd-desc">What exists? Graph-backed entity search for discovery, migrations, and targeted review scope.</div>
+          <pre class="cmd-example"><span class="d">grep: 3 matches</span>
+  <span class="w">src/auth/login.ts</span>
+    <span class="d">function</span> <span class="w">authenticateUser</span>  <span class="d">(deps: 4, dependents: 2)</span>
+    <span class="d">function</span> <span class="w">authorizeRequest</span> <span class="d">(deps: 3, dependents: 1)</span></pre>
         </div>
 
         <div class="cmd-card">
@@ -407,6 +409,13 @@
   <span class="d">→ depends on:</span>  <span class="c">db.findUser</span>, <span class="c">rateLimiter</span>
   <span class="d">← used by:</span>    <span class="c">loginRoute</span>, <span class="c">authMiddleware</span>
   <span class="r">! 42 entities transitively affected</span></pre>
+        </div>
+
+        <div class="cmd-card">
+          <div class="cmd-name"><code>sem blame</code></div>
+          <div class="cmd-desc">Who changed it? Per-entity blame showing the last commit that touched each function, class, or method.</div>
+          <pre class="cmd-example"><span class="d">│</span>  <span class="g">⊕</span> <span class="w">render_inline_diff</span>  <span class="c">a1a6fbf</span>  <span class="d">Rohan  04-03</span>
+<span class="d">│</span>  <span class="g">⊕</span> <span class="w">format_terminal</span>     <span class="c">a1a6fbf</span>  <span class="d">Rohan  04-03</span></pre>
         </div>
 
         <div class="cmd-card">
@@ -584,6 +593,35 @@
         ], pause: 80 },
         { text: '│', cls: 'd', pause: 20 },
         { text: '└──────────────────────────────────────────────────────', cls: 'd', pause: 150 },
+        { text: '', pause: 600 },
+        // --- sem grep ---
+        { text: '$ sem grep auth --type function', cls: 'cmd', pause: 500, typing: true },
+        { text: '', pause: 300 },
+        { parts: [
+          { text: 'grep: ', cls: 'd' },
+          { text: '3 matches', cls: 'w' },
+        ], pause: 80 },
+        { parts: [
+          { text: '  src/auth/login.ts', cls: 'w' },
+        ], pause: 80 },
+        { parts: [
+          { text: '    function ', cls: 'd' },
+          { text: 'authenticateUser', cls: 'w' },
+          { text: ' (deps: 4, dependents: 2)', cls: 'd' },
+        ], pause: 80 },
+        { parts: [
+          { text: '    function ', cls: 'd' },
+          { text: 'authorizeRequest', cls: 'w' },
+          { text: ' (deps: 3, dependents: 1)', cls: 'd' },
+        ], pause: 80 },
+        { parts: [
+          { text: '  tests/auth/login_test.ts', cls: 'w' },
+        ], pause: 80 },
+        { parts: [
+          { text: '    function ', cls: 'd' },
+          { text: 'test_authenticateUser', cls: 'w' },
+          { text: ' (deps: 1, dependents: 0)', cls: 'd' },
+        ], pause: 150 },
         { text: '', pause: 600 },
         // --- sem impact ---
         { text: '$ sem impact authenticateUser', cls: 'cmd', pause: 500, typing: true },

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -41,6 +41,19 @@ sem diff --file-exts .py .rs      # filter by extension
 sem diff -v                       # verbose inline content diffs
 ```
 
+### sem grep
+Graph-backed entity search. Find semantic candidates before impact analysis, migrations, or review.
+
+```
+sem grep auth                              # name match
+sem grep exec --content                    # search inside entity bodies too
+sem grep authenticate --type function      # filter by entity type
+sem grep --path src/auth --type function   # filter by file path
+sem grep --depends-on exec --ref-kind calls
+sem grep --tests --depends-on validateToken
+sem grep --min-dependents 20 --json
+```
+
 ### sem blame
 Entity-level blame. Who last modified each function/class, not each line.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -46,6 +46,8 @@ Graph-backed entity search. Find semantic candidates before impact analysis, mig
 
 ```
 sem grep auth                              # name match
+sem grep auth-user                         # matches AuthUser, auth_user, AUTH-USER
+sem grep AuthUser --case-sensitive         # literal case/style match
 sem grep exec --content                    # search inside entity bodies too
 sem grep authenticate --type function      # filter by entity type
 sem grep --path src/auth --type function   # filter by file path


### PR DESCRIPTION
## Summary

This PR adds `sem grep`, a graph-backed semantic search command for finding entities before running impact analysis, narrowing review scope, or doing migrations. It's also supported via the MCP side.

Instead of introducing a separate query language, `sem grep` reuses the existing entity graph and cache, so search results can be filtered using dependency relationships and graph metadata that already exist in `sem`.

## What changed

- added a new `sem grep` command to `sem-cli`
- wired the command into the main CLI surface
- support name matching by default, with optional entity body search via `--content`
- support filters for:
  - `--type`
  - `--path`
  - `--tests`
  - `--depends-on`
  - `--ref-kind`
  - `--min-dependencies`
  - `--min-dependents`
  - `--file-exts`
  - `--no-cache`
- added both terminal output and machine-readable JSON output
- added focused unit tests covering:
  - name vs content matching
  - dependency filtering and `--ref-kind`
  - test-only and graph-threshold filtering
- updated the README and docs site to document `sem grep`, add usage examples, and place it before `sem blame` for consistent command ordering

## Testing

- `cargo test -p sem-cli grep_`