### PR TITLE
bugfix/agent-safe-directory-handling

### DIFF
--- a/crates/sem-cli/src/commands/blame.rs
+++ b/crates/sem-cli/src/commands/blame.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use colored::Colorize;
-use git2::Repository;
+use sem_core::git::bridge::GitBridge;
 use sem_core::parser::plugins::create_default_registry;
 
 use super::truncate_str;
@@ -56,16 +56,16 @@ pub fn blame_command(opts: BlameOptions) {
     }
 
     // Open git repo and run blame
-    let repo: git2::Repository = match Repository::discover(root) {
+    let git = match GitBridge::open(root) {
         Ok(r) => r,
         Err(e) => {
-            eprintln!("{} Not a git repository: {}", "error:".red().bold(), e);
+            eprintln!("{} Cannot open git repository: {}", "error:".red().bold(), e);
             std::process::exit(1);
         }
     };
 
     // Resolve file path relative to repo root for git blame
-    let repo_root = repo.workdir().unwrap_or(root);
+    let repo_root = git.repo_root();
     let abs_file = std::fs::canonicalize(root.join(&opts.file_path)).unwrap_or(full_path.clone());
     let repo_root_canonical = std::fs::canonicalize(repo_root).unwrap_or(repo_root.to_path_buf());
     let relative_path = abs_file
@@ -73,7 +73,7 @@ pub fn blame_command(opts: BlameOptions) {
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_else(|_| opts.file_path.clone());
 
-    let blame: git2::Blame = match repo.blame_file(Path::new(&relative_path), None) {
+    let blame = match git.blame_file(Path::new(&relative_path)) {
         Ok(b) => b,
         Err(e) => {
             eprintln!("{} Cannot blame {}: {}", "error:".red().bold(), opts.file_path, e);
@@ -101,11 +101,7 @@ pub fn blame_command(opts: BlameOptions) {
                     latest_author = sig.name().unwrap_or("unknown").to_string();
                     let oid = hunk.final_commit_id();
                     latest_sha = format!("{}", oid);
-                    latest_summary = repo
-                        .find_commit(oid)
-                        .ok()
-                        .and_then(|c| c.summary().map(String::from))
-                        .unwrap_or_default();
+                    latest_summary = git.commit_summary(oid).unwrap_or_default();
 
                     // Format date
                     let ts = sig.when().seconds();

--- a/crates/sem-cli/src/commands/diff.rs
+++ b/crates/sem-cli/src/commands/diff.rs
@@ -323,8 +323,8 @@ pub fn diff_command(mut opts: DiffOptions) {
     } else {
         let git = match GitBridge::open(Path::new(&opts.cwd)) {
             Ok(g) => g,
-            Err(_) => {
-                eprintln!("\x1b[31mError: Not inside a Git repository.\x1b[0m");
+            Err(e) => {
+                eprintln!("\x1b[31mError: {e}\x1b[0m");
                 process::exit(1);
             }
         };
@@ -404,8 +404,8 @@ pub fn diff_command(mut opts: DiffOptions) {
         } else {
             match git.detect_and_get_files(&parsed.pathspecs) {
                 Ok((scope, files)) => (scope, files),
-                Err(_) => {
-                    eprintln!("\x1b[31mError: Not inside a Git repository.\x1b[0m");
+                Err(e) => {
+                    eprintln!("\x1b[31mError: {e}\x1b[0m");
                     process::exit(1);
                 }
             }

--- a/crates/sem-core/src/git/bridge.rs
+++ b/crates/sem-core/src/git/bridge.rs
@@ -1,5 +1,7 @@
+use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 
 use git2::{
     Delta, Diff, DiffOptions, ErrorCode, Repository,
@@ -25,13 +27,19 @@ pub struct GitBridge {
 
 impl GitBridge {
     pub fn open(path: &Path) -> Result<Self, GitError> {
-        let repo = Repository::discover(path).map_err(|e| {
-            if e.code() == ErrorCode::NotFound {
-                GitError::NotARepo
-            } else {
-                GitError::Git2(e)
+        let repo = match Repository::discover(path) {
+            Ok(repo) => repo,
+            Err(error) if should_retry_with_command_line_safe_directory(&error, path) => {
+                let _guard = owner_validation_lock()
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                unsafe { git2::opts::set_verify_owner_validation(false)? };
+                let repo = Repository::discover(path);
+                unsafe { git2::opts::set_verify_owner_validation(true)? };
+                repo.map_err(map_git_error)?
             }
-        })?;
+            Err(error) => return Err(map_git_error(error)),
+        };
         let repo_root = repo
             .workdir()
             .ok_or(GitError::NotARepo)?
@@ -455,10 +463,84 @@ impl GitBridge {
     }
 }
 
+fn map_git_error(error: git2::Error) -> GitError {
+    if error.code() == ErrorCode::NotFound {
+        GitError::NotARepo
+    } else {
+        GitError::Git2(error)
+    }
+}
+
+fn should_retry_with_command_line_safe_directory(error: &git2::Error, path: &Path) -> bool {
+    let safe_directories = command_line_safe_directories();
+    should_retry_with_safe_directory(error, path, &safe_directories)
+}
+
+fn should_retry_with_safe_directory(error: &git2::Error, path: &Path, safe_directories: &[String]) -> bool {
+    error.code() == ErrorCode::Owner
+        && nearest_git_root(path).is_some_and(|repo_root| {
+            safe_directories.iter().any(|safe_directory| {
+                safe_directory == "*"
+                    || paths_match(&repo_root, Path::new(safe_directory))
+            })
+        })
+}
+
+fn command_line_safe_directories() -> Vec<String> {
+    let count = env::var("GIT_CONFIG_COUNT")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or_default();
+
+    (0..count)
+        .filter_map(|index| {
+            let key = env::var(format!("GIT_CONFIG_KEY_{index}")).ok()?;
+            if key.eq_ignore_ascii_case("safe.directory") {
+                env::var(format!("GIT_CONFIG_VALUE_{index}")).ok()
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn nearest_git_root(path: &Path) -> Option<PathBuf> {
+    let mut current = if path.is_file() {
+        path.parent()?
+    } else {
+        path
+    };
+
+    loop {
+        if current.join(".git").exists() {
+            return Some(fs::canonicalize(current).unwrap_or_else(|_| current.to_path_buf()));
+        }
+
+        current = current.parent()?;
+    }
+}
+
+fn paths_match(left: &Path, right: &Path) -> bool {
+    let left = fs::canonicalize(left).unwrap_or_else(|_| left.to_path_buf());
+    let right = fs::canonicalize(right).unwrap_or_else(|_| right.to_path_buf());
+
+    if cfg!(windows) {
+        left.to_string_lossy()
+            .eq_ignore_ascii_case(&right.to_string_lossy())
+    } else {
+        left == right
+    }
+}
+
+fn owner_validation_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use git2::{Oid, Repository, Signature};
+    use git2::{ErrorClass, Oid, Repository, Signature};
     use tempfile::TempDir;
 
     fn commit_file(repo: &Repository, file_path: &str, contents: &str, message: &str) -> Oid {
@@ -502,6 +584,43 @@ mod tests {
 
         assert!(matches!(scope, DiffScope::Working));
         assert!(files.is_empty());
+    }
+
+    #[test]
+    fn owner_error_retries_for_command_line_safe_directory() {
+        let temp = TempDir::new().unwrap();
+        Repository::init(temp.path()).unwrap();
+
+        let owner_error = git2::Error::new(
+            ErrorCode::Owner,
+            ErrorClass::Config,
+            "owner mismatch",
+        );
+        let safe_directories = [temp.path().to_string_lossy().to_string()];
+
+        assert!(should_retry_with_safe_directory(
+            &owner_error,
+            temp.path(),
+            &safe_directories,
+        ));
+
+        let other_directories = [temp.path().join("other").to_string_lossy().to_string()];
+        assert!(!should_retry_with_safe_directory(
+            &owner_error,
+            temp.path(),
+            &other_directories,
+        ));
+
+        let not_found_error = git2::Error::new(
+            ErrorCode::NotFound,
+            ErrorClass::Repository,
+            "not found",
+        );
+        assert!(!should_retry_with_safe_directory(
+            &not_found_error,
+            temp.path(),
+            &["*".to_string()],
+        ));
     }
 
     #[test]

--- a/crates/sem-core/src/git/bridge.rs
+++ b/crates/sem-core/src/git/bridge.rs
@@ -3,9 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
-use git2::{
-    Delta, Diff, DiffOptions, ErrorCode, Repository,
-};
+use git2::{Blame, Delta, Diff, DiffOptions, ErrorCode, Oid, Repository};
 use thiserror::Error;
 
 use super::types::{CommitInfo, DiffScope, FileChange, FileStatus};
@@ -33,9 +31,8 @@ impl GitBridge {
                 let _guard = owner_validation_lock()
                     .lock()
                     .unwrap_or_else(|poisoned| poisoned.into_inner());
-                unsafe { git2::opts::set_verify_owner_validation(false)? };
+                let _owner_validation = OwnerValidationDisabled::new()?;
                 let repo = Repository::discover(path);
-                unsafe { git2::opts::set_verify_owner_validation(true)? };
                 repo.map_err(map_git_error)?
             }
             Err(error) => return Err(map_git_error(error)),
@@ -49,6 +46,17 @@ impl GitBridge {
 
     pub fn repo_root(&self) -> &Path {
         &self.repo_root
+    }
+
+    pub fn blame_file(&self, file_path: &Path) -> Result<Blame<'_>, GitError> {
+        Ok(self.repo.blame_file(file_path, None)?)
+    }
+
+    pub fn commit_summary(&self, oid: Oid) -> Option<String> {
+        self.repo
+            .find_commit(oid)
+            .ok()
+            .and_then(|commit| commit.summary().map(String::from))
     }
 
     pub fn get_head_sha(&self) -> Result<String, GitError> {
@@ -535,6 +543,25 @@ fn paths_match(left: &Path, right: &Path) -> bool {
 fn owner_validation_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
+}
+
+struct OwnerValidationDisabled;
+
+impl OwnerValidationDisabled {
+    fn new() -> Result<Self, GitError> {
+        // libgit2 stores this as a process-global option; callers hold owner_validation_lock.
+        unsafe { git2::opts::set_verify_owner_validation(false)? };
+        Ok(Self)
+    }
+}
+
+impl Drop for OwnerValidationDisabled {
+    fn drop(&mut self) {
+        // Restore the default before the owner-validation lock is released.
+        unsafe {
+            let _ = git2::opts::set_verify_owner_validation(true);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -3,7 +3,6 @@ use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use git2::Repository;
 use lru::LruCache;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
@@ -425,11 +424,9 @@ impl SemServer {
             }
         }
 
-        let repo = Repository::discover(&ctx.repo_root)
-            .map_err(|e| internal_err(format!("Git error: {}", e)))?;
-
-        let blame = repo
-            .blame_file(Path::new(&rel_path), None)
+        let blame = ctx
+            .git
+            .blame_file(Path::new(&rel_path))
             .map_err(|e| internal_err(format!("Cannot blame {}: {}", rel_path, e)))?;
 
         let mut results: Vec<serde_json::Value> = Vec::new();
@@ -450,11 +447,7 @@ impl SemServer {
                         latest_author = sig.name().unwrap_or("unknown").to_string();
                         let oid = hunk.final_commit_id();
                         latest_sha = format!("{}", oid);
-                        latest_summary = repo
-                            .find_commit(oid)
-                            .ok()
-                            .and_then(|c| c.summary().map(String::from))
-                            .unwrap_or_default();
+                        latest_summary = ctx.git.commit_summary(oid).unwrap_or_default();
                         latest_date = chrono_lite_format(sig.when().seconds());
                     }
                 }


### PR DESCRIPTION
## Summary

Fix `sem` repository discovery when running under agent-launched Git environments that provide `safe.directory` through command-line Git config, and apply the same behavior consistently to related git-backed commands.

## Problem

Running `sem diff` from an agent could fail even though the same command worked in a normal terminal. In the agent environment, Git sees `safe.directory` via `GIT_CONFIG_COUNT`, `GIT_CONFIG_KEY_*`, and `GIT_CONFIG_VALUE_*`, but libgit2 owner validation could still reject the repository.

Before this change, `sem diff` also mapped all `GitBridge::open` failures to “Not inside a Git repository,” which masked the real owner-validation error and made the failure look like bad repo discovery rather than a `safe.directory` mismatch.

## Fix

- Preserve non-`NotFound` libgit2 errors in `sem diff`, so owner-validation failures are reported as real git errors instead of “not a repo.”
- Teach `GitBridge::open` to recognize command-line `safe.directory` entries from the `GIT_CONFIG_*` environment variables.
- Retry repository discovery only for libgit2 `ErrorCode::Owner` errors, and only when the nearest git root matches a configured `safe.directory` entry or `*`.
- Guard the temporary libgit2 owner-validation disable behind a process-wide lock and an RAII restore guard, since that libgit2 option is process-global.
- Route CLI `sem blame` and MCP `sem_blame` through `GitBridge` instead of direct `Repository::discover`, so the same safe-directory behavior is centralized and shared.

## Validation

Ran:

- `cargo test -p sem-core`
- `cargo test -p sem-cli`
- `cargo test -p sem-mcp`
- `cargo run -q -p sem-cli -- diff --format plain --file-exts rs`