### PR TITLE
feat: add Scala language support via tree-sitter-scala

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1365,6 +1365,7 @@ dependencies = [
  "tree-sitter-python",
  "tree-sitter-ruby",
  "tree-sitter-rust",
+ "tree-sitter-scala",
  "tree-sitter-swift",
  "tree-sitter-typescript",
  "tree-sitter-xml",
@@ -1975,6 +1976,16 @@ name = "tree-sitter-rust"
 version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8ccb3e3a3495c8a943f6c3fd24c3804c471fd7f4f16087623c7fa4c0068e8a"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-scala"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83079f50ea7d03e0faf6be6260ed97538e6df7349ec3cbcbf5771f7b38e3c8b7"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/crates/sem-core/Cargo.toml
+++ b/crates/sem-core/Cargo.toml
@@ -36,6 +36,7 @@ tree-sitter-ocaml = "0.24"
 tree-sitter-htmlx-svelte = "0.1.7"
 tree-sitter-dart = "0.1.0"
 tree-sitter-perl-next = "0.1"
+tree-sitter-scala = "0.25"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/crates/sem-core/src/parser/plugins/code/languages.rs
+++ b/crates/sem-core/src/parser/plugins/code/languages.rs
@@ -599,7 +599,7 @@ static OCAML_INTERFACE_CONFIG: LanguageConfig = LanguageConfig {
 
 static SCALA_CONFIG: LanguageConfig = LanguageConfig {
     id: "scala",
-    extensions: &[".scala", ".sc"],
+    extensions: &[".scala", ".sc", ".sbt", ".kojo", ".mill"],
     entity_node_types: &[
         "class_definition",
         "object_definition",
@@ -666,7 +666,7 @@ pub fn get_all_code_extensions() -> &'static [&'static str] {
         ".dart",
         ".pl", ".pm", ".t",
         ".ml", ".mli",
-        ".scala", ".sc",
+        ".scala", ".sc", ".sbt", ".kojo", ".mill",
     ];
     EXTENSIONS
 }

--- a/crates/sem-core/src/parser/plugins/code/languages.rs
+++ b/crates/sem-core/src/parser/plugins/code/languages.rs
@@ -112,6 +112,10 @@ fn get_ocaml_interface() -> Option<Language> {
     Some(tree_sitter_ocaml::LANGUAGE_OCAML_INTERFACE.into())
 }
 
+fn get_scala() -> Option<Language> {
+    Some(tree_sitter_scala::LANGUAGE.into())
+}
+
 /// Inside JS/TS function bodies, suppress variable declarations so that local
 /// variables are not extracted as nested entities. Inner function/class
 /// declarations are still extracted for diff granularity.
@@ -593,6 +597,29 @@ static OCAML_INTERFACE_CONFIG: LanguageConfig = LanguageConfig {
     get_language: get_ocaml_interface,
 };
 
+static SCALA_CONFIG: LanguageConfig = LanguageConfig {
+    id: "scala",
+    extensions: &[".scala", ".sc"],
+    entity_node_types: &[
+        "class_definition",
+        "object_definition",
+        "trait_definition",
+        "enum_definition",
+        "function_definition",
+        "function_declaration",
+        "val_definition",
+        "given_definition",
+        "extension_definition",
+        "type_definition",
+        "package_object",
+    ],
+    container_node_types: &["template_body", "enum_body", "with_template_body"],
+    call_entity_identifiers: &[],
+    suppressed_nested_entities: &[],
+    scope_boundary_types: &[],
+    get_language: get_scala,
+};
+
 static ALL_CONFIGS: &[&LanguageConfig] = &[
     &TYPESCRIPT_CONFIG,
     &TSX_CONFIG,
@@ -617,6 +644,7 @@ static ALL_CONFIGS: &[&LanguageConfig] = &[
     &PERL_CONFIG,
     &OCAML_CONFIG,
     &OCAML_INTERFACE_CONFIG,
+    &SCALA_CONFIG,
 ];
 
 pub fn get_language_config(extension: &str) -> Option<&'static LanguageConfig> {
@@ -638,6 +666,7 @@ pub fn get_all_code_extensions() -> &'static [&'static str] {
         ".dart",
         ".pl", ".pm", ".t",
         ".ml", ".mli",
+        ".scala", ".sc",
     ];
     EXTENSIONS
 }

--- a/crates/sem-core/src/parser/plugins/code/mod.rs
+++ b/crates/sem-core/src/parser/plugins/code/mod.rs
@@ -1633,4 +1633,88 @@ end program main
         assert!(find("add").parent_id.is_some());
         assert!(find("greet").parent_id.is_some());
     }
+
+    #[test]
+    fn test_scala_entity_extraction() {
+        let code = r#"
+package com.example
+
+import scala.collection.mutable
+
+class UserService(val name: String) {
+  def getUsers(): List[User] = db.findAll()
+
+  def createUser(user: User): Unit = db.save(user)
+
+  private def validate(user: User): Boolean = true
+}
+
+object UserService {
+  def apply(name: String): UserService = new UserService(name)
+
+  val DefaultName: String = "default"
+}
+
+trait Repository[T] {
+  def findById(id: String): Option[T]
+  def findAll(): List[T]
+}
+
+case class User(id: String, name: String)
+
+type UserId = String
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "UserService.scala");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+        eprintln!("Scala entities: {:?}", entities.iter().map(|e| (&e.name, &e.entity_type)).collect::<Vec<_>>());
+
+        assert!(names.contains(&"UserService"), "Should find class UserService, got: {:?}", names);
+        assert!(names.contains(&"Repository"), "Should find trait Repository, got: {:?}", names);
+        assert!(names.contains(&"getUsers"), "Should find method getUsers, got: {:?}", names);
+        assert!(names.contains(&"createUser"), "Should find method createUser, got: {:?}", names);
+
+        // Methods should be nested under class
+        let get_users = entities.iter().find(|e| e.name == "getUsers").unwrap();
+        assert!(get_users.parent_id.is_some(), "getUsers should have parent_id");
+    }
+
+    #[test]
+    fn test_scala3_entity_extraction() {
+        let code = r#"
+package com.example
+
+enum Color:
+  case Red, Green, Blue
+
+enum Planet(mass: Double, radius: Double):
+  case Mercury extends Planet(3.303e+23, 2.4397e6)
+  case Venus   extends Planet(4.869e+24, 6.0518e6)
+
+object Main:
+  def main(args: Array[String]): Unit =
+    println("Hello, World!")
+
+trait Greeter:
+  def greet(name: String): String
+
+given Greeter with
+  def greet(name: String): String = s"Hello, $name!"
+
+extension (s: String)
+  def shout: String = s.toUpperCase + "!"
+
+type Predicate[A] = A => Boolean
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "Main.scala");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+        eprintln!("Scala 3 entities: {:?}", entities.iter().map(|e| (&e.name, &e.entity_type)).collect::<Vec<_>>());
+
+        assert!(names.contains(&"Color"), "Should find enum Color, got: {:?}", names);
+        assert!(names.contains(&"Planet"), "Should find enum Planet, got: {:?}", names);
+        assert!(names.contains(&"Main"), "Should find object Main, got: {:?}", names);
+        assert!(names.contains(&"Greeter"), "Should find trait Greeter, got: {:?}", names);
+        assert!(names.contains(&"Predicate"), "Should find type alias Predicate, got: {:?}", names);
+    }
 }


### PR DESCRIPTION
Adds entity-level semantic diffing for Scala 2 and Scala 3 source files using the tree-sitter-scala v0.25 grammar.

**Extensions supported** (per [github-linguist/linguist#7028](https://github.com/github-linguist/linguist/pull/7028)):
- `.scala` — standard Scala source files
- `.sc` — Scala scripts / Ammonite scripts
- `.sbt` — sbt build definitions
- `.mill` — Mill build scripts
- `.kojo` — Kojo learning environment

Entity types extracted:
- class_definition, object_definition, trait_definition
- enum_definition (Scala 3)
- function_definition, function_declaration
- val_definition, given_definition (Scala 3)
- extension_definition (Scala 3), type_definition, package_object

Container types: template_body, enum_body, with_template_body

This humble contribution has been sponsored by my employer @Chili-Piper