### PR TITLE
docs: update language count and table to include Scala

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/rust-stable-orange" alt="Rust">
   <img src="https://img.shields.io/badge/tests-133_passing-brightgreen" alt="Tests">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-yellow" alt="License"></a>
-  <img src="https://img.shields.io/badge/languages-23-blue" alt="Languages">
+  <img src="https://img.shields.io/badge/languages-24-blue" alt="Languages">
 </p>
 
 sem is a semantic version control tool that works on top of Git. It parses your code with tree-sitter, extracts every function, class, and method as an entity, and diffs at the entity level instead of lines. This means you see "function `blahh` was modified" instead of "lines x-y changed."
@@ -206,7 +206,7 @@ sem unsetup
 
 ## What it parses
 
-23 programming languages with full entity extraction via tree-sitter:
+24 programming languages with full entity extraction via tree-sitter:
 
 | Language | Extensions | Entities |
 |----------|-----------|----------|
@@ -226,6 +226,7 @@ sem unsetup
 | Bash | `.sh` | functions |
 | HCL/Terraform | `.hcl` `.tf` `.tfvars` | blocks, attributes (qualified names for nested blocks) |
 | Kotlin | `.kt` `.kts` | classes, interfaces, objects, functions, properties, companion objects |
+| Scala | `.scala` `.sc` `.sbt` `.mill` `.kojo` | classes, objects, traits, enums, functions, given instances, extensions, type aliases |
 | Fortran | `.f90` `.f95` `.f` | functions, subroutines, modules, programs |
 | Vue | `.vue` | template/script/style blocks + inner TS/JS entities |
 | XML | `.xml` `.plist` `.svg` `.csproj` | elements (nested, tag-name identity) |

--- a/SKILL.md
+++ b/SKILL.md
@@ -19,7 +19,7 @@ All cargo commands run from repo root. CI builds from `crates/` directory.
 
 ## Key Paths
 
-- Parsers: `crates/sem-core/src/parser/plugins/` (23 language plugins + shebang detection)
+- Parsers: `crates/sem-core/src/parser/plugins/` (24 language plugins + shebang detection)
 - Commands: `crates/sem-cli/src/commands/`
 - Entity model: `crates/sem-core/src/model/`
 - Git integration: `crates/sem-core/src/git/`


### PR DESCRIPTION
Documentation-only follow-up to #80.

**README.md**
- Language badge: 23 → 24
- "23 programming languages" → "24 programming languages"
- Add Scala row to the language table (after Kotlin, as both are JVM languages):
  - Extensions: `.scala` `.sc` `.sbt` `.mill` `.kojo`
  - Entities: classes, objects, traits, enums, functions, given instances, extensions, type aliases

**SKILL.md**
- "23 language plugins" → "24 language plugins"