### PR TITLE
feature/sem-entities-path-based

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,12 +169,17 @@ sem log authenticateUser --json
 
 ### sem entities
 
-List all entities in a file with their types and line ranges.
+List all entities under a file or directory path. No path is the same as `.`.
 
 ```bash
+sem entities
+
+sem entities .
+
 sem entities src/auth.ts
 
 # JSON output
+sem entities --json
 sem entities src/auth.ts --json
 ```
 

--- a/crates/sem-cli/src/commands/entities.rs
+++ b/crates/sem-cli/src/commands/entities.rs
@@ -1,76 +1,224 @@
-use std::path::Path;
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
 
 use colored::Colorize;
+use sem_core::model::entity::SemanticEntity;
 use sem_core::parser::plugins::create_default_registry;
+use sem_core::parser::registry::ParserRegistry;
 
 pub struct EntitiesOptions {
     pub cwd: String,
-    pub file_path: String,
+    pub path: Option<String>,
     pub json: bool,
 }
 
 pub fn entities_command(opts: EntitiesOptions) {
     let root = Path::new(&opts.cwd);
     let registry = create_default_registry();
+    let path_arg = opts.path.as_deref().filter(|p| !p.is_empty()).unwrap_or(".");
+    let (path_label, full_path) = resolve_path(root, path_arg);
 
-    let full_path = root.join(&opts.file_path);
+    let (entities, include_file) = if full_path.is_file() {
+        (extract_file_entities(&full_path, &registry, &path_label), false)
+    } else if full_path.is_dir() {
+        let file_paths = find_supported_files_in_path(root, &full_path, &registry);
+        (extract_files_entities(root, &file_paths, &registry), true)
+    } else {
+        eprintln!("{} Path not found '{}'", "error:".red().bold(), path_arg);
+        std::process::exit(1);
+    };
+
+    if opts.json {
+        let output: Vec<_> = entities
+            .iter()
+            .map(|e| entity_json(e, include_file))
+            .collect();
+        println!("{}", serde_json::to_string(&output).unwrap());
+    } else if should_group_by_file(&entities) {
+        print_grouped_entities(&path_label, &entities);
+    } else if let Some(file_path) = entities.first().map(|e| e.file_path.as_str()) {
+        print_file_entities(file_path, &entities);
+    } else {
+        println!("{} {}\n", "entities:".green().bold(), path_label.bold());
+    }
+}
+
+fn resolve_path(root: &Path, path_arg: &str) -> (String, PathBuf) {
+    let path = Path::new(path_arg);
+    let full_path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        root.join(path)
+    };
+
+    let label = if path.is_absolute() {
+        file_path_for_entity(root, &full_path)
+    } else {
+        path_arg.to_string()
+    };
+
+    (label, full_path)
+}
+
+fn find_supported_files_in_path(
+    root: &Path,
+    scan_path: &Path,
+    registry: &ParserRegistry,
+) -> Vec<String> {
+    let mut files = Vec::new();
+    let walker = ignore::WalkBuilder::new(scan_path)
+        .hidden(true)
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true)
+        .build();
+
+    for entry in walker {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(e) => {
+                eprintln!(
+                    "{} Cannot walk '{}': {}",
+                    "error:".red().bold(),
+                    scan_path.display(),
+                    e
+                );
+                std::process::exit(1);
+            }
+        };
+
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+
+        let file_path = file_path_for_entity(root, path);
+        if registry.get_plugin(&file_path).is_some() {
+            files.push(file_path);
+        }
+    }
+
+    files.sort();
+    files
+}
+
+fn extract_files_entities(
+    root: &Path,
+    file_paths: &[String],
+    registry: &ParserRegistry,
+) -> Vec<SemanticEntity> {
+    let mut entities = Vec::new();
+    for file_path in file_paths {
+        entities.extend(extract_file_entities(
+            &root.join(file_path),
+            registry,
+            file_path,
+        ));
+    }
+    entities
+}
+
+fn file_path_for_entity(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .ok()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or(path)
+        .to_string_lossy()
+        .to_string()
+}
+
+fn extract_file_entities(
+    full_path: &Path,
+    registry: &ParserRegistry,
+    file_path: &str,
+) -> Vec<SemanticEntity> {
     let content = match std::fs::read_to_string(&full_path) {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("{} Cannot read '{}': {}", "error:".red().bold(), opts.file_path, e);
+            eprintln!(
+                "{} Cannot read '{}': {}",
+                "error:".red().bold(),
+                file_path,
+                e
+            );
             std::process::exit(1);
         }
     };
 
-    let plugin = match registry.get_plugin_with_content(&opts.file_path, &content) {
+    let plugin = match registry.get_plugin_with_content(file_path, &content) {
         Some(p) => p,
         None => {
-            eprintln!("{} No parser for '{}'", "error:".red().bold(), opts.file_path);
+            eprintln!("{} No parser for '{}'", "error:".red().bold(), file_path);
             std::process::exit(1);
         }
     };
 
-    let entities = plugin.extract_entities(&content, &opts.file_path);
+    plugin.extract_entities(&content, file_path)
+}
 
-    if opts.json {
-        let output: Vec<_> = entities.iter().map(|e| {
-            serde_json::json!({
-                "name": e.name,
-                "type": e.entity_type,
-                "start_line": e.start_line,
-                "end_line": e.end_line,
-                "parent_id": e.parent_id,
-            })
-        }).collect();
-        println!("{}", serde_json::to_string(&output).unwrap());
-    } else {
-        println!("{} {}\n", "entities:".green().bold(), opts.file_path.bold());
+fn entity_json(entity: &SemanticEntity, include_file: bool) -> serde_json::Value {
+    let mut value = serde_json::json!({
+        "name": entity.name,
+        "type": entity.entity_type,
+        "start_line": entity.start_line,
+        "end_line": entity.end_line,
+        "parent_id": entity.parent_id,
+    });
 
-        // Build parent lookup for indentation
-        let parent_ids: std::collections::HashSet<&str> = entities
-            .iter()
-            .filter_map(|e| e.parent_id.as_deref())
-            .collect();
-
-        for entity in &entities {
-            let indent = if entity.parent_id.is_some() { "    " } else { "  " };
-            let is_parent = parent_ids.contains(entity.id.as_str())
-                || entities.iter().any(|e| e.parent_id.as_deref() == Some(&entity.id));
-
-            let name_display = if is_parent {
-                entity.name.bold().to_string()
-            } else {
-                entity.name.bold().to_string()
-            };
-
-            println!(
-                "{}{} {} (L{}:{})",
-                indent,
-                entity.entity_type.dimmed(),
-                name_display,
-                entity.start_line,
-                entity.end_line,
-            );
-        }
+    if include_file {
+        value["file"] = serde_json::json!(entity.file_path);
     }
+
+    value
+}
+
+fn print_file_entities(file_path: &str, entities: &[SemanticEntity]) {
+    println!("{} {}\n", "entities:".green().bold(), file_path.bold());
+    print_entity_rows(entities, "  ");
+}
+
+fn should_group_by_file(entities: &[SemanticEntity]) -> bool {
+    let files: BTreeSet<&str> = entities.iter().map(|e| e.file_path.as_str()).collect();
+    files.len() > 1
+}
+
+fn print_grouped_entities(path_label: &str, entities: &[SemanticEntity]) {
+    println!("{} {}\n", "entities:".green().bold(), path_label.bold());
+
+    let mut current_file: Option<&str> = None;
+    for entity in entities {
+        if current_file != Some(entity.file_path.as_str()) {
+            current_file = Some(entity.file_path.as_str());
+            println!("  {}", entity.file_path.bold());
+        }
+
+        let indent = if entity.parent_id.is_some() {
+            "      "
+        } else {
+            "    "
+        };
+        print_entity_row(entity, indent);
+    }
+}
+
+fn print_entity_rows(entities: &[SemanticEntity], base_indent: &str) {
+    for entity in entities {
+        let indent = if entity.parent_id.is_some() {
+            format!("{base_indent}  ")
+        } else {
+            base_indent.to_string()
+        };
+        print_entity_row(entity, &indent);
+    }
+}
+
+fn print_entity_row(entity: &SemanticEntity, indent: &str) {
+    println!(
+        "{}{} {} (L{}:{})",
+        indent,
+        entity.entity_type.dimmed(),
+        entity.name.bold(),
+        entity.start_line,
+        entity.end_line,
+    );
 }

--- a/crates/sem-cli/src/main.rs
+++ b/crates/sem-cli/src/main.rs
@@ -193,11 +193,11 @@ enum Commands {
         #[arg(long, short = 'v')]
         verbose: bool,
     },
-    /// List entities in a file
+    /// List entities under a file or directory path
     Entities {
-        /// File to extract entities from
+        /// File or directory path to extract entities from (defaults to .)
         #[arg()]
-        file: String,
+        path: Option<String>,
 
         /// Output format
         #[arg(long, value_parser = ["terminal", "json"])]
@@ -423,13 +423,13 @@ fn main() {
                 verbose,
             });
         }
-        Some(Commands::Entities { file, format, json }) => {
+        Some(Commands::Entities { path, format, json }) => {
             entities_command(EntitiesOptions {
                 cwd: std::env::current_dir()
                     .unwrap_or_default()
                     .to_string_lossy()
                     .to_string(),
-                file_path: file,
+                path,
                 json: resolve_json(format, json),
             });
         }

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -120,11 +120,11 @@ impl SemServer {
         }))
     }
 
-    fn find_supported_files(root: &Path, registry: &ParserRegistry) -> Vec<String> {
+    fn find_supported_files(root: &Path, registry: &ParserRegistry) -> Result<Vec<String>, String> {
         let mut files = Vec::new();
-        let _ = Self::walk_dir(root, root, registry, &mut files);
+        Self::walk_dir(root, root, registry, &mut files)?;
         files.sort();
-        files
+        Ok(files)
     }
 
     fn walk_dir(
@@ -561,7 +561,8 @@ impl SemServer {
             .map_err(internal_err)?;
         let (rel_path, _) = Self::resolve_file_path(&ctx.repo_root, &params.file_path);
 
-        let file_paths = Self::find_supported_files(&ctx.repo_root, &self.registry);
+        let file_paths =
+            Self::find_supported_files(&ctx.repo_root, &self.registry).map_err(internal_err)?;
         let (graph, all_entities) = self.get_or_build_graph(&ctx.repo_root, &file_paths).await;
 
         let entity_id = Self::find_entity_in_graph(&graph, &params.entity_name, &rel_path)?;
@@ -671,7 +672,8 @@ impl SemServer {
                 rel
             }
             None => {
-                let files = Self::find_supported_files(&ctx.repo_root, &self.registry);
+                let files = Self::find_supported_files(&ctx.repo_root, &self.registry)
+                    .map_err(internal_err)?;
                 let mut found_in: Vec<String> = Vec::new();
                 for fp in &files {
                     let full = ctx.repo_root.join(fp);
@@ -848,7 +850,8 @@ impl SemServer {
             .map_err(internal_err)?;
         let (rel_path, _) = Self::resolve_file_path(&ctx.repo_root, &params.file_path);
 
-        let file_paths = Self::find_supported_files(&ctx.repo_root, &self.registry);
+        let file_paths =
+            Self::find_supported_files(&ctx.repo_root, &self.registry).map_err(internal_err)?;
         let (graph, all_entities) = self.get_or_build_graph(&ctx.repo_root, &file_paths).await;
 
         let entity_id = Self::find_entity_in_graph(&graph, &params.entity_name, &rel_path)?;
@@ -897,6 +900,24 @@ impl ServerHandler for SemServer {
             "sem MCP server for entity-level semantic code intelligence. \
              6 tools: entities, diff, blame, impact, log, context.",
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_supported_files_returns_walk_errors() {
+        let missing_root = std::env::temp_dir().join(format!(
+            "sem-mcp-missing-root-{}",
+            std::process::id()
+        ));
+        let registry = ParserRegistry::new();
+
+        let err = SemServer::find_supported_files(&missing_root, &registry).unwrap_err();
+
+        assert!(err.contains("Failed to read directory"));
     }
 }
 

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -122,17 +122,23 @@ impl SemServer {
 
     fn find_supported_files(root: &Path, registry: &ParserRegistry) -> Vec<String> {
         let mut files = Vec::new();
-        Self::walk_dir(root, root, registry, &mut files);
+        let _ = Self::walk_dir(root, root, registry, &mut files);
         files.sort();
         files
     }
 
-    fn walk_dir(dir: &Path, root: &Path, registry: &ParserRegistry, files: &mut Vec<String>) {
+    fn walk_dir(
+        dir: &Path,
+        root: &Path,
+        registry: &ParserRegistry,
+        files: &mut Vec<String>,
+    ) -> Result<(), String> {
         let entries = match std::fs::read_dir(dir) {
             Ok(e) => e,
-            Err(_) => return,
+            Err(e) => return Err(format!("Failed to read directory {}: {}", dir.display(), e)),
         };
-        for entry in entries.flatten() {
+        for entry in entries {
+            let entry = entry.map_err(|e| format!("Failed to read directory entry: {}", e))?;
             let path = entry.path();
             if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
                 if name.starts_with('.')
@@ -148,7 +154,7 @@ impl SemServer {
                 }
             }
             if path.is_dir() {
-                Self::walk_dir(&path, root, registry, files);
+                Self::walk_dir(&path, root, registry, files)?;
             } else if let Ok(rel) = path.strip_prefix(root) {
                 let rel_str = rel.to_string_lossy().to_string();
                 if registry.get_plugin(&rel_str).is_some() {
@@ -156,11 +162,26 @@ impl SemServer {
                 }
             }
         }
+        Ok(())
     }
 
     fn read_file_at(abs_path: &Path, display_path: &str) -> Result<String, String> {
         std::fs::read_to_string(abs_path)
             .map_err(|e| format!("Failed to read {}: {}", display_path, e))
+    }
+
+    async fn extract_entities_from_files(
+        &self,
+        root: &Path,
+        file_paths: &[String],
+    ) -> Result<Vec<SemanticEntity>, String> {
+        let mut entities = Vec::new();
+        for rel_path in file_paths {
+            let abs_path = root.join(rel_path);
+            let content = Self::read_file_at(&abs_path, rel_path)?;
+            entities.extend(self.cached_extract_entities(&content, rel_path).await);
+        }
+        Ok(entities)
     }
 
     async fn cached_extract_entities(
@@ -330,35 +351,58 @@ impl SemServer {
 
     // ── Tool 1: Entities ──
 
-    #[tool(description = "List all semantic entities (functions, classes, etc.) in a file with their types and line ranges")]
+    #[tool(description = "List semantic entities (functions, classes, etc.) under a file or directory path. Defaults to '.'.")]
     async fn sem_entities(
         &self,
         Parameters(params): Parameters<EntitiesParams>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let path = params.path().unwrap_or(".");
         let ctx = self
-            .get_context(Some(&params.file_path))
+            .get_context(Some(path))
             .await
             .map_err(internal_err)?;
-        let (rel_path, abs_path) = Self::resolve_file_path(&ctx.repo_root, &params.file_path);
-        let content = Self::read_file_at(&abs_path, &rel_path).map_err(internal_err)?;
 
-        let entities = self.cached_extract_entities(&content, &rel_path).await;
-        if entities.is_empty() {
-            if self.registry.get_plugin(&rel_path).is_none() {
-                return Err(internal_err(format!("No parser for file: {}", rel_path)));
+        let (rel_path, abs_path) = Self::resolve_file_path(&ctx.repo_root, path);
+        let (entities, include_file) = if abs_path.is_file() {
+            let content = Self::read_file_at(&abs_path, &rel_path).map_err(internal_err)?;
+
+            let entities = self.cached_extract_entities(&content, &rel_path).await;
+            if entities.is_empty() {
+                if self.registry.get_plugin(&rel_path).is_none() {
+                    return Err(internal_err(format!("No parser for file: {}", rel_path)));
+                }
             }
-        }
+            (entities, false)
+        } else if abs_path.is_dir() {
+            let mut file_paths = Vec::new();
+            Self::walk_dir(&abs_path, &ctx.repo_root, &self.registry, &mut file_paths)
+                .map_err(internal_err)?;
+            file_paths.sort();
+
+            let all_entities = self
+                .extract_entities_from_files(&ctx.repo_root, &file_paths)
+                .await
+                .map_err(internal_err)?;
+            (all_entities, true)
+        } else {
+            return Err(internal_err(format!("Path not found: {}", path)));
+        };
+
         let result: Vec<serde_json::Value> = entities
             .iter()
             .map(|e| {
-                serde_json::json!({
+                let mut value = serde_json::json!({
                     "id": e.id,
                     "name": e.name,
                     "type": e.entity_type,
                     "start_line": e.start_line,
                     "end_line": e.end_line,
                     "parent_id": e.parent_id,
-                })
+                });
+                if include_file {
+                    value["file"] = serde_json::json!(e.file_path);
+                }
+                value
             })
             .collect();
 

--- a/crates/sem-mcp/src/tools.rs
+++ b/crates/sem-mcp/src/tools.rs
@@ -3,9 +3,16 @@ use serde::Deserialize;
 // ── Tool parameter structs ──
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct EntitiesParams {
-    #[schemars(description = "Path to the file (relative to repo root or absolute)")]
-    pub file_path: String,
+    #[schemars(description = "Optional path to a file or directory. If omitted, defaults to '.'.")]
+    pub path: Option<String>,
+}
+
+impl EntitiesParams {
+    pub fn path(&self) -> Option<&str> {
+        self.path.as_deref().filter(|p| !p.is_empty())
+    }
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -52,4 +59,34 @@ pub struct ContextParams {
     pub entity_name: String,
     #[schemars(description = "Maximum token budget. Defaults to 8000.")]
     pub token_budget: Option<usize>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EntitiesParams;
+
+    #[test]
+    fn entities_params_accepts_path() {
+        let params: EntitiesParams =
+            serde_json::from_value(serde_json::json!({ "path": "src/lib.rs" })).unwrap();
+
+        assert_eq!(params.path(), Some("src/lib.rs"));
+    }
+
+    #[test]
+    fn entities_params_allows_missing_path() {
+        let params: EntitiesParams = serde_json::from_value(serde_json::json!({})).unwrap();
+
+        assert_eq!(params.path(), None);
+    }
+
+    #[test]
+    fn entities_params_rejects_unknown_fields() {
+        let err = serde_json::from_value::<EntitiesParams>(serde_json::json!({
+            "unexpected": "src/lib.rs"
+        }))
+        .unwrap_err();
+
+        assert!(err.to_string().contains("unknown field"));
+    }
 }

--- a/docs/details.html
+++ b/docs/details.html
@@ -285,10 +285,10 @@
       <div class="cmd-doc">
         <div class="cmd-doc-header">
           <span class="cmd-doc-name">sem entities</span>
-          <span class="cmd-doc-desc">List all entities in a file</span>
+          <span class="cmd-doc-desc">List entities under a file or directory path</span>
         </div>
         <div class="cmd-doc-flags">
-          <div class="flag"><code>&lt;file&gt;</code> <span>File to extract entities from</span></div>
+          <div class="flag"><code>[path]</code> <span>File or directory path; defaults to <code>.</code></span></div>
           <div class="flag"><code>--json</code> <span>Output as JSON</span></div>
         </div>
       </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -419,7 +419,7 @@
 
         <div class="cmd-card">
           <div class="cmd-name"><code>sem entities</code></div>
-          <div class="cmd-desc">What's in a file? Lists every function, class, method, and type with line ranges.</div>
+          <div class="cmd-desc">What's under a path? Lists every function, class, method, and type with line ranges.</div>
           <pre class="cmd-example"><span class="d">entities: src/auth/login.ts</span>
   <span class="w">function validateToken</span>     <span class="d">(L12:24)</span>
   <span class="w">function authenticateUser</span>  <span class="d">(L26:45)</span>


### PR DESCRIPTION
sem entities now works via path, instead of being scoped to single files. this allows for repo-wide entity search across multiple files at once. The old calling shape remains the same, because "sem entities ./foo.ts" is, after all, also a path. By default, "sem entities" list all entities.

If only one file is found, no grouping happens.