### PR TITLE
fix(sem-cli): diff --format now uses the OutputFormat Enum directly

### DIFF
--- a/crates/sem-cli/src/commands/diff.rs
+++ b/crates/sem-cli/src/commands/diff.rs
@@ -31,6 +31,7 @@ pub enum OutputFormat {
     Terminal,
     Plain,
     Json,
+    #[value(alias="md")]
     Markdown,
 }
 

--- a/crates/sem-cli/src/commands/diff.rs
+++ b/crates/sem-cli/src/commands/diff.rs
@@ -26,7 +26,7 @@ pub struct DiffOptions {
     pub args: Vec<String>,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum OutputFormat {
     Terminal,
     Plain,

--- a/crates/sem-cli/src/commands/diff.rs
+++ b/crates/sem-cli/src/commands/diff.rs
@@ -31,7 +31,7 @@ pub enum OutputFormat {
     Terminal,
     Plain,
     Json,
-    #[value(alias="md")]
+    #[value(alias = "md")]
     Markdown,
 }
 

--- a/crates/sem-cli/src/main.rs
+++ b/crates/sem-cli/src/main.rs
@@ -64,9 +64,9 @@ enum Commands {
         #[arg(long)]
         patch: bool,
 
-        /// Output format: terminal, json, or markdown
+        /// Output format
         #[arg(long, default_value = "terminal")]
-        format: String,
+        format: OutputFormat,
 
         /// Show inline content diffs for each entity
         #[arg(long, short = 'v')]
@@ -80,7 +80,7 @@ enum Commands {
         #[arg(long, num_args = 1..)]
         file_exts: Vec<String>,
 
-        /// When to use colors: always, auto, never
+        /// When to use colors
         #[arg(long, default_value = "auto")]
         color: ColorMode,
 
@@ -247,12 +247,6 @@ fn main() {
             directory,
         }) => {
             apply_color_mode(color);
-            let output_format = match format.as_str() {
-                "json" => OutputFormat::Json,
-                "markdown" | "md" => OutputFormat::Markdown,
-                "plain" => OutputFormat::Plain,
-                _ => OutputFormat::Terminal,
-            };
 
             let cwd = directory.unwrap_or_else(|| {
                 std::env::current_dir()
@@ -263,7 +257,7 @@ fn main() {
 
             diff_command(DiffOptions {
                 cwd,
-                format: output_format,
+                format,
                 staged: staged || cached,
                 commit,
                 from,


### PR DESCRIPTION
## Changelog

### Changed

- `diff --format` now uses `OutputFormat` directly.

### Removed

- Removed repeated docs (clap already prints possible values)

## CLI Help Output

```nushell
sem diff -h
```

```diff
@@ -13,9 +13,9 @@
       --to <TO>                   End of commit range
       --stdin                     Read FileChange[] JSON from stdin instead of git
       --patch                     Read unified diff from stdin (e.g. git diff | sem diff --patch)
-      --format <FORMAT>           Output format: terminal, json, or markdown [default: terminal]
+      --format <FORMAT>           Output format [default: terminal] [possible values: terminal, plain, json, markdown]
   -v, --verbose                   Show inline content diffs for each entity
       --file-exts <FILE_EXTS>...  Only include files with these extensions (e.g. --file-exts .py .rs)
-      --color <COLOR>             When to use colors: always, auto, never [default: auto] [possible values: always, auto, never]
+      --color <COLOR>             When to use colors [default: auto] [possible values: always, auto, never]
   -C, --cwd <DIRECTORY>           Run as if started in this directory (like git -C)
   -h, --help                      Print help
```

## Shell Completions

This also fixes the generated shell completions

```nushell
sem completions nushell
```

```diff
@@ -6,6 +6,10 @@
     --version(-V)             # Print version
   ]

+  def "nu-complete sem diff format" [] {
+    [ "terminal" "plain" "json" "markdown" ]
+  }
+
   def "nu-complete sem diff color" [] {
     [ "always" "auto" "never" ]
   }
@@ -19,11 +23,11 @@
     --to: string              # End of commit range
     --stdin                   # Read FileChange[] JSON from stdin instead of git
     --patch                   # Read unified diff from stdin (e.g. git diff | sem diff --patch)
-    --format: string          # Output format: terminal, json, or markdown
+    --format: string@"nu-complete sem diff format" # Output format
     --verbose(-v)             # Show inline content diffs for each entity
     --profile                 # Show internal timing profile
     --file-exts: string       # Only include files with these extensions (e.g. --file-exts .py .rs)
-    --color: string@"nu-complete sem diff color" # When to use colors: always, auto, never
+    --color: string@"nu-complete sem diff color" # When to use colors
     --cwd(-C): string         # Run as if started in this directory (like git -C)
     --help(-h)                # Print help
     ...args: string           # Git refs, files, or pathspecs (supports ref1..ref2, ref1...ref2, -- paths)
```

## Proper Error Output

Before, an invalid format would fall back to Terminal. Now it throws a proper error including all the valid values.

```nushell
sem diff --format foo
```

```
error: invalid value 'foo' for '--format <FORMAT>'
  [possible values: terminal, plain, json, markdown]

For more information, try '--help'.
```