### PR TITLE
skip invalid files on path for entities

### DIFF
--- a/crates/sem-cli/src/commands/entities.rs
+++ b/crates/sem-cli/src/commands/entities.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeSet;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
 use colored::Colorize;
@@ -19,7 +20,13 @@ pub fn entities_command(opts: EntitiesOptions) {
     let (path_label, full_path) = resolve_path(root, path_arg);
 
     let (entities, include_file) = if full_path.is_file() {
-        (extract_file_entities(&full_path, &registry, &path_label), false)
+        (
+            extract_file_entities(&full_path, &registry, &path_label).unwrap_or_else(|e| {
+                eprintln!("{e}");
+                std::process::exit(1);
+            }),
+            false,
+        )
     } else if full_path.is_dir() {
         let file_paths = find_supported_files_in_path(root, &full_path, &registry);
         (extract_files_entities(root, &file_paths, &registry), true)
@@ -109,11 +116,17 @@ fn extract_files_entities(
 ) -> Vec<SemanticEntity> {
     let mut entities = Vec::new();
     for file_path in file_paths {
-        entities.extend(extract_file_entities(
-            &root.join(file_path),
-            registry,
-            file_path,
-        ));
+        match extract_file_entities(&root.join(file_path), registry, file_path) {
+            Ok(new_ents) => entities.extend(new_ents),
+            Err(e) => {
+                eprintln!(
+                    "{} Cannot read '{}': {}",
+                    "error:".red().bold(),
+                    file_path,
+                    e
+                );
+            }
+        }
     }
     entities
 }
@@ -131,19 +144,8 @@ fn extract_file_entities(
     full_path: &Path,
     registry: &ParserRegistry,
     file_path: &str,
-) -> Vec<SemanticEntity> {
-    let content = match std::fs::read_to_string(&full_path) {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!(
-                "{} Cannot read '{}': {}",
-                "error:".red().bold(),
-                file_path,
-                e
-            );
-            std::process::exit(1);
-        }
-    };
+) -> Result<Vec<SemanticEntity>, std::io::Error> {
+    let content = std::fs::read_to_string(&full_path)?;
 
     let plugin = match registry.get_plugin_with_content(file_path, &content) {
         Some(p) => p,
@@ -153,7 +155,7 @@ fn extract_file_entities(
         }
     };
 
-    plugin.extract_entities(&content, file_path)
+    Ok(plugin.extract_entities(&content, file_path))
 }
 
 fn entity_json(entity: &SemanticEntity, include_file: bool) -> serde_json::Value {

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -1,5 +1,6 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -178,7 +179,11 @@ impl SemServer {
         let mut entities = Vec::new();
         for rel_path in file_paths {
             let abs_path = root.join(rel_path);
-            let content = Self::read_file_at(&abs_path, rel_path)?;
+            let content = match std::fs::read_to_string(&abs_path) {
+                Ok(content) => content,
+                Err(err) if err.kind() == ErrorKind::InvalidData => continue,
+                Err(err) => return Err(format!("Failed to read {}: {}", rel_path, err)),
+            };
             entities.extend(self.cached_extract_entities(&content, rel_path).await);
         }
         Ok(entities)
@@ -575,8 +580,8 @@ impl SemServer {
                 let result: Vec<serde_json::Value> = deps
                     .iter()
                     .map(|d| serde_json::json!({
-                        "name": d.name, "type": d.entity_type,
-                        "file": d.file_path, "lines": [d.start_line, d.end_line],
+                            "name": d.name, "type": d.entity_type,
+                            "file": d.file_path, "lines": [d.start_line, d.end_line],
                     }))
                     .collect();
                 serde_json::json!({
@@ -591,8 +596,8 @@ impl SemServer {
                 let result: Vec<serde_json::Value> = deps
                     .iter()
                     .map(|d| serde_json::json!({
-                        "name": d.name, "type": d.entity_type,
-                        "file": d.file_path, "lines": [d.start_line, d.end_line],
+                            "name": d.name, "type": d.entity_type,
+                            "file": d.file_path, "lines": [d.start_line, d.end_line],
                     }))
                     .collect();
                 serde_json::json!({
@@ -607,8 +612,8 @@ impl SemServer {
                 let result: Vec<serde_json::Value> = tests
                     .iter()
                     .map(|d| serde_json::json!({
-                        "name": d.name, "type": d.entity_type,
-                        "file": d.file_path, "lines": [d.start_line, d.end_line],
+                            "name": d.name, "type": d.entity_type,
+                            "file": d.file_path, "lines": [d.start_line, d.end_line],
                     }))
                     .collect();
                 serde_json::json!({
@@ -628,10 +633,10 @@ impl SemServer {
 
                 let map_entities = |list: &[&sem_core::parser::graph::EntityInfo]| -> Vec<serde_json::Value> {
                     list.iter().map(|d| serde_json::json!({
-                        "name": d.name, "type": d.entity_type,
-                        "file": d.file_path, "lines": [d.start_line, d.end_line],
+                                    "name": d.name, "type": d.entity_type,
+                                    "file": d.file_path, "lines": [d.start_line, d.end_line],
                     })).collect()
-                };
+                    };
 
                 serde_json::json!({
                     "entity": params.entity_name,


### PR DESCRIPTION
When you run `sem context` on a directory, the whole command (or mcp command) fails if it contains any binary files. This fixes that issue. It still fails on single files.

Also my rust fmt is going haywire