### PR TITLE
Update tree-sitter-dart to 0.2.0

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1826,9 +1826,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-dart"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bba6bf8675e6fe92ba6da371a5497ee5df2a04d2c503e3599c8ad771f6f1faec"
+checksum = "325dd1e24ee9ee21111e9c43680ae7d6010aaa9f282b048a99b9c7163c1cf553"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/crates/sem-core/Cargo.toml
+++ b/crates/sem-core/Cargo.toml
@@ -34,7 +34,7 @@ tree-sitter-xml = "0.7"
 tree-sitter-embedded-template = "0.25"
 tree-sitter-ocaml = "0.24"
 tree-sitter-htmlx-svelte = "0.1.7"
-tree-sitter-dart = "0.1.0"
+tree-sitter-dart = "0.2.0"
 tree-sitter-perl-next = "0.1"
 tree-sitter-scala = "0.26"
 serde = { version = "1", features = ["derive"] }

--- a/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
+++ b/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
@@ -1089,6 +1089,21 @@ fn map_class_member_type(node: Node) -> &'static str {
     let mut cursor = node.walk();
     for child in node.named_children(&mut cursor) {
         match child.kind() {
+            "method_declaration" => {
+                if let Some(sig) = child.child_by_field_name("signature") {
+                    let mut inner = sig.walk();
+                    for inner_sig in sig.named_children(&mut inner) {
+                        return match inner_sig.kind() {
+                            "function_signature" => "method",
+                            "getter_signature" => "getter",
+                            "setter_signature" => "setter",
+                            "constructor_signature" | "factory_constructor_signature" => "constructor",
+                            "operator_signature" => "method",
+                            _ => continue,
+                        };
+                    }
+                }
+            }
             "method_signature" => {
                 let mut inner = child.walk();
                 for sig in child.named_children(&mut inner) {
@@ -1220,6 +1235,22 @@ fn walk_dart_class_member<T>(
     let mut cursor = node.walk();
     for child in node.named_children(&mut cursor) {
         match child.kind() {
+            "method_declaration" => {
+                if let Some(sig) = child.child_by_field_name("signature") {
+                    let mut inner = sig.walk();
+                    for inner_sig in sig.named_children(&mut inner) {
+                        if DART_CONSTRUCTOR_SIG_KINDS.contains(&inner_sig.kind()) {
+                            return resolve(inner_sig, source);
+                        }
+                        if let Some(name_node) = inner_sig.child_by_field_name("name") {
+                            return resolve(name_node, source);
+                        }
+                        if inner_sig.kind() == "operator_signature" {
+                            return resolve(inner_sig, source);
+                        }
+                    }
+                }
+            }
             "method_signature" | "declaration" => {
                 let mut inner = child.walk();
                 for sig in child.named_children(&mut inner) {

--- a/crates/sem-core/src/parser/plugins/code/mod.rs
+++ b/crates/sem-core/src/parser/plugins/code/mod.rs
@@ -1264,7 +1264,7 @@ set currentValue(int v) {
         );
         assert!(getter.unwrap().parent_id.is_none(), "Top-level getter should have no parent");
 
-        // tree-sitter-dart 0.1.0 parses top-level setters as function_signature
+        // tree-sitter-dart 0.2.0 parses top-level setters as function_signature
         // (treating `set` as a type_identifier). setter_signature is only
         // produced inside class_member → method_signature.
         let setter = entities.iter().find(|e| e.name == "currentValue" && e.entity_type == "function");


### PR DESCRIPTION
- Bumps `tree-sitter-dart` dependency from 0.1.0 to 0.2.0 in `Cargo.toml`.
- Updates AST entity extraction in `entity_extractor.rs` to handle the new `method_declaration` node that was introduced in the updated parser.
- Modifies comments in tests to accurately reflect the behavior of `tree-sitter-dart` 0.2.0.
