### PR TITLE
Fix native workspace tests for sem-plugin

### DIFF
--- a/crates/sem-plugin/Cargo.toml
+++ b/crates/sem-plugin/Cargo.toml
@@ -9,7 +9,13 @@ repository = "https://github.com/Ataraxy-Labs/sem"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[dependencies]
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+sem-core = { path = "../sem-core", default-features = false, features = ["wasm", "grammar-all"] }
+wit-bindgen = "0.40"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
 sem-core = { path = "../sem-core", default-features = false, features = ["wasm", "grammar-all"] }
 wit-bindgen = "0.40"
 serde = { version = "1", features = ["derive"] }

--- a/crates/sem-plugin/src/lib.rs
+++ b/crates/sem-plugin/src/lib.rs
@@ -4,35 +4,45 @@
 //! - `detect-changes`: extracts entities from before/after file content, diffs at entity level
 //! - `apply-changes`: reconstructs file bytes from entity snapshots
 
+#[cfg(any(target_arch = "wasm32", test))]
 wit_bindgen::generate!({
     path: "wit/lix-plugin.wit",
     world: "plugin",
 });
 
-use exports::lix::plugin::api::{
-    DetectStateContext, EntityChange, File, Guest, PluginError,
-};
+#[cfg(any(target_arch = "wasm32", test))]
+use exports::lix::plugin::api::{DetectStateContext, EntityChange, File, Guest, PluginError};
 
+#[cfg(any(target_arch = "wasm32", test))]
 use std::collections::HashMap;
+#[cfg(any(target_arch = "wasm32", test))]
 use std::sync::OnceLock;
 
+#[cfg(any(target_arch = "wasm32", test))]
 use sem_core::git::types::{FileChange, FileStatus};
+#[cfg(any(target_arch = "wasm32", test))]
 use sem_core::model::change::ChangeType;
+#[cfg(any(target_arch = "wasm32", test))]
 use sem_core::parser::differ::compute_semantic_diff;
+#[cfg(any(target_arch = "wasm32", test))]
 use sem_core::parser::plugins::create_default_registry;
+#[cfg(any(target_arch = "wasm32", test))]
 use sem_core::parser::registry::ParserRegistry;
 
 /// Cached registry — initialized once, reused across all detect_changes calls.
+#[cfg(any(target_arch = "wasm32", test))]
 fn registry() -> &'static ParserRegistry {
     static REGISTRY: OnceLock<ParserRegistry> = OnceLock::new();
     REGISTRY.get_or_init(create_default_registry)
 }
 
+#[cfg(any(target_arch = "wasm32", test))]
 struct SemPlugin;
 
-#[cfg(not(test))]
+#[cfg(target_arch = "wasm32")]
 export!(SemPlugin);
 
+#[cfg(any(target_arch = "wasm32", test))]
 impl Guest for SemPlugin {
     fn detect_changes(
         before: Option<File>,
@@ -42,13 +52,13 @@ impl Guest for SemPlugin {
         let after_str = String::from_utf8(after.data)
             .map_err(|e| PluginError::InvalidInput(format!("invalid UTF-8 in after: {e}")))?;
 
-        let before_str = match &before {
-            Some(f) => Some(
-                String::from_utf8(f.data.clone())
-                    .map_err(|e| PluginError::InvalidInput(format!("invalid UTF-8 in before: {e}")))?,
-            ),
-            None => None,
-        };
+        let before_str =
+            match &before {
+                Some(f) => Some(String::from_utf8(f.data.clone()).map_err(|e| {
+                    PluginError::InvalidInput(format!("invalid UTF-8 in before: {e}"))
+                })?),
+                None => None,
+            };
 
         let status = if before_str.is_none() {
             FileStatus::Added


### PR DESCRIPTION
## Summary
- Gate sem-plugin WIT generation, exports, and implementation behind wasm32 cfg
- Move sem-plugin dependencies to wasm32-only target dependencies
- Keep sem-plugin in the workspace while allowing native workspace tests to compile it without component exports

Closes #118

## Test plan
- cargo fmt --check -p sem-plugin
- cargo test --manifest-path crates/Cargo.toml --workspace --no-run
- cargo test --manifest-path crates/Cargo.toml --workspace
- npm test

## Notes
- Also attempted cargo check --manifest-path crates/Cargo.toml -p sem-plugin --target wasm32-wasip2; local WASI C sysroot is not configured, so tree-sitter C dependencies could not find stdlib.h/stdio.h.