### PR TITLE
Detect staged file renames in sem diff

### DIFF
--- a/crates/sem-core/src/git/bridge.rs
+++ b/crates/sem-core/src/git/bridge.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
-use git2::{Blame, Delta, Diff, DiffOptions, ErrorCode, Oid, Repository};
+use git2::{Blame, Delta, Diff, DiffFindOptions, DiffOptions, ErrorCode, Oid, Repository};
 use thiserror::Error;
 
 use super::types::{CommitInfo, DiffScope, FileChange, FileStatus};
@@ -132,11 +132,12 @@ impl GitBridge {
         };
 
         let mut opts = Self::make_diff_opts(pathspecs);
-        let diff = self.repo.diff_tree_to_index(
+        let mut diff = self.repo.diff_tree_to_index(
             head_tree.as_ref(),
             Some(&self.repo.index()?),
             Some(&mut opts),
         )?;
+        Self::detect_renames(&mut diff)?;
 
         Ok(self.diff_to_file_changes(&diff))
     }
@@ -145,7 +146,8 @@ impl GitBridge {
         let mut opts = Self::make_diff_opts(pathspecs);
         opts.include_untracked(false);
 
-        let diff = self.repo.diff_index_to_workdir(None, Some(&mut opts))?;
+        let mut diff = self.repo.diff_index_to_workdir(None, Some(&mut opts))?;
+        Self::detect_renames(&mut diff)?;
         Ok(self.diff_to_file_changes(&diff))
     }
 
@@ -161,11 +163,12 @@ impl GitBridge {
         };
 
         let mut opts = Self::make_diff_opts(pathspecs);
-        let diff = self.repo.diff_tree_to_tree(
+        let mut diff = self.repo.diff_tree_to_tree(
             parent_tree.as_ref(),
             Some(&tree),
             Some(&mut opts),
         )?;
+        Self::detect_renames(&mut diff)?;
 
         Ok(self.diff_to_file_changes(&diff))
     }
@@ -178,11 +181,12 @@ impl GitBridge {
         let to_tree = to_obj.peel_to_commit()?.tree()?;
 
         let mut opts = Self::make_diff_opts(pathspecs);
-        let diff = self.repo.diff_tree_to_tree(
+        let mut diff = self.repo.diff_tree_to_tree(
             Some(&from_tree),
             Some(&to_tree),
             Some(&mut opts),
         )?;
+        Self::detect_renames(&mut diff)?;
 
         Ok(self.diff_to_file_changes(&diff))
     }
@@ -190,11 +194,19 @@ impl GitBridge {
     fn get_ref_to_working_diff_files(&self, refspec: &str, pathspecs: &[String]) -> Result<Vec<FileChange>, GitError> {
         let tree = self.resolve_tree(refspec)?;
         let mut opts = Self::make_diff_opts(pathspecs);
-        let diff = self.repo.diff_tree_to_workdir_with_index(
+        let mut diff = self.repo.diff_tree_to_workdir_with_index(
             Some(&tree),
             Some(&mut opts),
         )?;
+        Self::detect_renames(&mut diff)?;
         Ok(self.diff_to_file_changes(&diff))
+    }
+
+    fn detect_renames(diff: &mut Diff) -> Result<(), GitError> {
+        let mut opts = DiffFindOptions::new();
+        opts.renames(true);
+        diff.find_similar(Some(&mut opts))?;
+        Ok(())
     }
 
     fn diff_to_file_changes(&self, diff: &Diff) -> Vec<FileChange> {
@@ -275,9 +287,13 @@ impl GitBridge {
                         file.after_content = self.read_working_file(&file.file_path);
                     }
                     if file.status != FileStatus::Added {
+                        let path = file
+                            .old_file_path
+                            .as_deref()
+                            .unwrap_or(&file.file_path);
                         file.before_content = head_tree
                             .as_ref()
-                            .and_then(|t| self.read_blob_from_tree(t, &file.file_path));
+                            .and_then(|t| self.read_blob_from_tree(t, path));
                     }
                 }
             }
@@ -290,9 +306,13 @@ impl GitBridge {
                             .or_else(|| self.read_working_file(&file.file_path));
                     }
                     if file.status != FileStatus::Added {
+                        let path = file
+                            .old_file_path
+                            .as_deref()
+                            .unwrap_or(&file.file_path);
                         file.before_content = head_tree
                             .as_ref()
-                            .and_then(|t| self.read_blob_from_tree(t, &file.file_path));
+                            .and_then(|t| self.read_blob_from_tree(t, path));
                     }
                 }
             }
@@ -306,9 +326,13 @@ impl GitBridge {
                             self.read_blob_from_tree(&after_tree, &file.file_path);
                     }
                     if file.status != FileStatus::Added {
+                        let path = file
+                            .old_file_path
+                            .as_deref()
+                            .unwrap_or(&file.file_path);
                         file.before_content = before_tree
                             .as_ref()
-                            .and_then(|t| self.read_blob_from_tree(t, &file.file_path));
+                            .and_then(|t| self.read_blob_from_tree(t, path));
                     }
                 }
             }
@@ -337,8 +361,12 @@ impl GitBridge {
                         file.after_content = self.read_working_file(&file.file_path);
                     }
                     if file.status != FileStatus::Added {
+                        let path = file
+                            .old_file_path
+                            .as_deref()
+                            .unwrap_or(&file.file_path);
                         file.before_content =
-                            self.read_blob_from_tree(&before_tree, &file.file_path);
+                            self.read_blob_from_tree(&before_tree, path);
                     }
                 }
             }
@@ -594,6 +622,9 @@ impl Drop for OwnerValidationDisabled {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::change::ChangeType;
+    use crate::parser::differ::compute_semantic_diff;
+    use crate::parser::plugins::create_default_registry;
     use git2::{ErrorClass, Oid, Repository, Signature};
     use tempfile::TempDir;
 
@@ -700,6 +731,82 @@ mod tests {
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].file_path, "sample.ts");
         assert_eq!(files[0].status, FileStatus::Modified);
+    }
+
+    #[test]
+    fn staged_file_rename_is_reported_as_single_rename_with_old_contents() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path()).unwrap();
+
+        let contents = "export function foo() {\n  return 1;\n}\n";
+        commit_file(&repo, "old.ts", contents, "init");
+
+        fs::rename(temp.path().join("old.ts"), temp.path().join("new.ts")).unwrap();
+        let mut index = repo.index().unwrap();
+        index.remove_path(Path::new("old.ts")).unwrap();
+        index.add_path(Path::new("new.ts")).unwrap();
+        index.write().unwrap();
+
+        let bridge = GitBridge::open(temp.path()).unwrap();
+        let files = bridge.get_changed_files(&DiffScope::Staged, &[]).unwrap();
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].status, FileStatus::Renamed);
+        assert_eq!(files[0].file_path, "new.ts");
+        assert_eq!(files[0].old_file_path.as_deref(), Some("old.ts"));
+        assert_eq!(files[0].before_content.as_deref(), Some(contents));
+        assert_eq!(files[0].after_content.as_deref(), Some(contents));
+    }
+
+    #[test]
+    fn staged_file_rename_with_edit_reports_single_moved_entity() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path()).unwrap();
+
+        let before = "\
+// shared header 01
+// shared header 02
+// shared header 03
+// shared header 04
+// shared header 05
+// shared header 06
+// shared header 07
+// shared header 08
+// shared header 09
+// shared header 10
+export function foo() {
+  return alpha + beta + gamma;
+}
+";
+        let after = before.replace(
+            "return alpha + beta + gamma;",
+            "return one + two + three;",
+        );
+
+        commit_file(&repo, "old.ts", before, "init");
+        fs::rename(temp.path().join("old.ts"), temp.path().join("new.ts")).unwrap();
+        fs::write(temp.path().join("new.ts"), &after).unwrap();
+
+        let mut index = repo.index().unwrap();
+        index.remove_path(Path::new("old.ts")).unwrap();
+        index.add_path(Path::new("new.ts")).unwrap();
+        index.write().unwrap();
+
+        let bridge = GitBridge::open(temp.path()).unwrap();
+        let files = bridge.get_changed_files(&DiffScope::Staged, &[]).unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].status, FileStatus::Renamed);
+
+        let registry = create_default_registry();
+        let result = compute_semantic_diff(&files, &registry, None, None);
+
+        assert_eq!(result.added_count, 0);
+        assert_eq!(result.deleted_count, 0);
+        assert_eq!(result.moved_count, 1);
+        assert_eq!(result.changes.len(), 1);
+        assert_eq!(result.changes[0].change_type, ChangeType::Moved);
+        assert_eq!(result.changes[0].entity_name, "foo");
+        assert_eq!(result.changes[0].old_file_path.as_deref(), Some("old.ts"));
     }
 
     #[test]

--- a/crates/sem-core/src/model/identity.rs
+++ b/crates/sem-core/src/model/identity.rs
@@ -52,6 +52,18 @@ fn classify_match(before: &SemanticEntity, after: &SemanticEntity) -> ChangeType
     }
 }
 
+fn same_signature_across_file_rename(
+    before: &SemanticEntity,
+    after: &SemanticEntity,
+    before_by_id: &HashMap<&str, &SemanticEntity>,
+    after_by_id: &HashMap<&str, &SemanticEntity>,
+) -> bool {
+    before.file_path != after.file_path
+        && before.entity_type == after.entity_type
+        && before.name == after.name
+        && parent_name(before, before_by_id) == parent_name(after, after_by_id)
+}
+
 fn make_change(
     after_entity: &SemanticEntity,
     change_type: ChangeType,
@@ -103,15 +115,16 @@ fn make_change(
     }
 }
 
-/// 3-phase entity matching algorithm:
+/// Entity matching algorithm:
 /// 1. Exact ID match — same entity ID in before/after → modified or unchanged
 /// 2. Content hash match — same hash, different ID → renamed or moved
-/// 3. Fuzzy similarity — >80% content similarity → probable rename
+/// 3. Same signature across file rename → moved, even if content changed
+/// 4. Fuzzy similarity — >80% content similarity → probable rename
 pub fn match_entities(
     before: &[SemanticEntity],
     after: &[SemanticEntity],
     _file_path: &str,
-    _similarity_fn: Option<&dyn Fn(&SemanticEntity, &SemanticEntity) -> f64>,
+    similarity_fn: Option<&dyn Fn(&SemanticEntity, &SemanticEntity) -> f64>,
     commit_sha: Option<&str>,
     author: Option<&str>,
 ) -> MatchResult {
@@ -213,7 +226,42 @@ pub fn match_entities(
         }
     }
 
-    // Phase 3: Fuzzy similarity (>80% threshold)
+    // Phase 3: Same logical signature across a file rename.
+    // A file path change changes entity IDs, so renamed files with edited
+    // entities need a signature fallback to avoid add/delete pairs.
+    for after_entity in &unmatched_after {
+        if matched_after.contains(after_entity.id.as_str()) {
+            continue;
+        }
+
+        let mut best_match: Option<&SemanticEntity> = None;
+        let mut best_score = f64::NEG_INFINITY;
+
+        for before_entity in &unmatched_before {
+            if matched_before.contains(before_entity.id.as_str()) {
+                continue;
+            }
+            if !same_signature_across_file_rename(before_entity, after_entity, &before_by_id, &after_by_id) {
+                continue;
+            }
+
+            let score = similarity_fn
+                .map(|f| f(before_entity, after_entity))
+                .unwrap_or_else(|| default_similarity(before_entity, after_entity));
+            if score > best_score {
+                best_score = score;
+                best_match = Some(before_entity);
+            }
+        }
+
+        if let Some(before_entity) = best_match {
+            matched_before.insert(&before_entity.id);
+            matched_after.insert(&after_entity.id);
+            changes.push(make_change(after_entity, classify_match(before_entity, after_entity), Some(before_entity), commit_sha, author, &combined_by_id));
+        }
+    }
+
+    // Phase 4: Fuzzy similarity (>80% threshold)
     // Optimized: pre-compute token sets once per entity, group by type
     let still_unmatched_before: Vec<&SemanticEntity> = unmatched_before
         .iter()
@@ -312,7 +360,7 @@ pub fn match_entities(
         }
     }
 
-    // Phase 4: Intra-file reorder detection
+    // Phase 5: Intra-file reorder detection
     // For entities that matched by exact ID with identical content (unchanged),
     // check if their relative ordering changed within the file.
     detect_reorders(before, after, &matched_before, &matched_after, &mut changes, commit_sha, author, &combined_by_id);
@@ -521,6 +569,28 @@ mod tests {
         let result = match_entities(&before, &after, "a.ts", None, None, None);
         assert_eq!(result.changes.len(), 1);
         assert_eq!(result.changes[0].change_type, ChangeType::Renamed);
+    }
+
+    #[test]
+    fn test_same_signature_file_rename_with_content_change_is_moved() {
+        let before = vec![make_entity(
+            "old.ts::function::foo",
+            "foo",
+            "export function foo() { return alpha + beta + gamma; }",
+            "old.ts",
+        )];
+        let after = vec![make_entity(
+            "new.ts::function::foo",
+            "foo",
+            "export function foo() { return one + two + three; }",
+            "new.ts",
+        )];
+
+        let result = match_entities(&before, &after, "new.ts", None, None, None);
+
+        assert_eq!(result.changes.len(), 1);
+        assert_eq!(result.changes[0].change_type, ChangeType::Moved);
+        assert_eq!(result.changes[0].old_file_path.as_deref(), Some("old.ts"));
     }
 
     #[test]

--- a/crates/sem-core/src/parser/differ.rs
+++ b/crates/sem-core/src/parser/differ.rs
@@ -441,6 +441,16 @@ mod tests {
         }
     }
 
+    fn renamed_file(old_path: &str, new_path: &str, before: &str, after: &str) -> FileChange {
+        FileChange {
+            file_path: new_path.to_string(),
+            status: FileStatus::Renamed,
+            old_file_path: Some(old_path.to_string()),
+            before_content: Some(before.to_string()),
+            after_content: Some(after.to_string()),
+        }
+    }
+
     #[test]
     fn test_parent_suppressed_when_only_child_modified() {
         let before = "class UserService:\n    def get_user(self, user_id):\n        return db.find(user_id)\n";
@@ -501,5 +511,26 @@ mod tests {
                 .any(|c| c.entity_name == "UserService" && c.change_type == ChangeType::Modified),
             "class should remain Modified when its own declaration changed, got: {names:?}"
         );
+    }
+
+    #[test]
+    fn renamed_file_with_edited_entity_reports_move_not_add_delete() {
+        let before = "def foo():\n    return alpha + beta + gamma\n";
+        let after = "def foo():\n    return one + two + three\n";
+
+        let registry = create_default_registry();
+        let result = compute_semantic_diff(
+            &[renamed_file("old.py", "new.py", before, after)],
+            &registry,
+            None,
+            None,
+        );
+
+        assert_eq!(result.added_count, 0);
+        assert_eq!(result.deleted_count, 0);
+        assert_eq!(result.moved_count, 1);
+        assert_eq!(result.changes.len(), 1);
+        assert_eq!(result.changes[0].entity_name, "foo");
+        assert_eq!(result.changes[0].old_file_path.as_deref(), Some("old.py"));
     }
 }


### PR DESCRIPTION
## Summary
- enable libgit2 rename detection before converting diffs into FileChange values
- load before_content from old_file_path for renamed files
- keep same-signature entities paired across renamed files even when the entity body changes

Closes #117

## Test plan
- cargo test -p sem-core git::bridge::tests::staged_file_rename_with_edit_reports_single_moved_entity --manifest-path crates/Cargo.toml
- cargo test -p sem-core --lib --manifest-path crates/Cargo.toml
- cargo test --workspace --exclude sem-plugin --manifest-path crates/Cargo.toml
- manual CLI repro: staged git mv reports moved: 1 with oldPath instead of add/delete
- manual CLI repro: staged git mv plus edited entity reports moved: 1 with oldPath instead of add/delete

Note: cargo test --workspace --manifest-path crates/Cargo.toml was attempted, but local sem-plugin linking fails with undefined _cabi_post_lix/_lix symbols on this machine before completing. The non-plugin workspace suite passes.