### PR TITLE
Improve the flake setup

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -42,4 +42,12 @@ pkgs.rustPlatform.buildRustPackage rec {
   #     --fish ./autocompletion/${pname}.fish \
   #     --zsh  ./autocompletion/_${pname}
   # '';
+
+  meta = {
+    description = "Semantic version control CLI";
+    homepage = "https://github.com/Ataraxy-Labs/sem";
+    license = with lib.licenses; [mit asl20];
+    mainProgram = "sem";
+    platforms = lib.platforms.unix;
+  };
 }

--- a/package.nix
+++ b/package.nix
@@ -17,6 +17,11 @@ pkgs.rustPlatform.buildRustPackage rec {
       # "dummy-0.14.0" = lib.fakeHash;
     };
   };
+  cargoBuildFlags = [
+    "--package"
+    "sem-cli"
+  ];
+  cargoTestFlags = cargoBuildFlags;
 
   # disable tests
   checkType = "debug";


### PR DESCRIPTION
Adds a meta section to set mainProgram, needed as per https://github.com/NixOS/nixpkgs/blob/b0353eaef17eec676c6633525c263be393f9818b/lib/meta.nix#L534

Also fixes the build to only target `sem-cli`, while the WASM situation gets sorted out.