### PR TITLE
Fix 6 deferred issues from Iron-Ham audit (#139, #140, #147, #148, #160, #161)

### DIFF
--- a/crates/sem-cli/src/commands/log.rs
+++ b/crates/sem-cli/src/commands/log.rs
@@ -24,6 +24,7 @@ enum EntityChangeType {
     Deleted,
     Moved,
     Reappeared,
+    Renamed,
 }
 
 impl EntityChangeType {
@@ -35,6 +36,7 @@ impl EntityChangeType {
             EntityChangeType::Deleted => "deleted",
             EntityChangeType::Moved => "moved",
             EntityChangeType::Reappeared => "reappeared",
+            EntityChangeType::Renamed => "renamed",
         }
     }
 
@@ -46,6 +48,7 @@ impl EntityChangeType {
             EntityChangeType::Deleted => "deleted".red(),
             EntityChangeType::Moved => "moved".blue(),
             EntityChangeType::Reappeared => "reappeared".green(),
+            EntityChangeType::Renamed => "renamed".cyan(),
         }
     }
 }
@@ -128,194 +131,206 @@ pub fn log_command(opts: LogOptions) {
         std::process::exit(1);
     }
 
-    // Walk commits, tracking entity across file moves
-    let mut current_git_file = git_file_path.clone();
+    // Walk commits, tracking entity across file moves and renames.
+    // Uses follow-renames to automatically track file renames in git history.
+    let commits = match bridge.get_file_commits_follow_renames(&git_file_path, opts.limit) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("{} Failed to get file history: {}", "error:".red().bold(), e);
+            std::process::exit(1);
+        }
+    };
+
+    if commits.is_empty() {
+        eprintln!("{} No commits found for {}", "warning:".yellow().bold(), git_file_path);
+        return;
+    }
+
     let mut entries: Vec<LogEntry> = Vec::new();
     let mut prev_entity_content: Option<String> = None;
     let mut prev_structural_hash: Option<String> = None;
     let mut entity_type = String::new();
     let mut found_at_least_once = false;
-    let mut total_commits = 0usize;
-    let mut skip_until_sha: Option<String> = None;
+    let mut tracked_entity_name = opts.entity_name.clone();
+    let total_commits = commits.len();
 
-    loop {
-        let commits = match bridge.get_file_commits(&current_git_file, opts.limit) {
-            Ok(c) => c,
-            Err(e) => {
-                if total_commits == 0 {
-                    eprintln!("{} Failed to get file history: {}", "error:".red().bold(), e);
-                    std::process::exit(1);
+    // Process commits oldest-first
+    let reversed: Vec<_> = commits.iter().rev().collect();
+
+    for fci in &reversed {
+        let commit = &fci.commit;
+        let current_git_file = &fci.file_path;
+
+        let file_content = bridge
+            .read_file_at_ref(&commit.sha, current_git_file)
+            .ok()
+            .flatten();
+
+        let found_entity = file_content.as_ref().and_then(|c| {
+            let entities = registry.extract_entities(current_git_file, c);
+            entities.into_iter().find(|e| e.name == tracked_entity_name)
+        });
+
+        let date = chrono_lite_format(commit.date.parse::<i64>().unwrap_or(0));
+        let msg_first_line = commit.message.lines().next().unwrap_or("").to_string();
+
+        match found_entity {
+            Some(ent) => {
+                if !found_at_least_once {
+                    entity_type = ent.entity_type.clone();
                 }
-                break;
-            }
-        };
 
-        if commits.is_empty() && total_commits == 0 {
-            eprintln!("{} No commits found for {}", "warning:".yellow().bold(), current_git_file);
-            return;
-        }
+                let cur_content_hash = &ent.content_hash;
+                let cur_structural_hash = ent.structural_hash.as_deref();
 
-        let reversed: Vec<_> = commits.iter().rev().collect();
+                if !found_at_least_once {
+                    found_at_least_once = true;
+                    entries.push(LogEntry {
+                        sha: commit.sha.clone(),
+                        short_sha: commit.short_sha.clone(),
+                        author: commit.author.clone(),
+                        date,
+                        message: msg_first_line,
+                        change_type: EntityChangeType::Added,
+                        content: Some(ent.content.clone()),
+                        prev_content: None,
+                        file_path: Some(current_git_file.clone()),
+                        prev_file_path: None,
+                    });
+                } else if prev_entity_content.is_none() {
+                    entries.push(LogEntry {
+                        sha: commit.sha.clone(),
+                        short_sha: commit.short_sha.clone(),
+                        author: commit.author.clone(),
+                        date,
+                        message: msg_first_line,
+                        change_type: EntityChangeType::Reappeared,
+                        content: Some(ent.content.clone()),
+                        prev_content: None,
+                        file_path: Some(current_git_file.clone()),
+                        prev_file_path: None,
+                    });
+                } else {
+                    let prev_hash = prev_entity_content
+                        .as_ref()
+                        .map(|c| sem_core::utils::hash::content_hash(c));
+                    let content_changed =
+                        prev_hash.as_deref() != Some(cur_content_hash.as_str());
 
-        // After a file move, skip commits until the move commit
-        let start_idx = if let Some(ref sha) = skip_until_sha {
-            reversed
-                .iter()
-                .position(|c| c.sha == *sha)
-                .map(|i| i + 1)
-                .unwrap_or(reversed.len())
-        } else {
-            0
-        };
-        skip_until_sha = None;
-
-        total_commits += reversed.len().saturating_sub(start_idx);
-        let mut moved = false;
-
-        for commit in &reversed[start_idx..] {
-            let file_content = bridge
-                .read_file_at_ref(&commit.sha, &current_git_file)
-                .ok()
-                .flatten();
-
-            let found_entity = file_content.as_ref().and_then(|c| {
-                let entities = registry.extract_entities(&current_git_file, c);
-                entities.into_iter().find(|e| e.name == opts.entity_name)
-            });
-
-            let date = chrono_lite_format(commit.date.parse::<i64>().unwrap_or(0));
-            let msg_first_line = commit.message.lines().next().unwrap_or("").to_string();
-
-            match found_entity {
-                Some(ent) => {
-                    if !found_at_least_once {
-                        entity_type = ent.entity_type.clone();
-                    }
-
-                    let cur_content_hash = &ent.content_hash;
-                    let cur_structural_hash = ent.structural_hash.as_deref();
-
-                    if !found_at_least_once {
-                        found_at_least_once = true;
-                        entries.push(LogEntry {
-                            sha: commit.sha.clone(),
-                            short_sha: commit.short_sha.clone(),
-                            author: commit.author.clone(),
-                            date,
-                            message: msg_first_line,
-                            change_type: EntityChangeType::Added,
-                            content: Some(ent.content.clone()),
-                            prev_content: None,
-                            file_path: Some(current_git_file.clone()),
-                            prev_file_path: None,
-                        });
-                    } else if prev_entity_content.is_none() {
-                        entries.push(LogEntry {
-                            sha: commit.sha.clone(),
-                            short_sha: commit.short_sha.clone(),
-                            author: commit.author.clone(),
-                            date,
-                            message: msg_first_line,
-                            change_type: EntityChangeType::Reappeared,
-                            content: Some(ent.content.clone()),
-                            prev_content: None,
-                            file_path: Some(current_git_file.clone()),
-                            prev_file_path: None,
-                        });
-                    } else {
-                        let prev_hash = prev_entity_content
-                            .as_ref()
-                            .map(|c| sem_core::utils::hash::content_hash(c));
-                        let content_changed =
-                            prev_hash.as_deref() != Some(cur_content_hash.as_str());
-
-                        if content_changed {
-                            let structural_changed =
-                                match (cur_structural_hash, prev_structural_hash.as_deref()) {
-                                    (Some(cur), Some(prev)) => cur != prev,
-                                    _ => true,
-                                };
-                            let change_type = if structural_changed {
-                                EntityChangeType::ModifiedLogic
-                            } else {
-                                EntityChangeType::ModifiedCosmetic
+                    if content_changed {
+                        let structural_changed =
+                            match (cur_structural_hash, prev_structural_hash.as_deref()) {
+                                (Some(cur), Some(prev)) => cur != prev,
+                                _ => true,
                             };
+                        let change_type = if structural_changed {
+                            EntityChangeType::ModifiedLogic
+                        } else {
+                            EntityChangeType::ModifiedCosmetic
+                        };
+                        entries.push(LogEntry {
+                            sha: commit.sha.clone(),
+                            short_sha: commit.short_sha.clone(),
+                            author: commit.author.clone(),
+                            date,
+                            message: msg_first_line,
+                            change_type,
+                            content: Some(ent.content.clone()),
+                            prev_content: prev_entity_content.clone(),
+                            file_path: Some(current_git_file.clone()),
+                            prev_file_path: None,
+                        });
+                    }
+                }
+
+                prev_entity_content = Some(ent.content.clone());
+                prev_structural_hash = ent.structural_hash.clone();
+            }
+            None => {
+                // Entity not found by name. Before cross-file search,
+                // try same-file structural hash fallback to detect renames.
+                if let Some(ref prev_shash) = prev_structural_hash {
+                    let renamed_entity = file_content.as_ref().and_then(|c| {
+                        let entities = registry.extract_entities(current_git_file, c);
+                        entities.into_iter().find(|e| {
+                            e.structural_hash.as_deref() == Some(prev_shash.as_str())
+                        })
+                    });
+
+                    if let Some(ent) = renamed_entity {
+                        // Entity was renamed within the same file
+                        entries.push(LogEntry {
+                            sha: commit.sha.clone(),
+                            short_sha: commit.short_sha.clone(),
+                            author: commit.author.clone(),
+                            date,
+                            message: msg_first_line,
+                            change_type: EntityChangeType::Renamed,
+                            content: Some(ent.content.clone()),
+                            prev_content: prev_entity_content.clone(),
+                            file_path: Some(current_git_file.clone()),
+                            prev_file_path: None,
+                        });
+
+                        // Update tracked name to continue backward traversal
+                        tracked_entity_name = ent.name.clone();
+                        prev_entity_content = Some(ent.content.clone());
+                        prev_structural_hash = ent.structural_hash.clone();
+                        if !found_at_least_once {
+                            entity_type = ent.entity_type.clone();
+                            found_at_least_once = true;
+                        }
+                        continue;
+                    }
+                }
+
+                // Try cross-file search
+                if prev_entity_content.is_some() {
+                    let cross = search_entity_cross_file(
+                        &bridge,
+                        &registry,
+                        &commit.sha,
+                        &tracked_entity_name,
+                        prev_structural_hash.as_deref(),
+                        current_git_file,
+                    );
+
+                    match cross {
+                        Some((new_file, ent)) => {
                             entries.push(LogEntry {
                                 sha: commit.sha.clone(),
                                 short_sha: commit.short_sha.clone(),
                                 author: commit.author.clone(),
                                 date,
                                 message: msg_first_line,
-                                change_type,
+                                change_type: EntityChangeType::Moved,
                                 content: Some(ent.content.clone()),
                                 prev_content: prev_entity_content.clone(),
+                                file_path: Some(new_file),
+                                prev_file_path: Some(current_git_file.clone()),
+                            });
+
+                            prev_entity_content = Some(ent.content.clone());
+                            prev_structural_hash = ent.structural_hash.clone();
+                        }
+                        None => {
+                            entries.push(LogEntry {
+                                sha: commit.sha.clone(),
+                                short_sha: commit.short_sha.clone(),
+                                author: commit.author.clone(),
+                                date,
+                                message: msg_first_line,
+                                change_type: EntityChangeType::Deleted,
+                                content: None,
+                                prev_content: prev_entity_content.take(),
                                 file_path: Some(current_git_file.clone()),
                                 prev_file_path: None,
                             });
-                        }
-                    }
-
-                    prev_entity_content = Some(ent.content.clone());
-                    prev_structural_hash = ent.structural_hash.clone();
-                }
-                None => {
-                    // Entity not in tracked file. Try cross-file search.
-                    if prev_entity_content.is_some() {
-                        let cross = search_entity_cross_file(
-                            &bridge,
-                            &registry,
-                            &commit.sha,
-                            &opts.entity_name,
-                            prev_structural_hash.as_deref(),
-                            &current_git_file,
-                        );
-
-                        match cross {
-                            Some((new_file, ent)) => {
-                                let prev_file = current_git_file.clone();
-                                entries.push(LogEntry {
-                                    sha: commit.sha.clone(),
-                                    short_sha: commit.short_sha.clone(),
-                                    author: commit.author.clone(),
-                                    date,
-                                    message: msg_first_line,
-                                    change_type: EntityChangeType::Moved,
-                                    content: Some(ent.content.clone()),
-                                    prev_content: prev_entity_content.clone(),
-                                    file_path: Some(new_file.clone()),
-                                    prev_file_path: Some(prev_file),
-                                });
-
-                                prev_entity_content = Some(ent.content.clone());
-                                prev_structural_hash = ent.structural_hash.clone();
-                                skip_until_sha = Some(commit.sha.clone());
-                                current_git_file = new_file;
-                                moved = true;
-                                break;
-                            }
-                            None => {
-                                entries.push(LogEntry {
-                                    sha: commit.sha.clone(),
-                                    short_sha: commit.short_sha.clone(),
-                                    author: commit.author.clone(),
-                                    date,
-                                    message: msg_first_line,
-                                    change_type: EntityChangeType::Deleted,
-                                    content: None,
-                                    prev_content: prev_entity_content.take(),
-                                    file_path: Some(current_git_file.clone()),
-                                    prev_file_path: None,
-                                });
-                                prev_structural_hash = None;
-                            }
+                            prev_structural_hash = None;
                         }
                     }
                 }
             }
-        }
-
-        if !moved {
-            break;
         }
     }
 
@@ -405,6 +420,14 @@ fn print_terminal(
                     format!("→ moved to {}", new_fp).blue()
                 );
             }
+        }
+
+        // Show rename info
+        if matches!(entry.change_type, EntityChangeType::Renamed) {
+            println!(
+                "│    {}",
+                "→ entity renamed (structural hash match)".cyan()
+            );
         }
 
         if verbose {

--- a/crates/sem-core/src/git/bridge.rs
+++ b/crates/sem-core/src/git/bridge.rs
@@ -6,7 +6,7 @@ use std::sync::{Mutex, OnceLock};
 use git2::{Blame, Delta, Diff, DiffFindOptions, DiffOptions, ErrorCode, Oid, Repository};
 use thiserror::Error;
 
-use super::types::{CommitInfo, DiffScope, FileChange, FileStatus};
+use super::types::{CommitInfo, DiffScope, FileChange, FileCommitInfo, FileStatus};
 
 #[derive(Error, Debug)]
 pub enum GitError {
@@ -472,6 +472,111 @@ impl GitBridge {
         }
 
         Ok(commits)
+    }
+
+    /// Get commits that modified a specific file, following renames across history.
+    /// Like `git log --follow`: when the tracked path disappears between commits,
+    /// compute a diff with rename detection to find the old filename and continue.
+    /// Returns commits in reverse chronological order (newest first).
+    pub fn get_file_commits_follow_renames(
+        &self,
+        file_path: &str,
+        limit: usize,
+    ) -> Result<Vec<FileCommitInfo>, GitError> {
+        let mut revwalk = self.repo.revwalk()?;
+        revwalk.push_head()?;
+        revwalk.set_sorting(git2::Sort::TIME)?;
+
+        let mut results = Vec::new();
+        let mut tracked_path = file_path.to_string();
+
+        for oid_result in revwalk {
+            let oid = oid_result?;
+            let commit = self.repo.find_commit(oid)?;
+            let tree = commit.tree()?;
+
+            let path = Path::new(&tracked_path);
+            let file_in_commit = tree.get_path(path).ok().map(|e| e.id());
+
+            let (parent_tree_opt, file_in_parent) = if commit.parent_count() > 0 {
+                let parent = commit.parent(0)?;
+                let ptree = parent.tree()?;
+                let fip = ptree.get_path(path).ok().map(|e| e.id());
+                (Some(ptree), fip)
+            } else {
+                (None, None)
+            };
+
+            let changed = match (file_in_commit, file_in_parent) {
+                (Some(cur), Some(prev)) => cur != prev,
+                (Some(_), None) => true,
+                (None, Some(_)) => true,
+                (None, None) => false,
+            };
+
+            if changed {
+                let sha_str = oid.to_string();
+                results.push(FileCommitInfo {
+                    commit: CommitInfo {
+                        short_sha: sha_str[..7.min(sha_str.len())].to_string(),
+                        sha: sha_str,
+                        author: commit.author().name().unwrap_or("unknown").to_string(),
+                        date: commit.time().seconds().to_string(),
+                        message: commit.message().unwrap_or("").to_string(),
+                    },
+                    file_path: tracked_path.clone(),
+                });
+
+                if results.len() >= limit {
+                    break;
+                }
+            }
+
+            // If the file is not in this commit's tree, check if it was renamed.
+            // Compute diff between parent and this commit with rename detection.
+            if file_in_commit.is_none() && parent_tree_opt.is_some() {
+                let mut diff = self.repo.diff_tree_to_tree(
+                    parent_tree_opt.as_ref(),
+                    Some(&tree),
+                    None,
+                )?;
+                let mut find_opts = DiffFindOptions::new();
+                find_opts.renames(true);
+                diff.find_similar(Some(&mut find_opts))?;
+
+                let mut found_rename = false;
+                for delta in diff.deltas() {
+                    if delta.status() == Delta::Renamed {
+                        let new_path = delta
+                            .new_file()
+                            .path()
+                            .and_then(|p| p.to_str())
+                            .unwrap_or("");
+                        if new_path == tracked_path {
+                            // The tracked file was renamed FROM old_path
+                            let old_path = delta
+                                .old_file()
+                                .path()
+                                .and_then(|p| p.to_str())
+                                .unwrap_or("")
+                                .to_string();
+                            if !old_path.is_empty() {
+                                tracked_path = old_path;
+                                found_rename = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                if !found_rename {
+                    // File truly deleted, stop tracking
+                    break;
+                }
+            }
+        }
+
+        Ok(results)
     }
 
     /// Get all file paths changed in a single commit (vs its parent).

--- a/crates/sem-core/src/git/types.rs
+++ b/crates/sem-core/src/git/types.rs
@@ -40,3 +40,11 @@ pub struct CommitInfo {
     pub date: String,
     pub message: String,
 }
+
+/// A commit together with the file path that was active at that commit.
+/// Used by `get_file_commits_follow_renames` to track files across renames.
+#[derive(Debug, Clone)]
+pub struct FileCommitInfo {
+    pub commit: CommitInfo,
+    pub file_path: String,
+}

--- a/crates/sem-core/src/model/entity.rs
+++ b/crates/sem-core/src/model/entity.rs
@@ -35,6 +35,18 @@ pub fn build_entity_id(
     }
 }
 
+/// Build an entity ID with a line-number disambiguator for overloads.
+pub fn build_entity_id_disambiguated(
+    file_path: &str,
+    entity_type: &str,
+    name: &str,
+    parent_id: Option<&str>,
+    line: usize,
+) -> String {
+    let base = build_entity_id(file_path, entity_type, name, parent_id);
+    format!("{base}@L{line}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
+++ b/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
@@ -1,6 +1,7 @@
 use tree_sitter::{Node, Tree};
 
-use crate::model::entity::{build_entity_id, SemanticEntity};
+use std::collections::HashMap;
+use crate::model::entity::{build_entity_id, build_entity_id_disambiguated, SemanticEntity};
 use crate::utils::hash::{content_hash, structural_hash, structural_hash_excluding_range};
 use super::languages::LanguageConfig;
 
@@ -20,6 +21,30 @@ pub fn extract_entities(
         source_code.as_bytes(),
         None,
     );
+
+    // Post-pass: disambiguate colliding entity IDs by appending @L{line}.
+    // Two overloads with the same name (e.g. function overloads in C++/TS)
+    // get identical IDs; re-assign all colliding entries with line suffixes.
+    let mut id_indices: HashMap<String, Vec<usize>> = HashMap::new();
+    for (i, entity) in entities.iter().enumerate() {
+        id_indices.entry(entity.id.clone()).or_default().push(i);
+    }
+    for (_id, indices) in &id_indices {
+        if indices.len() > 1 {
+            for &idx in indices {
+                let e = &entities[idx];
+                let new_id = build_entity_id_disambiguated(
+                    &e.file_path,
+                    &e.entity_type,
+                    &e.name,
+                    e.parent_id.as_deref(),
+                    e.start_line,
+                );
+                entities[idx].id = new_id;
+            }
+        }
+    }
+
     entities
 }
 
@@ -156,7 +181,8 @@ fn visit_node(
                 .filter(|c| c.kind() == "variable_declarator")
                 .collect();
             if declarators.len() > 1 {
-                let should_skip = should_skip_entity(config, suppression_context, node_type);
+                let should_skip = should_skip_entity(config, suppression_context, node_type)
+                    && promote_js_ts_const_function(node, config).is_none();
                 if !should_skip {
                     for declarator in &declarators {
                         if let Some(name_node) = declarator.child_by_field_name("name") {
@@ -240,11 +266,53 @@ fn visit_node(
             }
         }
 
+        // JS/TS test call expressions: describe("name", () => {}), test(...), it(...), etc.
+        if node_type == "call_expression" && matches!(config.id, "typescript" | "tsx" | "javascript") {
+            if let Some((test_name, test_entity_type, is_container)) =
+                extract_js_test_call(node, source)
+            {
+                let content_str = node_text(node, source);
+                let content = content_str.to_string();
+                let struct_hash = compute_structural_hash(node, source);
+                let entity = SemanticEntity {
+                    id: build_entity_id(file_path, test_entity_type, &test_name, parent_id),
+                    file_path: file_path.to_string(),
+                    entity_type: test_entity_type.to_string(),
+                    name: test_name.clone(),
+                    parent_id: parent_id.map(String::from),
+                    content_hash: content_hash(&content),
+                    structural_hash: Some(struct_hash),
+                    content,
+                    start_line: node.start_position().row + 1,
+                    end_line: node.end_position().row + 1,
+                    metadata: None,
+                };
+
+                let entity_id = entity.id.clone();
+                entities.push(entity);
+
+                if is_container {
+                    // Recurse into the callback body to extract nested test entities
+                    if let Some(callback) = find_test_callback(node) {
+                        if let Some(body) = callback.child_by_field_name("body") {
+                            let mut cursor = body.walk();
+                            let nested: Vec<_> = body.named_children(&mut cursor).collect();
+                            for n in nested.into_iter().rev() {
+                                worklist.push((n, Some(entity_id.clone()), sup_owned.clone()));
+                            }
+                        }
+                    }
+                }
+                continue;
+            }
+        }
+
         if config.entity_node_types.contains(&node_type) {
             if let Some(name) = extract_name(node, source) {
                 let name = qualify_hcl_name(&name, node_type, parent_id, suppression_context);
                 let entity_type = map_entity_type(node, config);
-                let should_skip = should_skip_entity(config, suppression_context, node_type);
+                let should_skip = should_skip_entity(config, suppression_context, node_type)
+                    && promote_js_ts_const_function(node, config).is_none();
                 if !should_skip {
                     // Go method_declaration: extract receiver type for parent linkage.
                     // e.g. `func (t *Transaction) Execute(...)` -> parent is Transaction struct
@@ -1627,4 +1695,80 @@ fn extract_go_receiver_struct(
         }
     }
     None
+}
+
+/// Check if a JS/TS call_expression is a test framework call (describe, test, it, etc.).
+/// Returns (name, entity_type, is_container) if matched.
+fn extract_js_test_call(node: Node, source: &[u8]) -> Option<(String, &'static str, bool)> {
+    let func = node.child_by_field_name("function")?;
+    let (callee_name, _modifier) = match func.kind() {
+        "identifier" => {
+            let name = node_text(func, source);
+            (name, None)
+        }
+        "member_expression" => {
+            // describe.skip, test.only, it.each, etc.
+            let obj = func.child_by_field_name("object")?;
+            let prop = func.child_by_field_name("property")?;
+            if obj.kind() != "identifier" {
+                return None;
+            }
+            (node_text(obj, source), Some(node_text(prop, source)))
+        }
+        _ => return None,
+    };
+
+    let (entity_type, is_container) = match callee_name {
+        "describe" => ("test_suite", true),
+        "test" | "it" => ("test", false),
+        "beforeEach" | "afterEach" | "beforeAll" | "afterAll" => ("test_hook", false),
+        _ => return None,
+    };
+
+    // Extract the test name from the first string argument
+    let mut cursor = node.walk();
+    let args = node
+        .named_children(&mut cursor)
+        .find(|c| c.kind() == "arguments")?;
+
+    let mut args_cursor = args.walk();
+    let first_arg = args.named_children(&mut args_cursor).next()?;
+
+    let test_name = match first_arg.kind() {
+        "string" | "template_string" => {
+            let text = node_text(first_arg, source);
+            text.trim_matches(|c: char| c == '\'' || c == '"' || c == '`')
+                .to_string()
+        }
+        _ => {
+            // Hooks like beforeEach don't need a string name
+            if matches!(callee_name, "beforeEach" | "afterEach" | "beforeAll" | "afterAll") {
+                callee_name.to_string()
+            } else {
+                return None;
+            }
+        }
+    };
+
+    Some((test_name, entity_type, is_container))
+}
+
+/// Find the callback function argument in a test call (the second argument).
+fn find_test_callback(node: Node) -> Option<Node> {
+    let mut cursor = node.walk();
+    let args = node
+        .named_children(&mut cursor)
+        .find(|c| c.kind() == "arguments")?;
+    let mut args_cursor = args.walk();
+    let mut children = args.named_children(&mut args_cursor);
+    children.next(); // skip the first argument (name string)
+    let callback = children.next()?;
+    if matches!(
+        callback.kind(),
+        "arrow_function" | "function_expression" | "generator_function"
+    ) {
+        Some(callback)
+    } else {
+        None
+    }
 }

--- a/crates/sem-core/src/parser/scope_resolve.rs
+++ b/crates/sem-core/src/parser/scope_resolve.rs
@@ -604,6 +604,57 @@ fn build_scopes_from_ast(
             }
         }
 
+        // Rust mod_item: create a module scope so nested functions resolve
+        // names from the parent scope (e.g. super::target() walks up correctly).
+        if kind == "mod_item" {
+            let mod_name = node
+                .child_by_field_name("name")
+                .and_then(|n| n.utf8_text(source).ok())
+                .unwrap_or("");
+            let mod_scope_idx = scopes.len();
+            scopes.push(Scope {
+                parent: Some(current_scope),
+                defs: HashMap::new(),
+                types: HashMap::new(),
+                pending_call_types: HashMap::new(),
+                owner_id: None,
+                kind: "module",
+            });
+
+            // Register any entities that are children of this module
+            let mod_entity = file_entities.iter().find(|e| {
+                e.name == mod_name
+                    && e.entity_type == "module"
+                    && {
+                        let line = node.start_position().row + 1;
+                        e.start_line <= line && line <= e.end_line
+                    }
+            }).copied();
+
+            if let Some(me) = mod_entity {
+                scopes[mod_scope_idx].owner_id = Some(me.id.clone());
+                entity_scope_map.entry(me.id.clone()).or_insert(current_scope);
+                entity_inner_scope.insert(me.id.clone(), mod_scope_idx);
+
+                // Register child entities in the module scope
+                if let Some(children) = children_by_parent.get(me.id.as_str()) {
+                    for child_entity in children {
+                        scopes[mod_scope_idx]
+                            .defs
+                            .insert(child_entity.name.clone(), child_entity.id.clone());
+                        entity_scope_map.insert(child_entity.id.clone(), mod_scope_idx);
+                    }
+                }
+            }
+
+            let mut cursor = node.walk();
+            let children: Vec<_> = node.named_children(&mut cursor).collect();
+            for child in children.into_iter().rev() {
+                worklist.push((child, mod_scope_idx));
+            }
+            continue;
+        }
+
         // Function-like scope: config-driven
         let is_function_like = config.function_scope_nodes.contains(&kind);
 
@@ -1971,6 +2022,11 @@ fn extract_imports_from_ast(
                     extract_python_import(child, file_path, source, symbol_table, entity_map, import_table, scopes);
                     true
                 }
+                "import_statement" if config.self_keywords.contains(&"self") && config.self_keywords.contains(&"cls") => {
+                    // Python: `import mod` or `import mod as m`
+                    extract_python_module_import(child, file_path, source, symbol_table, entity_map, import_table, scopes);
+                    true
+                }
                 "import_statement" if !config.self_keywords.contains(&"cls") => {
                     // TS import_statement (not Python - Python uses import_from_statement)
                     extract_ts_import(child, file_path, source, symbol_table, entity_map, import_table, scopes);
@@ -2048,6 +2104,21 @@ fn extract_ts_import(
                                 resolve_import_name(original, local, source_module, file_path, symbol_table, entity_map, import_table, scopes);
                             }
                         }
+                    }
+                } else if clause_child.kind() == "namespace_import" {
+                    // import * as m from './module'
+                    // Register all entities from source module so m.foo() resolves
+                    let mut ns_cursor = clause_child.walk();
+                    let alias = clause_child
+                        .child_by_field_name("alias")
+                        .or_else(|| {
+                            clause_child.named_children(&mut ns_cursor)
+                                .find(|c| c.kind() == "identifier")
+                        })
+                        .and_then(|n| n.utf8_text(source).ok())
+                        .unwrap_or("");
+                    if !alias.is_empty() {
+                        register_namespace_import(alias, source_module, file_path, symbol_table, entity_map, import_table, scopes);
                     }
                 } else if clause_child.kind() == "identifier" {
                     // Default import: import Foo from './module'
@@ -2249,6 +2320,50 @@ fn resolve_import_name(
     }
 }
 
+/// Register all entities from a source module under a namespace alias.
+/// For `import * as m from './module'`, all entities from the module
+/// are registered so that `m.foo()` resolves via the method call path.
+fn register_namespace_import(
+    alias: &str,
+    source_module: &str,
+    file_path: &str,
+    symbol_table: &HashMap<String, Vec<String>>,
+    entity_map: &HashMap<String, EntityInfo>,
+    import_table: &mut HashMap<(String, String), String>,
+    scopes: &mut Vec<Scope>,
+) {
+    // Find all entities whose file matches the source_module stem
+    for (name, target_ids) in symbol_table {
+        for target_id in target_ids {
+            if let Some(info) = entity_map.get(target_id) {
+                let stem = info.file_path.rsplit('/').next().unwrap_or(&info.file_path);
+                let stem = stem
+                    .strip_suffix(".ts")
+                    .or_else(|| stem.strip_suffix(".js"))
+                    .or_else(|| stem.strip_suffix(".tsx"))
+                    .or_else(|| stem.strip_suffix(".jsx"))
+                    .or_else(|| stem.strip_suffix(".py"))
+                    .unwrap_or(stem);
+                if stem == source_module && info.parent_id.is_none() {
+                    // Register entity_name under the alias for method-call resolution
+                    import_table.insert(
+                        (file_path.to_string(), name.clone()),
+                        target_id.clone(),
+                    );
+                    if !scopes.is_empty() {
+                        scopes[0].defs.insert(name.clone(), target_id.clone());
+                    }
+                }
+            }
+        }
+    }
+    // Also register the alias itself so that type tracking for `alias.method()` works:
+    // the resolve_ref MethodCall path checks import_table for the receiver.
+    // We don't have a single entity for the module, so this is handled by the
+    // Go-style package-qualified call fallback (checking method name in import_table).
+    let _ = (alias, file_path); // used above
+}
+
 fn extract_python_import(
     node: tree_sitter::Node,
     file_path: &str,
@@ -2324,6 +2439,58 @@ fn extract_python_import(
                 }
             }
         }
+    }
+}
+
+/// Python: `import mod` or `import mod as m` — registers all entities from
+/// the module so that `m.foo()` resolves via the method-call path.
+fn extract_python_module_import(
+    node: tree_sitter::Node,
+    file_path: &str,
+    source: &[u8],
+    symbol_table: &HashMap<String, Vec<String>>,
+    entity_map: &HashMap<String, EntityInfo>,
+    import_table: &mut HashMap<(String, String), String>,
+    scopes: &mut Vec<Scope>,
+) {
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        let (module_name, _alias) = match child.kind() {
+            "dotted_name" => {
+                let name = child.utf8_text(source).unwrap_or("");
+                (name, name)
+            }
+            "aliased_import" => {
+                let orig = child
+                    .child_by_field_name("name")
+                    .and_then(|n| n.utf8_text(source).ok())
+                    .unwrap_or("");
+                let alias = child
+                    .child_by_field_name("alias")
+                    .and_then(|n| n.utf8_text(source).ok())
+                    .unwrap_or(orig);
+                (orig, alias)
+            }
+            _ => continue,
+        };
+
+        if module_name.is_empty() {
+            continue;
+        }
+
+        // The module stem is the last component of the dotted name
+        let source_module = module_name.rsplit('.').next().unwrap_or(module_name);
+
+        // Register all entities from the source module
+        register_namespace_import(
+            _alias,
+            source_module,
+            file_path,
+            symbol_table,
+            entity_map,
+            import_table,
+            scopes,
+        );
     }
 }
 
@@ -2478,20 +2645,33 @@ fn extract_call_ref(
         let text = func.utf8_text(source).unwrap_or("");
         let parts: Vec<&str> = text.split("::").collect();
         if parts.len() >= 2 {
-            let type_name = parts[parts.len() - 2];
+            // Handle super:: and self:: prefixed paths by emitting a call
+            // to the final name so scope chain resolution can find it.
+            let is_path_prefix =
+                parts[0] == "super" || parts[0] == "self" || parts[0] == "crate";
             let method_name = parts[parts.len() - 1];
-            if !type_name.is_empty() && !method_name.is_empty() {
-                refs.push(AstRef {
-                    kind: AstRefKind::Call(method_name.to_string()),
-                    row,
-                });
-                if type_name.chars().next().map_or(false, |c| c.is_uppercase())
-                    && !is_builtin(type_name, config)
-                {
+            if is_path_prefix {
+                if !method_name.is_empty() && !is_builtin(method_name, config) {
                     refs.push(AstRef {
-                        kind: AstRefKind::Call(type_name.to_string()),
+                        kind: AstRefKind::Call(method_name.to_string()),
                         row,
                     });
+                }
+            } else {
+                let type_name = parts[parts.len() - 2];
+                if !type_name.is_empty() && !method_name.is_empty() {
+                    refs.push(AstRef {
+                        kind: AstRefKind::Call(method_name.to_string()),
+                        row,
+                    });
+                    if type_name.chars().next().map_or(false, |c| c.is_uppercase())
+                        && !is_builtin(type_name, config)
+                    {
+                        refs.push(AstRef {
+                            kind: AstRefKind::Call(type_name.to_string()),
+                            row,
+                        });
+                    }
                 }
             }
         }
@@ -2571,9 +2751,9 @@ fn resolve_ref(
                             .map_or(false, |e| e.file_path == file_path)
                     })
                     .or_else(|| {
-                        // For lowercase calls, only fall back to global if there's exactly one match
-                        // (avoid ambiguous resolution that bag-of-words creates)
-                        if is_constructor || target_ids.len() == 1 {
+                        // Only fall back to cross-file global for constructor calls.
+                        // Lowercase calls require explicit imports to avoid false positives.
+                        if is_constructor {
                             target_ids.first()
                         } else {
                             None


### PR DESCRIPTION
## Summary

Addresses the 6 harder issues deferred from PR #164 that touch core entity extraction, graph resolution, and history tracking.

- **#160 — TSX handler visibility**: Exempt const-assigned arrow/function expressions from nested entity suppression so `const handleClick = () => {}` inside components is extracted
- **#161 — Jest test entities**: Add JS/TS handler for test call expressions (`describe`, `test`, `it`, `beforeEach`, `afterEach`, `beforeAll`, `afterAll`) with `test_suite`, `test`, and `test_hook` entity types
- **#140 — Overload ID collisions**: Add collision-detection post-pass to disambiguate same-name overloads with `@L{line}` suffix on entity IDs
- **#147 — Rust `#[test]` call edges**: Add `mod_item` as scope-creating node for Rust and handle `super::`/`self::`/`crate::` prefixed scoped identifiers in call extraction
- **#148 — Import-based resolution**: Tighten global symbol fallback to constructor-only, add TS namespace import (`import * as m`) handling, add Python module-alias import (`import mod as m`) handling
- **#139 — Log rename tracking**: Add `get_file_commits_follow_renames()` for `git log --follow` behavior, add `Renamed` change type with structural hash fallback for same-file entity renames

## Test plan

- [x] `cargo test -p sem-core` — all 212 tests pass
- [x] `cargo test -p sem-cli` — all 14 tests pass
- [x] `cargo test -p sem-mcp` — all 6 tests pass
- [ ] Manual: `sem entities /tmp/component.tsx --json` shows handlers (#160)
- [ ] Manual: `sem entities callback-only.test.ts --json` shows test entities (#161)
- [ ] Manual: `sem graph` on overloaded file shows both overloads (#140)
- [ ] Manual: `sem impact target` with `#[test]` shows dependent (#147)
- [ ] Manual: `sem impact foo` with namespace import shows caller (#148)
- [ ] Manual: `sem log stable --file new.py` shows full history across rename (#139)