### PR TITLE
feat: add --no-cosmetics flag to sem diff

### DIFF
--- a/crates/sem-cli/src/commands/diff.rs
+++ b/crates/sem-cli/src/commands/diff.rs
@@ -25,6 +25,7 @@ pub struct DiffOptions {
     pub verbose: bool,
     pub profile: bool,
     pub file_exts: Vec<String>,
+    pub no_cosmetics: bool,
     pub args: Vec<String>,
 }
 
@@ -605,8 +606,18 @@ fn run_diff_pipeline(
     let registry_ms = t2.elapsed().as_secs_f64() * 1000.0;
 
     let t3 = Instant::now();
-    let result = compute_semantic_diff(&file_changes, &registry, None, None);
+    let mut result = compute_semantic_diff(&file_changes, &registry, None, None);
     let parse_diff_ms = t3.elapsed().as_secs_f64() * 1000.0;
+
+    // Filter out cosmetic-only changes when --no-cosmetics is set
+    if opts.no_cosmetics {
+        let before_count = result.changes.len();
+        result.changes.retain(|c| c.structural_change != Some(false));
+        let removed = before_count - result.changes.len();
+        if removed > 0 {
+            result.modified_count = result.modified_count.saturating_sub(removed);
+        }
+    }
 
     // Record lifetime stats (best-effort)
     let _ = SemLifetimeStats::load().record_diff(&result).save();

--- a/crates/sem-cli/src/main.rs
+++ b/crates/sem-cli/src/main.rs
@@ -86,6 +86,10 @@ enum Commands {
         #[arg(long, num_args = 1..)]
         file_exts: Vec<String>,
 
+        /// Hide cosmetic changes (formatting, whitespace, comments only)
+        #[arg(long)]
+        no_cosmetics: bool,
+
         /// When to use colors
         #[arg(long, default_value = "auto")]
         color: ColorMode,
@@ -323,6 +327,7 @@ fn main() {
             json,
             profile,
             file_exts,
+            no_cosmetics,
             color,
             directory,
         }) => {
@@ -349,6 +354,7 @@ fn main() {
                 verbose,
                 profile,
                 file_exts,
+                no_cosmetics,
                 args,
             });
         }
@@ -536,6 +542,7 @@ fn main() {
                 verbose: false,
                 profile: false,
                 file_exts: vec![],
+                no_cosmetics: false,
                 args: vec![],
             });
         }


### PR DESCRIPTION
## Summary
- Add `--no-cosmetics` flag to `sem diff` that filters out formatting, whitespace, and comment-only changes
- Uses the existing `structural_change` detection — changes where the AST structural hash is identical but raw content differs are considered cosmetic
- Adjusts `modified_count` in the summary to reflect the filtered output

## Usage
```bash
sem diff --no-cosmetics          # hide cosmetic changes from working tree diff
sem diff HEAD~1 --no-cosmetics   # hide cosmetic changes from last commit
```

Closes #166