### PR TITLE
Reject unknown fields in stdin file changes

### DIFF
--- a/crates/sem-cli/tests/stdin.rs
+++ b/crates/sem-cli/tests/stdin.rs
@@ -1,0 +1,49 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_sem_diff_stdin(input: &str, args: &[&str]) -> std::process::Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_sem"))
+        .arg("diff")
+        .arg("--stdin")
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let mut stdin = child.stdin.take().unwrap();
+    stdin.write_all(input.as_bytes()).unwrap();
+    drop(stdin);
+
+    child.wait_with_output().unwrap()
+}
+
+#[test]
+fn diff_stdin_rejects_unknown_file_change_fields() {
+    let output = run_sem_diff_stdin(
+        r#"[{"filePath":"b.ts","oldPath":"a.ts","status":"renamed","beforeContent":"function foo(){}","afterContent":"function foo(){}"}]"#,
+        &[],
+    );
+
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("Error parsing stdin JSON"));
+    assert!(stderr.contains("unknown field `oldPath`"));
+}
+
+#[test]
+fn diff_stdin_accepts_old_file_path_for_renames() {
+    let output = run_sem_diff_stdin(
+        r#"[{"filePath":"b.ts","oldFilePath":"a.ts","status":"renamed","beforeContent":"function foo(){}","afterContent":"function foo(){}"}]"#,
+        &["--format", "json"],
+    );
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains(r#""moved":1"#));
+    assert!(stdout.contains(r#""filePath":"b.ts""#));
+    assert!(stdout.contains(r#""oldFilePath":"a.ts""#));
+}

--- a/crates/sem-core/src/git/types.rs
+++ b/crates/sem-core/src/git/types.rs
@@ -20,7 +20,7 @@ pub enum FileStatus {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct FileChange {
     pub file_path: String,
     pub status: FileStatus,
@@ -47,4 +47,31 @@ pub struct CommitInfo {
 pub struct FileCommitInfo {
     pub commit: CommitInfo,
     pub file_path: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FileChange, FileStatus};
+
+    #[test]
+    fn file_change_rejects_unknown_fields() {
+        let err = serde_json::from_str::<FileChange>(
+            r#"{"filePath":"b.ts","oldPath":"a.ts","status":"renamed"}"#,
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("unknown field `oldPath`"));
+    }
+
+    #[test]
+    fn file_change_accepts_known_camel_case_fields() {
+        let change = serde_json::from_str::<FileChange>(
+            r#"{"filePath":"b.ts","oldFilePath":"a.ts","status":"renamed"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(change.file_path, "b.ts");
+        assert_eq!(change.old_file_path.as_deref(), Some("a.ts"));
+        assert_eq!(change.status, FileStatus::Renamed);
+    }
 }


### PR DESCRIPTION
## Summary
- Reject unknown JSON keys when deserializing `FileChange` stdin payloads
- Add core deserialization coverage for typoed and valid camelCase fields
- Add CLI integration coverage for `sem diff --stdin` error reporting and rename handling

Closes #180

## Test plan
- `cargo test --manifest-path crates/Cargo.toml -p sem-core git::types`
- `cargo test --manifest-path crates/Cargo.toml -p sem-cli --test stdin`
- `cargo test --manifest-path crates/Cargo.toml --workspace`
- `npm test`
- Manual repro in a throwaway git repo using `crates/target/debug/sem diff --stdin` with `oldPath` and `oldFilePath`
