### PR TITLE
Suppress C and C++ block-local variables

### DIFF
--- a/crates/sem-core/src/parser/plugins/code/languages.rs
+++ b/crates/sem-core/src/parser/plugins/code/languages.rs
@@ -377,6 +377,30 @@ const JS_TS_SCOPE_BOUNDARIES: &[&str] = &[
     "generator_function",
 ];
 
+/// Inside C function bodies, suppress `declaration` nodes so that block-local
+/// variables are not extracted as nested entities. Inner type declarations are
+/// still reached by traversal after the wrapper is skipped.
+const C_SUPPRESSED_NESTED: &[SuppressedNestedEntity] = &[SuppressedNestedEntity {
+    parent_entity_node_type: "function_definition",
+    child_entity_node_type: "declaration",
+}];
+
+/// Inside C++ function-like bodies, suppress `declaration` nodes so that
+/// block-local variables are not extracted as nested entities. Inner type
+/// declarations are still reached by traversal after the wrapper is skipped.
+const CPP_SUPPRESSED_NESTED: &[SuppressedNestedEntity] = &[
+    SuppressedNestedEntity {
+        parent_entity_node_type: "function_definition",
+        child_entity_node_type: "declaration",
+    },
+    SuppressedNestedEntity {
+        parent_entity_node_type: "lambda_expression",
+        child_entity_node_type: "declaration",
+    },
+];
+
+const CPP_SCOPE_BOUNDARIES: &[&str] = &["lambda_expression"];
+
 #[cfg(feature = "lang-typescript")]
 static TYPESCRIPT_CONFIG: LanguageConfig = LanguageConfig {
     id: "typescript",
@@ -549,7 +573,7 @@ static C_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["compound_statement"],
     call_entity_identifiers: &[],
-    suppressed_nested_entities: &[],
+    suppressed_nested_entities: C_SUPPRESSED_NESTED,
     scope_boundary_types: &[],
     get_language: get_c,
     scope_resolve: None,
@@ -571,8 +595,8 @@ static CPP_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["field_declaration_list", "declaration_list", "compound_statement"],
     call_entity_identifiers: &[],
-    suppressed_nested_entities: &[],
-    scope_boundary_types: &[],
+    suppressed_nested_entities: CPP_SUPPRESSED_NESTED,
+    scope_boundary_types: CPP_SCOPE_BOUNDARIES,
     get_language: get_cpp,
     scope_resolve: Some(&CPP_SCOPE_CONFIG),
 };

--- a/crates/sem-core/src/parser/plugins/code/mod.rs
+++ b/crates/sem-core/src/parser/plugins/code/mod.rs
@@ -204,6 +204,29 @@ int main() {
     }
 
     #[test]
+    fn test_c_function_locals_not_extracted() {
+        let code = r#"
+int global_count = 0;
+int helper(void);
+
+int main(void) {
+    int local = helper();
+    const char *message = "hello";
+    return local + global_count;
+}
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "main.c");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+
+        assert!(names.contains(&"global_count"), "got: {:?}", names);
+        assert!(names.contains(&"helper"), "got: {:?}", names);
+        assert!(names.contains(&"main"), "got: {:?}", names);
+        assert!(!names.contains(&"local"), "got: {:?}", names);
+        assert!(!names.contains(&"message"), "got: {:?}", names);
+    }
+
+    #[test]
     fn test_cpp_entity_extraction() {
         let code = "namespace math {\nclass Vector3 {\npublic:\n    float length() const { return 0; }\n};\n}\nvoid greet() {}\n";
         let plugin = CodeParserPlugin;
@@ -212,6 +235,33 @@ int main() {
         assert!(names.contains(&"math"), "got: {:?}", names);
         assert!(names.contains(&"Vector3"), "got: {:?}", names);
         assert!(names.contains(&"greet"), "got: {:?}", names);
+    }
+
+    #[test]
+    fn test_cpp_function_locals_not_extracted() {
+        let code = r#"
+int global_value = 1;
+int helper();
+
+int main() {
+    int local = helper();
+    auto lambda = []() {
+        int lambda_local = 3;
+        return lambda_local;
+    };
+    return local + lambda();
+}
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "main.cpp");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+
+        assert!(names.contains(&"global_value"), "got: {:?}", names);
+        assert!(names.contains(&"helper"), "got: {:?}", names);
+        assert!(names.contains(&"main"), "got: {:?}", names);
+        assert!(!names.contains(&"local"), "got: {:?}", names);
+        assert!(!names.contains(&"lambda"), "got: {:?}", names);
+        assert!(!names.contains(&"lambda_local"), "got: {:?}", names);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- suppress C/C++ `declaration` entities when traversing function-like bodies
- preserve top-level globals and function prototypes
- add C and C++ regression coverage for block-local variables

Closes #211

## Test plan
- `cargo test -p sem-core`
- `cargo test -p sem-cli`
- `cargo build -p sem-cli`
- `/Users/zer0/Developer/oss/sem-wt-a149abe4/crates/target/debug/sem entities main.c --json` in `/Users/zer0/Developer/sem-issue-211-validation-a149abe4`
- `/Users/zer0/Developer/oss/sem-wt-a149abe4/crates/target/debug/sem entities main.cpp --json` in `/Users/zer0/Developer/sem-issue-211-validation-a149abe4`