### PR TITLE
Skip binary and generated files in repo scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ sem impact authenticateUser --json
 
 # Disambiguate by file
 sem impact authenticateUser --file src/auth.ts
+
+# Include generated/build directories that repo-wide scans skip by default
+sem impact authenticateUser --no-default-excludes
 ```
 
 ### sem blame
@@ -198,6 +201,9 @@ sem entities src/auth.ts
 # JSON output
 sem entities --json
 sem entities src/auth.ts --json
+
+# Include generated/build directories that repo-wide scans skip by default
+sem entities --no-default-excludes
 ```
 
 ### sem context
@@ -212,6 +218,9 @@ sem context authenticateUser --budget 4000
 
 # JSON output
 sem context authenticateUser --json
+
+# Include generated/build directories that repo-wide scans skip by default
+sem context authenticateUser --no-default-excludes
 ```
 
 ## Use as default Git diff

--- a/crates/sem-cli/src/commands/context.rs
+++ b/crates/sem-cli/src/commands/context.rs
@@ -14,6 +14,7 @@ pub struct ContextOptions {
     pub json: bool,
     pub file_exts: Vec<String>,
     pub no_cache: bool,
+    pub no_default_excludes: bool,
 }
 
 pub fn context_command(opts: ContextOptions) {
@@ -25,7 +26,12 @@ pub fn context_command(opts: ContextOptions) {
     let registry = super::create_registry(&root.to_string_lossy());
     let ext_filter = super::graph::normalize_exts(&opts.file_exts);
 
-    let file_paths = super::graph::find_supported_files_public(root, &registry, &ext_filter);
+    let file_paths = super::graph::find_supported_files_with_options(
+        root,
+        &registry,
+        &ext_filter,
+        opts.no_default_excludes,
+    );
     let (graph, all_entities) = super::graph::get_or_build_graph(root, &file_paths, &registry, opts.no_cache);
 
     let entity = find_entity(&graph, opts.entity_name.as_deref(), opts.entity_id.as_deref(), opts.file_path.as_deref());

--- a/crates/sem-cli/src/commands/entities.rs
+++ b/crates/sem-cli/src/commands/entities.rs
@@ -9,6 +9,7 @@ pub struct EntitiesOptions {
     pub cwd: String,
     pub path: Option<String>,
     pub json: bool,
+    pub no_default_excludes: bool,
 }
 
 pub fn entities_command(opts: EntitiesOptions) {
@@ -31,7 +32,13 @@ pub fn entities_command(opts: EntitiesOptions) {
             false,
         )
     } else if full_path.is_dir() {
-        let file_paths = find_supported_files_in_path(root, &full_path, &registry);
+        let file_paths = super::files::find_supported_files_in_path(
+            root,
+            &full_path,
+            &registry,
+            &[],
+            opts.no_default_excludes,
+        );
         (extract_files_entities(root, &file_paths, &registry), true)
     } else {
         eprintln!("{} Path not found '{}'", "error:".red().bold(), path_arg);
@@ -70,77 +77,25 @@ fn resolve_path(root: &Path, path_arg: &str) -> (String, PathBuf) {
     (label, full_path)
 }
 
-fn find_supported_files_in_path(
-    root: &Path,
-    scan_path: &Path,
-    registry: &ParserRegistry,
-) -> Vec<String> {
-    let mut files = Vec::new();
-    let walker = ignore::WalkBuilder::new(scan_path)
-        .hidden(true)
-        .git_ignore(true)
-        .git_global(true)
-        .git_exclude(true)
-        .build();
-
-    for entry in walker {
-        let entry = match entry {
-            Ok(entry) => entry,
-            Err(e) => {
-                eprintln!(
-                    "{} Cannot walk '{}': {}",
-                    "error:".red().bold(),
-                    scan_path.display(),
-                    e
-                );
-                std::process::exit(1);
-            }
-        };
-
-        let path = entry.path();
-        if !path.is_file() {
-            continue;
-        }
-
-        let file_path = file_path_for_entity(root, path);
-        if registry.get_plugin(&file_path).is_some() {
-            files.push(file_path);
-        }
-    }
-
-    files.sort();
-    files
-}
-
 fn extract_files_entities(
     root: &Path,
     file_paths: &[String],
     registry: &ParserRegistry,
 ) -> Vec<SemanticEntity> {
-    let mut entities = Vec::new();
-    for file_path in file_paths {
-        match extract_file_entities(&root.join(file_path), registry, file_path) {
-            Ok(new_ents) => entities.extend(new_ents),
-            Err(e) => {
-                eprintln!(
-                    "{} Cannot read '{}': {}",
-                    "warning:".yellow().bold(),
-                    file_path,
-                    e
-                );
-            }
-        }
-    }
+    let mut entities = registry.extract_all_entities(root, file_paths);
+    entities.sort_by(|a, b| {
+        a.file_path
+            .cmp(&b.file_path)
+            .then(a.start_line.cmp(&b.start_line))
+            .then(a.end_line.cmp(&b.end_line))
+            .then(a.entity_type.cmp(&b.entity_type))
+            .then(a.name.cmp(&b.name))
+    });
     entities
 }
 
 fn file_path_for_entity(root: &Path, path: &Path) -> String {
-    path.strip_prefix(root)
-        .ok()
-        .filter(|p| !p.as_os_str().is_empty())
-        .unwrap_or(path)
-        .to_string_lossy()
-        .to_string()
+    super::files::file_path_for_entity(root, path)
 }
 
 fn extract_file_entities(

--- a/crates/sem-cli/src/commands/files.rs
+++ b/crates/sem-cli/src/commands/files.rs
@@ -1,0 +1,140 @@
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+use colored::Colorize;
+use sem_core::utils::scan::{is_default_excluded, is_probably_binary_path};
+use sem_core::parser::registry::ParserRegistry;
+
+const BINARY_PROBE_BYTES: usize = 4096;
+
+pub fn find_supported_files_in_path(
+    root: &Path,
+    scan_path: &Path,
+    registry: &ParserRegistry,
+    ext_filter: &[String],
+    no_default_excludes: bool,
+) -> Vec<String> {
+    let mut files = Vec::new();
+
+    let mut builder = ignore::WalkBuilder::new(scan_path);
+    builder
+        .hidden(true)
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true);
+
+    let semignore = root.join(".semignore");
+    if semignore.exists() {
+        builder.add_ignore(semignore);
+    }
+
+    let walker = builder.build();
+
+    for entry in walker {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(e) => {
+                eprintln!(
+                    "{} Cannot walk '{}': {}",
+                    "error:".red().bold(),
+                    scan_path.display(),
+                    e
+                );
+                std::process::exit(1);
+            }
+        };
+
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+
+        let rel_path = file_path_for_entity(root, path);
+        if !no_default_excludes && is_default_excluded(&rel_path) {
+            continue;
+        }
+        if !ext_filter.is_empty()
+            && !ext_filter
+                .iter()
+                .any(|ext| rel_path.ends_with(ext.as_str()))
+        {
+            continue;
+        }
+        if is_probably_binary_path(&rel_path) {
+            continue;
+        }
+        if registry.get_plugin(&rel_path).is_none() {
+            continue;
+        }
+        if has_nul_byte(path).unwrap_or(false) {
+            continue;
+        }
+        files.push(rel_path);
+    }
+
+    files.sort();
+    files
+}
+
+pub fn file_path_for_entity(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .ok()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn has_nul_byte(path: &Path) -> std::io::Result<bool> {
+    let mut file = File::open(path)?;
+    let mut buffer = [0; BINARY_PROBE_BYTES];
+    let len = file.read(&mut buffer)?;
+    Ok(buffer[..len].contains(&0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sem_core::parser::plugins::create_default_registry;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir() -> std::path::PathBuf {
+        let name = format!(
+            "sem-cli-files-test-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let path = std::env::temp_dir().join(name);
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[test]
+    fn scan_skips_binary_files_and_default_excludes() {
+        let root = temp_dir();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::create_dir_all(root.join("dist")).unwrap();
+        fs::write(root.join("src/main.rs"), "fn main() {}\n").unwrap();
+        fs::write(root.join("src/blob.weird"), b"abc\0def").unwrap();
+        fs::write(root.join("src/icon.png"), b"\x89PNG\r\n").unwrap();
+        fs::write(root.join("dist/generated.js"), "function generated() {}\n").unwrap();
+
+        let registry = create_default_registry();
+        let files = find_supported_files_in_path(&root, &root, &registry, &[], false);
+
+        assert_eq!(files, vec!["src/main.rs".to_string()]);
+
+        let files_with_generated = find_supported_files_in_path(&root, &root, &registry, &[], true);
+        assert!(files_with_generated.contains(&"src/main.rs".to_string()));
+        assert!(files_with_generated.contains(&"dist/generated.js".to_string()));
+        assert!(!files_with_generated.contains(&"src/blob.weird".to_string()));
+        assert!(!files_with_generated.contains(&"src/icon.png".to_string()));
+
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/crates/sem-cli/src/commands/graph.rs
+++ b/crates/sem-cli/src/commands/graph.rs
@@ -24,7 +24,8 @@ pub fn graph_command(opts: GraphOptions) {
     let root = root.as_path();
     let registry = super::create_registry(&root.to_string_lossy());
     let ext_filter = normalize_exts(&opts.file_exts);
-    let file_paths = find_supported_files_inner(root, &registry, &ext_filter, opts.no_default_excludes);
+    let file_paths =
+        find_supported_files_inner(root, &registry, &ext_filter, opts.no_default_excludes);
     let (graph, _entities) = get_or_build_graph(root, &file_paths, &registry, opts.no_cache);
 
     if opts.json {
@@ -55,90 +56,36 @@ pub fn normalize_exts(exts: &[String]) -> Vec<String> {
 }
 
 /// Find all supported files in the repo (public for use by other commands).
-pub fn find_supported_files_public(root: &Path, registry: &ParserRegistry, ext_filter: &[String]) -> Vec<String> {
-    find_supported_files_inner(root, registry, ext_filter, false)
+pub fn find_supported_files_public(
+    root: &Path,
+    registry: &ParserRegistry,
+    ext_filter: &[String],
+) -> Vec<String> {
+    find_supported_files_with_options(root, registry, ext_filter, false)
 }
 
-/// File names that are always excluded from graph/index (lockfiles, generated content).
-const DEFAULT_EXCLUDED_FILES: &[&str] = &[
-    "Cargo.lock",
-    "package-lock.json",
-    "yarn.lock",
-    "pnpm-lock.yaml",
-    "Gemfile.lock",
-    "Pipfile.lock",
-    "poetry.lock",
-    "composer.lock",
-    "go.sum",
-    "flake.lock",
-];
-
-/// Directory names that are always excluded from graph/index (fixtures, benchmarks, vendor).
-const DEFAULT_EXCLUDED_DIRS: &[&str] = &[
-    "fixtures",
-    "fixture",
-    "benchmarks",
-    "vendor",
-    "node_modules",
-    "test-harness",
-];
-
-fn is_default_excluded(rel_path: &str) -> bool {
-    // Check file name
-    if let Some(file_name) = rel_path.rsplit('/').next() {
-        if DEFAULT_EXCLUDED_FILES.contains(&file_name) {
-            return true;
-        }
-    }
-    // Check directory components
-    for component in rel_path.split('/') {
-        if DEFAULT_EXCLUDED_DIRS.contains(&component) {
-            return true;
-        }
-    }
-    false
+pub fn find_supported_files_with_options(
+    root: &Path,
+    registry: &ParserRegistry,
+    ext_filter: &[String],
+    no_default_excludes: bool,
+) -> Vec<String> {
+    super::files::find_supported_files_in_path(
+        root,
+        root,
+        registry,
+        ext_filter,
+        no_default_excludes,
+    )
 }
 
-fn find_supported_files_inner(root: &Path, registry: &ParserRegistry, ext_filter: &[String], no_default_excludes: bool) -> Vec<String> {
-    let mut files = Vec::new();
-
-    // Use the `ignore` crate to walk the filesystem respecting .gitignore and .semignore
-    let mut builder = ignore::WalkBuilder::new(root);
-    builder
-        .hidden(true)       // skip hidden files/dirs
-        .git_ignore(true)   // respect .gitignore
-        .git_global(true)   // respect global gitignore
-        .git_exclude(true); // respect .git/info/exclude
-
-    // Respect .semignore if present
-    let semignore = root.join(".semignore");
-    if semignore.exists() {
-        builder.add_ignore(semignore);
-    }
-
-    let walker = builder.build();
-
-    for entry in walker.flatten() {
-        let path = entry.path();
-        if !path.is_file() {
-            continue;
-        }
-        if let Ok(rel) = path.strip_prefix(root) {
-            let rel_str = rel.to_string_lossy().to_string();
-            if !no_default_excludes && is_default_excluded(&rel_str) {
-                continue;
-            }
-            if !ext_filter.is_empty() && !ext_filter.iter().any(|ext| rel_str.ends_with(ext.as_str())) {
-                continue;
-            }
-            if registry.get_plugin(&rel_str).is_some() {
-                files.push(rel_str);
-            }
-        }
-    }
-
-    files.sort();
-    files
+fn find_supported_files_inner(
+    root: &Path,
+    registry: &ParserRegistry,
+    ext_filter: &[String],
+    no_default_excludes: bool,
+) -> Vec<String> {
+    find_supported_files_with_options(root, registry, ext_filter, no_default_excludes)
 }
 
 /// Build the entity graph + entities, using the disk cache when possible.

--- a/crates/sem-cli/src/commands/impact.rs
+++ b/crates/sem-cli/src/commands/impact.rs
@@ -14,6 +14,7 @@ pub struct ImpactOptions {
     pub mode: ImpactMode,
     pub depth: usize,
     pub no_cache: bool,
+    pub no_default_excludes: bool,
 }
 
 pub enum ImpactMode {
@@ -32,7 +33,12 @@ pub fn impact_command(opts: ImpactOptions) {
     let registry = super::create_registry(&root.to_string_lossy());
 
     let ext_filter = super::graph::normalize_exts(&opts.file_exts);
-    let file_paths = super::graph::find_supported_files_public(root, &registry, &ext_filter);
+    let file_paths = super::graph::find_supported_files_with_options(
+        root,
+        &registry,
+        &ext_filter,
+        opts.no_default_excludes,
+    );
     let (graph, all_entities) = super::graph::get_or_build_graph(root, &file_paths, &registry, opts.no_cache);
 
     let entity = find_entity(&graph, opts.entity_name.as_deref(), opts.entity_id.as_deref(), opts.file_hint.as_deref());

--- a/crates/sem-cli/src/commands/mod.rs
+++ b/crates/sem-cli/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod blame;
 pub mod context;
 pub mod diff;
 pub mod entities;
+pub mod files;
 pub mod graph;
 pub mod impact;
 pub mod log;

--- a/crates/sem-cli/src/commands/verify.rs
+++ b/crates/sem-cli/src/commands/verify.rs
@@ -8,6 +8,7 @@ pub struct VerifyOptions {
     pub json: bool,
     pub diff: bool,
     pub file_exts: Vec<String>,
+    pub no_default_excludes: bool,
 }
 
 pub fn verify_command(opts: VerifyOptions) {
@@ -15,12 +16,25 @@ pub fn verify_command(opts: VerifyOptions) {
     let registry = super::create_registry(&opts.cwd);
 
     let ext_filter = super::graph::normalize_exts(&opts.file_exts);
-    let file_paths = super::graph::find_supported_files_public(root, &registry, &ext_filter);
+    let file_paths = super::graph::find_supported_files_with_options(
+        root,
+        &registry,
+        &ext_filter,
+        opts.no_default_excludes,
+    );
     let (graph, all_entities) =
         super::graph::get_or_build_graph(root, &file_paths, &registry, false);
 
     if opts.diff {
-        verify_diff(root, &graph, &all_entities, &registry, &ext_filter, opts.json);
+        verify_diff(
+            root,
+            &graph,
+            &all_entities,
+            &registry,
+            &ext_filter,
+            opts.no_default_excludes,
+            opts.json,
+        );
     } else {
         verify_full(&graph, &all_entities, opts.json);
     }
@@ -89,10 +103,11 @@ fn verify_diff(
     new_entities: &[sem_core::model::entity::SemanticEntity],
     registry: &sem_core::parser::registry::ParserRegistry,
     ext_filter: &[String],
+    no_default_excludes: bool,
     json: bool,
 ) {
     // Get HEAD entities for comparison
-    let old_entities = match get_head_entities(root, registry, ext_filter) {
+    let old_entities = match get_head_entities(root, registry, ext_filter, no_default_excludes) {
         Some(entities) => entities,
         None => {
             if json {
@@ -166,8 +181,14 @@ fn get_head_entities(
     root: &Path,
     registry: &sem_core::parser::registry::ParserRegistry,
     ext_filter: &[String],
+    no_default_excludes: bool,
 ) -> Option<Vec<sem_core::model::entity::SemanticEntity>> {
-    let file_paths = super::graph::find_supported_files_public(root, registry, ext_filter);
+    let file_paths = super::graph::find_supported_files_with_options(
+        root,
+        registry,
+        ext_filter,
+        no_default_excludes,
+    );
     let mut all_entities = Vec::new();
 
     for fp in &file_paths {

--- a/crates/sem-cli/src/main.rs
+++ b/crates/sem-cli/src/main.rs
@@ -147,6 +147,10 @@ enum Commands {
         /// Skip the SQLite entity cache (rebuild from scratch)
         #[arg(long)]
         no_cache: bool,
+
+        /// Include directories and generated files that are excluded by default
+        #[arg(long)]
+        no_default_excludes: bool,
     },
     /// Show the full entity dependency graph
     Graph {
@@ -170,7 +174,7 @@ enum Commands {
         #[arg(long)]
         no_cache: bool,
 
-        /// Include directories that are excluded by default (fixtures, vendor, node_modules, etc.)
+        /// Include directories and generated files that are excluded by default
         #[arg(long)]
         no_default_excludes: bool,
     },
@@ -227,6 +231,10 @@ enum Commands {
         /// Output as JSON (shorthand for --format json)
         #[arg(long)]
         json: bool,
+
+        /// Include directories and generated files that are excluded by default
+        #[arg(long)]
+        no_default_excludes: bool,
     },
     /// Show token-budgeted context for an entity
     Context {
@@ -261,6 +269,10 @@ enum Commands {
         /// Skip the SQLite entity cache (rebuild from scratch)
         #[arg(long)]
         no_cache: bool,
+
+        /// Include directories and generated files that are excluded by default
+        #[arg(long)]
+        no_default_excludes: bool,
     },
     /// Verify function call arity across the codebase
     Verify {
@@ -279,6 +291,10 @@ enum Commands {
         /// Only include files with these extensions (e.g. --file-exts .py .rs)
         #[arg(long, num_args = 1..)]
         file_exts: Vec<String>,
+
+        /// Include directories and generated files that are excluded by default
+        #[arg(long)]
+        no_default_excludes: bool,
     },
     /// Show lifetime diff statistics
     Stats,
@@ -411,6 +427,7 @@ fn main() {
             file_exts,
             depth,
             no_cache,
+            no_default_excludes,
         }) => {
             let mode = if deps {
                 ImpactMode::Deps
@@ -435,6 +452,7 @@ fn main() {
                 mode,
                 depth,
                 no_cache,
+                no_default_excludes,
             });
         }
         Some(Commands::Log {
@@ -457,7 +475,12 @@ fn main() {
                 verbose,
             });
         }
-        Some(Commands::Entities { path, format, json }) => {
+        Some(Commands::Entities {
+            path,
+            format,
+            json,
+            no_default_excludes,
+        }) => {
             entities_command(EntitiesOptions {
                 cwd: std::env::current_dir()
                     .unwrap_or_default()
@@ -465,6 +488,7 @@ fn main() {
                     .to_string(),
                 path,
                 json: resolve_json(format, json),
+                no_default_excludes,
             });
         }
         Some(Commands::Context {
@@ -476,6 +500,7 @@ fn main() {
             json,
             file_exts,
             no_cache,
+            no_default_excludes,
         }) => {
             context_command(ContextOptions {
                 cwd: std::env::current_dir()
@@ -489,6 +514,7 @@ fn main() {
                 json: resolve_json(format, json),
                 file_exts,
                 no_cache,
+                no_default_excludes,
             });
         }
         Some(Commands::Verify {
@@ -496,6 +522,7 @@ fn main() {
             json,
             diff,
             file_exts,
+            no_default_excludes,
         }) => {
             verify_command(VerifyOptions {
                 cwd: std::env::current_dir()
@@ -505,6 +532,7 @@ fn main() {
                 json: resolve_json(format, json),
                 diff,
                 file_exts,
+                no_default_excludes,
             });
         }
         Some(Commands::Stats) => {

--- a/crates/sem-core/src/utils/mod.rs
+++ b/crates/sem-core/src/utils/mod.rs
@@ -1,1 +1,2 @@
 pub mod hash;
+pub mod scan;

--- a/crates/sem-core/src/utils/scan.rs
+++ b/crates/sem-core/src/utils/scan.rs
@@ -1,0 +1,193 @@
+/// File names that are excluded from repo-wide scans by default.
+const DEFAULT_EXCLUDED_FILES: &[&str] = &[
+    "Cargo.lock",
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "Gemfile.lock",
+    "Pipfile.lock",
+    "poetry.lock",
+    "composer.lock",
+    "go.sum",
+    "flake.lock",
+];
+
+/// Directory names that are excluded wherever they appear in repo-wide scans.
+const DEFAULT_EXCLUDED_ANY_DIRS: &[&str] = &[
+    "fixtures",
+    "fixture",
+    "benchmarks",
+    "vendor",
+    "node_modules",
+    "test-harness",
+    ".next",
+    ".turbo",
+    ".cache",
+    "coverage",
+];
+
+/// Top-level output directories excluded by default.
+const DEFAULT_EXCLUDED_ROOT_DIRS: &[&str] = &["out", "dist", "build", "target"];
+
+/// File suffixes for generated text assets that do not produce useful entities.
+const DEFAULT_EXCLUDED_SUFFIXES: &[&str] = &[".min.js", ".min.css"];
+
+/// File suffixes that are not useful source text for semantic extraction.
+const BINARY_FILE_SUFFIXES: &[&str] = &[
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".webp",
+    ".ico",
+    ".tiff",
+    ".tif",
+    ".bmp",
+    ".heic",
+    ".heif",
+    ".avif",
+    ".woff",
+    ".woff2",
+    ".ttf",
+    ".otf",
+    ".eot",
+    ".mp3",
+    ".mp4",
+    ".mov",
+    ".avi",
+    ".webm",
+    ".ogg",
+    ".wav",
+    ".flac",
+    ".m4a",
+    ".m4v",
+    ".mkv",
+    ".zip",
+    ".tar",
+    ".tar.gz",
+    ".tgz",
+    ".bz2",
+    ".gz",
+    ".xz",
+    ".7z",
+    ".rar",
+    ".so",
+    ".dylib",
+    ".dll",
+    ".a",
+    ".lib",
+    ".o",
+    ".obj",
+    ".class",
+    ".jar",
+    ".pyc",
+    ".pyo",
+    ".pdb",
+    ".exe",
+    ".app",
+    ".apk",
+    ".ipa",
+    ".aar",
+    ".swiftmodule",
+    ".swiftdoc",
+    ".swiftsourceinfo",
+    ".wasm",
+    ".car",
+    ".icns",
+    ".riv",
+    ".pdf",
+    ".nib",
+    ".storyboardc",
+    ".db",
+    ".sqlite",
+    ".sqlite3",
+    ".realm",
+    ".profdata",
+];
+
+/// Directory/package suffixes that contain compiled assets rather than source.
+const BINARY_DIR_SUFFIXES: &[&str] = &[".framework", ".xcframework", ".dsym", ".app"];
+
+pub fn is_default_excluded(rel_path: &str) -> bool {
+    let normalized = rel_path.replace('\\', "/");
+    let lower = normalized.to_ascii_lowercase();
+
+    if let Some(file_name) = lower.rsplit('/').next() {
+        if DEFAULT_EXCLUDED_FILES
+            .iter()
+            .any(|excluded| excluded.eq_ignore_ascii_case(file_name))
+        {
+            return true;
+        }
+    }
+
+    if DEFAULT_EXCLUDED_SUFFIXES
+        .iter()
+        .any(|suffix| lower.ends_with(suffix))
+    {
+        return true;
+    }
+
+    let components: Vec<&str> = lower.split('/').collect();
+    if components
+        .iter()
+        .any(|component| DEFAULT_EXCLUDED_ANY_DIRS.contains(component))
+    {
+        return true;
+    }
+
+    if components
+        .first()
+        .is_some_and(|component| DEFAULT_EXCLUDED_ROOT_DIRS.contains(component))
+    {
+        return true;
+    }
+
+    components
+        .windows(3)
+        .any(|window| window == ["_next", "static", "chunks"])
+}
+
+pub fn is_probably_binary_path(rel_path: &str) -> bool {
+    let normalized = rel_path.replace('\\', "/");
+    let lower = normalized.to_ascii_lowercase();
+
+    if BINARY_FILE_SUFFIXES
+        .iter()
+        .any(|suffix| lower.ends_with(suffix))
+    {
+        return true;
+    }
+
+    lower.split('/').any(|component| {
+        BINARY_DIR_SUFFIXES
+            .iter()
+            .any(|suffix| component.ends_with(suffix))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_excludes_generated_and_build_paths() {
+        assert!(is_default_excluded("dist/app.js"));
+        assert!(is_default_excluded("site/out/_next/static/chunks/app.js"));
+        assert!(is_default_excluded("src/generated.min.js"));
+        assert!(is_default_excluded("target/debug/build.rs"));
+        assert!(!is_default_excluded("src/app.js"));
+        assert!(!is_default_excluded("src/build/mod.rs"));
+        assert!(!is_default_excluded("packages/compiler/build/index.ts"));
+        assert!(!is_default_excluded("tools/dist/analyzer.py"));
+    }
+
+    #[test]
+    fn detects_binary_asset_paths() {
+        assert!(is_probably_binary_path("Snapshots/icon.png"));
+        assert!(is_probably_binary_path("Frameworks/Foo.framework/Foo"));
+        assert!(is_probably_binary_path("Modules/Foo.swiftmodule"));
+        assert!(!is_probably_binary_path("Assets/icon.svg"));
+        assert!(!is_probably_binary_path("src/main.rs"));
+    }
+}

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -1,6 +1,7 @@
 use std::collections::hash_map::DefaultHasher;
+use std::fs::File;
 use std::hash::{Hash, Hasher};
-use std::io::ErrorKind;
+use std::io::{ErrorKind, Read};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -16,6 +17,7 @@ use sem_core::parser::differ::compute_semantic_diff;
 use sem_core::parser::graph::EntityGraph;
 use sem_core::parser::plugins::create_default_registry;
 use sem_core::parser::registry::ParserRegistry;
+use sem_core::utils::scan::{is_default_excluded, is_probably_binary_path};
 use tokio::sync::Mutex;
 
 use crate::cache;
@@ -37,6 +39,15 @@ fn content_hash_u64(content: &str) -> u64 {
     let mut hasher = DefaultHasher::new();
     content.hash(&mut hasher);
     hasher.finish()
+}
+
+const BINARY_PROBE_BYTES: usize = 4096;
+
+fn has_nul_byte(path: &Path) -> std::io::Result<bool> {
+    let mut file = File::open(path)?;
+    let mut buffer = [0; BINARY_PROBE_BYTES];
+    let len = file.read(&mut buffer)?;
+    Ok(buffer[..len].contains(&0))
 }
 
 /// Cached entity graph + all entities, keyed by manifest hash.
@@ -132,22 +143,34 @@ impl SemServer {
             ));
         }
         let mut files = Vec::new();
-        let walker = ignore::WalkBuilder::new(root)
+        let mut builder = ignore::WalkBuilder::new(root);
+        builder
             .hidden(true)
             .git_ignore(true)
             .git_global(true)
-            .git_exclude(true)
-            .build();
+            .git_exclude(true);
+        let semignore = root.join(".semignore");
+        if semignore.exists() {
+            builder.add_ignore(semignore);
+        }
+        let walker = builder.build();
         for entry in walker.flatten() {
             let path = entry.path();
             if !path.is_file() {
                 continue;
             }
             if let Ok(rel) = path.strip_prefix(root) {
-                let rel_str = rel.to_string_lossy().to_string();
-                if registry.get_plugin(&rel_str).is_some() {
-                    files.push(rel_str);
+                let rel_str = rel.to_string_lossy().replace('\\', "/");
+                if is_default_excluded(&rel_str) || is_probably_binary_path(&rel_str) {
+                    continue;
                 }
+                if registry.get_plugin(&rel_str).is_none() {
+                    continue;
+                }
+                if has_nul_byte(path).unwrap_or(false) {
+                    continue;
+                }
+                files.push(rel_str);
             }
         }
         files.sort();
@@ -161,22 +184,34 @@ impl SemServer {
         registry: &ParserRegistry,
     ) -> Result<Vec<String>, String> {
         let mut files = Vec::new();
-        let walker = ignore::WalkBuilder::new(dir)
+        let mut builder = ignore::WalkBuilder::new(dir);
+        builder
             .hidden(true)
             .git_ignore(true)
             .git_global(true)
-            .git_exclude(true)
-            .build();
+            .git_exclude(true);
+        let semignore = prefix_root.join(".semignore");
+        if semignore.exists() {
+            builder.add_ignore(semignore);
+        }
+        let walker = builder.build();
         for entry in walker.flatten() {
             let path = entry.path();
             if !path.is_file() {
                 continue;
             }
             if let Ok(rel) = path.strip_prefix(prefix_root) {
-                let rel_str = rel.to_string_lossy().to_string();
-                if registry.get_plugin(&rel_str).is_some() {
-                    files.push(rel_str);
+                let rel_str = rel.to_string_lossy().replace('\\', "/");
+                if is_default_excluded(&rel_str) || is_probably_binary_path(&rel_str) {
+                    continue;
                 }
+                if registry.get_plugin(&rel_str).is_none() {
+                    continue;
+                }
+                if has_nul_byte(path).unwrap_or(false) {
+                    continue;
+                }
+                files.push(rel_str);
             }
         }
         files.sort();
@@ -918,6 +953,22 @@ impl ServerHandler for SemServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir() -> PathBuf {
+        let name = format!(
+            "sem-mcp-files-test-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let path = std::env::temp_dir().join(name);
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
 
     #[test]
     fn find_supported_files_returns_walk_errors() {
@@ -939,6 +990,24 @@ mod tests {
         assert_eq!(info.instructions.as_deref(), Some(MCP_INSTRUCTIONS));
         assert!(MCP_INSTRUCTIONS.contains("sem_entities"));
         assert!(!MCP_INSTRUCTIONS.contains("tools: entities"));
+    }
+
+    #[test]
+    fn find_supported_files_skips_binary_and_default_excludes() {
+        let root = temp_dir();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::create_dir_all(root.join("dist")).unwrap();
+        fs::write(root.join("src/app.js"), "export function app() {}\n").unwrap();
+        fs::write(root.join("src/blob.weird"), b"abc\0def").unwrap();
+        fs::write(root.join("src/icon.png"), b"\x89PNG\r\n").unwrap();
+        fs::write(root.join("dist/generated.js"), "export function generated() {}\n").unwrap();
+
+        let registry = create_default_registry();
+        let files = SemServer::find_supported_files(&root, &registry).unwrap();
+
+        assert_eq!(files, vec!["src/app.js".to_string()]);
+
+        fs::remove_dir_all(root).unwrap();
     }
 }
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -57,6 +57,7 @@ sem graph
 sem graph --entity validateToken
 sem graph --file-exts .py
 sem graph --format json
+sem graph --no-default-excludes
 ```
 
 ### sem impact
@@ -66,6 +67,7 @@ Transitive impact analysis. If this entity changes, what else is affected? BFS t
 sem impact validateToken
 sem impact validateToken --json
 sem impact validateToken --file-exts .py
+sem impact validateToken --no-default-excludes
 ```
 
 ## Key Features


### PR DESCRIPTION
## Summary

- share repo scan filtering across entities, graph, impact, context, verify, and MCP repo walks
- skip binary assets by extension and by a 4 KiB NUL-byte probe before UTF-8 decoding
- exclude generated/build output by default, with `--no-default-excludes` added to entities, impact, context, and verify
- use parallel entity extraction for repo-wide `sem entities` while sorting output deterministically

Fixes #189
Fixes #191

## Test plan

- `cargo test -p sem-cli`
- `cargo test -p sem-mcp`
- `cargo test`
- `npm test`
- validation repo: `/Users/zer0/Developer/sem-validation-189-191`
  - `sem entities --json` emitted no stderr and only included `src/app.js`
  - `sem entities --json --no-default-excludes` emitted no stderr and included generated/minified text files while still skipping binary/NUL files
  - `sem graph --json --no-cache`, `sem impact liveFeature --json --no-cache`, `sem verify --json`, and `sem context liveFeature --json --no-cache` emitted no stderr
