### PR TITLE
Harden sem setup and unsetup

### DIFF
--- a/crates/sem-cli/src/commands/diff.rs
+++ b/crates/sem-cli/src/commands/diff.rs
@@ -26,6 +26,7 @@ pub struct DiffOptions {
     pub profile: bool,
     pub file_exts: Vec<String>,
     pub no_cosmetics: bool,
+    pub label: Option<String>,
     pub args: Vec<String>,
 }
 
@@ -48,7 +49,11 @@ struct ParsedArgs {
 
 enum ParsedScope {
     /// Two files to compare directly
-    FileCompare(String, String),
+    FileCompare {
+        before: String,
+        after: String,
+        label: Option<String>,
+    },
     /// A single ref compared to working tree
     RefToWorking(String),
     /// A range between two refs
@@ -203,11 +208,18 @@ fn parse_args(args: Vec<String>, cwd: &str) -> ParsedArgs {
         let b = &refs[1];
 
         // If both exist as files on disk and no pathspecs, treat as file comparison
-        if pathspecs.is_empty() && Path::new(cwd).join(a).exists() && Path::new(cwd).join(b).exists() {
+        if pathspecs.is_empty()
+            && Path::new(cwd).join(a).exists()
+            && Path::new(cwd).join(b).exists()
+        {
             // But check if they're also valid git refs — prefer ref interpretation
             // Only fall back to file comparison if neither resolves as a ref
             return ParsedArgs {
-                scope: Some(ParsedScope::FileCompare(a.clone(), b.clone())),
+                scope: Some(ParsedScope::FileCompare {
+                    before: a.clone(),
+                    after: b.clone(),
+                    label: None,
+                }),
                 pathspecs,
             };
         }
@@ -223,7 +235,11 @@ fn parse_args(args: Vec<String>, cwd: &str) -> ParsedArgs {
     // When sem is set as diff.external, git passes 7 positional args per file.
     if refs.len() == 7 {
         return ParsedArgs {
-            scope: Some(ParsedScope::FileCompare(refs[1].clone(), refs[4].clone())),
+            scope: Some(ParsedScope::FileCompare {
+                before: refs[1].clone(),
+                after: refs[4].clone(),
+                label: Some(refs[0].clone()),
+            }),
             pathspecs,
         };
     }
@@ -363,7 +379,7 @@ pub fn diff_command(mut opts: DiffOptions) {
                     *a = maybe_resolve_ref(a, root);
                     *b = maybe_resolve_ref(b, root);
                 }
-                ParsedScope::FileCompare(_, _) => {}
+                ParsedScope::FileCompare { .. } => {}
             }
         }
         if let Some(ref mut sha) = opts.commit {
@@ -391,17 +407,22 @@ pub fn diff_command(mut opts: DiffOptions) {
             process::exit(1);
         });
         (changes, true)
-    } else if let Some(ParsedScope::FileCompare(ref a, ref b)) = parsed.scope {
+    } else if let Some(ParsedScope::FileCompare {
+        ref before,
+        ref after,
+        ref label,
+    }) = parsed.scope
+    {
         // Compare two arbitrary files: sem diff file1.ts file2.ts
-        let path_a = Path::new(&opts.cwd).join(a);
-        let path_b = Path::new(&opts.cwd).join(b);
+        let path_a = Path::new(&opts.cwd).join(before);
+        let path_b = Path::new(&opts.cwd).join(after);
 
         // If we're in a git repo and both resolve as refs, prefer ref comparison
         if let Ok(git) = GitBridge::open(Path::new(&opts.cwd)) {
-            if git.is_valid_rev(a) && git.is_valid_rev(b) {
+            if git.is_valid_rev(before) && git.is_valid_rev(after) {
                 let scope = DiffScope::Range {
-                    from: a.clone(),
-                    to: b.clone(),
+                    from: before.clone(),
+                    to: after.clone(),
                 };
                 match git.get_changed_files(&scope, &parsed.pathspecs) {
                     Ok(files) => {
@@ -425,7 +446,11 @@ pub fn diff_command(mut opts: DiffOptions) {
         });
 
         let change = FileChange {
-            file_path: b.clone(),
+            file_path: opts
+                .label
+                .clone()
+                .or_else(|| label.clone())
+                .unwrap_or_else(|| after.clone()),
             old_file_path: None,
             status: sem_core::git::types::FileStatus::Modified,
             before_content: Some(content_a),
@@ -520,7 +545,7 @@ pub fn diff_command(mut opts: DiffOptions) {
                         }
                     }
                 }
-                ParsedScope::FileCompare(_, _) => unreachable!(),
+                ParsedScope::FileCompare { .. } => unreachable!(),
             };
             match git.get_changed_files(&scope, &parsed.pathspecs) {
                 Ok(files) => (scope, files),

--- a/crates/sem-cli/src/commands/setup.rs
+++ b/crates/sem-cli/src/commands/setup.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use colored::Colorize;
@@ -21,7 +21,7 @@ fn wrapper_script() -> String {
     "#!/bin/sh\n\
      # Wrapper for git diff.external: translates git's 7-arg format to sem diff\n\
      # Args: path old-file old-hex old-mode new-file new-hex new-mode\n\
-     exec sem diff \"$2\" \"$5\"\n"
+     exec sem diff --label \"$1\" \"$2\" \"$5\"\n"
         .to_string()
 }
 
@@ -30,18 +30,8 @@ fn wrapper_script() -> String {
     "@echo off\r\n\
      rem Wrapper for git diff.external: translates git's 7-arg format to sem diff\r\n\
      rem Args: path old-file old-hex old-mode new-file new-hex new-mode\r\n\
-     sem diff \"%~2\" \"%~5\"\r\n"
+     sem diff --label \"%~1\" \"%~2\" \"%~5\"\r\n"
         .to_string()
-}
-
-#[cfg(unix)]
-fn wrapper_name() -> &'static str {
-    "sem-diff-wrapper"
-}
-
-#[cfg(windows)]
-fn wrapper_name() -> &'static str {
-    "sem-diff-wrapper.bat"
 }
 
 #[cfg(unix)]
@@ -55,6 +45,69 @@ fn set_executable(path: &std::path::Path) -> Result<(), Box<dyn std::error::Erro
 fn set_executable(_path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
     // .bat files are executable by default on Windows
     Ok(())
+}
+
+fn diff_external_value() -> Option<String> {
+    let output = Command::new("git")
+        .args(["config", "--global", "--get", "diff.external"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+fn is_configured_wrapper(value: &str, wrapper_path: &Path) -> bool {
+    let value_path = Path::new(value);
+
+    value
+        == wrapper_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default()
+        || value_path == wrapper_path
+        || matches!(
+            (
+                std::fs::canonicalize(value_path),
+                std::fs::canonicalize(wrapper_path)
+            ),
+            (Ok(value), Ok(wrapper)) if value == wrapper
+        )
+}
+
+fn wrapper_is_owned(path: &Path) -> bool {
+    fs::read_to_string(path).is_ok_and(|content| content == wrapper_script())
+}
+
+fn git_path(path: &str) -> Option<PathBuf> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--git-path", path])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let resolved = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if resolved.is_empty() {
+        return None;
+    }
+
+    let path = PathBuf::from(resolved);
+    if path.is_absolute() {
+        Some(path)
+    } else {
+        std::env::current_dir().ok().map(|cwd| cwd.join(path))
+    }
 }
 
 pub fn run() -> Result<(), Box<dyn std::error::Error>> {
@@ -82,7 +135,10 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     // Set diff.external globally
     let status = Command::new("git")
-        .args(["config", "--global", "diff.external", wrapper_name()])
+        .arg("config")
+        .arg("--global")
+        .arg("diff.external")
+        .arg(&path)
         .status()?;
     if !status.success() {
         return Err("Failed to set diff.external in git config".into());
@@ -90,7 +146,7 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
     println!(
         "{} Set git config --global diff.external = {}",
         "✓".green().bold(),
-        wrapper_name(),
+        path.display(),
     );
 
     // Install pre-commit hook if we're in a git repo
@@ -121,60 +177,23 @@ fn pre_commit_hook_section() -> String {
     )
 }
 
-fn resolve_hooks_dir() -> Option<PathBuf> {
-    // Respect core.hooksPath if set
-    let hooks_path = Command::new("git")
-        .args(["config", "core.hooksPath"])
-        .output();
-
-    if let Ok(output) = &hooks_path {
-        if output.status.success() {
-            let custom = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if !custom.is_empty() {
-                let p = PathBuf::from(&custom);
-                // Could be relative to repo root
-                if p.is_absolute() {
-                    return Some(p);
-                }
-                // Resolve relative to working tree
-                if let Ok(wt) = Command::new("git")
-                    .args(["rev-parse", "--show-toplevel"])
-                    .output()
-                {
-                    if wt.status.success() {
-                        let root = String::from_utf8_lossy(&wt.stdout).trim().to_string();
-                        return Some(PathBuf::from(root).join(custom));
-                    }
-                }
-            }
-        }
-    }
-
-    // Default: .git/hooks
-    let git_dir = Command::new("git")
-        .args(["rev-parse", "--git-dir"])
-        .output();
-
-    match git_dir {
-        Ok(output) if output.status.success() => {
-            let dir = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            Some(PathBuf::from(dir).join("hooks"))
-        }
-        _ => None,
-    }
+fn resolve_pre_commit_hook_path() -> Option<PathBuf> {
+    git_path("hooks/pre-commit")
 }
 
 fn install_pre_commit_hook() {
-    let hooks_dir = match resolve_hooks_dir() {
-        Some(d) => d,
+    let hook_path = match resolve_pre_commit_hook_path() {
+        Some(p) => p,
         None => return, // Not in a git repo, skip
+    };
+    let hooks_dir = match hook_path.parent() {
+        Some(d) => d,
+        None => return,
     };
 
     if !hooks_dir.exists() {
-        let _ = fs::create_dir_all(&hooks_dir);
+        let _ = fs::create_dir_all(hooks_dir);
     }
-
-    let hook_path = hooks_dir.join("pre-commit");
 
     if hook_path.exists() {
         // Append sem section if not already present
@@ -220,31 +239,54 @@ fn install_pre_commit_hook() {
 }
 
 pub fn unsetup() -> Result<(), Box<dyn std::error::Error>> {
-    // Unset diff.external
-    let status = Command::new("git")
-        .args(["config", "--global", "--unset", "diff.external"])
-        .status()?;
-    if status.success() {
-        println!(
-            "{} Removed diff.external from global git config",
-            "✓".green().bold(),
-        );
-    } else {
-        println!(
-            "{} diff.external was not set in global git config",
-            "✓".green().bold(),
-        );
+    let path = wrapper_path();
+    let existing_diff_external = diff_external_value();
+    let wrapper_configured = existing_diff_external
+        .as_deref()
+        .is_some_and(|value| is_configured_wrapper(value, &path));
+
+    match existing_diff_external {
+        Some(value) if wrapper_configured => {
+            let status = Command::new("git")
+                .args(["config", "--global", "--unset", "diff.external"])
+                .status()?;
+            if status.success() {
+                println!(
+                    "{} Removed diff.external from global git config",
+                    "✓".green().bold(),
+                );
+            }
+        }
+        Some(value) => {
+            println!(
+                "{} Leaving diff.external untouched ({})",
+                "note:".yellow().bold(),
+                value
+            );
+        }
+        None => {
+            println!(
+                "{} diff.external was not set in global git config",
+                "✓".green().bold(),
+            );
+        }
     }
 
-    // Remove wrapper script
-    let path = wrapper_path();
     if path.exists() {
-        fs::remove_file(&path)?;
-        println!(
-            "{} Removed wrapper script at {}",
-            "✓".green().bold(),
-            path.display()
-        );
+        if wrapper_configured && wrapper_is_owned(&path) {
+            fs::remove_file(&path)?;
+            println!(
+                "{} Removed wrapper script at {}",
+                "✓".green().bold(),
+                path.display()
+            );
+        } else {
+            println!(
+                "{} leaving {} untouched (not owned by this sem install)",
+                "note:".yellow().bold(),
+                path.display()
+            );
+        }
     }
 
     // Remove pre-commit hook section
@@ -259,12 +301,10 @@ pub fn unsetup() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn remove_pre_commit_hook() {
-    let hooks_dir = match resolve_hooks_dir() {
-        Some(d) => d,
+    let hook_path = match resolve_pre_commit_hook_path() {
+        Some(p) => p,
         None => return,
     };
-
-    let hook_path = hooks_dir.join("pre-commit");
     if !hook_path.exists() {
         return;
     }

--- a/crates/sem-cli/src/main.rs
+++ b/crates/sem-cli/src/main.rs
@@ -34,6 +34,10 @@ enum ColorMode {
 enum Commands {
     /// Show semantic diff of changes (supports git diff syntax). Untracked files are excluded, matching git behavior.
     Diff {
+        /// Display path label for direct file comparison
+        #[arg(long, hide = true)]
+        label: Option<String>,
+
         /// Git refs, files, or pathspecs (supports ref1..ref2, ref1...ref2, -- paths)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
@@ -314,6 +318,7 @@ fn main() {
 
     match cli.command {
         Some(Commands::Diff {
+            label,
             args,
             staged,
             cached,
@@ -355,6 +360,7 @@ fn main() {
                 profile,
                 file_exts,
                 no_cosmetics,
+                label,
                 args,
             });
         }
@@ -543,6 +549,7 @@ fn main() {
                 profile: false,
                 file_exts: vec![],
                 no_cosmetics: false,
+                label: None,
                 args: vec![],
             });
         }

--- a/crates/sem-cli/tests/setup_regressions.rs
+++ b/crates/sem-cli/tests/setup_regressions.rs
@@ -1,0 +1,309 @@
+#![cfg(unix)]
+
+use std::env;
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(name: &str) -> Self {
+        let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = env::temp_dir().join(format!(
+            "sem-cli-{name}-{}-{nanos}-{id}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path).unwrap();
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+struct IsolatedEnv {
+    _tmp: TempDir,
+    home: PathBuf,
+    gitconfig: PathBuf,
+    path: OsString,
+}
+
+impl IsolatedEnv {
+    fn new(name: &str) -> Self {
+        let tmp = TempDir::new(name);
+        let home = tmp.path().join("home");
+        fs::create_dir_all(&home).unwrap();
+
+        let sem_dir = sem_bin().parent().unwrap().to_path_buf();
+        let path =
+            env::join_paths([sem_dir, PathBuf::from("/usr/bin"), PathBuf::from("/bin")]).unwrap();
+
+        Self {
+            gitconfig: tmp.path().join("gitconfig"),
+            _tmp: tmp,
+            home,
+            path,
+        }
+    }
+
+    fn apply(&self, command: &mut Command) {
+        command
+            .env("HOME", &self.home)
+            .env("GIT_CONFIG_GLOBAL", &self.gitconfig)
+            .env("PATH", &self.path)
+            .env("NO_COLOR", "1")
+            .env_remove("GIT_EXTERNAL_DIFF");
+    }
+
+    fn wrapper_path(&self) -> PathBuf {
+        self.home.join(".local/bin/sem-diff-wrapper")
+    }
+}
+
+fn sem_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_sem"))
+}
+
+fn output_text(output: &Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn assert_success(output: Output, context: &str) -> Output {
+    assert!(
+        output.status.success(),
+        "{context} failed with status {:?}\n{}",
+        output.status.code(),
+        output_text(&output)
+    );
+    output
+}
+
+fn assert_failure(output: Output, context: &str) -> Output {
+    assert!(
+        !output.status.success(),
+        "{context} unexpectedly succeeded\n{}",
+        output_text(&output)
+    );
+    output
+}
+
+fn run_git(repo: &Path, env: &IsolatedEnv, args: &[&str]) -> Output {
+    let mut command = Command::new("git");
+    command.args(args).current_dir(repo);
+    env.apply(&mut command);
+    assert_success(
+        command.output().unwrap(),
+        &format!("git {}", args.join(" ")),
+    )
+}
+
+fn run_sem(repo: &Path, env: &IsolatedEnv, args: &[&str]) -> Output {
+    let mut command = Command::new(sem_bin());
+    command.args(args).current_dir(repo);
+    env.apply(&mut command);
+    assert_success(
+        command.output().unwrap(),
+        &format!("sem {}", args.join(" ")),
+    )
+}
+
+fn init_repo(root: &Path, env: &IsolatedEnv) {
+    fs::create_dir_all(root).unwrap();
+    run_git(root, env, &["init", "-q"]);
+    run_git(root, env, &["config", "user.email", "t@t.com"]);
+    run_git(root, env, &["config", "user.name", "test"]);
+}
+
+fn commit_python_file(repo: &Path, env: &IsolatedEnv) {
+    fs::write(repo.join("a.py"), "def foo():\n    return 1\n").unwrap();
+    run_git(repo, env, &["add", "a.py"]);
+    run_git(repo, env, &["commit", "-q", "-m", "init"]);
+}
+
+fn path_from_git(repo: &Path, env: &IsolatedEnv, args: &[&str]) -> PathBuf {
+    let output = run_git(repo, env, args);
+    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let path = PathBuf::from(raw);
+    if path.is_absolute() {
+        path
+    } else {
+        repo.join(path)
+    }
+}
+
+#[test]
+fn setup_writes_absolute_external_and_labels_cached_diff() {
+    let tmp = TempDir::new("setup-path");
+    let env = IsolatedEnv::new("setup-path-env");
+    let repo = tmp.path().join("repo");
+    init_repo(&repo, &env);
+    commit_python_file(&repo, &env);
+
+    fs::write(repo.join("a.py"), "def foo():\n    return 2\n").unwrap();
+    run_git(&repo, &env, &["add", "a.py"]);
+
+    run_sem(&repo, &env, &["setup"]);
+
+    let config = run_git(
+        &repo,
+        &env,
+        &["config", "--global", "--get", "diff.external"],
+    );
+    let configured = String::from_utf8_lossy(&config.stdout).trim().to_string();
+    assert_eq!(configured, env.wrapper_path().display().to_string());
+    assert!(Path::new(&configured).is_absolute());
+    assert_ne!(configured, "sem-diff-wrapper");
+
+    let wrapper = fs::read_to_string(env.wrapper_path()).unwrap();
+    assert!(wrapper.contains("sem diff --label \"$1\" \"$2\" \"$5\""));
+    assert!(!wrapper.contains("\"$@\""));
+
+    let diff = run_git(&repo, &env, &["diff", "--cached"]);
+    let stdout = String::from_utf8_lossy(&diff.stdout);
+    assert!(
+        stdout.contains("a.py"),
+        "cached diff should use repo path\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("git-blob"),
+        "cached diff should not expose temporary blob paths\n{stdout}"
+    );
+}
+
+#[test]
+fn unsetup_keeps_foreign_wrapper_when_external_is_unset() {
+    let tmp = TempDir::new("unsetup-foreign");
+    let env = IsolatedEnv::new("unsetup-foreign-env");
+    fs::create_dir_all(env.wrapper_path().parent().unwrap()).unwrap();
+    let foreign = "#!/bin/sh\n# hand edited wrapper\nexec sem diff \"$2\" \"$5\"\n";
+    fs::write(env.wrapper_path(), foreign).unwrap();
+
+    run_sem(tmp.path(), &env, &["unsetup"]);
+
+    assert_eq!(fs::read_to_string(env.wrapper_path()).unwrap(), foreign);
+}
+
+#[test]
+fn unsetup_unsets_external_but_keeps_modified_wrapper() {
+    let tmp = TempDir::new("unsetup-modified");
+    let env = IsolatedEnv::new("unsetup-modified-env");
+    fs::create_dir_all(env.wrapper_path().parent().unwrap()).unwrap();
+    let modified = "#!/bin/sh\n# locally modified wrapper\nexec sem diff \"$@\"\n";
+    fs::write(env.wrapper_path(), modified).unwrap();
+    run_git(
+        tmp.path(),
+        &env,
+        &[
+            "config",
+            "--global",
+            "diff.external",
+            env.wrapper_path().to_str().unwrap(),
+        ],
+    );
+
+    run_sem(tmp.path(), &env, &["unsetup"]);
+
+    assert_eq!(fs::read_to_string(env.wrapper_path()).unwrap(), modified);
+    let mut command = Command::new("git");
+    command
+        .args(["config", "--global", "--get", "diff.external"])
+        .current_dir(tmp.path());
+    env.apply(&mut command);
+    assert_failure(command.output().unwrap(), "git config --get diff.external");
+}
+
+#[test]
+fn unsetup_removes_owned_wrapper_when_external_points_to_it() {
+    let tmp = TempDir::new("unsetup-owned");
+    let env = IsolatedEnv::new("unsetup-owned-env");
+    let repo = tmp.path().join("repo");
+    init_repo(&repo, &env);
+
+    run_sem(&repo, &env, &["setup"]);
+    assert!(env.wrapper_path().exists());
+
+    run_sem(&repo, &env, &["unsetup"]);
+    assert!(!env.wrapper_path().exists());
+
+    let mut command = Command::new("git");
+    command
+        .args(["config", "--global", "--get", "diff.external"])
+        .current_dir(&repo);
+    env.apply(&mut command);
+    assert_failure(command.output().unwrap(), "git config --get diff.external");
+}
+
+#[test]
+fn setup_and_unsetup_use_git_path_for_linked_worktree_hooks() {
+    let tmp = TempDir::new("linked-hooks");
+    let env = IsolatedEnv::new("linked-hooks-env");
+    let repo = tmp.path().join("repo");
+    let linked = tmp.path().join("repo-linked");
+    init_repo(&repo, &env);
+    commit_python_file(&repo, &env);
+    run_git(
+        &repo,
+        &env,
+        &[
+            "worktree",
+            "add",
+            "-q",
+            "--detach",
+            linked.to_str().unwrap(),
+            "HEAD",
+        ],
+    );
+
+    run_sem(&linked, &env, &["setup"]);
+
+    let hook_path = path_from_git(
+        &linked,
+        &env,
+        &["rev-parse", "--git-path", "hooks/pre-commit"],
+    );
+    let wrong_hook_path =
+        path_from_git(&linked, &env, &["rev-parse", "--git-dir"]).join("hooks/pre-commit");
+
+    assert!(
+        hook_path.exists(),
+        "hook should be installed at {:?}",
+        hook_path
+    );
+    assert_ne!(hook_path, wrong_hook_path);
+    assert!(
+        !wrong_hook_path.exists(),
+        "hook should not be installed in linked worktree private git dir"
+    );
+    assert!(fs::read_to_string(&hook_path)
+        .unwrap()
+        .contains("# === sem pre-commit hook ==="));
+
+    run_sem(&linked, &env, &["unsetup"]);
+    assert!(
+        !hook_path.exists(),
+        "unsetup from linked worktree should remove the real hook"
+    );
+}


### PR DESCRIPTION
## Summary
- write diff.external as the absolute wrapper path and forward git's full external-diff argument list so cached diffs keep repo-relative labels
- make unsetup preserve foreign or modified wrapper scripts and leave unrelated diff.external values untouched
- resolve pre-commit hooks through git --git-path so linked worktrees and hooksPath behave correctly

Closes #171
Closes #172
Closes #200
Closes #201

## Test plan
- cargo test -p sem-cli --test setup_regressions
- cargo test --workspace
- npm test
- dummy repo validation under ~/Developer/oss with isolated HOME and GIT_CONFIG_GLOBAL: setup, git diff --cached, linked worktree hook install/removal, unsetup