### PR TITLE
Fix graph import resolution for paths and aliases

### DIFF
--- a/crates/sem-core/src/parser/graph.rs
+++ b/crates/sem-core/src/parser/graph.rs
@@ -28,8 +28,36 @@ macro_rules! maybe_par_iter {
 
 use crate::git::types::{FileChange, FileStatus};
 use crate::model::entity::SemanticEntity;
+use crate::parser::import_resolution::find_import_target;
 use crate::parser::registry::{resolve_go_method_parent_ids, ParserRegistry};
 use crate::parser::scope_resolve;
+
+fn build_scope_consumed_words(
+    resolution_log: &[scope_resolve::ResolutionEntry],
+) -> HashMap<String, HashSet<String>> {
+    let mut consumed_by_entity: HashMap<String, HashSet<String>> = HashMap::new();
+    for entry in resolution_log {
+        let words = consumed_by_entity
+            .entry(entry.from_entity.clone())
+            .or_default();
+        add_scope_reference_words(words, &entry.reference);
+    }
+    consumed_by_entity
+}
+
+fn add_scope_reference_words(words: &mut HashSet<String>, reference: &str) {
+    let reference = reference.strip_suffix("()").unwrap_or(reference);
+    if let Some((receiver, member)) = reference.rsplit_once('.') {
+        if !receiver.is_empty() {
+            words.insert(receiver.to_string());
+        }
+        if !member.is_empty() {
+            words.insert(member.to_string());
+        }
+    } else if !reference.is_empty() {
+        words.insert(reference.to_string());
+    }
+}
 
 /// A reference from one entity to another.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -141,6 +169,7 @@ impl EntityGraph {
         let mut parent_child_pairs: HashSet<(&str, &str)> = HashSet::new();
         let mut class_child_names: HashSet<(&str, &str)> = HashSet::new();
         let mut class_entity_names: HashSet<&str> = HashSet::new();
+        let mut class_entity_files: HashSet<(&str, &str)> = HashSet::new();
         let mut id_to_name: HashMap<&str, &str> = HashMap::with_capacity(all_entities.len());
         let mut scope_entity_ranges: HashMap<String, Vec<(usize, usize, String)>> = HashMap::new();
 
@@ -170,6 +199,7 @@ impl EntityGraph {
 
             if matches!(entity.entity_type.as_str(), "class" | "struct" | "interface" | "class_type") {
                 class_entity_names.insert(entity.name.as_str());
+                class_entity_files.insert((entity.name.as_str(), entity.file_path.as_str()));
             }
 
             id_to_name.insert(entity.id.as_str(), entity.name.as_str());
@@ -266,14 +296,12 @@ impl EntityGraph {
                 .and_then(|c| c.scope_resolve)
                 .is_some()
         });
-        let (scope_edges, scope_resolved_entities) = if has_scope_lang {
+        let (scope_edges, scope_consumed_words) = if has_scope_lang {
             let result = scope_resolve::resolve_with_scopes_full(root, file_paths, &all_entities, &entity_map, Some(parsed_files), Some(pre_built));
-            let resolved_entity_ids: HashSet<String> = result.edges.iter()
-                .map(|(from, _, _)| from.clone())
-                .collect();
-            (result.edges, resolved_entity_ids)
+            let consumed_words = build_scope_consumed_words(&result.resolution_log);
+            (result.edges, consumed_words)
         } else {
-            (vec![], HashSet::new())
+            (vec![], HashMap::new())
         };
 
         // Pass 2: Extract references in parallel, then resolve against symbol table
@@ -283,11 +311,6 @@ impl EntityGraph {
         // Skip entities from non-code file types (JSON, SQL, etc.) that can't produce edges
         let resolved_refs: Vec<(String, String, RefType)> = maybe_par_iter!(all_entities)
             .flat_map(|entity| {
-                // Skip entities already resolved by scope resolver
-                if scope_resolved_entities.contains(&entity.id) {
-                    return vec![];
-                }
-
                 // Skip entities from file types that don't have language configs
                 // (JSON, SQL, YAML, etc. — they extract entities but never produce reference edges)
                 let ext = entity.file_path.rfind('.').map(|i| &entity.file_path[i..]).unwrap_or("");
@@ -296,7 +319,10 @@ impl EntityGraph {
                 }
 
                 let mut entity_edges = Vec::new();
-                let mut consumed_words: HashSet<String> = HashSet::new();
+                let mut consumed_words = scope_consumed_words
+                    .get(&entity.id)
+                    .cloned()
+                    .unwrap_or_default();
 
                 // Strip comments/strings once, reuse for both dot-chain and bag-of-words
                 let stripped = strip_comments_and_strings(&entity.content);
@@ -305,6 +331,7 @@ impl EntityGraph {
                 let dot_chains = extract_dot_chains(&stripped);
 
                 for (receiver, member) in &dot_chains {
+                    let edge_count_before = entity_edges.len();
                     if *receiver == "self" || *receiver == "this" {
                         // self.B / this.B: resolve to sibling method in enclosing class
                         if let Some(class_name) = enclosing_class.get(entity.id.as_str()) {
@@ -322,7 +349,7 @@ impl EntityGraph {
                                 }
                             }
                         }
-                    } else if class_entity_names.contains(*receiver) {
+                    } else if class_entity_files.contains(&(*receiver, entity.file_path.as_str())) {
                         // ClassName.B: resolve to class member
                         if let Some(members) = class_members.get(*receiver) {
                             for (n, tid) in members {
@@ -339,7 +366,9 @@ impl EntityGraph {
                             }
                         }
                     }
-                    // Unresolved chains fall through to bag-of-words below
+                    if entity_edges.len() == edge_count_before {
+                        consumed_words.insert(member.to_string());
+                    }
                 }
 
                 // Phase 2: Bag-of-words resolution (skip words consumed by dot-chains)
@@ -653,6 +682,11 @@ impl EntityGraph {
             .filter(|e| matches!(e.entity_type.as_str(), "class" | "struct" | "interface" | "class_type"))
             .map(|e| e.name.as_str())
             .collect();
+        let class_entity_files: HashSet<(&str, &str)> = all_entities
+            .iter()
+            .filter(|e| matches!(e.entity_type.as_str(), "class" | "struct" | "interface" | "class_type"))
+            .map(|e| (e.name.as_str(), e.file_path.as_str()))
+            .collect();
 
         let id_to_name: HashMap<&str, &str> = all_entities
             .iter()
@@ -697,7 +731,7 @@ impl EntityGraph {
                 .and_then(|c| c.scope_resolve)
                 .is_some()
         });
-        let (scope_edges, scope_resolved_entities) = if has_scope_lang {
+        let (scope_edges, scope_consumed_words) = if has_scope_lang {
             // Pass pre-parsed stale-file trees; scope_resolve reads affected clean files from disk
             let resolve_set: HashSet<&str> = resolve_file_paths.iter().map(|s| s.as_str()).collect();
             let relevant_parsed: Vec<(String, String, tree_sitter::Tree)> = parsed_files
@@ -706,22 +740,16 @@ impl EntityGraph {
                 .collect();
             let pre = if relevant_parsed.is_empty() { None } else { Some(relevant_parsed) };
             let result = scope_resolve::resolve_with_scopes_full(root, &resolve_file_paths, &all_entities, &entity_map, pre, None);
-            let resolved_entity_ids: HashSet<String> = result.edges.iter()
-                .map(|(from, _, _)| from.clone())
-                .collect();
-            (result.edges, resolved_entity_ids)
+            let consumed_words = build_scope_consumed_words(&result.resolution_log);
+            (result.edges, consumed_words)
         } else {
-            (vec![], HashSet::new())
+            (vec![], HashMap::new())
         };
 
         // Resolve references only for entities in needs_resolution
         let resolved_refs: Vec<(String, String, RefType)> = maybe_par_iter!(all_entities)
             .filter(|e| needs_resolution.contains(e.id.as_str()))
             .flat_map(|entity| {
-                if scope_resolved_entities.contains(&entity.id) {
-                    return vec![];
-                }
-
                 // Skip entities from non-code file types (JSON, SQL, etc.)
                 let ext = entity.file_path.rfind('.').map(|i| &entity.file_path[i..]).unwrap_or("");
                 if crate::parser::plugins::code::languages::get_language_config(ext).is_none() {
@@ -729,7 +757,10 @@ impl EntityGraph {
                 }
 
                 let mut entity_edges = Vec::new();
-                let mut consumed_words: HashSet<String> = HashSet::new();
+                let mut consumed_words = scope_consumed_words
+                    .get(&entity.id)
+                    .cloned()
+                    .unwrap_or_default();
 
                 // Strip comments/strings once, reuse for both dot-chain and bag-of-words
                 let stripped = strip_comments_and_strings(&entity.content);
@@ -738,6 +769,7 @@ impl EntityGraph {
                 let dot_chains = extract_dot_chains(&stripped);
 
                 for (receiver, member) in &dot_chains {
+                    let edge_count_before = entity_edges.len();
                     if *receiver == "self" || *receiver == "this" {
                         if let Some(class_name) = enclosing_class.get(entity.id.as_str()) {
                             if let Some(members) = class_members.get(class_name) {
@@ -754,7 +786,7 @@ impl EntityGraph {
                                 }
                             }
                         }
-                    } else if class_entity_names.contains(*receiver) {
+                    } else if class_entity_files.contains(&(*receiver, entity.file_path.as_str())) {
                         if let Some(members) = class_members.get(*receiver) {
                             for (n, tid) in members {
                                 if *n == *member {
@@ -769,6 +801,9 @@ impl EntityGraph {
                                 }
                             }
                         }
+                    }
+                    if entity_edges.len() == edge_count_before {
+                        consumed_words.insert(member.to_string());
                     }
                 }
 
@@ -1421,12 +1456,6 @@ fn build_import_table(
                         let module_path = &rest[..import_pos];
                         let names_str = &rest[import_pos + skip..];
 
-                        let source_module = module_path
-                            .trim_start_matches('.')
-                            .rsplit('.')
-                            .next()
-                            .unwrap_or(module_path.trim_start_matches('.'));
-
                         for name_part in names_str.split(',') {
                             let name_part = name_part.trim();
                             let imported_name = name_part.split_whitespace().next().unwrap_or(name_part);
@@ -1437,17 +1466,13 @@ fn build_import_table(
                             }
 
                             if let Some(target_ids) = symbol_table.get(imported_name) {
-                                let target = target_ids.iter().find(|id| {
-                                    entity_map.get(*id).map_or(false, |e| {
-                                        let stem = e.file_path.rsplit('/').next().unwrap_or(&e.file_path);
-                                        let stem = stem.strip_suffix(".py")
-                                            .or_else(|| stem.strip_suffix(".ts"))
-                                            .or_else(|| stem.strip_suffix(".js"))
-                                            .or_else(|| stem.strip_suffix(".rs"))
-                                            .unwrap_or(stem);
-                                        stem == source_module
-                                    })
-                                });
+                                let target = find_import_target(
+                                    target_ids,
+                                    module_path,
+                                    file_path,
+                                    &[".py"],
+                                    entity_map,
+                                );
                                 if let Some(target_id) = target {
                                     local_imports.push((
                                         (file_path.clone(), imported_name.to_string()),
@@ -1476,8 +1501,6 @@ fn build_import_table(
                 for cap in JS_NAMED_RE.captures_iter(content) {
                     let names_str = cap.get(1).unwrap().as_str();
                     let module_path = cap.get(2).unwrap().as_str();
-                    let source_module = module_path.rsplit('/').next().unwrap_or(module_path);
-                    let source_module = strip_js_ext(source_module);
 
                     for name_part in names_str.split(',') {
                         let name_part = name_part.trim();
@@ -1497,13 +1520,13 @@ fn build_import_table(
                         if original_name.is_empty() || local_name.is_empty() { continue; }
 
                         if let Some(target_ids) = symbol_table.get(original_name) {
-                            let target = target_ids.iter().find(|id| {
-                                entity_map.get(*id).map_or(false, |e| {
-                                    let stem = e.file_path.rsplit('/').next().unwrap_or(&e.file_path);
-                                    let stem = strip_file_ext(stem);
-                                    stem == source_module
-                                })
-                            });
+                            let target = find_import_target(
+                                target_ids,
+                                module_path,
+                                file_path,
+                                &[".ts", ".tsx", ".js", ".jsx"],
+                                entity_map,
+                            );
                             if let Some(target_id) = target {
                                 local_imports.push((
                                     (file_path.clone(), local_name.to_string()),
@@ -1517,17 +1540,15 @@ fn build_import_table(
                 for cap in JS_DEFAULT_RE.captures_iter(content) {
                     let local_name = cap.get(1).unwrap().as_str();
                     let module_path = cap.get(2).unwrap().as_str();
-                    let source_module = module_path.rsplit('/').next().unwrap_or(module_path);
-                    let source_module = strip_js_ext(source_module);
 
                     if let Some(target_ids) = symbol_table.get(local_name) {
-                        let target = target_ids.iter().find(|id| {
-                            entity_map.get(*id).map_or(false, |e| {
-                                let stem = e.file_path.rsplit('/').next().unwrap_or(&e.file_path);
-                                let stem = strip_file_ext(stem);
-                                stem == source_module
-                            })
-                        });
+                        let target = find_import_target(
+                            target_ids,
+                            module_path,
+                            file_path,
+                            &[".ts", ".tsx", ".js", ".jsx"],
+                            entity_map,
+                        );
                         if let Some(target_id) = target {
                             local_imports.push((
                                 (file_path.clone(), local_name.to_string()),
@@ -1663,15 +1684,6 @@ fn resolve_rust_import(
             );
         }
     }
-}
-
-/// Strip JS/TS extensions from a module name.
-fn strip_js_ext(s: &str) -> &str {
-    s.strip_suffix(".js")
-        .or_else(|| s.strip_suffix(".ts"))
-        .or_else(|| s.strip_suffix(".jsx"))
-        .or_else(|| s.strip_suffix(".tsx"))
-        .unwrap_or(s)
 }
 
 /// Strip common file extensions from a filename.
@@ -2343,6 +2355,392 @@ export function main() { return helper(); }
             deps.iter().any(|d| d.name == "helper"),
             "main should depend on helper via JS import. Deps: {:?}",
             deps.iter().map(|d| &d.name).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_js_ts_relative_import_resolution_uses_full_path() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "src/a/util.ts", "\
+export function helper() { return 1; }
+");
+        write_file(root, "src/b/util.ts", "\
+export function helper() { return 2; }
+");
+        write_file(root, "src/main.ts", "\
+import { helper } from './b/util';
+export function caller() { return helper(); }
+");
+
+        let (graph, _) = EntityGraph::build(
+            root,
+            &["src/a/util.ts".into(), "src/b/util.ts".into(), "src/main.ts".into()],
+            &registry,
+        );
+
+        let caller_id = graph.entities.keys()
+            .find(|id| id.contains("caller"))
+            .expect("caller entity should exist");
+        let deps = graph.get_dependencies(caller_id);
+        assert!(
+            deps.iter().any(|d| d.name == "helper" && d.file_path == "src/b/util.ts"),
+            "caller should resolve helper to src/b/util.ts. Deps: {:?}",
+            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+        assert!(
+            !deps.iter().any(|d| d.name == "helper" && d.file_path == "src/a/util.ts"),
+            "caller should not resolve helper to src/a/util.ts. Deps: {:?}",
+            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_js_ts_relative_import_with_extension_prefers_exact_file() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "src/util.js", "\
+export function helper() { return 1; }
+");
+        write_file(root, "src/util.ts", "\
+export function helper() { return 2; }
+");
+        write_file(root, "src/main.ts", "\
+import { helper } from './util.ts';
+export function caller() { return helper(); }
+");
+
+        let (graph, _) = EntityGraph::build(
+            root,
+            &["src/util.js".into(), "src/util.ts".into(), "src/main.ts".into()],
+            &registry,
+        );
+
+        let caller_id = graph.entities.keys()
+            .find(|id| id.contains("caller"))
+            .expect("caller entity should exist");
+        let deps = graph.get_dependencies(caller_id);
+        assert!(
+            deps.iter().any(|d| d.name == "helper" && d.file_path == "src/util.ts"),
+            "caller should resolve helper to explicit src/util.ts. Deps: {:?}",
+            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+        assert!(
+            !deps.iter().any(|d| d.name == "helper" && d.file_path == "src/util.js"),
+            "caller should not resolve explicit ./util.ts to src/util.js. Deps: {:?}",
+            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_python_relative_import_resolution_uses_full_path() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "src/a/util.py", "\
+def helper():
+    return 1
+");
+        write_file(root, "src/b/util.py", "\
+def helper():
+    return 2
+");
+        write_file(root, "src/main.py", "\
+from .b.util import helper
+
+def caller():
+    return helper()
+");
+
+        let (graph, _) = EntityGraph::build(
+            root,
+            &["src/a/util.py".into(), "src/b/util.py".into(), "src/main.py".into()],
+            &registry,
+        );
+
+        let caller_id = graph.entities.keys()
+            .find(|id| id.contains("caller"))
+            .expect("caller entity should exist");
+        let deps = graph.get_dependencies(caller_id);
+        assert!(
+            deps.iter().any(|d| d.name == "helper" && d.file_path == "src/b/util.py"),
+            "caller should resolve helper to src/b/util.py. Deps: {:?}",
+            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+        assert!(
+            !deps.iter().any(|d| d.name == "helper" && d.file_path == "src/a/util.py"),
+            "caller should not resolve helper to src/a/util.py. Deps: {:?}",
+            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_python_absolute_import_resolution_uses_full_path() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "src/a/util.py", "\
+def helper():
+    return 1
+");
+        write_file(root, "src/b/util.py", "\
+def helper():
+    return 2
+");
+        write_file(root, "src/main.py", "\
+from src.b.util import helper
+
+def caller():
+    return helper()
+");
+
+        let (graph, _) = EntityGraph::build(
+            root,
+            &["src/a/util.py".into(), "src/b/util.py".into(), "src/main.py".into()],
+            &registry,
+        );
+
+        let caller_id = graph.entities.keys()
+            .find(|id| id.contains("caller"))
+            .expect("caller entity should exist");
+        let deps = graph.get_dependencies(caller_id);
+        assert!(
+            deps.iter().any(|d| d.name == "helper" && d.file_path == "src/b/util.py"),
+            "caller should resolve helper to src/b/util.py. Deps: {:?}",
+            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+        assert!(
+            !deps.iter().any(|d| d.name == "helper" && d.file_path == "src/a/util.py"),
+            "caller should not resolve helper to src/a/util.py. Deps: {:?}",
+            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_js_ts_named_import_does_not_resolve_unrelated_method_receiver() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "lib.ts", "\
+export function foo() { return 1; }
+");
+        write_file(root, "main.ts", "\
+import { foo } from './lib';
+export function caller(other) { return other.foo(); }
+export function actual() { return foo(); }
+");
+
+        let (graph, _) = EntityGraph::build(
+            root,
+            &["lib.ts".into(), "main.ts".into()],
+            &registry,
+        );
+
+        let caller_id = graph.entities.keys()
+            .find(|id| id.contains("caller"))
+            .expect("caller entity should exist");
+        let caller_deps = graph.get_dependencies(caller_id);
+        assert!(
+            !caller_deps.iter().any(|d| d.name == "foo" && d.file_path == "lib.ts"),
+            "other.foo() should not resolve through a bare named import. Deps: {:?}",
+            caller_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+
+        let actual_id = graph.entities.keys()
+            .find(|id| id.contains("actual"))
+            .expect("actual entity should exist");
+        let actual_deps = graph.get_dependencies(actual_id);
+        assert!(
+            actual_deps.iter().any(|d| d.name == "foo" && d.file_path == "lib.ts"),
+            "foo() should still resolve through the named import. Deps: {:?}",
+            actual_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_unresolved_method_does_not_block_unrelated_fallback_import() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "lib.ts", "\
+export const answer = 1;
+export function foo() { return 1; }
+");
+        write_file(root, "main.ts", "\
+import { answer, foo } from './lib';
+export function caller(other) {
+    other.foo();
+    return answer;
+}
+");
+
+        let (graph, _) = EntityGraph::build(
+            root,
+            &["lib.ts".into(), "main.ts".into()],
+            &registry,
+        );
+
+        let caller_id = graph.entities.keys()
+            .find(|id| id.contains("caller"))
+            .expect("caller entity should exist");
+        let deps = graph.get_dependencies(caller_id);
+        assert!(
+            deps.iter().any(|d| d.name == "answer" && d.file_path == "lib.ts"),
+            "unresolved other.foo() should not block bare answer import fallback. Deps: {:?}",
+            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+        assert!(
+            !deps.iter().any(|d| d.name == "foo" && d.file_path == "lib.ts"),
+            "other.foo() should not resolve through the named import. Deps: {:?}",
+            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_js_ts_namespace_import_respects_receiver_alias() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "lib.ts", "\
+export function foo() { return 1; }
+");
+        write_file(root, "other.ts", "\
+export function foo() { return 2; }
+");
+        write_file(root, "main.ts", "\
+import * as lib from './lib';
+export function caller(other) { return other.foo(); }
+export function actual() { return lib.foo(); }
+");
+
+        let (graph, _) = EntityGraph::build(
+            root,
+            &["lib.ts".into(), "other.ts".into(), "main.ts".into()],
+            &registry,
+        );
+
+        let caller_id = graph.entities.keys()
+            .find(|id| id.contains("caller"))
+            .expect("caller entity should exist");
+        let caller_deps = graph.get_dependencies(caller_id);
+        assert!(
+            !caller_deps.iter().any(|d| d.name == "foo"),
+            "other.foo() should not resolve via namespace import lib. Deps: {:?}",
+            caller_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+
+        let actual_id = graph.entities.keys()
+            .find(|id| id.contains("actual"))
+            .expect("actual entity should exist");
+        let actual_deps = graph.get_dependencies(actual_id);
+        assert!(
+            actual_deps.iter().any(|d| d.name == "foo" && d.file_path == "lib.ts"),
+            "lib.foo() should resolve to lib.ts. Deps: {:?}",
+            actual_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+        assert!(
+            !actual_deps.iter().any(|d| d.name == "foo" && d.file_path == "other.ts"),
+            "lib.foo() should not resolve to other.ts. Deps: {:?}",
+            actual_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_js_ts_local_binding_shadows_imported_class_receiver() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "lib.ts", "\
+export class Service {
+    static run() { return 1; }
+}
+");
+        write_file(root, "main.ts", "\
+import { Service } from './lib';
+export function caller(Service) { return Service.run(); }
+");
+
+        let (graph, _) = EntityGraph::build(
+            root,
+            &["lib.ts".into(), "main.ts".into()],
+            &registry,
+        );
+
+        let caller_id = graph.entities.keys()
+            .find(|id| id.contains("caller"))
+            .expect("caller entity should exist");
+        let deps = graph.get_dependencies(caller_id);
+        assert!(
+            !deps.iter().any(|d| d.name == "run" && d.file_path == "lib.ts"),
+            "local parameter Service should shadow imported class receiver. Deps: {:?}",
+            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+        assert!(
+            !deps.iter().any(|d| d.name == "Service" && d.file_path == "lib.ts"),
+            "local parameter Service should shadow imported class name. Deps: {:?}",
+            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_js_ts_local_binding_shadows_namespace_receiver() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "lib.ts", "\
+export function foo() { return 1; }
+");
+        write_file(root, "main.ts", "\
+import * as lib from './lib';
+export function caller(lib) { return lib.foo(); }
+");
+
+        let (graph, _) = EntityGraph::build(
+            root,
+            &["lib.ts".into(), "main.ts".into()],
+            &registry,
+        );
+
+        let caller_id = graph.entities.keys()
+            .find(|id| id.contains("caller"))
+            .expect("caller entity should exist");
+        let deps = graph.get_dependencies(caller_id);
+        assert!(
+            !deps.iter().any(|d| d.name == "foo" && d.file_path == "lib.ts"),
+            "local parameter lib should shadow namespace import receiver. Deps: {:?}",
+            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_js_ts_local_binding_shadows_named_import_call() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "lib.ts", "\
+export function foo() { return 1; }
+");
+        write_file(root, "main.ts", "\
+import { foo } from './lib';
+export function caller(foo) { return foo(); }
+");
+
+        let (graph, _) = EntityGraph::build(
+            root,
+            &["lib.ts".into(), "main.ts".into()],
+            &registry,
+        );
+
+        let caller_id = graph.entities.keys()
+            .find(|id| id.contains("caller"))
+            .expect("caller entity should exist");
+        let deps = graph.get_dependencies(caller_id);
+        assert!(
+            !deps.iter().any(|d| d.name == "foo" && d.file_path == "lib.ts"),
+            "local parameter foo should shadow named import. Deps: {:?}",
+            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
         );
     }
 

--- a/crates/sem-core/src/parser/import_resolution.rs
+++ b/crates/sem-core/src/parser/import_resolution.rs
@@ -1,0 +1,239 @@
+use std::collections::{HashMap, HashSet};
+use std::path::{Component, Path, PathBuf};
+
+use crate::parser::graph::EntityInfo;
+
+pub(crate) fn find_import_target<'a>(
+    target_ids: &'a [String],
+    source_path: &str,
+    file_path: &str,
+    extensions: &[&str],
+    entity_map: &HashMap<String, EntityInfo>,
+) -> Option<&'a String> {
+    if let Some(candidates) = import_file_candidates(file_path, source_path, extensions) {
+        return candidates.iter().find_map(|candidate_path| {
+            target_ids.iter().find(|id| {
+                entity_map
+                    .get(*id)
+                    .map_or(false, |e| e.file_path == *candidate_path)
+            })
+        });
+    }
+
+    let source_module = import_stem(source_path);
+    target_ids.iter().find(|id| {
+        entity_map
+            .get(*id)
+            .map_or(false, |e| file_stem(&e.file_path) == source_module)
+    })
+}
+
+pub(crate) fn import_source_matches_file(
+    importing_file_path: &str,
+    source_path: &str,
+    extensions: &[&str],
+    candidate_file_path: &str,
+) -> bool {
+    import_file_candidates(importing_file_path, source_path, extensions).map_or_else(
+        || file_stem(candidate_file_path) == import_stem(source_path),
+        |paths| paths.iter().any(|path| path == candidate_file_path),
+    )
+}
+
+fn import_file_candidates(
+    file_path: &str,
+    source_path: &str,
+    extensions: &[&str],
+) -> Option<Vec<String>> {
+    let source_path = source_path.trim();
+    if source_path.is_empty() {
+        return None;
+    }
+
+    let module_path = if source_path.starts_with('.')
+        && !source_path.starts_with("./")
+        && !source_path.starts_with("../")
+    {
+        python_relative_module_path(file_path, source_path)?
+    } else if source_path.starts_with("./") || source_path.starts_with("../") {
+        let base_dir = Path::new(file_path)
+            .parent()
+            .unwrap_or_else(|| Path::new(""));
+        normalize_repo_path(base_dir.join(source_path))?
+    } else if extensions.len() == 1 && extensions[0] == ".py" && source_path.contains('.') {
+        normalize_repo_path(PathBuf::from(source_path.replace('.', "/")))?
+    } else {
+        return None;
+    };
+
+    Some(module_candidates(&module_path, extensions))
+}
+
+fn python_relative_module_path(file_path: &str, source_path: &str) -> Option<String> {
+    let dot_count = source_path.chars().take_while(|c| *c == '.').count();
+    if dot_count == 0 {
+        return None;
+    }
+
+    let mut base = PathBuf::from(
+        Path::new(file_path)
+            .parent()
+            .unwrap_or_else(|| Path::new("")),
+    );
+    for _ in 1..dot_count {
+        base = base.parent()?.to_path_buf();
+    }
+
+    let remainder = source_path[dot_count..].replace('.', "/");
+    if remainder.is_empty() {
+        normalize_repo_path(base)
+    } else {
+        normalize_repo_path(base.join(remainder))
+    }
+}
+
+fn module_candidates(module_path: &str, extensions: &[&str]) -> Vec<String> {
+    let mut candidates = Vec::new();
+    let known_ext = extensions.iter().find(|ext| module_path.ends_with(**ext));
+
+    if let Some(_ext) = known_ext {
+        candidates.push(module_path.to_string());
+    } else {
+        for ext in extensions {
+            candidates.push(format!("{module_path}{ext}"));
+        }
+        for ext in extensions {
+            candidates.push(format!("{module_path}/index{ext}"));
+        }
+    }
+
+    let mut seen = HashSet::new();
+    candidates.retain(|candidate| seen.insert(candidate.clone()));
+    candidates
+}
+
+fn normalize_repo_path(path: PathBuf) -> Option<String> {
+    let mut parts: Vec<String> = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                parts.pop()?;
+            }
+            Component::Normal(part) => parts.push(part.to_str()?.to_string()),
+            Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+    Some(parts.join("/"))
+}
+
+fn import_stem(source_path: &str) -> &str {
+    let source_path = source_path.trim_start_matches('.');
+    let source_path = source_path.rsplit('/').next().unwrap_or(source_path);
+    let stem = file_stem(source_path);
+    if stem == source_path {
+        source_path.rsplit('.').next().unwrap_or(source_path)
+    } else {
+        stem
+    }
+}
+
+fn file_stem(file_path: &str) -> &str {
+    let file_name = file_path.rsplit('/').next().unwrap_or(file_path);
+    file_name
+        .strip_suffix(".py")
+        .or_else(|| file_name.strip_suffix(".rs"))
+        .or_else(|| file_name.strip_suffix(".ts"))
+        .or_else(|| file_name.strip_suffix(".tsx"))
+        .or_else(|| file_name.strip_suffix(".js"))
+        .or_else(|| file_name.strip_suffix(".jsx"))
+        .or_else(|| file_name.strip_suffix(".go"))
+        .unwrap_or(file_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entity(file_path: &str) -> EntityInfo {
+        EntityInfo {
+            id: format!("{file_path}::function::helper"),
+            name: "helper".to_string(),
+            entity_type: "function".to_string(),
+            file_path: file_path.to_string(),
+            parent_id: None,
+            start_line: 1,
+            end_line: 1,
+        }
+    }
+
+    #[test]
+    fn explicit_relative_import_prefers_exact_extension() {
+        let ids = vec![
+            "src/util.js::function::helper".to_string(),
+            "src/util.ts::function::helper".to_string(),
+        ];
+        let entity_map = HashMap::from([
+            (ids[0].clone(), entity("src/util.js")),
+            (ids[1].clone(), entity("src/util.ts")),
+        ]);
+
+        let target = find_import_target(
+            &ids,
+            "./util.ts",
+            "src/main.ts",
+            &[".ts", ".tsx", ".js", ".jsx"],
+            &entity_map,
+        );
+
+        assert_eq!(target, Some(&ids[1]));
+    }
+
+    #[test]
+    fn explicit_relative_import_requires_exact_extension() {
+        let ids = vec!["src/util.js::function::helper".to_string()];
+        let entity_map = HashMap::from([(ids[0].clone(), entity("src/util.js"))]);
+
+        let target = find_import_target(
+            &ids,
+            "./util.ts",
+            "src/main.ts",
+            &[".ts", ".tsx", ".js", ".jsx"],
+            &entity_map,
+        );
+
+        assert_eq!(target, None);
+    }
+
+    #[test]
+    fn absolute_python_import_uses_dotted_path() {
+        let ids = vec![
+            "src/a/util.py::function::helper".to_string(),
+            "src/b/util.py::function::helper".to_string(),
+        ];
+        let entity_map = HashMap::from([
+            (ids[0].clone(), entity("src/a/util.py")),
+            (ids[1].clone(), entity("src/b/util.py")),
+        ]);
+
+        let target = find_import_target(&ids, "src.b.util", "src/main.py", &[".py"], &entity_map);
+
+        assert_eq!(target, Some(&ids[1]));
+    }
+
+    #[test]
+    fn bare_import_with_extension_uses_file_stem() {
+        let ids = vec!["src/util.ts::function::helper".to_string()];
+        let entity_map = HashMap::from([(ids[0].clone(), entity("src/util.ts"))]);
+
+        let target = find_import_target(
+            &ids,
+            "util.ts",
+            "src/main.ts",
+            &[".ts", ".tsx", ".js", ".jsx"],
+            &entity_map,
+        );
+
+        assert_eq!(target, Some(&ids[0]));
+    }
+}

--- a/crates/sem-core/src/parser/mod.rs
+++ b/crates/sem-core/src/parser/mod.rs
@@ -7,4 +7,5 @@ pub mod verify;
 pub mod context;
 #[cfg(feature = "git")]
 pub mod hotspot;
+mod import_resolution;
 pub mod scope_resolve;

--- a/crates/sem-core/src/parser/scope_resolve.rs
+++ b/crates/sem-core/src/parser/scope_resolve.rs
@@ -11,7 +11,7 @@
 //! - Tracks variable types through assignments (x = Foo() → x.method → Foo.method)
 //! - Uses AST structure, not string matching
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -29,6 +29,7 @@ macro_rules! maybe_par_iter {
     }};
 }
 use crate::parser::graph::{EntityInfo, RefType};
+use crate::parser::import_resolution::{find_import_target, import_source_matches_file};
 use crate::parser::plugins::code::languages::{
     get_language_config, AssignmentStrategy, CallNodeStyle, ClassNameField, InitStrategy,
     ParamNameField, ScopeResolveConfig,
@@ -39,6 +40,8 @@ pub struct Scope {
     parent: Option<usize>,
     /// Definitions visible in this scope: name -> entity_id
     defs: HashMap<String, String>,
+    /// Local bindings that shadow outer names but are not graph entities.
+    bindings: HashSet<String>,
     /// Variable type bindings: var_name -> class_name (from `x = Foo()`)
     types: HashMap<String, String>,
     /// Unresolved call assignments: var_name -> function_name (from `x = func()`)
@@ -312,6 +315,7 @@ pub(crate) fn resolve_with_scopes_full(
             let mut scopes: Vec<Scope> = vec![Scope {
                 parent: None,
                 defs: HashMap::new(),
+                bindings: HashSet::new(),
                 types: HashMap::new(),
                 pending_call_types: HashMap::new(),
                 owner_id: None,
@@ -560,6 +564,7 @@ fn build_scopes_from_ast(
                     scopes.push(Scope {
                         parent: Some(current_scope),
                         defs: HashMap::new(),
+                        bindings: HashSet::new(),
                         types: HashMap::new(),
                         pending_call_types: HashMap::new(),
                         owner_id: Some(ce.id.clone()),
@@ -590,6 +595,7 @@ fn build_scopes_from_ast(
                 scopes.push(Scope {
                     parent: Some(current_scope),
                     defs: HashMap::new(),
+                    bindings: HashSet::new(),
                     types: HashMap::new(),
                     pending_call_types: HashMap::new(),
                     owner_id: None,
@@ -615,6 +621,7 @@ fn build_scopes_from_ast(
             scopes.push(Scope {
                 parent: Some(current_scope),
                 defs: HashMap::new(),
+                bindings: HashSet::new(),
                 types: HashMap::new(),
                 pending_call_types: HashMap::new(),
                 owner_id: None,
@@ -684,6 +691,7 @@ fn build_scopes_from_ast(
             scopes.push(Scope {
                 parent: Some(parent_scope),
                 defs: HashMap::new(),
+                bindings: HashSet::new(),
                 types: HashMap::new(),
                 pending_call_types: HashMap::new(),
                 owner_id: None,
@@ -854,6 +862,7 @@ fn scan_function_params(
             if param_name.is_empty() || rule.skip_names.contains(&param_name) {
                 continue;
             }
+            scopes[scope_idx].bindings.insert(param_name.to_string());
 
             if let Some(type_node) = child.child_by_field_name(rule.type_field) {
                 let type_text = extract_base_type(type_node, source);
@@ -903,6 +912,7 @@ fn scan_single_assignment(
         Ok(n) => n.to_string(),
         Err(_) => return,
     };
+    scopes[scope_idx].bindings.insert(var_name.clone());
 
     record_type_from_rhs(right, &var_name, scope_idx, scopes, source);
 }
@@ -925,6 +935,7 @@ fn scan_ts_var_declaration(
             if var_name.is_empty() {
                 continue;
             }
+            scopes[scope_idx].bindings.insert(var_name.clone());
 
             // Check for explicit type annotation: `const x: Foo = ...`
             if let Some(type_ann) = child.child_by_field_name("type") {
@@ -972,6 +983,7 @@ fn scan_rust_let_declaration(
     if var_name.is_empty() {
         return;
     }
+    scopes[scope_idx].bindings.insert(var_name.clone());
 
     // Check for explicit type annotation: `let x: Connection = ...`
     if let Some(type_node) = node.child_by_field_name("type") {
@@ -1021,6 +1033,7 @@ fn scan_go_short_var(
     if var_name.is_empty() {
         return;
     }
+    scopes[scope_idx].bindings.insert(var_name.clone());
 
     let rhs = if right.kind() == "expression_list" {
         match right.named_child(0) {
@@ -1055,6 +1068,7 @@ fn scan_go_var_declaration(
                     if first.kind() == "identifier" {
                         let name = first.utf8_text(source).unwrap_or("").to_string();
                         if !name.is_empty() {
+                            scopes[scope_idx].bindings.insert(name.clone());
                             // Check for type child
                             if let Some(type_node) = child.child_by_field_name("type") {
                                 let type_text = extract_base_type(type_node, source);
@@ -1069,6 +1083,7 @@ fn scan_go_var_declaration(
                 }
                 continue;
             }
+            scopes[scope_idx].bindings.insert(var_name.clone());
 
             // Check for explicit type
             if let Some(type_node) = child.child_by_field_name("type") {
@@ -2066,17 +2081,7 @@ fn extract_ts_import(
         .unwrap_or("")
         .trim_matches(|c: char| c == '\'' || c == '"');
 
-    let source_module = source_path
-        .rsplit('/')
-        .next()
-        .unwrap_or(source_path);
-    // Strip extensions
-    let source_module = source_module
-        .strip_suffix(".ts").or_else(|| source_module.strip_suffix(".js"))
-        .or_else(|| source_module.strip_suffix(".tsx")).or_else(|| source_module.strip_suffix(".jsx"))
-        .unwrap_or(source_module);
-
-    if source_module.is_empty() {
+    if source_path.is_empty() {
         return;
     }
 
@@ -2101,7 +2106,7 @@ fn extract_ts_import(
                                 .unwrap_or(original);
 
                             if !original.is_empty() {
-                                resolve_import_name(original, local, source_module, file_path, symbol_table, entity_map, import_table, scopes);
+                                resolve_import_name(original, local, source_path, file_path, &[".ts", ".tsx", ".js", ".jsx"], symbol_table, entity_map, import_table, scopes);
                             }
                         }
                     }
@@ -2118,13 +2123,13 @@ fn extract_ts_import(
                         .and_then(|n| n.utf8_text(source).ok())
                         .unwrap_or("");
                     if !alias.is_empty() {
-                        register_namespace_import(alias, source_module, file_path, symbol_table, entity_map, import_table, scopes);
+                        register_namespace_import(alias, source_path, file_path, &[".ts", ".tsx", ".js", ".jsx"], symbol_table, entity_map, import_table, scopes);
                     }
                 } else if clause_child.kind() == "identifier" {
                     // Default import: import Foo from './module'
                     let name = clause_child.utf8_text(source).unwrap_or("");
                     if !name.is_empty() {
-                        resolve_import_name(name, name, source_module, file_path, symbol_table, entity_map, import_table, scopes);
+                        resolve_import_name(name, name, source_path, file_path, &[".ts", ".tsx", ".js", ".jsx"], symbol_table, entity_map, import_table, scopes);
                     }
                 }
             }
@@ -2175,7 +2180,7 @@ fn extract_rust_use(
                 (name_part, name_part)
             };
             if !original.is_empty() {
-                resolve_import_name(original, local, source_module, file_path, symbol_table, entity_map, import_table, scopes);
+                resolve_import_name(original, local, source_module, file_path, &[".rs"], symbol_table, entity_map, import_table, scopes);
             }
         }
     } else {
@@ -2196,7 +2201,7 @@ fn extract_rust_use(
             parts[0]
         };
         if !original.is_empty() && !source_module.is_empty() {
-            resolve_import_name(original, local, source_module, file_path, symbol_table, entity_map, import_table, scopes);
+            resolve_import_name(original, local, source_module, file_path, &[".rs"], symbol_table, entity_map, import_table, scopes);
         }
     }
 }
@@ -2282,29 +2287,22 @@ fn register_go_package_imports(
 fn resolve_import_name(
     original_name: &str,
     local_name: &str,
-    source_module: &str,
+    source_path: &str,
     file_path: &str,
+    extensions: &[&str],
     symbol_table: &HashMap<String, Vec<String>>,
     entity_map: &HashMap<String, EntityInfo>,
     import_table: &mut HashMap<(String, String), String>,
     scopes: &mut Vec<Scope>,
 ) {
     if let Some(target_ids) = symbol_table.get(original_name) {
-        let target = target_ids.iter().find(|id| {
-            entity_map.get(*id).map_or(false, |e| {
-                let stem = e.file_path.rsplit('/').next().unwrap_or(&e.file_path);
-                let stem = stem
-                    .strip_suffix(".py")
-                    .or_else(|| stem.strip_suffix(".rs"))
-                    .or_else(|| stem.strip_suffix(".ts"))
-                    .or_else(|| stem.strip_suffix(".tsx"))
-                    .or_else(|| stem.strip_suffix(".js"))
-                    .or_else(|| stem.strip_suffix(".jsx"))
-                    .or_else(|| stem.strip_suffix(".go"))
-                    .unwrap_or(stem);
-                stem == source_module
-            })
-        });
+        let target = find_import_target(
+            target_ids,
+            source_path,
+            file_path,
+            extensions,
+            entity_map,
+        );
 
         if let Some(target_id) = target {
             import_table.insert(
@@ -2325,43 +2323,29 @@ fn resolve_import_name(
 /// are registered so that `m.foo()` resolves via the method call path.
 fn register_namespace_import(
     alias: &str,
-    source_module: &str,
+    source_path: &str,
     file_path: &str,
+    extensions: &[&str],
     symbol_table: &HashMap<String, Vec<String>>,
     entity_map: &HashMap<String, EntityInfo>,
     import_table: &mut HashMap<(String, String), String>,
-    scopes: &mut Vec<Scope>,
+    _scopes: &mut Vec<Scope>,
 ) {
-    // Find all entities whose file matches the source_module stem
+    // Find all top-level entities whose file matches the imported module.
     for (name, target_ids) in symbol_table {
         for target_id in target_ids {
             if let Some(info) = entity_map.get(target_id) {
-                let stem = info.file_path.rsplit('/').next().unwrap_or(&info.file_path);
-                let stem = stem
-                    .strip_suffix(".ts")
-                    .or_else(|| stem.strip_suffix(".js"))
-                    .or_else(|| stem.strip_suffix(".tsx"))
-                    .or_else(|| stem.strip_suffix(".jsx"))
-                    .or_else(|| stem.strip_suffix(".py"))
-                    .unwrap_or(stem);
-                if stem == source_module && info.parent_id.is_none() {
-                    // Register entity_name under the alias for method-call resolution
+                if import_source_matches_file(file_path, source_path, extensions, &info.file_path)
+                    && info.parent_id.is_none() {
+                    let qualified_name = format!("{alias}.{name}");
                     import_table.insert(
-                        (file_path.to_string(), name.clone()),
+                        (file_path.to_string(), qualified_name.clone()),
                         target_id.clone(),
                     );
-                    if !scopes.is_empty() {
-                        scopes[0].defs.insert(name.clone(), target_id.clone());
-                    }
                 }
             }
         }
     }
-    // Also register the alias itself so that type tracking for `alias.method()` works:
-    // the resolve_ref MethodCall path checks import_table for the receiver.
-    // We don't have a single entity for the module, so this is handled by the
-    // Go-style package-qualified call fallback (checking method name in import_table).
-    let _ = (alias, file_path); // used above
 }
 
 fn extract_python_import(
@@ -2380,12 +2364,6 @@ fn extract_python_import(
     let module_name = module_node
         .and_then(|n| n.utf8_text(source).ok())
         .unwrap_or("");
-
-    let source_module = module_name
-        .trim_start_matches('.')
-        .rsplit('.')
-        .next()
-        .unwrap_or(module_name.trim_start_matches('.'));
 
     // Walk children to find imported names
     let mut cursor = node.walk();
@@ -2410,34 +2388,7 @@ fn extract_python_import(
                 continue;
             }
 
-            // Resolve against symbol table, preferring entities from the source module
-            if let Some(target_ids) = symbol_table.get(original) {
-                let target = target_ids.iter().find(|id| {
-                    entity_map.get(*id).map_or(false, |e| {
-                        let stem = e.file_path.rsplit('/').next().unwrap_or(&e.file_path);
-                        let stem = stem
-                            .strip_suffix(".py")
-                            .or_else(|| stem.strip_suffix(".rs"))
-                            .or_else(|| stem.strip_suffix(".ts"))
-                            .or_else(|| stem.strip_suffix(".js"))
-                            .unwrap_or(stem);
-                        stem == source_module
-                    })
-                });
-
-                if let Some(target_id) = target {
-                    import_table.insert(
-                        (file_path.to_string(), local.to_string()),
-                        target_id.clone(),
-                    );
-                    // Also add to module scope definitions
-                    if !scopes.is_empty() {
-                        scopes[0]
-                            .defs
-                            .insert(local.to_string(), target_id.clone());
-                    }
-                }
-            }
+            resolve_import_name(original, local, module_name, file_path, &[".py"], symbol_table, entity_map, import_table, scopes);
         }
     }
 }
@@ -2478,14 +2429,12 @@ fn extract_python_module_import(
             continue;
         }
 
-        // The module stem is the last component of the dotted name
-        let source_module = module_name.rsplit('.').next().unwrap_or(module_name);
-
         // Register all entities from the source module
         register_namespace_import(
             _alias,
-            source_module,
+            module_name,
             file_path,
+            &[".py"],
             symbol_table,
             entity_map,
             import_table,
@@ -2725,6 +2674,10 @@ fn resolve_ref(
 ) -> Option<(String, RefType, &'static str)> {
     match &ast_ref.kind {
         AstRefKind::Call(name) => {
+            if is_local_binding_in_scopes(scope_idx, scopes, name) {
+                return None;
+            }
+
             // 1. Walk scope chain for the name
             if let Some(eid) = lookup_scope_chain(scope_idx, scopes, name) {
                 if eid != from_entity_id {
@@ -2832,31 +2785,59 @@ fn resolve_ref(
                 }
             }
 
-            // Fallback: check import table for the receiver
-            let key = (file_path.to_string(), receiver.clone());
-            if let Some(target_id) = import_table.get(&key) {
-                if let Some(info) = entity_map.get(target_id) {
-                    if matches!(info.entity_type.as_str(), "class" | "struct") {
-                        if let Some(members) = class_members.get(&info.name) {
-                            if let Some((_, mid)) =
-                                members.iter().find(|(n, _)| n == method)
-                            {
-                                return Some((
-                                    mid.clone(),
-                                    RefType::Calls,
-                                    "type_tracking",
-                                ));
+            // ClassName.method() static call, only when ClassName is visible and
+            // not shadowed by a local binding.
+            if !is_local_binding_in_scopes(scope_idx, scopes, receiver) {
+                if let Some(class_id) = lookup_scope_chain(scope_idx, scopes, receiver) {
+                    if let Some(info) = entity_map.get(&class_id) {
+                        if matches!(info.entity_type.as_str(), "class" | "struct" | "interface")
+                            && info.name == receiver.as_str()
+                        {
+                            if let Some(members) = class_members.get(&info.name) {
+                                if let Some((_, mid)) = members.iter().find(|(n, _)| n == method) {
+                                    return Some((mid.clone(), RefType::Calls, "scope_chain"));
+                                }
                             }
                         }
                     }
                 }
             }
 
+            // Fallback: check import table for the receiver
+            if !is_local_binding_in_scopes(scope_idx, scopes, receiver) {
+                let key = (file_path.to_string(), receiver.clone());
+                if let Some(target_id) = import_table.get(&key) {
+                    if let Some(info) = entity_map.get(target_id) {
+                        if matches!(info.entity_type.as_str(), "class" | "struct") {
+                            if let Some(members) = class_members.get(&info.name) {
+                                if let Some((_, mid)) =
+                                    members.iter().find(|(n, _)| n == method)
+                                {
+                                    return Some((
+                                        mid.clone(),
+                                        RefType::Calls,
+                                        "type_tracking",
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Namespace import: alias.method()
+                let key = (file_path.to_string(), format!("{receiver}.{method}"));
+                if let Some(target_id) = import_table.get(&key) {
+                    return Some((target_id.clone(), RefType::Calls, "import"));
+                }
+            }
+
             // Go package-qualified call: package.Function()
             // Try the method name directly in the import table
-            let key = (file_path.to_string(), method.clone());
-            if let Some(target_id) = import_table.get(&key) {
-                return Some((target_id.clone(), RefType::Calls, "import"));
+            if file_path.ends_with(".go") {
+                let key = (file_path.to_string(), method.clone());
+                if let Some(target_id) = import_table.get(&key) {
+                    return Some((target_id.clone(), RefType::Calls, "import"));
+                }
             }
 
             None
@@ -2898,6 +2879,24 @@ fn lookup_scope_chain(
         match scopes[idx].parent {
             Some(p) => idx = p,
             None => return None,
+        }
+    }
+}
+
+/// Walk up the scope chain looking for a local binding that shadows a definition.
+fn is_local_binding_in_scopes(
+    start_scope: usize,
+    scopes: &[Scope],
+    name: &str,
+) -> bool {
+    let mut idx = start_scope;
+    loop {
+        if scopes[idx].bindings.contains(name) {
+            return true;
+        }
+        match scopes[idx].parent {
+            Some(p) => idx = p,
+            None => return false,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Resolve Python and JS/TS imports by full module path before falling back to basename matching.
- Preserve namespace import aliases so `lib.foo()` resolves without making `other.foo()` match a bare import.
- Treat explicit import extensions as exact file targets and add regressions for path collisions.

Closes #196
Closes #197

## Test plan

- `cargo test -p sem-core`
- `cargo test -p sem-cli`
- `cargo build -p sem-cli`
- Throwaway `sem graph --json --no-cache` repos covering:
  - TypeScript relative path collision (`./b/util` vs `./a/util`)
  - Explicit `./util.ts` resolution and missing-extension non-fallthrough
  - Python relative and absolute dotted path collisions
  - TypeScript namespace import alias receiver matching
  - Named import plus unrelated `other.foo()` receiver with unrelated fallback import

Note: `cargo test -p sem-core` still emits pre-existing warnings in `scope_resolve_bench.rs`.
