### PR TITLE
Fix duplicate Markdown heading diff detection

### DIFF
--- a/crates/sem-core/src/parser/differ.rs
+++ b/crates/sem-core/src/parser/differ.rs
@@ -533,4 +533,36 @@ mod tests {
         assert_eq!(result.changes[0].entity_name, "foo");
         assert_eq!(result.changes[0].old_file_path.as_deref(), Some("old.py"));
     }
+
+    #[test]
+    fn duplicate_markdown_heading_reports_first_section_modification() {
+        let before = "# Same Title\n\noriginal content of section A\n\n# Same Title\n\ncontent of section B\n";
+        let after = "# Same Title\n\nMODIFIED content of section A\n\n# Same Title\n\ncontent of section B\n";
+
+        let registry = create_default_registry();
+        let result = compute_semantic_diff(
+            &[modified_file("doc.md", before, after)],
+            &registry,
+            None,
+            None,
+        );
+
+        assert_eq!(result.modified_count, 1, "{:?}", result.changes);
+        assert_eq!(result.changes.len(), 1, "{:?}", result.changes);
+
+        let change = &result.changes[0];
+        assert_eq!(change.change_type, ChangeType::Modified);
+        assert_eq!(change.entity_name, "Same Title");
+        assert_eq!(change.entity_line, 1);
+        assert!(change
+            .before_content
+            .as_deref()
+            .unwrap_or_default()
+            .contains("original content of section A"));
+        assert!(change
+            .after_content
+            .as_deref()
+            .unwrap_or_default()
+            .contains("MODIFIED content of section A"));
+    }
 }

--- a/crates/sem-core/src/parser/plugins/markdown.rs
+++ b/crates/sem-core/src/parser/plugins/markdown.rs
@@ -1,6 +1,7 @@
 use regex::Regex;
+use std::collections::HashMap;
 
-use crate::model::entity::{build_entity_id, SemanticEntity};
+use crate::model::entity::{build_entity_id, build_entity_id_disambiguated, SemanticEntity};
 use crate::parser::plugin::SemanticParserPlugin;
 use crate::utils::hash::content_hash;
 
@@ -25,67 +26,86 @@ impl SemanticParserPlugin for MarkdownParserPlugin {
             name: String,
             start_line: usize,
             lines: Vec<String>,
-            parent_id: Option<String>,
+            base_id: String,
+            parent_index: Option<usize>,
         }
 
         let mut sections: Vec<Section> = Vec::new();
-        let mut current_section: Option<Section> = None;
-        let mut section_stack: Vec<(usize, String)> = Vec::new(); // (level, name)
+        let mut current_section: Option<usize> = None;
+        let mut section_stack: Vec<(usize, usize)> = Vec::new(); // (level, section index)
 
         for (i, &line) in lines.iter().enumerate() {
             if let Some(caps) = heading_re.captures(line) {
-                // Close previous section
-                if let Some(sec) = current_section.take() {
-                    sections.push(sec);
-                }
-
                 let level = caps[1].len();
                 let name = caps[2].trim().to_string();
 
                 // Find parent: pop headings with >= level
-                while section_stack
-                    .last()
-                    .map_or(false, |(l, _)| *l >= level)
-                {
+                while section_stack.last().map_or(false, |(l, _)| *l >= level) {
                     section_stack.pop();
                 }
 
-                let parent_id = section_stack.last().map(|(_, parent_name)| {
-                    build_entity_id(file_path, "heading", parent_name, None)
-                });
+                let parent_index = section_stack.last().map(|(_, index)| *index);
 
-                current_section = Some(Section {
+                sections.push(Section {
                     level,
                     name: name.clone(),
                     start_line: i + 1,
                     lines: vec![line.to_string()],
-                    parent_id,
+                    base_id: build_entity_id(file_path, "heading", &name, None),
+                    parent_index,
                 });
+                let section_index = sections.len() - 1;
 
-                section_stack.push((level, name));
-            } else if let Some(ref mut sec) = current_section {
-                sec.lines.push(line.to_string());
+                current_section = Some(section_index);
+                section_stack.push((level, section_index));
+            } else if let Some(index) = current_section {
+                sections[index].lines.push(line.to_string());
             } else {
                 // Content before first heading — preamble
                 if !line.trim().is_empty() {
                     if current_section.is_none() {
-                        current_section = Some(Section {
+                        sections.push(Section {
                             level: 0,
                             name: "(preamble)".to_string(),
                             start_line: i + 1,
                             lines: vec![line.to_string()],
-                            parent_id: None,
+                            base_id: build_entity_id(file_path, "preamble", "(preamble)", None),
+                            parent_index: None,
                         });
+                        current_section = Some(sections.len() - 1);
                     }
                 }
             }
         }
 
-        if let Some(sec) = current_section {
-            sections.push(sec);
+        let mut id_counts: HashMap<&str, usize> = HashMap::new();
+        for section in &sections {
+            *id_counts.entry(section.base_id.as_str()).or_default() += 1;
         }
 
-        for section in &sections {
+        let section_ids: Vec<String> = sections
+            .iter()
+            .map(|section| {
+                if id_counts[section.base_id.as_str()] > 1 {
+                    let entity_type = if section.level == 0 {
+                        "preamble"
+                    } else {
+                        "heading"
+                    };
+                    build_entity_id_disambiguated(
+                        file_path,
+                        entity_type,
+                        &section.name,
+                        None,
+                        section.start_line,
+                    )
+                } else {
+                    section.base_id.clone()
+                }
+            })
+            .collect();
+
+        for (index, section) in sections.iter().enumerate() {
             let section_content = section.lines.join("\n").trim().to_string();
             if section_content.is_empty() {
                 continue;
@@ -98,11 +118,13 @@ impl SemanticParserPlugin for MarkdownParserPlugin {
             };
 
             entities.push(SemanticEntity {
-                id: build_entity_id(file_path, entity_type, &section.name, None),
+                id: section_ids[index].clone(),
                 file_path: file_path.to_string(),
                 entity_type: entity_type.to_string(),
                 name: section.name.clone(),
-                parent_id: section.parent_id.clone(),
+                parent_id: section
+                    .parent_index
+                    .map(|parent_index| section_ids[parent_index].clone()),
                 content_hash: content_hash(&section_content),
                 structural_hash: None,
                 content: section_content,
@@ -113,5 +135,83 @@ impl SemanticParserPlugin for MarkdownParserPlugin {
         }
 
         entities
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unique_heading_keeps_legacy_id() {
+        let content = "# Overview\n\nbody\n";
+        let plugin = MarkdownParserPlugin;
+        let entities = plugin.extract_entities(content, "doc.md");
+
+        assert_eq!(entities.len(), 1);
+        assert_eq!(entities[0].id, "doc.md::heading::Overview");
+    }
+
+    #[test]
+    fn duplicate_heading_names_get_line_disambiguated_ids() {
+        let content = "# Same Title\n\nfirst body\n\n# Same Title\n\nsecond body\n";
+        let plugin = MarkdownParserPlugin;
+        let entities = plugin.extract_entities(content, "doc.md");
+
+        let headings: Vec<&SemanticEntity> = entities
+            .iter()
+            .filter(|entity| entity.entity_type == "heading")
+            .collect();
+
+        assert_eq!(headings.len(), 2);
+        assert_eq!(headings[0].id, "doc.md::heading::Same Title@L1");
+        assert_eq!(headings[1].id, "doc.md::heading::Same Title@L5");
+        assert_ne!(headings[0].content_hash, headings[1].content_hash);
+    }
+
+    #[test]
+    fn duplicate_parent_headings_disambiguate_child_parent_ids() {
+        let content = "# Release\n## Fixed\nfirst fix\n# Release\n## Fixed\nsecond fix\n";
+        let plugin = MarkdownParserPlugin;
+        let entities = plugin.extract_entities(content, "CHANGELOG.md");
+
+        let fixed_sections: Vec<&SemanticEntity> = entities
+            .iter()
+            .filter(|entity| entity.name == "Fixed")
+            .collect();
+
+        assert_eq!(fixed_sections.len(), 2);
+        assert_eq!(
+            fixed_sections[0].parent_id.as_deref(),
+            Some("CHANGELOG.md::heading::Release@L1")
+        );
+        assert_eq!(
+            fixed_sections[1].parent_id.as_deref(),
+            Some("CHANGELOG.md::heading::Release@L4")
+        );
+    }
+
+    #[test]
+    fn duplicate_child_headings_under_unique_parents_keep_distinct_parents() {
+        let content = "# Product A\n## Usage\nfirst usage\n# Product B\n## Usage\nsecond usage\n";
+        let plugin = MarkdownParserPlugin;
+        let entities = plugin.extract_entities(content, "README.md");
+
+        let usage_sections: Vec<&SemanticEntity> = entities
+            .iter()
+            .filter(|entity| entity.name == "Usage")
+            .collect();
+
+        assert_eq!(usage_sections.len(), 2);
+        assert_eq!(usage_sections[0].id, "README.md::heading::Usage@L2");
+        assert_eq!(usage_sections[1].id, "README.md::heading::Usage@L5");
+        assert_eq!(
+            usage_sections[0].parent_id.as_deref(),
+            Some("README.md::heading::Product A")
+        );
+        assert_eq!(
+            usage_sections[1].parent_id.as_deref(),
+            Some("README.md::heading::Product B")
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Disambiguate colliding Markdown heading entity IDs with @L line suffixes
- Preserve legacy IDs for unique headings
- Keep child parent IDs pointed at the resolved parent entity ID
- Add regression coverage for duplicate top-level headings, duplicate nested headings, and the original diff reproduction

Closes #169

## Test plan
- cargo test -p sem-core markdown
- cargo test --workspace
- Built target/debug/sem and verified the issue reproduction in a throwaway git repo reports 1 modified heading instead of no semantic changes