### PR TITLE
Align MCP diff JSON with CLI output

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1444,6 +1444,7 @@ dependencies = [
  "sem-core",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/sem-cli/src/formatters/json.rs
+++ b/crates/sem-cli/src/formatters/json.rs
@@ -1,45 +1,7 @@
 use sem_core::parser::differ::DiffResult;
-use serde_json::json;
 
 pub fn format_json(result: &DiffResult) -> String {
-    let changes: Vec<serde_json::Value> = result
-        .changes
-        .iter()
-        .map(|c| {
-            json!({
-                "entityId": c.entity_id,
-                "changeType": c.change_type,
-                "entityType": c.entity_type,
-                "entityName": c.entity_name,
-                "oldEntityName": c.old_entity_name,
-                "filePath": c.file_path,
-                "oldFilePath": c.old_file_path,
-                "oldParentId": c.old_parent_id,
-                "beforeContent": c.before_content,
-                "afterContent": c.after_content,
-                "commitSha": c.commit_sha,
-                "author": c.author,
-                "structuralChange": c.structural_change,
-            })
-        })
-        .collect();
-
-    let output = json!({
-        "summary": {
-            "fileCount": result.file_count,
-            "added": result.added_count,
-            "modified": result.modified_count,
-            "deleted": result.deleted_count,
-            "moved": result.moved_count,
-            "renamed": result.renamed_count,
-            "reordered": result.reordered_count,
-            "orphan": result.orphan_count,
-            "total": result.changes.len(),
-        },
-        "changes": changes,
-    });
-
-    serde_json::to_string(&output).unwrap_or_default()
+    sem_core::format::json::format_diff_json(result)
 }
 
 #[cfg(test)]

--- a/crates/sem-core/src/format/json.rs
+++ b/crates/sem-core/src/format/json.rs
@@ -1,0 +1,120 @@
+use crate::parser::differ::DiffResult;
+use serde_json::{json, Value};
+
+pub fn diff_json_value(result: &DiffResult) -> Value {
+    let changes: Vec<Value> = result
+        .changes
+        .iter()
+        .map(|c| {
+            json!({
+                "entityId": c.entity_id,
+                "changeType": c.change_type,
+                "entityType": c.entity_type,
+                "entityName": c.entity_name,
+                "oldEntityName": c.old_entity_name,
+                "filePath": c.file_path,
+                "oldFilePath": c.old_file_path,
+                "oldParentId": c.old_parent_id,
+                "beforeContent": c.before_content,
+                "afterContent": c.after_content,
+                "commitSha": c.commit_sha,
+                "author": c.author,
+                "structuralChange": c.structural_change,
+            })
+        })
+        .collect();
+
+    json!({
+        "summary": {
+            "fileCount": result.file_count,
+            "added": result.added_count,
+            "modified": result.modified_count,
+            "deleted": result.deleted_count,
+            "moved": result.moved_count,
+            "renamed": result.renamed_count,
+            "reordered": result.reordered_count,
+            "orphan": result.orphan_count,
+            "total": result.changes.len(),
+        },
+        "changes": changes,
+    })
+}
+
+pub fn format_diff_json(result: &DiffResult) -> String {
+    serde_json::to_string(&diff_json_value(result)).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::change::{ChangeType, SemanticChange};
+
+    #[test]
+    fn diff_json_value_matches_cli_envelope() {
+        let result = DiffResult {
+            changes: vec![SemanticChange {
+                id: "internal-change-id".to_string(),
+                entity_id: "src/lib.rs::function::foo".to_string(),
+                change_type: ChangeType::Modified,
+                entity_type: "function".to_string(),
+                entity_name: "foo".to_string(),
+                entity_line: 12,
+                parent_name: Some("module".to_string()),
+                file_path: "src/lib.rs".to_string(),
+                old_entity_name: Some("bar".to_string()),
+                old_file_path: Some("src/old.rs".to_string()),
+                old_parent_id: Some("old-parent".to_string()),
+                before_content: Some("fn bar() {}".to_string()),
+                after_content: Some("fn foo() {}".to_string()),
+                commit_sha: Some("abc123".to_string()),
+                author: Some("Ada".to_string()),
+                timestamp: Some("2026-05-26".to_string()),
+                structural_change: Some(true),
+            }],
+            file_count: 1,
+            added_count: 0,
+            modified_count: 1,
+            deleted_count: 0,
+            moved_count: 0,
+            renamed_count: 0,
+            reordered_count: 0,
+            orphan_count: 0,
+            total_entities_before: 1,
+            total_entities_after: 1,
+        };
+
+        let value = diff_json_value(&result);
+
+        assert_eq!(
+            value,
+            json!({
+                "summary": {
+                    "fileCount": 1,
+                    "added": 0,
+                    "modified": 1,
+                    "deleted": 0,
+                    "moved": 0,
+                    "renamed": 0,
+                    "reordered": 0,
+                    "orphan": 0,
+                    "total": 1,
+                },
+                "changes": [{
+                    "entityId": "src/lib.rs::function::foo",
+                    "changeType": "modified",
+                    "entityType": "function",
+                    "entityName": "foo",
+                    "oldEntityName": "bar",
+                    "filePath": "src/lib.rs",
+                    "oldFilePath": "src/old.rs",
+                    "oldParentId": "old-parent",
+                    "beforeContent": "fn bar() {}",
+                    "afterContent": "fn foo() {}",
+                    "commitSha": "abc123",
+                    "author": "Ada",
+                    "structuralChange": true,
+                }],
+            })
+        );
+    }
+}

--- a/crates/sem-core/src/format/mod.rs
+++ b/crates/sem-core/src/format/mod.rs
@@ -1,0 +1,1 @@
+pub mod json;

--- a/crates/sem-core/src/lib.rs
+++ b/crates/sem-core/src/lib.rs
@@ -2,3 +2,4 @@ pub mod model;
 pub mod git;
 pub mod parser;
 pub mod utils;
+pub mod format;

--- a/crates/sem-mcp/Cargo.toml
+++ b/crates/sem-mcp/Cargo.toml
@@ -29,6 +29,9 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 
+[dev-dependencies]
+tempfile = "3.24.0"
+
 [features]
 default = []
 vendored-openssl = ["openssl"]

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -9,6 +9,7 @@ use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{CallToolResult, Content, ServerCapabilities, ServerInfo};
 use rmcp::{tool, tool_handler, tool_router, ServerHandler};
+use sem_core::format::json::format_diff_json;
 use sem_core::git::bridge::GitBridge;
 use sem_core::git::types::DiffScope;
 use sem_core::model::entity::SemanticEntity;
@@ -451,35 +452,8 @@ impl SemServer {
         let diff_result =
             compute_semantic_diff(&file_changes, &self.registry, None, None);
 
-        let changes: Vec<serde_json::Value> = diff_result
-            .changes
-            .iter()
-            .map(|c| {
-                let mut obj = serde_json::json!({
-                    "file": c.file_path,
-                    "entity_name": c.entity_name,
-                    "entity_type": c.entity_type,
-                    "change_type": c.change_type.to_string(),
-                });
-                if let Some(ref old_name) = c.old_entity_name {
-                    obj["old_entity_name"] = serde_json::json!(old_name);
-                }
-                if let Some(ref old_path) = c.old_file_path {
-                    obj["old_file_path"] = serde_json::json!(old_path);
-                }
-                obj
-            })
-            .collect();
-
         Ok(CallToolResult::success(vec![Content::text(
-            serde_json::to_string_pretty(&serde_json::json!({
-                "base_ref": params.base_ref.as_deref().unwrap_or("working-tree"),
-                "target_ref": params.target_ref.as_deref().unwrap_or("HEAD"),
-                "files_analyzed": diff_result.file_count,
-                "total_changes": changes.len(),
-                "changes": changes,
-            }))
-            .unwrap_or_default(),
+            format_diff_json(&diff_result),
         )]))
     }
 
@@ -918,6 +892,7 @@ impl ServerHandler for SemServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::process::Command;
 
     #[test]
     fn find_supported_files_returns_walk_errors() {
@@ -939,6 +914,69 @@ mod tests {
         assert_eq!(info.instructions.as_deref(), Some(MCP_INSTRUCTIONS));
         assert!(MCP_INSTRUCTIONS.contains("sem_entities"));
         assert!(!MCP_INSTRUCTIONS.contains("tools: entities"));
+    }
+
+    #[tokio::test]
+    async fn sem_diff_returns_cli_json_envelope() {
+        let temp = tempfile::tempdir().unwrap();
+        run_git(temp.path(), &["init"]);
+        run_git(temp.path(), &["config", "user.name", "Sem Test"]);
+        run_git(temp.path(), &["config", "user.email", "sem@example.com"]);
+
+        let file_path = temp.path().join("a.py");
+        std::fs::write(&file_path, "def foo():\n    return 1\n").unwrap();
+        run_git(temp.path(), &["add", "a.py"]);
+        run_git(temp.path(), &["commit", "-m", "initial"]);
+
+        std::fs::write(
+            &file_path,
+            "def foo():\n    return 1\n\n\ndef bar():\n    return 2\n",
+        )
+        .unwrap();
+        let file_path = std::fs::canonicalize(file_path).unwrap();
+
+        let result = SemServer::new()
+            .sem_diff(Parameters(DiffParams {
+                base_ref: None,
+                target_ref: None,
+                file_path: Some(file_path.to_string_lossy().to_string()),
+            }))
+            .await
+            .unwrap();
+
+        let text = match &result.content.first().unwrap().raw {
+            rmcp::model::RawContent::Text(text) => &text.text,
+            other => panic!("expected text content, got {other:?}"),
+        };
+        let payload: serde_json::Value = serde_json::from_str(text).unwrap();
+        let changes = payload["changes"].as_array().unwrap();
+        let change = changes.first().unwrap();
+
+        assert!(payload.get("summary").is_some());
+        assert_eq!(payload["summary"]["fileCount"], 1);
+        assert_eq!(payload["summary"]["total"], changes.len());
+        assert!(payload.get("base_ref").is_none());
+        assert!(payload.get("files_analyzed").is_none());
+        assert!(change.get("entityId").is_some());
+        assert!(change.get("changeType").is_some());
+        assert!(change.get("filePath").is_some());
+        assert!(change.get("entity_name").is_none());
+        assert!(change.get("change_type").is_none());
+    }
+
+    fn run_git(repo: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .current_dir(repo)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {} failed\nstdout:\n{}\nstderr:\n{}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 }
 


### PR DESCRIPTION
## Summary
- Move the canonical sem diff JSON envelope into sem-core and keep the CLI formatter as a thin wrapper
- Update MCP sem_diff to return the same summary/changes shape and camelCase fields as sem diff --format json
- Add regression coverage for the shared formatter and MCP sem_diff response shape

Closes #206

## Test plan
- cargo test -p sem-core format::json
- cargo test -p sem-mcp sem_diff_returns_cli_json_envelope
- cargo test -p sem-core -p sem-cli -p sem-mcp
- cargo build -p sem-cli -p sem-mcp
- Dummy git repo validation comparing target/debug/sem diff --format json with sem-mcp sem_diff over JSON-RPC