### PR TITLE
Count orphan changes in summary buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,10 @@ sem diff --format json
     "added": 1,
     "modified": 1,
     "deleted": 1,
+    "moved": 0,
+    "renamed": 0,
+    "reordered": 0,
+    "orphan": 0,
     "total": 3
   },
   "changes": [
@@ -347,6 +351,8 @@ sem diff --format json
   ]
 }
 ```
+
+The named change-type buckets (`added`, `modified`, `deleted`, `moved`, `renamed`, `reordered`) always sum to `total`. `orphan` is a cross-cutting metadata count for module-level changes, and those changes are already included in the named change-type buckets.
 
 ## As a library
 

--- a/crates/sem-cli/src/formatters/json.rs
+++ b/crates/sem-cli/src/formatters/json.rs
@@ -41,3 +41,48 @@ pub fn format_json(result: &DiffResult) -> String {
 
     serde_json::to_string(&output).unwrap_or_default()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sem_core::git::types::{FileChange, FileStatus};
+    use sem_core::parser::differ::compute_semantic_diff;
+    use sem_core::parser::plugins::create_default_registry;
+
+    fn modified_file(path: &str, before: &str, after: &str) -> FileChange {
+        FileChange {
+            file_path: path.to_string(),
+            status: FileStatus::Modified,
+            old_file_path: None,
+            before_content: Some(before.to_string()),
+            after_content: Some(after.to_string()),
+        }
+    }
+
+    #[test]
+    fn summary_change_type_buckets_sum_to_total_with_orphans() {
+        let registry = create_default_registry();
+        let result = compute_semantic_diff(
+            &[modified_file(
+                "svc.py",
+                "def foo():\n    return 1\n",
+                "# just a comment\n",
+            )],
+            &registry,
+            None,
+            None,
+        );
+
+        let output: serde_json::Value = serde_json::from_str(&format_json(&result)).unwrap();
+        let summary = &output["summary"];
+        let bucket_total = summary["added"].as_u64().unwrap()
+            + summary["modified"].as_u64().unwrap()
+            + summary["deleted"].as_u64().unwrap()
+            + summary["moved"].as_u64().unwrap()
+            + summary["renamed"].as_u64().unwrap()
+            + summary["reordered"].as_u64().unwrap();
+
+        assert_eq!(bucket_total, summary["total"].as_u64().unwrap());
+        assert_eq!(summary["orphan"], 1);
+    }
+}

--- a/crates/sem-cli/src/formatters/markdown.rs
+++ b/crates/sem-cli/src/formatters/markdown.rs
@@ -1,3 +1,4 @@
+use super::orphan_summary_parts;
 use sem_core::model::change::ChangeType;
 use sem_core::parser::differ::DiffResult;
 use similar::{ChangeTag, TextDiff};
@@ -95,7 +96,9 @@ pub fn format_markdown(result: &DiffResult, verbose: bool) -> String {
                                         match diff_change.tag() {
                                             ChangeTag::Delete => deletes.push(line.to_string()),
                                             ChangeTag::Insert => inserts.push(line.to_string()),
-                                            ChangeTag::Equal => post_table.push(format!("  {line}")),
+                                            ChangeTag::Equal => {
+                                                post_table.push(format!("  {line}"))
+                                            }
                                         }
                                     }
 
@@ -118,8 +121,7 @@ pub fn format_markdown(result: &DiffResult, verbose: bool) -> String {
                     _ => {}
                 }
             } else if change.change_type == ChangeType::Modified {
-                if let (Some(before), Some(after)) =
-                    (&change.before_content, &change.after_content)
+                if let (Some(before), Some(after)) = (&change.before_content, &change.after_content)
                 {
                     let before_lines: Vec<&str> = before.lines().collect();
                     let after_lines: Vec<&str> = after.lines().collect();
@@ -140,10 +142,7 @@ pub fn format_markdown(result: &DiffResult, verbose: bool) -> String {
             }
 
             // Show rename/move details
-            if matches!(
-                change.change_type,
-                ChangeType::Renamed | ChangeType::Moved
-            ) {
+            if matches!(change.change_type, ChangeType::Renamed | ChangeType::Moved) {
                 if let Some(ref old_path) = change.old_file_path {
                     post_table.push(String::new());
                     post_table.push(format!("> from {old_path}"));
@@ -179,20 +178,23 @@ pub fn format_markdown(result: &DiffResult, verbose: bool) -> String {
     if result.reordered_count > 0 {
         parts.push(format!("{} reordered", result.reordered_count));
     }
-    if result.orphan_count > 0 {
-        parts.push(format!("{} orphan", result.orphan_count));
-    }
-
     let files_label = if result.file_count == 1 {
         "file"
     } else {
         "files"
     };
+    let orphan_parts = orphan_summary_parts(result);
+    let orphan_suffix = if orphan_parts.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", orphan_parts.join(", "))
+    };
 
     lines.push(format!(
-        "**Summary:** {} across {} {files_label}",
+        "**Summary:** {} across {} {files_label}{}",
         parts.join(", "),
         result.file_count,
+        orphan_suffix,
     ));
 
     lines.join("\n")

--- a/crates/sem-cli/src/formatters/mod.rs
+++ b/crates/sem-cli/src/formatters/mod.rs
@@ -1,4 +1,94 @@
-pub mod terminal;
+use sem_core::model::change::ChangeType;
+use sem_core::parser::differ::DiffResult;
+
 pub mod json;
 pub mod markdown;
 pub mod plain;
+pub mod terminal;
+
+pub(crate) fn orphan_summary_parts(result: &DiffResult) -> Vec<String> {
+    let mut added = 0;
+    let mut modified = 0;
+    let mut deleted = 0;
+    let mut moved = 0;
+    let mut renamed = 0;
+    let mut reordered = 0;
+
+    for change in result.changes.iter().filter(|c| c.entity_type == "orphan") {
+        match change.change_type {
+            ChangeType::Added => added += 1,
+            ChangeType::Modified => modified += 1,
+            ChangeType::Deleted => deleted += 1,
+            ChangeType::Moved => moved += 1,
+            ChangeType::Renamed => renamed += 1,
+            ChangeType::Reordered => reordered += 1,
+        }
+    }
+
+    [
+        (added, "added"),
+        (modified, "modified"),
+        (deleted, "deleted"),
+        (moved, "moved"),
+        (renamed, "renamed"),
+        (reordered, "reordered"),
+    ]
+    .into_iter()
+    .filter_map(|(count, label)| {
+        if count == 0 {
+            None
+        } else {
+            let noun = if count == 1 { "orphan" } else { "orphans" };
+            Some(format!("{count} {label} {noun}"))
+        }
+    })
+    .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sem_core::git::types::{FileChange, FileStatus};
+    use sem_core::parser::differ::compute_semantic_diff;
+    use sem_core::parser::plugins::create_default_registry;
+
+    fn modified_file(path: &str, before: &str, after: &str) -> FileChange {
+        FileChange {
+            file_path: path.to_string(),
+            status: FileStatus::Modified,
+            old_file_path: None,
+            before_content: Some(before.to_string()),
+            after_content: Some(after.to_string()),
+        }
+    }
+
+    #[test]
+    fn orphan_summary_parts_partition_orphans_by_change_type() {
+        let registry = create_default_registry();
+        let result = compute_semantic_diff(
+            &[
+                modified_file(
+                    "added.py",
+                    "def foo():\n    return 1\n",
+                    "# just a comment\n",
+                ),
+                modified_file(
+                    "modified.py",
+                    "# old comment\n\ndef bar():\n    return 2\n",
+                    "# new comment\n\ndef bar():\n    return 2\n",
+                ),
+            ],
+            &registry,
+            None,
+            None,
+        );
+
+        assert_eq!(
+            orphan_summary_parts(&result),
+            vec![
+                "1 added orphan".to_string(),
+                "1 modified orphan".to_string()
+            ]
+        );
+    }
+}

--- a/crates/sem-cli/src/formatters/plain.rs
+++ b/crates/sem-cli/src/formatters/plain.rs
@@ -1,3 +1,4 @@
+use super::orphan_summary_parts;
 use colored::Colorize;
 use sem_core::model::change::ChangeType;
 use sem_core::parser::differ::DiffResult;
@@ -48,7 +49,10 @@ pub fn format_plain(result: &DiffResult) -> String {
                     lines.push(format!("       {}", format!("from {old_path}").dimmed()));
                 } else if let Some(ref old_parent) = change.old_parent_id {
                     let parent_name = old_parent.rsplit("::").next().unwrap_or(old_parent);
-                    lines.push(format!("       {}", format!("moved from {parent_name}").dimmed()));
+                    lines.push(format!(
+                        "       {}",
+                        format!("moved from {parent_name}").dimmed()
+                    ));
                 }
             }
         }
@@ -62,29 +66,54 @@ pub fn format_plain(result: &DiffResult) -> String {
         parts.push(format!("{} added", result.added_count).green().to_string());
     }
     if result.modified_count > 0 {
-        parts.push(format!("{} modified", result.modified_count).yellow().to_string());
+        parts.push(
+            format!("{} modified", result.modified_count)
+                .yellow()
+                .to_string(),
+        );
     }
     if result.deleted_count > 0 {
-        parts.push(format!("{} deleted", result.deleted_count).red().to_string());
+        parts.push(
+            format!("{} deleted", result.deleted_count)
+                .red()
+                .to_string(),
+        );
     }
     if result.moved_count > 0 {
         parts.push(format!("{} moved", result.moved_count).blue().to_string());
     }
     if result.renamed_count > 0 {
-        parts.push(format!("{} renamed", result.renamed_count).cyan().to_string());
+        parts.push(
+            format!("{} renamed", result.renamed_count)
+                .cyan()
+                .to_string(),
+        );
     }
     if result.reordered_count > 0 {
-        parts.push(format!("{} reordered", result.reordered_count).magenta().to_string());
+        parts.push(
+            format!("{} reordered", result.reordered_count)
+                .magenta()
+                .to_string(),
+        );
     }
-    if result.orphan_count > 0 {
-        parts.push(format!("{} orphan", result.orphan_count).dimmed().to_string());
-    }
-
-    let files_label = if result.file_count == 1 { "file" } else { "files" };
+    let files_label = if result.file_count == 1 {
+        "file"
+    } else {
+        "files"
+    };
+    let orphan_parts = orphan_summary_parts(result);
+    let orphan_suffix = if orphan_parts.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", orphan_parts.join(", "))
+            .dimmed()
+            .to_string()
+    };
     lines.push(format!(
-        "{} across {} {files_label}",
+        "{} across {} {files_label}{}",
         parts.join(", "),
         result.file_count,
+        orphan_suffix,
     ));
 
     lines.join("\n")

--- a/crates/sem-cli/src/formatters/terminal.rs
+++ b/crates/sem-cli/src/formatters/terminal.rs
@@ -1,3 +1,4 @@
+use super::orphan_summary_parts;
 use colored::Colorize;
 use sem_core::model::change::ChangeType;
 use sem_core::parser::differ::DiffResult;
@@ -288,20 +289,25 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
                 .to_string(),
         );
     }
-    if result.orphan_count > 0 {
-        parts.push(format!("{} orphan", result.orphan_count).dimmed().to_string());
-    }
-
     let files_label = if result.file_count == 1 {
         "file"
     } else {
         "files"
     };
+    let orphan_parts = orphan_summary_parts(result);
+    let orphan_suffix = if orphan_parts.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", orphan_parts.join(", "))
+            .dimmed()
+            .to_string()
+    };
 
     lines.push(format!(
-        "Summary: {} across {} {files_label}",
+        "Summary: {} across {} {files_label}{}",
         parts.join(", "),
         result.file_count,
+        orphan_suffix,
     ));
 
     // Show noise-filtered line when entities were analyzed

--- a/crates/sem-core/src/parser/differ.rs
+++ b/crates/sem-core/src/parser/differ.rs
@@ -138,7 +138,8 @@ pub fn compute_semantic_diff(
         total_entities_after += after_count;
     }
 
-    // Single-pass counting (exclude orphan changes from entity counts)
+    // Single-pass counting. Orphans are first-class changes for the
+    // change-type buckets, and orphan_count is cross-cutting metadata.
     let mut added_count = 0;
     let mut modified_count = 0;
     let mut deleted_count = 0;
@@ -150,7 +151,6 @@ pub fn compute_semantic_diff(
     for c in &all_changes {
         if c.entity_type == "orphan" {
             orphan_count += 1;
-            continue;
         }
         match c.change_type {
             ChangeType::Added => added_count += 1,
@@ -564,5 +564,36 @@ mod tests {
             .as_deref()
             .unwrap_or_default()
             .contains("MODIFIED content of section A"));
+    }
+
+    #[test]
+    fn orphan_changes_count_toward_change_type_buckets() {
+        let before = "def foo():\n    return 1\n\ndef bar():\n    return 2\n";
+        let after = "# just a comment\n";
+
+        let registry = create_default_registry();
+        let result = compute_semantic_diff(
+            &[modified_file("svc.py", before, after)],
+            &registry,
+            None,
+            None,
+        );
+
+        assert_eq!(result.added_count, 1);
+        assert_eq!(result.deleted_count, 2);
+        assert_eq!(result.modified_count, 0);
+        assert_eq!(result.orphan_count, 1);
+        assert!(result
+            .changes
+            .iter()
+            .any(|c| c.entity_type == "orphan" && c.change_type == ChangeType::Added));
+
+        let named_bucket_total = result.added_count
+            + result.modified_count
+            + result.deleted_count
+            + result.moved_count
+            + result.renamed_count
+            + result.reordered_count;
+        assert_eq!(named_bucket_total, result.changes.len());
     }
 }

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -135,7 +135,7 @@ sem diff --format json
 Returns:
 ```json
 {
-  "summary": { "fileCount": 2, "added": 1, "modified": 1, "deleted": 1, "total": 3 },
+  "summary": { "fileCount": 2, "added": 1, "modified": 1, "deleted": 1, "moved": 0, "renamed": 0, "reordered": 0, "orphan": 0, "total": 3 },
   "changes": [
     {
       "entityId": "src/auth.ts::function::validateToken",
@@ -147,6 +147,8 @@ Returns:
   ]
 }
 ```
+
+The named change-type buckets (added, modified, deleted, moved, renamed, reordered) always sum to total. Orphan is metadata for module-level changes already included in those buckets.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

- Count orphan semantic changes in the normal change-type buckets while keeping `summary.orphan` as metadata.
- Add typed orphan details to plain, markdown, and terminal summaries.
- Document the JSON summary invariant for programmatic consumers.

Fixes #174

## Test plan

- `rustfmt --edition 2021 --check crates/sem-core/src/parser/differ.rs crates/sem-cli/src/formatters/mod.rs crates/sem-cli/src/formatters/json.rs crates/sem-cli/src/formatters/plain.rs crates/sem-cli/src/formatters/markdown.rs crates/sem-cli/src/formatters/terminal.rs`
- `cargo test --workspace`
- `npm test`
- `cargo build -p sem-cli`
- Disposable repo repro under `~/Developer/sem-174-validation`: `sem diff --format json` now reports `added: 1`, `deleted: 2`, `orphan: 1`, `total: 3`; plain output reports `1 added, 2 deleted across 1 file (1 added orphan)`.
