### PR TITLE
Handle nested TypeScript class fields

### DIFF
--- a/crates/sem-cli/src/commands/entities.rs
+++ b/crates/sem-cli/src/commands/entities.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use colored::Colorize;
@@ -183,30 +183,54 @@ fn print_grouped_entities(path_label: &str, entities: &[SemanticEntity]) {
     println!("{} {}\n", "entities:".green().bold(), path_label.bold());
 
     let mut current_file: Option<&str> = None;
+    let entities_by_id = entities_by_id(entities);
     for entity in entities {
         if current_file != Some(entity.file_path.as_str()) {
             current_file = Some(entity.file_path.as_str());
             println!("  {}", entity.file_path.bold());
         }
 
-        let indent = if entity.parent_id.is_some() {
-            "      "
-        } else {
-            "    "
-        };
-        print_entity_row(entity, indent);
+        let indent = entity_indent(entity, &entities_by_id, "    ");
+        print_entity_row(entity, &indent);
     }
 }
 
 fn print_entity_rows(entities: &[SemanticEntity], base_indent: &str) {
+    let entities_by_id = entities_by_id(entities);
     for entity in entities {
-        let indent = if entity.parent_id.is_some() {
-            format!("{base_indent}  ")
-        } else {
-            base_indent.to_string()
-        };
+        let indent = entity_indent(entity, &entities_by_id, base_indent);
         print_entity_row(entity, &indent);
     }
+}
+
+fn entities_by_id(entities: &[SemanticEntity]) -> HashMap<&str, &SemanticEntity> {
+    entities.iter().map(|entity| (entity.id.as_str(), entity)).collect()
+}
+
+fn entity_indent(
+    entity: &SemanticEntity,
+    entities_by_id: &HashMap<&str, &SemanticEntity>,
+    base_indent: &str,
+) -> String {
+    format!("{base_indent}{}", "  ".repeat(entity_depth(entity, entities_by_id)))
+}
+
+fn entity_depth(entity: &SemanticEntity, entities_by_id: &HashMap<&str, &SemanticEntity>) -> usize {
+    let mut depth = 0;
+    let mut current_parent = entity.parent_id.as_deref();
+    let mut seen = HashSet::new();
+
+    while let Some(parent_id) = current_parent {
+        if !seen.insert(parent_id) {
+            break;
+        }
+        depth += 1;
+        current_parent = entities_by_id
+            .get(parent_id)
+            .and_then(|parent| parent.parent_id.as_deref());
+    }
+
+    depth
 }
 
 fn print_entity_row(entity: &SemanticEntity, indent: &str) {
@@ -218,4 +242,50 @@ fn print_entity_row(entity: &SemanticEntity, indent: &str) {
         entity.start_line,
         entity.end_line,
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entity(id: &str, parent_id: Option<&str>) -> SemanticEntity {
+        SemanticEntity {
+            id: id.to_string(),
+            file_path: "a.ts".to_string(),
+            entity_type: "field".to_string(),
+            name: id.rsplit("::").next().unwrap_or(id).to_string(),
+            parent_id: parent_id.map(String::from),
+            content: String::new(),
+            content_hash: String::new(),
+            structural_hash: None,
+            start_line: 1,
+            end_line: 1,
+            metadata: None,
+        }
+    }
+
+    #[test]
+    fn entity_depth_follows_parent_chain() {
+        let root = entity("a.ts::class::L1", None);
+        let child = entity("a.ts::class::L1::L2", Some("a.ts::class::L1"));
+        let grandchild = entity("a.ts::class::L1::L2::L3", Some("a.ts::class::L1::L2"));
+        let entities = vec![root, child, grandchild];
+        let entities_by_id = entities_by_id(&entities);
+
+        assert_eq!(entity_depth(&entities[0], &entities_by_id), 0);
+        assert_eq!(entity_depth(&entities[1], &entities_by_id), 1);
+        assert_eq!(entity_depth(&entities[2], &entities_by_id), 2);
+        assert_eq!(entity_indent(&entities[2], &entities_by_id, "  "), "      ");
+    }
+
+    #[test]
+    fn entity_depth_handles_missing_or_cyclic_parents() {
+        let missing = entity("a.ts::field::missing", Some("a.ts::field::unknown"));
+        let cyclic = entity("a.ts::field::cyclic", Some("a.ts::field::cyclic"));
+        let entities = vec![missing, cyclic];
+        let entities_by_id = entities_by_id(&entities);
+
+        assert_eq!(entity_depth(&entities[0], &entities_by_id), 1);
+        assert_eq!(entity_depth(&entities[1], &entities_by_id), 1);
+    }
 }

--- a/crates/sem-core/src/parser/differ.rs
+++ b/crates/sem-core/src/parser/differ.rs
@@ -197,6 +197,7 @@ fn suppress_redundant_parents(
         "namespace",
         "export",
         "package",
+        "field",
         "svelte_instance_script",
         "svelte_module_script",
         "object",
@@ -705,6 +706,55 @@ mod tests {
                 .iter()
                 .any(|c| c.entity_name == "UserService" && c.change_type == ChangeType::Modified),
             "class should remain Modified when its own declaration changed, got: {names:?}"
+        );
+    }
+
+    #[test]
+    fn test_nested_typescript_class_field_diff_reports_leaf_method() {
+        let before = r#"class L1 {
+  L2 = class {
+    L3 = class {
+      L4 = class {
+        method() { return 1; }
+      };
+    };
+  };
+}
+"#;
+        let after = r#"class L1 {
+  L2 = class {
+    L3 = class {
+      L4 = class {
+        method() { return 999; }
+      };
+    };
+  };
+}
+"#;
+
+        let registry = create_default_registry();
+        let result = compute_semantic_diff(
+            &[modified_file("a.ts", before, after)],
+            &registry,
+            None,
+            None,
+        );
+
+        let changes: Vec<_> = result
+            .changes
+            .iter()
+            .map(|c| (c.entity_name.as_str(), c.entity_type.as_str()))
+            .collect();
+        assert!(
+            result
+                .changes
+                .iter()
+                .any(|c| c.entity_id == "a.ts::class::L1::L2::L3::L4::method"),
+            "expected method leaf change, got: {changes:?}"
+        );
+        assert!(
+            !result.changes.iter().any(|c| c.entity_type == "field"),
+            "field containers should be suppressed when only a nested method changed, got: {changes:?}"
         );
     }
 

--- a/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
+++ b/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
@@ -228,13 +228,16 @@ fn visit_node(
                 .filter(|c| c.kind() == "variable_declarator")
                 .collect();
             if declarators.len() > 1 {
-                let should_skip = should_skip_entity(config, suppression_context, node_type)
-                    && promote_js_ts_const_function(node, config).is_none();
-                if !should_skip {
-                    for declarator in &declarators {
-                        if let Some(name_node) = declarator.child_by_field_name("name") {
+                let skip_declaration = should_skip_entity(config, suppression_context, node_type);
+                let mut initializer_children = Vec::new();
+                for declarator in &declarators {
+                    let emitted_entity_id = if let Some(name_node) =
+                        declarator.child_by_field_name("name")
+                    {
+                        let entity_type =
+                            map_js_ts_declarator_entity_type(node, *declarator, config);
+                        if !skip_declaration || entity_type == "function" {
                             let name = node_text(name_node, source).to_string();
-                            let entity_type = map_entity_type(node, config);
                             let content = node_text(*declarator, source).to_string();
                             let struct_hash = compute_structural_hash(*declarator, source);
                             let entity = SemanticEntity {
@@ -250,10 +253,36 @@ fn visit_node(
                                 end_line: declarator.end_position().row + 1,
                                 metadata: None,
                             };
+
+                            let entity_id = entity.id.clone();
                             entities.push(entity);
+                            Some(entity_id)
+                        } else {
+                            None
                         }
+                    } else {
+                        None
+                    };
+
+                    // Suppressed local declarators do not have an entity of
+                    // their own, so their initializer is traversed under the
+                    // surrounding parent, matching the single-declarator path.
+                    let initializer_parent = emitted_entity_id.as_deref().or(parent_id);
+                    if let Some(initializer_child) =
+                        js_ts_initializer_child(config, *declarator, initializer_parent)
+                    {
+                        initializer_children.push(initializer_child);
                     }
                 }
+                // The worklist is LIFO; push in reverse so initializers are
+                // visited in source order.
+                for initializer_child in initializer_children.into_iter().rev() {
+                    worklist.push(initializer_child);
+                }
+                // The multi-declarator branch has already emitted each
+                // declarator and queued initializer traversal. Continuing here
+                // prevents the declaration node from also emitting only the
+                // first declarator through the generic path below.
                 continue;
             }
         }
@@ -429,24 +458,24 @@ fn visit_node(
                         }
                     }
 
-                    // For variable declarations, also traverse into initializers
-                    // that are scope boundaries (arrow functions, function expressions)
-                    // so that inner class/function declarations are extracted.
+                    // For JS/TS variable declarations and class fields, traverse
+                    // initializers that can contain nested entity declarations.
                     if node_type == "lexical_declaration" || node_type == "variable_declaration" {
                         let mut vd_cursor = node.walk();
                         for child in node.named_children(&mut vd_cursor) {
                             if child.kind() == "variable_declarator" {
-                                if let Some(value) = child.child_by_field_name("value") {
-                                    if config.scope_boundary_types.contains(&value.kind()) {
-                                        worklist.push((
-                                            value,
-                                            Some(entity_id.clone()),
-                                            Some(value.kind().to_string()),
-                                        ));
-                                    }
-                                }
+                                push_js_ts_initializer_children(
+                                    &mut worklist,
+                                    config,
+                                    child,
+                                    &entity_id,
+                                );
                             }
                         }
+                    } else if node_type == "public_field_definition"
+                        || node_type == "field_definition"
+                    {
+                        push_js_ts_initializer_children(&mut worklist, config, node, &entity_id);
                     }
 
                     continue;
@@ -1771,6 +1800,15 @@ fn swift_class_declaration_type(node: Node) -> Option<&'static str> {
     swift_declaration_keyword_type(declaration_kind.kind())
 }
 
+fn map_js_ts_declarator_entity_type(
+    declaration: Node,
+    declarator: Node,
+    config: &LanguageConfig,
+) -> &'static str {
+    promote_js_ts_const_declarator_function(declaration, declarator, config)
+        .unwrap_or_else(|| map_node_type(declaration.kind()))
+}
+
 /// Check whether a C/C++ `declaration` node contains a `function_declarator`
 /// descendant, indicating it is a function prototype rather than a variable.
 fn has_function_declarator(node: Node) -> bool {
@@ -1825,12 +1863,84 @@ fn promote_js_ts_const_function(node: Node, config: &LanguageConfig) -> Option<&
 
     let mut cursor = node.walk();
     let declarator = node.named_children(&mut cursor).find(|child| child.kind() == "variable_declarator")?;
+    promote_js_ts_const_declarator_function(node, declarator, config)
+}
+
+fn promote_js_ts_const_declarator_function(
+    declaration: Node,
+    declarator: Node,
+    config: &LanguageConfig,
+) -> Option<&'static str> {
+    if !matches!(config.id, "typescript" | "tsx" | "javascript") {
+        return None;
+    }
+
+    if declaration.kind() != "lexical_declaration" {
+        return None;
+    }
+
+    let declaration_kind = declaration.child_by_field_name("kind")?;
+    if declaration_kind.kind() != "const" {
+        return None;
+    }
+
     let value = declarator.child_by_field_name("value")?;
 
     match value.kind() {
         "arrow_function" | "function_expression" | "generator_function" => Some("function"),
         _ => None,
     }
+}
+
+fn push_js_ts_initializer_children<'tree>(
+    worklist: &mut Vec<(Node<'tree>, Option<String>, Option<String>)>,
+    config: &LanguageConfig,
+    node: Node<'tree>,
+    entity_id: &str,
+) {
+    if let Some(initializer_child) = js_ts_initializer_child(config, node, Some(entity_id)) {
+        worklist.push(initializer_child);
+    }
+}
+
+fn js_ts_initializer_child<'tree>(
+    config: &LanguageConfig,
+    node: Node<'tree>,
+    parent_id: Option<&str>,
+) -> Option<(Node<'tree>, Option<String>, Option<String>)> {
+    if !matches!(config.id, "typescript" | "tsx" | "javascript") {
+        return None;
+    }
+
+    let value = js_ts_initializer_value(config, node)?;
+    Some((
+        value,
+        parent_id.map(String::from),
+        Some(value.kind().to_string()),
+    ))
+}
+
+fn js_ts_initializer_value<'tree>(
+    config: &LanguageConfig,
+    node: Node<'tree>,
+) -> Option<Node<'tree>> {
+    if let Some(value) = node.child_by_field_name("value") {
+        return is_js_ts_initializer_node(config, value).then_some(value);
+    }
+
+    if !matches!(node.kind(), "public_field_definition" | "field_definition") {
+        return None;
+    }
+
+    let mut cursor = node.walk();
+    let initializer = node
+        .named_children(&mut cursor)
+        .find(|child| is_js_ts_initializer_node(config, *child));
+    initializer
+}
+
+fn is_js_ts_initializer_node(config: &LanguageConfig, node: Node) -> bool {
+    config.scope_boundary_types.contains(&node.kind()) || node.kind() == "class"
 }
 
 /// Dart constructor signatures use `field("name", seq(identifier, optional(".", identifier)))`,

--- a/crates/sem-core/src/parser/plugins/code/mod.rs
+++ b/crates/sem-core/src/parser/plugins/code/mod.rs
@@ -597,6 +597,58 @@ function outer() {
     }
 
     #[test]
+    fn test_typescript_nested_anonymous_class_fields() {
+        let code = r#"
+class L1 {
+  L2 = class {
+    L3 = class {
+      L4 = class {
+        method() { return 1; }
+      };
+    };
+  };
+}
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "a.ts");
+        let find = |name: &str| {
+            entities.iter().find(|e| e.name == name).unwrap_or_else(|| {
+                panic!(
+                    "missing {name}; got: {:?}",
+                    entities
+                        .iter()
+                        .map(|e| (&e.name, &e.entity_type, &e.parent_id))
+                        .collect::<Vec<_>>()
+                )
+            })
+        };
+
+        let l1 = find("L1");
+        assert_eq!(l1.entity_type, "class");
+        let l1_id = l1.id.clone();
+
+        let l2 = find("L2");
+        assert_eq!(l2.entity_type, "field");
+        assert_eq!(l2.parent_id.as_deref(), Some(l1_id.as_str()));
+        let l2_id = l2.id.clone();
+
+        let l3 = find("L3");
+        assert_eq!(l3.entity_type, "field");
+        assert_eq!(l3.parent_id.as_deref(), Some(l2_id.as_str()));
+        let l3_id = l3.id.clone();
+
+        let l4 = find("L4");
+        assert_eq!(l4.entity_type, "field");
+        assert_eq!(l4.parent_id.as_deref(), Some(l3_id.as_str()));
+        let l4_id = l4.id.clone();
+
+        let method = find("method");
+        assert_eq!(method.entity_type, "method");
+        assert_eq!(method.parent_id.as_deref(), Some(l4_id.as_str()));
+        assert_eq!(method.id, "a.ts::class::L1::L2::L3::L4::method");
+    }
+
+    #[test]
     fn test_nested_functions_python() {
         let code = "def outer():\n    def inner():\n        return 42\n    return inner()\n";
         let plugin = CodeParserPlugin;
@@ -1085,6 +1137,66 @@ const handler = () => {
         let handler = entities.iter().find(|e| e.name == "handler").unwrap();
 
         assert_eq!(handler.entity_type, "function");
+    }
+
+    #[test]
+    fn test_js_ts_multi_declarator_promotes_each_const_initializer() {
+        let code = r#"
+const value = 1, handler = () => value;
+const first = () => 1, second = 2;
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "sample.ts");
+        let find = |name: &str| {
+            entities.iter().find(|e| e.name == name).unwrap_or_else(|| {
+                panic!(
+                    "missing {name}; got: {:?}",
+                    entities.iter().map(|e| (&e.name, &e.entity_type)).collect::<Vec<_>>()
+                )
+            })
+        };
+
+        assert_eq!(find("value").entity_type, "variable");
+        assert_eq!(find("handler").entity_type, "function");
+        assert_eq!(find("first").entity_type, "function");
+        assert_eq!(find("second").entity_type, "variable");
+    }
+
+    #[test]
+    fn test_suppressed_multi_declarator_traverses_skipped_initializers() {
+        let code = r#"
+function wrapper() {
+  const holder = class {
+    run() { return 1; }
+  }, handler = () => {
+    class Inner {
+      go() { return 2; }
+    }
+  }, value = 1;
+}
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "sample.ts");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+        let find = |name: &str| {
+            entities.iter().find(|e| e.name == name).unwrap_or_else(|| {
+                panic!(
+                    "missing {name}; got: {:?}",
+                    entities
+                        .iter()
+                        .map(|e| (&e.name, &e.entity_type, &e.parent_id))
+                        .collect::<Vec<_>>()
+                )
+            })
+        };
+
+        assert_eq!(find("wrapper").entity_type, "function");
+        assert_eq!(find("handler").entity_type, "function");
+        assert!(names.contains(&"run"), "got: {:?}", names);
+        assert!(names.contains(&"Inner"), "got: {:?}", names);
+        assert!(names.contains(&"go"), "got: {:?}", names);
+        assert!(!names.contains(&"holder"), "got: {:?}", names);
+        assert!(!names.contains(&"value"), "got: {:?}", names);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- descend into JS/TS class-expression initializers on fields and declarators so nested entities are preserved
- classify JS/TS multi-declarator consts from each declarator's own initializer
- render `sem entities` indentation from parent_id depth and suppress field container diffs when nested children explain the change

Fixes #177
Fixes #203

## Test plan
- `cargo test -p sem-core test_typescript_nested_anonymous_class_fields`
- `cargo test -p sem-core test_js_ts_multi_declarator_promotes_each_const_initializer`
- `cargo test -p sem-core test_nested_typescript_class_field_diff_reports_leaf_method`
- `cargo test -p sem-cli entity_depth`
- `cargo test --workspace`
- dummy repo validation with `target/debug/sem entities`, `target/debug/sem diff --format json`, and `target/debug/sem entities --json`