### PR TITLE
Resolve Go method parents across files

### DIFF
--- a/crates/sem-cli/src/commands/entities.rs
+++ b/crates/sem-cli/src/commands/entities.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use colored::Colorize;
 use sem_core::model::entity::SemanticEntity;
-use sem_core::parser::registry::ParserRegistry;
+use sem_core::parser::registry::{resolve_go_method_parent_ids, ParserRegistry};
 
 pub struct EntitiesOptions {
     pub cwd: String,
@@ -131,6 +131,7 @@ fn extract_files_entities(
             }
         }
     }
+    resolve_go_method_parent_ids(&mut entities);
     entities
 }
 

--- a/crates/sem-core/src/parser/graph.rs
+++ b/crates/sem-core/src/parser/graph.rs
@@ -28,7 +28,7 @@ macro_rules! maybe_par_iter {
 
 use crate::git::types::{FileChange, FileStatus};
 use crate::model::entity::SemanticEntity;
-use crate::parser::registry::ParserRegistry;
+use crate::parser::registry::{resolve_go_method_parent_ids, ParserRegistry};
 use crate::parser::scope_resolve;
 
 /// A reference from one entity to another.
@@ -132,6 +132,7 @@ impl EntityGraph {
                 parsed_files.push(p);
             }
         }
+        resolve_go_method_parent_ids(&mut all_entities);
 
         // Pass A: Build all lookup structures in a single pass over all_entities.
         // This merges what was previously 6 separate O(E) iterations.
@@ -483,7 +484,27 @@ impl EntityGraph {
             }
         }
 
-        // Entity-level diffing: compare new stale-file entities against cached versions
+        // Merge clean cached entities with newly parsed stale-file entities before
+        // repairing Go method parents; Go receiver types may live in clean files.
+        let mut all_entities: Vec<SemanticEntity> = cached_entities
+            .into_iter()
+            .chain(new_entities.into_iter())
+            .collect();
+        let entity_ids_before_parent_repair: HashSet<String> =
+            all_entities.iter().map(|e| e.id.clone()).collect();
+        resolve_go_method_parent_ids(&mut all_entities);
+        let parent_repaired_ids: HashSet<&str> = all_entities
+            .iter()
+            .filter(|e| !entity_ids_before_parent_repair.contains(&e.id))
+            .map(|e| e.id.as_str())
+            .collect();
+
+        // Entity-level diffing: compare repaired stale-file entities against cached versions.
+        let stale_cached_entity_ids: HashSet<&str> = stale_file_cached_entities
+            .iter()
+            .map(|e| e.id.as_str())
+            .collect();
+
         // Build content_hash lookup from cached stale-file entities
         let cached_hashes: HashMap<&str, &str> = stale_file_cached_entities
             .iter()
@@ -493,7 +514,10 @@ impl EntityGraph {
         // Classify new stale-file entities
         let mut truly_changed_ids: HashSet<String> = HashSet::new();
         let mut content_clean_ids: HashSet<String> = HashSet::new();
-        for entity in &new_entities {
+        for entity in all_entities
+            .iter()
+            .filter(|e| stale_set.contains(e.file_path.as_str()))
+        {
             match cached_hashes.get(entity.id.as_str()) {
                 Some(old_hash) if *old_hash == entity.content_hash.as_str() => {
                     content_clean_ids.insert(entity.id.clone());
@@ -506,17 +530,15 @@ impl EntityGraph {
         }
 
         // Detect deleted entities: in cached stale but not in new
-        let new_entity_ids: HashSet<&str> = new_entities.iter().map(|e| e.id.as_str()).collect();
+        let new_entity_ids: HashSet<&str> = all_entities
+            .iter()
+            .filter(|e| stale_set.contains(e.file_path.as_str()))
+            .map(|e| e.id.as_str())
+            .collect();
         let deleted_ids: HashSet<&str> = stale_file_cached_entities
             .iter()
             .filter(|e| !new_entity_ids.contains(e.id.as_str()))
             .map(|e| e.id.as_str())
-            .collect();
-
-        // Merge: cached (clean) entities + new (stale) entities
-        let all_entities: Vec<SemanticEntity> = cached_entities
-            .into_iter()
-            .chain(new_entities.into_iter())
             .collect();
 
         // Find affected clean entities: only care about edges pointing to truly_changed/deleted
@@ -540,6 +562,10 @@ impl EntityGraph {
             .filter(|e| stale_set.contains(e.file_path.as_str()))
             .map(|e| e.id.as_str())
             .collect();
+        let current_entity_ids: HashSet<&str> = all_entities
+            .iter()
+            .map(|e| e.id.as_str())
+            .collect();
 
         // Keep edges where both endpoints are in clean (non-stale) files and from_entity
         // is not affected by target changes. Drop ALL cached edges from stale-file entities
@@ -548,8 +574,16 @@ impl EntityGraph {
         let kept_edges: Vec<EntityRef> = cached_edges
             .into_iter()
             .filter(|e| {
-                let from_stale = stale_entity_ids.contains(e.from_entity.as_str());
-                let to_stale = stale_entity_ids.contains(e.to_entity.as_str());
+                if !current_entity_ids.contains(e.from_entity.as_str())
+                    || !current_entity_ids.contains(e.to_entity.as_str())
+                {
+                    return false;
+                }
+
+                let from_stale = stale_entity_ids.contains(e.from_entity.as_str())
+                    || stale_cached_entity_ids.contains(e.from_entity.as_str());
+                let to_stale = stale_entity_ids.contains(e.to_entity.as_str())
+                    || stale_cached_entity_ids.contains(e.to_entity.as_str());
 
                 if !from_stale && !to_stale && !affected_clean_ids.contains(&e.from_entity) {
                     // Both endpoints in clean files, from not affected
@@ -567,6 +601,7 @@ impl EntityGraph {
             .filter(|e| {
                 truly_changed_ids.contains(&e.id)
                     || content_clean_ids.contains(&e.id)
+                    || parent_repaired_ids.contains(e.id.as_str())
                     || affected_clean_ids.contains(&e.id)
             })
             .map(|e| e.id.as_str())
@@ -2071,6 +2106,79 @@ mod tests {
         assert_eq!(graph.entities.len(), 2);
         let bar_deps = graph.get_dependencies("b.ts::function::bar");
         assert!(bar_deps.iter().any(|d| d.name == "foo"));
+    }
+
+    #[cfg(feature = "lang-go")]
+    #[test]
+    fn test_go_method_parent_resolves_across_files_in_graph() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "models.go", "package demo\n\ntype Service struct{}\n");
+        write_file(
+            root,
+            "methods.go",
+            "package demo\n\nfunc (s *Service) Run() {}\n",
+        );
+
+        let (graph, entities) =
+            EntityGraph::build(root, &["models.go".into(), "methods.go".into()], &registry);
+        let service = graph
+            .entities
+            .get("models.go::type::Service")
+            .expect("Service type should be in the graph");
+        let run = entities
+            .iter()
+            .find(|e| e.name == "Run" && e.file_path == "methods.go")
+            .expect("Run method should be extracted");
+
+        assert_eq!(run.parent_id.as_deref(), Some(service.id.as_str()));
+        assert!(graph.entities.contains_key("models.go::type::Service::Run"));
+    }
+
+    #[cfg(feature = "lang-go")]
+    #[test]
+    fn test_incremental_go_parent_repair_handles_clean_cached_method() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+        let models = "package demo\n\ntype Service struct{}\n";
+        let methods = "package demo\n\nfunc (s *Service) Run() {}\n";
+
+        write_file(root, "models.go", models);
+        write_file(root, "methods.go", methods);
+
+        let cached_entities = registry.extract_entities("methods.go", methods);
+        let cached_run = cached_entities
+            .iter()
+            .find(|e| e.name == "Run")
+            .expect("cached Run method should be extracted");
+        assert_eq!(
+            cached_run.parent_id.as_deref(),
+            Some("methods.go::type::Service")
+        );
+
+        let stale_file_cached_entities = registry.extract_entities("models.go", models);
+        let (graph, entities) = EntityGraph::build_incremental(
+            root,
+            &["models.go".into()],
+            &["models.go".into(), "methods.go".into()],
+            cached_entities,
+            vec![],
+            stale_file_cached_entities,
+            &registry,
+        );
+        let service = graph
+            .entities
+            .get("models.go::type::Service")
+            .expect("Service type should be in the graph");
+        let run = entities
+            .iter()
+            .find(|e| e.name == "Run" && e.file_path == "methods.go")
+            .expect("Run method should be retained from clean cache");
+
+        assert_eq!(run.parent_id.as_deref(), Some(service.id.as_str()));
+        assert!(graph.entities.contains_key("models.go::type::Service::Run"));
+        assert!(!graph.entities.contains_key("methods.go::type::Service::Run"));
     }
 
     #[test]

--- a/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
+++ b/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
@@ -30,6 +30,10 @@ pub fn extract_entities(
         source_code.as_bytes(),
     );
 
+    if config.id == "go" {
+        attach_go_package_metadata(tree.root_node(), source_code.as_bytes(), &mut entities);
+    }
+
     // Post-pass: disambiguate colliding entity IDs by appending @L{line}.
     // Two overloads with the same name (e.g. function overloads in C++/TS)
     // get identical IDs; re-assign all colliding entries with line suffixes.
@@ -54,6 +58,41 @@ pub fn extract_entities(
     }
 
     entities
+}
+
+fn attach_go_package_metadata(root: Node, source: &[u8], entities: &mut [SemanticEntity]) {
+    let Some(package_name) = extract_go_package_name(root, source) else {
+        return;
+    };
+
+    for entity in entities {
+        entity
+            .metadata
+            .get_or_insert_with(HashMap::new)
+            .insert("go.package".to_string(), package_name.clone());
+    }
+}
+
+fn extract_go_package_name(root: Node, source: &[u8]) -> Option<String> {
+    let mut cursor = root.walk();
+    for child in root.named_children(&mut cursor) {
+        if child.kind() != "package_clause" {
+            continue;
+        }
+
+        if let Some(name) = child.child_by_field_name("name") {
+            return Some(node_text(name, source).to_string());
+        }
+
+        let mut package_cursor = child.walk();
+        for package_child in child.named_children(&mut package_cursor) {
+            if matches!(package_child.kind(), "package_identifier" | "identifier") {
+                return Some(node_text(package_child, source).to_string());
+            }
+        }
+    }
+
+    None
 }
 
 fn visit_node(

--- a/crates/sem-core/src/parser/registry.rs
+++ b/crates/sem-core/src/parser/registry.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
-use crate::model::entity::SemanticEntity;
+use crate::model::entity::{build_entity_id, SemanticEntity};
 
 macro_rules! maybe_par_iter {
     ($slice:expr) => {{
@@ -249,7 +249,7 @@ impl ParserRegistry {
         root: &Path,
         file_paths: &[String],
     ) -> Vec<SemanticEntity> {
-        maybe_par_iter!(file_paths)
+        let mut entities: Vec<SemanticEntity> = maybe_par_iter!(file_paths)
             .flat_map(|fp| {
                 let full = root.join(fp);
                 let content = match std::fs::read_to_string(&full) {
@@ -258,8 +258,110 @@ impl ParserRegistry {
                 };
                 self.extract_entities(fp, &content)
             })
-            .collect()
+            .collect();
+        resolve_go_method_parent_ids(&mut entities);
+        entities
     }
+}
+
+pub fn resolve_go_method_parent_ids(entities: &mut [SemanticEntity]) {
+    let mut types_by_package: HashMap<(String, String, String), String> = HashMap::new();
+
+    for entity in entities.iter() {
+        if !is_go_file(&entity.file_path) || !is_go_receiver_type_entity(entity) {
+            continue;
+        }
+
+        let package_name = go_package_name(entity).unwrap_or("");
+
+        types_by_package
+            .entry((
+                go_package_dir(&entity.file_path).to_string(),
+                package_name.to_string(),
+                entity.name.clone(),
+            ))
+            .or_insert_with(|| entity.id.clone());
+    }
+
+    for entity in entities.iter_mut() {
+        if !is_go_file(&entity.file_path) || entity.entity_type != "method" {
+            continue;
+        }
+
+        let package_name = go_package_name(entity).unwrap_or("");
+        let Some(receiver_name) = extract_go_receiver_type_name(&entity.content) else {
+            continue;
+        };
+
+        let key = (
+            go_package_dir(&entity.file_path).to_string(),
+            package_name.to_string(),
+            receiver_name,
+        );
+
+        let Some(parent_id) = types_by_package.get(&key) else {
+            continue;
+        };
+
+        if entity.parent_id.as_deref() == Some(parent_id.as_str()) {
+            continue;
+        }
+
+        entity.parent_id = Some(parent_id.clone());
+        entity.id = build_entity_id(
+            &entity.file_path,
+            &entity.entity_type,
+            &entity.name,
+            Some(parent_id),
+        );
+    }
+}
+
+fn is_go_file(file_path: &str) -> bool {
+    file_path.ends_with(".go")
+}
+
+fn is_go_receiver_type_entity(entity: &SemanticEntity) -> bool {
+    matches!(
+        entity.entity_type.as_str(),
+        "type" | "struct" | "class" | "interface"
+    )
+}
+
+fn go_package_name(entity: &SemanticEntity) -> Option<&str> {
+    entity
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("go.package"))
+        .map(String::as_str)
+}
+
+fn go_package_dir(file_path: &str) -> &str {
+    file_path.rsplit_once('/').map_or("", |(dir, _)| dir)
+}
+
+fn extract_go_receiver_type_name(content: &str) -> Option<String> {
+    let after_func = content.trim_start().strip_prefix("func")?.trim_start();
+    let receiver = after_func.strip_prefix('(')?;
+    let receiver_end = receiver.find(')')?;
+    let receiver = receiver[..receiver_end].trim();
+    if receiver.is_empty() {
+        return None;
+    }
+
+    let receiver_type = receiver.split_whitespace().last().unwrap_or(receiver);
+
+    let receiver_type = receiver_type.trim_start_matches('*').trim();
+    let receiver_type = receiver_type
+        .split_once('[')
+        .map_or(receiver_type, |(name, _)| name)
+        .trim();
+    let receiver_type = receiver_type
+        .rsplit_once('.')
+        .map_or(receiver_type, |(_, name)| name)
+        .trim();
+
+    (!receiver_type.is_empty()).then(|| receiver_type.to_string())
 }
 
 /// Restore original file path in entities when a custom extension mapping was used.
@@ -553,6 +655,15 @@ fn extract_vim_filetype(line: &str) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use crate::parser::plugins::create_default_registry;
+    use tempfile::TempDir;
+
+    fn write_file(dir: &TempDir, name: &str, content: &str) {
+        let path = dir.path().join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, content).unwrap();
+    }
 
     #[test]
     fn test_registry_matches_compound_svelte_typescript_suffix() {
@@ -667,6 +778,84 @@ mod tests {
             .expect("should detect Rust");
         let entities = plugin.extract_entities(content, "lib");
         assert!(entities.iter().any(|e| e.name == "process"));
+    }
+
+    #[cfg(feature = "lang-go")]
+    #[test]
+    fn test_go_method_parent_resolves_across_files() {
+        let registry = create_default_registry();
+        let dir = TempDir::new().unwrap();
+        write_file(&dir, "models.go", "package demo\n\ntype Service struct{}\n");
+        write_file(
+            &dir,
+            "methods.go",
+            "package demo\n\nfunc (s *Service) Run() {}\n",
+        );
+
+        let entities = registry.extract_all_entities(
+            dir.path(),
+            &["models.go".to_string(), "methods.go".to_string()],
+        );
+        let service = entities
+            .iter()
+            .find(|e| e.name == "Service" && e.file_path == "models.go")
+            .expect("Service type should be extracted");
+        let run = entities
+            .iter()
+            .find(|e| e.name == "Run" && e.file_path == "methods.go")
+            .expect("Run method should be extracted");
+
+        assert_eq!(run.parent_id.as_deref(), Some(service.id.as_str()));
+        assert_eq!(run.id, format!("{}::Run", service.id));
+    }
+
+    #[cfg(feature = "lang-go")]
+    #[test]
+    fn test_go_method_parent_resolution_is_package_directory_scoped() {
+        let registry = create_default_registry();
+        let dir = TempDir::new().unwrap();
+        write_file(&dir, "alpha/models.go", "package demo\n\ntype Service struct{}\n");
+        write_file(
+            &dir,
+            "alpha/methods.go",
+            "package demo\n\nfunc (s *Service) Run() {}\n",
+        );
+        write_file(&dir, "beta/models.go", "package demo\n\ntype Service struct{}\n");
+        write_file(
+            &dir,
+            "beta/methods.go",
+            "package demo\n\nfunc (s *Service) Run() {}\n",
+        );
+
+        let entities = registry.extract_all_entities(
+            dir.path(),
+            &[
+                "alpha/models.go".to_string(),
+                "alpha/methods.go".to_string(),
+                "beta/models.go".to_string(),
+                "beta/methods.go".to_string(),
+            ],
+        );
+
+        let alpha_service = entities
+            .iter()
+            .find(|e| e.name == "Service" && e.file_path == "alpha/models.go")
+            .expect("alpha Service type should be extracted");
+        let beta_service = entities
+            .iter()
+            .find(|e| e.name == "Service" && e.file_path == "beta/models.go")
+            .expect("beta Service type should be extracted");
+        let alpha_run = entities
+            .iter()
+            .find(|e| e.name == "Run" && e.file_path == "alpha/methods.go")
+            .expect("alpha Run method should be extracted");
+        let beta_run = entities
+            .iter()
+            .find(|e| e.name == "Run" && e.file_path == "beta/methods.go")
+            .expect("beta Run method should be extracted");
+
+        assert_eq!(alpha_run.parent_id.as_deref(), Some(alpha_service.id.as_str()));
+        assert_eq!(beta_run.parent_id.as_deref(), Some(beta_service.id.as_str()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Attach parsed Go package metadata to code entities
- Repair Go method parent IDs after multi-file extraction so receiver methods point at real package-local type entities
- Apply the repair in entities output, full graph builds, and incremental graph builds

Fixes #204

## Test plan
- cargo test -p sem-core
- cargo test -p sem-cli
- cargo build -p sem-cli
- Disposable Go repo: sem entities . --json reports Run parent_id as models.go::type::Service