### PR TITLE
Include line spans in diff JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,10 @@ sem diff --format json
       "changeType": "added",
       "entityType": "function",
       "entityName": "validateToken",
+      "startLine": 12,
+      "endLine": 18,
+      "oldStartLine": null,
+      "oldEndLine": null,
       "filePath": "src/auth.ts"
     }
   ]

--- a/crates/sem-cli/src/formatters/json.rs
+++ b/crates/sem-cli/src/formatters/json.rs
@@ -11,6 +11,10 @@ pub fn format_json(result: &DiffResult) -> String {
                 "changeType": c.change_type,
                 "entityType": c.entity_type,
                 "entityName": c.entity_name,
+                "startLine": c.start_line,
+                "endLine": c.end_line,
+                "oldStartLine": c.old_start_line,
+                "oldEndLine": c.old_end_line,
                 "oldEntityName": c.old_entity_name,
                 "filePath": c.file_path,
                 "oldFilePath": c.old_file_path,
@@ -46,6 +50,7 @@ pub fn format_json(result: &DiffResult) -> String {
 mod tests {
     use super::*;
     use sem_core::git::types::{FileChange, FileStatus};
+    use sem_core::model::change::SemanticChange;
     use sem_core::parser::differ::compute_semantic_diff;
     use sem_core::parser::plugins::create_default_registry;
 
@@ -84,5 +89,48 @@ mod tests {
 
         assert_eq!(bucket_total, summary["total"].as_u64().unwrap());
         assert_eq!(summary["orphan"], 1);
+    }
+
+    #[test]
+    fn diff_json_includes_current_and_previous_line_spans() {
+        let change: SemanticChange = serde_json::from_value(serde_json::json!({
+            "id": "change::a.ts::function::foo",
+            "entityId": "a.ts::function::foo",
+            "changeType": "modified",
+            "entityType": "function",
+            "entityName": "foo",
+            "entityLine": 7,
+            "startLine": 7,
+            "endLine": 9,
+            "oldStartLine": 3,
+            "oldEndLine": 5,
+            "filePath": "a.ts",
+            "beforeContent": "function foo() { return 1; }",
+            "afterContent": "function foo() { return 999; }",
+            "structuralChange": true
+        }))
+        .unwrap();
+
+        let result = DiffResult {
+            changes: vec![change],
+            file_count: 1,
+            added_count: 0,
+            modified_count: 1,
+            deleted_count: 0,
+            moved_count: 0,
+            renamed_count: 0,
+            reordered_count: 0,
+            orphan_count: 0,
+            total_entities_before: 1,
+            total_entities_after: 1,
+        };
+
+        let output: serde_json::Value = serde_json::from_str(&format_json(&result)).unwrap();
+        let change = &output["changes"][0];
+
+        assert_eq!(change["startLine"], 7);
+        assert_eq!(change["endLine"], 9);
+        assert_eq!(change["oldStartLine"], 3);
+        assert_eq!(change["oldEndLine"], 5);
     }
 }

--- a/crates/sem-core/src/model/change.rs
+++ b/crates/sem-core/src/model/change.rs
@@ -35,6 +35,14 @@ pub struct SemanticChange {
     pub entity_name: String,
     #[serde(default)]
     pub entity_line: usize,
+    #[serde(default)]
+    pub start_line: usize,
+    #[serde(default)]
+    pub end_line: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub old_start_line: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub old_end_line: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_name: Option<String>,
     pub file_path: String,

--- a/crates/sem-core/src/model/identity.rs
+++ b/crates/sem-core/src/model/identity.rs
@@ -91,6 +91,10 @@ fn make_change(
         entity_type: primary.entity_type.clone(),
         entity_name: primary.name.clone(),
         entity_line: primary.start_line,
+        start_line: primary.start_line,
+        end_line: primary.end_line,
+        old_start_line: before_entity.map(|b| b.start_line),
+        old_end_line: before_entity.map(|b| b.end_line),
         parent_name: parent_name(primary, by_id),
         file_path: primary.file_path.clone(),
         old_entity_name: before_entity.and_then(|b| {
@@ -102,7 +106,11 @@ fn make_change(
         old_parent_id: before_entity.and_then(|b| {
             (b.parent_id != after_entity.parent_id).then(|| b.parent_id.clone()).flatten()
         }),
-        before_content: before_entity.map(|b| b.content.clone()),
+        before_content: if change_type == ChangeType::Reordered {
+            None
+        } else {
+            before_entity.map(|b| b.content.clone())
+        },
         after_content: if change_type == ChangeType::Deleted || change_type == ChangeType::Reordered {
             None
         } else {
@@ -466,11 +474,11 @@ fn detect_reorders(
         let lis_set = longest_increasing_subsequence_indices(&after_lines);
 
         // Entities NOT in LIS were reordered
-        for (i, (_before_entity, after_entity)) in pairs.iter().enumerate() {
+        for (i, (before_entity, after_entity)) in pairs.iter().enumerate() {
             if lis_set.contains(&i) {
                 continue;
             }
-            changes.push(make_change(after_entity, ChangeType::Reordered, None, commit_sha, author, by_id));
+            changes.push(make_change(after_entity, ChangeType::Reordered, Some(before_entity), commit_sha, author, by_id));
         }
     }
 }
@@ -541,6 +549,32 @@ mod tests {
         let result = match_entities(&before, &after, "a.ts", None, None, None);
         assert_eq!(result.changes.len(), 1);
         assert_eq!(result.changes[0].change_type, ChangeType::Modified);
+    }
+
+    #[test]
+    fn test_change_line_spans_track_current_and_previous_entities() {
+        let before = vec![make_entity_at(
+            "a::f::foo",
+            "foo",
+            "fn foo() { old }",
+            "a.rs",
+            3,
+        )];
+        let after = vec![make_entity_at(
+            "a::f::foo",
+            "foo",
+            "fn foo() { new }",
+            "a.rs",
+            7,
+        )];
+
+        let result = match_entities(&before, &after, "a.rs", None, None, None);
+
+        assert_eq!(result.changes.len(), 1);
+        assert_eq!(result.changes[0].start_line, 7);
+        assert_eq!(result.changes[0].end_line, 9);
+        assert_eq!(result.changes[0].old_start_line, Some(3));
+        assert_eq!(result.changes[0].old_end_line, Some(5));
     }
 
     #[test]
@@ -812,6 +846,10 @@ mod tests {
         let result = match_entities(&before, &after, "a.rs", None, None, None);
         assert_eq!(result.changes.len(), 1);
         assert_eq!(result.changes[0].change_type, ChangeType::Reordered);
+        assert!(result.changes[0].before_content.is_none());
+        assert!(result.changes[0].old_start_line.is_some());
+        assert!(result.changes[0].old_end_line.is_some());
+        assert_ne!(result.changes[0].old_start_line, Some(result.changes[0].start_line));
         // Either beta or gamma is marked, LIS picks the minimum
         assert!(result.changes[0].entity_name == "beta" || result.changes[0].entity_name == "gamma");
     }

--- a/crates/sem-core/src/parser/differ.rs
+++ b/crates/sem-core/src/parser/differ.rs
@@ -367,62 +367,220 @@ fn detect_orphan_changes(
         .flat_map(|e| e.start_line..=e.end_line)
         .collect();
 
-    // Extract uncovered lines, preserving line numbers for context
-    let before_orphan: String = before_text
-        .lines()
-        .enumerate()
-        .filter(|(i, _)| !before_covered.contains(&(i + 1)))
-        .map(|(_, l)| l)
-        .collect::<Vec<_>>()
-        .join("\n");
-    let after_orphan: String = after_text
-        .lines()
-        .enumerate()
-        .filter(|(i, _)| !after_covered.contains(&(i + 1)))
-        .map(|(_, l)| l)
-        .collect::<Vec<_>>()
-        .join("\n");
+    let before_orphans = orphan_segments(before_text, &before_covered);
+    let after_orphans = orphan_segments(after_text, &after_covered);
+    let mut changes = Vec::new();
 
-    // Skip if orphan content is unchanged
-    if before_orphan == after_orphan {
-        return Vec::new();
+    for (before_idx, after_idx) in orphan_segment_change_pairs(&before_orphans, &after_orphans) {
+        let before_orphan = before_idx.and_then(|idx| before_orphans.get(idx));
+        let after_orphan = after_idx.and_then(|idx| after_orphans.get(idx));
+        let before_content = orphan_content(before_orphan);
+        let after_content = orphan_content(after_orphan);
+
+        // Skip if orphan content is unchanged, including blank-only segments.
+        if before_content == after_content {
+            continue;
+        }
+
+        let change_type = if before_content.is_none() {
+            ChangeType::Added
+        } else if after_content.is_none() {
+            ChangeType::Deleted
+        } else {
+            ChangeType::Modified
+        };
+
+        let current_orphan = match change_type {
+            ChangeType::Deleted => before_orphan,
+            _ => after_orphan.or(before_orphan),
+        };
+        let Some(current_orphan) = current_orphan else {
+            continue;
+        };
+        let span_label = if change_type == ChangeType::Deleted {
+            "oldL"
+        } else {
+            "L"
+        };
+        let orphan_id = format!(
+            "{}::orphan::{}@{}{}-{}",
+            file.file_path,
+            change_type,
+            span_label,
+            current_orphan.start_line,
+            current_orphan.end_line
+        );
+
+        changes.push(SemanticChange {
+            id: format!("change::{orphan_id}"),
+            entity_id: orphan_id,
+            change_type,
+            entity_type: "orphan".to_string(),
+            entity_name: "module-level".to_string(),
+            entity_line: current_orphan.start_line,
+            start_line: current_orphan.start_line,
+            end_line: current_orphan.end_line,
+            old_start_line: before_orphan.map(|orphan| orphan.start_line),
+            old_end_line: before_orphan.map(|orphan| orphan.end_line),
+            parent_name: None,
+            file_path: file.file_path.clone(),
+            old_entity_name: None,
+            old_file_path: None,
+            old_parent_id: None,
+            before_content: before_content.map(str::to_string),
+            after_content: after_content.map(str::to_string),
+            commit_sha: commit_sha.map(String::from),
+            author: author.map(String::from),
+            timestamp: None,
+            structural_change: Some(true),
+        });
     }
 
-    let change_type = if before_orphan.trim().is_empty() {
-        ChangeType::Added
-    } else if after_orphan.trim().is_empty() {
-        ChangeType::Deleted
-    } else {
-        ChangeType::Modified
-    };
+    changes
+}
 
-    vec![SemanticChange {
-        id: format!("{}::orphan", file.file_path),
-        entity_id: format!("{}::orphan", file.file_path),
-        change_type,
-        entity_type: "orphan".to_string(),
-        entity_name: "module-level".to_string(),
-        entity_line: 0,
-        parent_name: None,
-        file_path: file.file_path.clone(),
-        old_entity_name: None,
-        old_file_path: None,
-        old_parent_id: None,
-        before_content: if before_orphan.is_empty() {
-            None
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct OrphanSegment {
+    start_line: usize,
+    end_line: usize,
+    content: String,
+}
+
+fn orphan_segments(text: &str, covered_lines: &HashSet<usize>) -> Vec<OrphanSegment> {
+    let mut segments = Vec::new();
+    let mut current_start: Option<usize> = None;
+    let mut current_lines: Vec<&str> = Vec::new();
+    let mut last_line_number = 0;
+
+    for (i, line) in text.lines().enumerate() {
+        let line_number = i + 1;
+        last_line_number = line_number;
+        if covered_lines.contains(&line_number) {
+            if let Some(start_line) = current_start.take() {
+                segments.push(OrphanSegment {
+                    start_line,
+                    end_line: line_number - 1,
+                    content: current_lines.join("\n"),
+                });
+                current_lines.clear();
+            }
+            continue;
+        }
+
+        current_start.get_or_insert(line_number);
+        current_lines.push(line);
+    }
+
+    if let Some(start_line) = current_start {
+        segments.push(OrphanSegment {
+            start_line,
+            end_line: last_line_number.max(start_line),
+            content: current_lines.join("\n"),
+        });
+    }
+
+    segments
+}
+
+fn orphan_content(segment: Option<&OrphanSegment>) -> Option<&str> {
+    segment
+        .map(|segment| segment.content.as_str())
+        .filter(|content| !content.trim().is_empty())
+}
+
+fn orphan_segment_change_pairs(
+    before: &[OrphanSegment],
+    after: &[OrphanSegment],
+) -> Vec<(Option<usize>, Option<usize>)> {
+    let anchors = orphan_segment_lcs(before, after);
+    let mut pairs = Vec::new();
+    let mut before_start = 0;
+    let mut after_start = 0;
+
+    for (before_anchor, after_anchor) in anchors {
+        append_orphan_gap_pairs(
+            &mut pairs,
+            before_start,
+            before_anchor,
+            after_start,
+            after_anchor,
+        );
+        before_start = before_anchor + 1;
+        after_start = after_anchor + 1;
+    }
+
+    append_orphan_gap_pairs(
+        &mut pairs,
+        before_start,
+        before.len(),
+        after_start,
+        after.len(),
+    );
+
+    pairs
+}
+
+fn append_orphan_gap_pairs(
+    pairs: &mut Vec<(Option<usize>, Option<usize>)>,
+    before_start: usize,
+    before_end: usize,
+    after_start: usize,
+    after_end: usize,
+) {
+    let before_len = before_end.saturating_sub(before_start);
+    let after_len = after_end.saturating_sub(after_start);
+
+    if before_len == after_len {
+        for i in 0..before_len {
+            pairs.push((Some(before_start + i), Some(after_start + i)));
+        }
+        return;
+    }
+
+    for i in 0..before_len {
+        pairs.push((Some(before_start + i), None));
+    }
+    for i in 0..after_len {
+        pairs.push((None, Some(after_start + i)));
+    }
+}
+
+fn orphan_segment_lcs(before: &[OrphanSegment], after: &[OrphanSegment]) -> Vec<(usize, usize)> {
+    let mut dp = vec![vec![0; after.len() + 1]; before.len() + 1];
+
+    for i in (0..before.len()).rev() {
+        for j in (0..after.len()).rev() {
+            dp[i][j] = if orphan_segments_equal(&before[i], &after[j]) {
+                dp[i + 1][j + 1] + 1
+            } else {
+                dp[i + 1][j].max(dp[i][j + 1])
+            };
+        }
+    }
+
+    let mut anchors = Vec::new();
+    let mut i = 0;
+    let mut j = 0;
+    while i < before.len() && j < after.len() {
+        if orphan_segments_equal(&before[i], &after[j]) {
+            anchors.push((i, j));
+            i += 1;
+            j += 1;
+        } else if dp[i + 1][j] >= dp[i][j + 1] {
+            i += 1;
         } else {
-            Some(before_orphan)
-        },
-        after_content: if after_orphan.is_empty() {
-            None
-        } else {
-            Some(after_orphan)
-        },
-        commit_sha: commit_sha.map(String::from),
-        author: author.map(String::from),
-        timestamp: None,
-        structural_change: Some(true),
-    }]
+            j += 1;
+        }
+    }
+
+    anchors
+}
+
+fn orphan_segments_equal(before: &OrphanSegment, after: &OrphanSegment) -> bool {
+    match (orphan_content(Some(before)), orphan_content(Some(after))) {
+        (Some(before), Some(after)) => before == after,
+        _ => false,
+    }
 }
 
 #[cfg(test)]
@@ -451,6 +609,22 @@ mod tests {
         }
     }
 
+    fn entity_span(id: &str, start_line: usize, end_line: usize) -> SemanticEntity {
+        SemanticEntity {
+            id: id.to_string(),
+            file_path: "a.rs".to_string(),
+            entity_type: "function".to_string(),
+            name: id.to_string(),
+            parent_id: None,
+            content: String::new(),
+            content_hash: String::new(),
+            structural_hash: None,
+            start_line,
+            end_line,
+            metadata: None,
+        }
+    }
+
     #[test]
     fn orphan_only_change_counts_file_and_orphan() {
         let before = "# old module comment\n\ndef value():\n    return 1\n";
@@ -467,7 +641,10 @@ mod tests {
         assert_eq!(result.changes.len(), 1);
         assert_eq!(result.file_count, 1);
         assert_eq!(result.orphan_count, 1);
-        assert_eq!(result.modified_count, 0);
+        // A changed comment is a Modified orphan, and orphan changes are counted
+        // in their change-type bucket as well as orphan_count.
+        assert_eq!(result.modified_count, 1);
+        assert_eq!(result.changes[0].change_type, ChangeType::Modified);
         assert_eq!(result.changes[0].entity_type, "orphan");
     }
 
@@ -615,5 +792,97 @@ mod tests {
             + result.renamed_count
             + result.reordered_count;
         assert_eq!(named_bucket_total, result.changes.len());
+    }
+
+    #[test]
+    fn orphan_changes_use_contiguous_line_spans() {
+        let file = modified_file(
+            "a.rs",
+            "use alpha;\nfn foo() {}\nuse beta;\nfn bar() {}\n",
+            "use gamma;\nfn foo() {}\nuse delta;\nfn bar() {}\n",
+        );
+        let entities = vec![entity_span("foo", 2, 2), entity_span("bar", 4, 4)];
+
+        let changes = detect_orphan_changes(&file, &entities, &entities, None, None);
+
+        assert_eq!(changes.len(), 2);
+        assert_eq!(changes[0].start_line, 1);
+        assert_eq!(changes[0].end_line, 1);
+        assert_eq!(changes[0].old_start_line, Some(1));
+        assert_eq!(changes[0].old_end_line, Some(1));
+        assert_eq!(changes[0].before_content.as_deref(), Some("use alpha;"));
+        assert_eq!(changes[0].after_content.as_deref(), Some("use gamma;"));
+        assert_eq!(changes[1].start_line, 3);
+        assert_eq!(changes[1].end_line, 3);
+        assert_eq!(changes[1].old_start_line, Some(3));
+        assert_eq!(changes[1].old_end_line, Some(3));
+        assert_eq!(changes[1].before_content.as_deref(), Some("use beta;"));
+        assert_eq!(changes[1].after_content.as_deref(), Some("use delta;"));
+    }
+
+    #[test]
+    fn blank_only_orphan_segments_are_ignored() {
+        let file = modified_file("a.rs", "fn foo() {}\n", "\nfn foo() {}\n");
+        let before_entities = vec![entity_span("foo", 1, 1)];
+        let after_entities = vec![entity_span("foo", 2, 2)];
+
+        let changes =
+            detect_orphan_changes(&file, &before_entities, &after_entities, None, None);
+
+        assert!(changes.is_empty());
+    }
+
+    #[test]
+    fn inserted_orphan_segment_does_not_modify_unchanged_later_segment() {
+        let file = modified_file(
+            "a.rs",
+            "fn foo() {}\nuse a;\nfn bar() {}\n",
+            "use x;\nfn foo() {}\nuse a;\nfn bar() {}\n",
+        );
+        let before_entities = vec![entity_span("foo", 1, 1), entity_span("bar", 3, 3)];
+        let after_entities = vec![entity_span("foo", 2, 2), entity_span("bar", 4, 4)];
+
+        let changes =
+            detect_orphan_changes(&file, &before_entities, &after_entities, None, None);
+
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].change_type, ChangeType::Added);
+        assert_eq!(changes[0].start_line, 1);
+        assert_eq!(changes[0].end_line, 1);
+        assert!(changes[0].old_start_line.is_none());
+        assert_eq!(changes[0].before_content, None);
+        assert_eq!(changes[0].after_content.as_deref(), Some("use x;"));
+    }
+
+    #[test]
+    fn uneven_orphan_gaps_are_not_forced_into_modifications() {
+        let file = modified_file(
+            "a.rs",
+            "use a;\nfn foo() {}\nuse old;\nfn mid() {}\nuse c;\nfn bar() {}\n",
+            "use a;\nfn foo() {}\nuse new1;\nfn mid() {}\nuse new2;\nfn baz() {}\nuse c;\nfn bar() {}\n",
+        );
+        let before_entities = vec![
+            entity_span("foo", 2, 2),
+            entity_span("mid", 4, 4),
+            entity_span("bar", 6, 6),
+        ];
+        let after_entities = vec![
+            entity_span("foo", 2, 2),
+            entity_span("mid", 4, 4),
+            entity_span("baz", 6, 6),
+            entity_span("bar", 8, 8),
+        ];
+
+        let changes =
+            detect_orphan_changes(&file, &before_entities, &after_entities, None, None);
+
+        assert_eq!(changes.len(), 3);
+        assert_eq!(changes[0].change_type, ChangeType::Deleted);
+        assert!(changes[0].entity_id.contains("::deleted@oldL3-3"));
+        assert_eq!(changes[0].before_content.as_deref(), Some("use old;"));
+        assert_eq!(changes[1].change_type, ChangeType::Added);
+        assert_eq!(changes[1].after_content.as_deref(), Some("use new1;"));
+        assert_eq!(changes[2].change_type, ChangeType::Added);
+        assert_eq!(changes[2].after_content.as_deref(), Some("use new2;"));
     }
 }

--- a/docs/details.html
+++ b/docs/details.html
@@ -351,6 +351,10 @@
       <span class="b">"changeType"</span>: <span class="g">"added"</span>,
       <span class="b">"entityType"</span>: <span class="d">"function"</span>,
       <span class="b">"entityName"</span>: <span class="w">"validateToken"</span>,
+      <span class="b">"startLine"</span>: <span class="y">12</span>,
+      <span class="b">"endLine"</span>: <span class="y">18</span>,
+      <span class="b">"oldStartLine"</span>: <span class="d">null</span>,
+      <span class="b">"oldEndLine"</span>: <span class="d">null</span>,
       <span class="b">"filePath"</span>: <span class="d">"src/auth.ts"</span>
     <span class="d">}</span>
   <span class="d">]</span>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -142,6 +142,10 @@ Returns:
       "changeType": "added",
       "entityType": "function",
       "entityName": "validateToken",
+      "startLine": 12,
+      "endLine": 18,
+      "oldStartLine": null,
+      "oldEndLine": null,
       "filePath": "src/auth.ts"
     }
   ]


### PR DESCRIPTION
## Summary

- Add current and previous line spans to semantic change records and expose them from `sem diff --format json` as `startLine`, `endLine`, `oldStartLine`, and `oldEndLine`.
- Preserve old spans for modified, moved, renamed, deleted, and reordered entities.
- Split orphan changes into aligned contiguous segments so reported line spans stay navigable.
- Update JSON output examples in README and docs.

Closes #188

## Test plan

- `cargo test --workspace`
- Built `sem-cli` and verified the issue #188 TypeScript reproduction in a dummy git repo under `/Users/zer0/Developer/oss`.
- Verified inserted orphan segment alignment in a dummy git repo under `/Users/zer0/Developer/oss`.