### PR TITLE
Follow renames in log and fix blame attribution

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1385,6 +1385,7 @@ dependencies = [
  "serde",
  "serde_json",
  "similar",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/sem-cli/Cargo.toml
+++ b/crates/sem-cli/Cargo.toml
@@ -48,3 +48,6 @@ pkg-fmt = "zip"
 
 [features]
 vendored-openssl = ["openssl-sys/vendored"]
+
+[dev-dependencies]
+tempfile = "3.24.0"

--- a/crates/sem-cli/src/commands/blame.rs
+++ b/crates/sem-cli/src/commands/blame.rs
@@ -1,7 +1,9 @@
+use std::collections::HashMap;
 use std::path::Path;
 
 use colored::Colorize;
 use sem_core::git::bridge::GitBridge;
+use sem_core::git::types::BlameLineInfo;
 
 use super::truncate_str;
 
@@ -18,7 +20,7 @@ struct EntityBlame {
     end_line: usize,
     author: String,
     date: String,
-    commit_sha: String,
+    commit_sha: Option<String>,
     summary: String,
 }
 
@@ -31,7 +33,12 @@ pub fn blame_command(opts: BlameOptions) {
     let content = match std::fs::read_to_string(&full_path) {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("{} Cannot read {}: {}", "error:".red().bold(), opts.file_path, e);
+            eprintln!(
+                "{} Cannot read {}: {}",
+                "error:".red().bold(),
+                opts.file_path,
+                e
+            );
             std::process::exit(1);
         }
     };
@@ -43,7 +50,11 @@ pub fn blame_command(opts: BlameOptions) {
             return;
         }
 
-        eprintln!("{} No entities found in {}", "warning:".yellow().bold(), opts.file_path);
+        eprintln!(
+            "{} No entities found in {}",
+            "warning:".yellow().bold(),
+            opts.file_path
+        );
         return;
     }
 
@@ -51,7 +62,11 @@ pub fn blame_command(opts: BlameOptions) {
     let git = match GitBridge::open(root) {
         Ok(r) => r,
         Err(e) => {
-            eprintln!("{} Cannot open git repository: {}", "error:".red().bold(), e);
+            eprintln!(
+                "{} Cannot open git repository: {}",
+                "error:".red().bold(),
+                e
+            );
             std::process::exit(1);
         }
     };
@@ -65,53 +80,67 @@ pub fn blame_command(opts: BlameOptions) {
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_else(|_| opts.file_path.clone());
 
-    let blame = match git.blame_file(Path::new(&relative_path)) {
+    let blame = match git.blame_file_porcelain(Path::new(&relative_path)) {
         Ok(b) => b,
         Err(e) => {
-            eprintln!("{} Cannot blame {}: {}", "error:".red().bold(), opts.file_path, e);
+            eprintln!(
+                "{} Cannot blame {}: {}",
+                "error:".red().bold(),
+                opts.file_path,
+                e
+            );
             std::process::exit(1);
         }
     };
+    let blame_by_line: HashMap<usize, BlameLineInfo> = blame
+        .into_iter()
+        .map(|line| (line.line_number, line))
+        .collect();
 
     // For each entity, find the most recent commit that touched its lines
     let mut results: Vec<EntityBlame> = Vec::new();
 
     for entity in &entities {
         // Find the latest commit across the entity's line range
-        let mut latest_time: i64 = 0;
-        let mut latest_author = String::new();
-        let mut latest_sha = String::new();
-        let mut latest_summary = String::new();
-        let mut latest_date = String::new();
+        let mut selected: Option<&BlameLineInfo> = None;
 
         for line in entity.start_line..=entity.end_line {
-            if let Some(hunk) = blame.get_line(line) {
-                let sig = hunk.final_signature();
-                let time = sig.when().seconds();
-                if time > latest_time {
-                    latest_time = time;
-                    latest_author = sig.name().unwrap_or("unknown").to_string();
-                    let oid = hunk.final_commit_id();
-                    latest_sha = format!("{}", oid);
-                    latest_summary = git.commit_summary(oid).unwrap_or_default();
+            if let Some(info) = blame_by_line.get(&line) {
+                if info.commit_sha.is_none() {
+                    selected = Some(info);
+                    break;
+                }
 
-                    // Format date
-                    let ts = sig.when().seconds();
-                    let naive = chrono_lite_format(ts);
-                    latest_date = naive;
+                let is_newer = match (info.author_time, selected.and_then(|s| s.author_time)) {
+                    (Some(current), Some(previous)) => current > previous,
+                    (Some(_), None) => true,
+                    _ => selected.is_none(),
+                };
+                if is_newer {
+                    selected = Some(info);
                 }
             }
         }
+
+        let (author, date, commit_sha, summary) = match selected {
+            Some(info) => (
+                info.author.clone(),
+                info.author_time.map(chrono_lite_format).unwrap_or_default(),
+                info.commit_sha.clone(),
+                info.summary.clone(),
+            ),
+            None => (String::new(), String::new(), None, String::new()),
+        };
 
         results.push(EntityBlame {
             name: entity.name.clone(),
             entity_type: entity.entity_type.clone(),
             start_line: entity.start_line,
             end_line: entity.end_line,
-            author: latest_author,
-            date: latest_date,
-            commit_sha: latest_sha,
-            summary: latest_summary,
+            author,
+            date,
+            commit_sha,
+            summary,
         });
     }
 
@@ -123,32 +152,33 @@ pub fn blame_command(opts: BlameOptions) {
                     "name": r.name,
                     "type": r.entity_type,
                     "lines": [r.start_line, r.end_line],
-                    "author": if r.author.is_empty() { "uncommitted" } else { &r.author },
+                    "author": if r.author.is_empty() { "unknown" } else { &r.author },
                     "date": r.date,
-                    "commit": if r.commit_sha.is_empty() { "uncommitted" } else { &r.commit_sha },
+                    "commit": r.commit_sha.clone(),
                     "summary": r.summary,
                 })
             })
             .collect();
         println!("{}", serde_json::to_string(&output).unwrap());
     } else {
-        println!(
-            "{}",
-            format!("┌─ {} ", opts.file_path).bold()
-        );
+        println!("{}", format!("┌─ {} ", opts.file_path).bold());
         println!("│");
 
         // Group by parent (top-level vs nested)
         let max_name_len = results.iter().map(|r| r.name.len()).max().unwrap_or(10);
-        let max_type_len = results.iter().map(|r| r.entity_type.len()).max().unwrap_or(8);
+        let max_type_len = results
+            .iter()
+            .map(|r| r.entity_type.len())
+            .max()
+            .unwrap_or(8);
 
         for r in &results {
-            let sha_short = if r.commit_sha.is_empty() {
+            let sha_short = if r.commit_sha.is_none() {
                 "uncommtd"
-            } else if r.commit_sha.len() >= 8 {
-                &r.commit_sha[..8]
+            } else if r.commit_sha.as_deref().unwrap_or_default().len() >= 8 {
+                &r.commit_sha.as_deref().unwrap_or_default()[..8]
             } else {
-                &r.commit_sha
+                r.commit_sha.as_deref().unwrap_or_default()
             };
 
             let is_nested = results.iter().any(|other| {

--- a/crates/sem-cli/src/commands/log.rs
+++ b/crates/sem-cli/src/commands/log.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use colored::Colorize;
 use sem_core::git::bridge::GitBridge;
+use sem_core::git::types::CommitInfo;
 use sem_core::model::entity::SemanticEntity;
 use sem_core::parser::registry::ParserRegistry;
 
@@ -23,7 +24,6 @@ enum EntityChangeType {
     ModifiedCosmetic,
     Deleted,
     Moved,
-    Reappeared,
     Renamed,
 }
 
@@ -35,7 +35,6 @@ impl EntityChangeType {
             EntityChangeType::ModifiedCosmetic => "modified (cosmetic)",
             EntityChangeType::Deleted => "deleted",
             EntityChangeType::Moved => "moved",
-            EntityChangeType::Reappeared => "reappeared",
             EntityChangeType::Renamed => "renamed",
         }
     }
@@ -47,7 +46,6 @@ impl EntityChangeType {
             EntityChangeType::ModifiedCosmetic => "modified (cosmetic)".dimmed(),
             EntityChangeType::Deleted => "deleted".red(),
             EntityChangeType::Moved => "moved".blue(),
-            EntityChangeType::Reappeared => "reappeared".green(),
             EntityChangeType::Renamed => "renamed".cyan(),
         }
     }
@@ -66,6 +64,13 @@ struct LogEntry {
     prev_file_path: Option<String>,
 }
 
+#[derive(Clone)]
+struct EntityOccurrence {
+    commit_index: usize,
+    file_path: String,
+    entity: SemanticEntity,
+}
+
 pub fn log_command(opts: LogOptions) {
     let root = Path::new(&opts.cwd);
     let registry = super::create_registry(&opts.cwd);
@@ -78,11 +83,12 @@ pub fn log_command(opts: LogOptions) {
         }
     };
 
-    // Resolve file path: use provided or auto-detect
+    // Resolve file path when possible. Historical entities need --file so the
+    // search can stay bounded to the relevant file history.
     let file_path = match opts.file_path {
-        Some(fp) => fp,
+        Some(fp) => Some(fp),
         None => match find_entity_file(root, &registry, &opts.entity_name) {
-            FindResult::Found(fp) => fp,
+            FindResult::Found(fp) => Some(fp),
             FindResult::Ambiguous(files) => {
                 eprintln!(
                     "{} Entity '{}' found in multiple files:",
@@ -97,7 +103,7 @@ pub fn log_command(opts: LogOptions) {
             }
             FindResult::NotFound => {
                 eprintln!(
-                    "{} Entity '{}' not found in any file",
+                    "{} Entity '{}' not found in the working tree. Use --file to search historical entities.",
                     "error:".red().bold(),
                     opts.entity_name
                 );
@@ -106,242 +112,100 @@ pub fn log_command(opts: LogOptions) {
         },
     };
 
-    // Convert file_path to be relative to git repo root (for git operations)
     let repo_root = bridge.repo_root();
     let abs_cwd = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
     let abs_repo = std::fs::canonicalize(repo_root).unwrap_or_else(|_| repo_root.to_path_buf());
-    let git_file_path = if abs_cwd != abs_repo {
-        // cwd is a subdirectory of repo root, prepend the prefix
-        let prefix = abs_cwd.strip_prefix(&abs_repo).unwrap_or(Path::new(""));
-        prefix.join(&file_path).to_string_lossy().to_string()
-    } else {
-        file_path.clone()
-    };
 
-    // Verify the file has a parser (read content for shebang detection on extensionless files)
-    let file_content_hint = std::fs::read_to_string(root.join(&file_path)).unwrap_or_default();
-    let resolved_fp = registry.resolve_file_path(&file_path);
-    let detection_fp = resolved_fp.as_deref().unwrap_or(&file_path);
-    if registry.get_plugin_with_content(detection_fp, &file_content_hint).is_none() {
-        eprintln!(
-            "{} Unsupported file type: {}",
-            "error:".red().bold(),
-            file_path
-        );
-        std::process::exit(1);
+    let git_file_path = file_path.as_ref().map(|fp| {
+        if abs_cwd != abs_repo {
+            let prefix = abs_cwd.strip_prefix(&abs_repo).unwrap_or(Path::new(""));
+            prefix.join(fp).to_string_lossy().to_string()
+        } else {
+            fp.clone()
+        }
+    });
+
+    if let Some(fp) = &file_path {
+        let file_content_hint = std::fs::read_to_string(root.join(fp)).unwrap_or_default();
+        let resolved_fp = registry.resolve_file_path(fp);
+        let detection_fp = resolved_fp.as_deref().unwrap_or(fp);
+        if registry
+            .get_plugin_with_content(detection_fp, &file_content_hint)
+            .is_none()
+        {
+            eprintln!("{} Unsupported file type: {}", "error:".red().bold(), fp);
+            std::process::exit(1);
+        }
     }
 
-    // Walk commits, tracking entity across file moves and renames.
-    // Uses follow-renames to automatically track file renames in git history.
-    let commits = match bridge.get_file_commits_follow_renames(&git_file_path, opts.limit) {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("{} Failed to get file history: {}", "error:".red().bold(), e);
-            std::process::exit(1);
+    let use_file_history = git_file_path.as_deref().is_some_and(|path| {
+        bridge
+            .get_head_sha()
+            .ok()
+            .and_then(|head| entity_by_name_at_ref(&bridge, &registry, &head, path, &opts.entity_name))
+            .is_some()
+    });
+
+    let mut commits = if use_file_history {
+        let path = git_file_path.as_deref().unwrap();
+        match bridge.get_file_commits_follow_renames(path, 0) {
+            Ok(file_commits) if !file_commits.is_empty() => {
+                file_commits.into_iter().map(|info| info.commit).collect()
+            }
+            Ok(_) => match bridge.get_log(0) {
+                Ok(c) => c,
+                Err(e) => {
+                    eprintln!("{} Failed to get history: {}", "error:".red().bold(), e);
+                    std::process::exit(1);
+                }
+            },
+            Err(e) => {
+                eprintln!("{} Failed to get file history: {}", "error:".red().bold(), e);
+                std::process::exit(1);
+            }
+        }
+    } else {
+        match bridge.get_log(0) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("{} Failed to get history: {}", "error:".red().bold(), e);
+                std::process::exit(1);
+            }
         }
     };
 
     if commits.is_empty() {
-        eprintln!("{} No commits found for {}", "warning:".yellow().bold(), git_file_path);
+        eprintln!("{} No commits found", "warning:".yellow().bold());
         return;
     }
+    commits.reverse();
 
-    let mut entries: Vec<LogEntry> = Vec::new();
-    let mut prev_entity_content: Option<String> = None;
-    let mut prev_structural_hash: Option<String> = None;
-    let mut entity_type = String::new();
-    let mut found_at_least_once = false;
-    let mut tracked_entity_name = opts.entity_name.clone();
     let total_commits = commits.len();
-
-    // Process commits oldest-first
-    let reversed: Vec<_> = commits.iter().rev().collect();
-
-    for fci in &reversed {
-        let commit = &fci.commit;
-        let current_git_file = &fci.file_path;
-
-        let file_content = bridge
-            .read_file_at_ref(&commit.sha, current_git_file)
-            .ok()
-            .flatten();
-
-        let found_entity = file_content.as_ref().and_then(|c| {
-            let entities = registry.extract_entities(current_git_file, c);
-            entities.into_iter().find(|e| e.name == tracked_entity_name)
-        });
-
-        let date = chrono_lite_format(commit.date.parse::<i64>().unwrap_or(0));
-        let msg_first_line = commit.message.lines().next().unwrap_or("").to_string();
-
-        match found_entity {
-            Some(ent) => {
-                if !found_at_least_once {
-                    entity_type = ent.entity_type.clone();
-                }
-
-                let cur_content_hash = &ent.content_hash;
-                let cur_structural_hash = ent.structural_hash.as_deref();
-
-                if !found_at_least_once {
-                    found_at_least_once = true;
-                    entries.push(LogEntry {
-                        sha: commit.sha.clone(),
-                        short_sha: commit.short_sha.clone(),
-                        author: commit.author.clone(),
-                        date,
-                        message: msg_first_line,
-                        change_type: EntityChangeType::Added,
-                        content: Some(ent.content.clone()),
-                        prev_content: None,
-                        file_path: Some(current_git_file.clone()),
-                        prev_file_path: None,
-                    });
-                } else if prev_entity_content.is_none() {
-                    entries.push(LogEntry {
-                        sha: commit.sha.clone(),
-                        short_sha: commit.short_sha.clone(),
-                        author: commit.author.clone(),
-                        date,
-                        message: msg_first_line,
-                        change_type: EntityChangeType::Reappeared,
-                        content: Some(ent.content.clone()),
-                        prev_content: None,
-                        file_path: Some(current_git_file.clone()),
-                        prev_file_path: None,
-                    });
-                } else {
-                    let prev_hash = prev_entity_content
-                        .as_ref()
-                        .map(|c| sem_core::utils::hash::content_hash(c));
-                    let content_changed =
-                        prev_hash.as_deref() != Some(cur_content_hash.as_str());
-
-                    if content_changed {
-                        let structural_changed =
-                            match (cur_structural_hash, prev_structural_hash.as_deref()) {
-                                (Some(cur), Some(prev)) => cur != prev,
-                                _ => true,
-                            };
-                        let change_type = if structural_changed {
-                            EntityChangeType::ModifiedLogic
-                        } else {
-                            EntityChangeType::ModifiedCosmetic
-                        };
-                        entries.push(LogEntry {
-                            sha: commit.sha.clone(),
-                            short_sha: commit.short_sha.clone(),
-                            author: commit.author.clone(),
-                            date,
-                            message: msg_first_line,
-                            change_type,
-                            content: Some(ent.content.clone()),
-                            prev_content: prev_entity_content.clone(),
-                            file_path: Some(current_git_file.clone()),
-                            prev_file_path: None,
-                        });
-                    }
-                }
-
-                prev_entity_content = Some(ent.content.clone());
-                prev_structural_hash = ent.structural_hash.clone();
-            }
-            None => {
-                // Entity not found by name. Before cross-file search,
-                // try same-file structural hash fallback to detect renames.
-                if let Some(ref prev_shash) = prev_structural_hash {
-                    let renamed_entity = file_content.as_ref().and_then(|c| {
-                        let entities = registry.extract_entities(current_git_file, c);
-                        entities.into_iter().find(|e| {
-                            e.structural_hash.as_deref() == Some(prev_shash.as_str())
-                        })
-                    });
-
-                    if let Some(ent) = renamed_entity {
-                        // Entity was renamed within the same file
-                        entries.push(LogEntry {
-                            sha: commit.sha.clone(),
-                            short_sha: commit.short_sha.clone(),
-                            author: commit.author.clone(),
-                            date,
-                            message: msg_first_line,
-                            change_type: EntityChangeType::Renamed,
-                            content: Some(ent.content.clone()),
-                            prev_content: prev_entity_content.clone(),
-                            file_path: Some(current_git_file.clone()),
-                            prev_file_path: None,
-                        });
-
-                        // Update tracked name to continue backward traversal
-                        tracked_entity_name = ent.name.clone();
-                        prev_entity_content = Some(ent.content.clone());
-                        prev_structural_hash = ent.structural_hash.clone();
-                        if !found_at_least_once {
-                            entity_type = ent.entity_type.clone();
-                            found_at_least_once = true;
-                        }
-                        continue;
-                    }
-                }
-
-                // Try cross-file search
-                if prev_entity_content.is_some() {
-                    let cross = search_entity_cross_file(
-                        &bridge,
-                        &registry,
-                        &commit.sha,
-                        &tracked_entity_name,
-                        prev_structural_hash.as_deref(),
-                        current_git_file,
-                    );
-
-                    match cross {
-                        Some((new_file, ent)) => {
-                            entries.push(LogEntry {
-                                sha: commit.sha.clone(),
-                                short_sha: commit.short_sha.clone(),
-                                author: commit.author.clone(),
-                                date,
-                                message: msg_first_line,
-                                change_type: EntityChangeType::Moved,
-                                content: Some(ent.content.clone()),
-                                prev_content: prev_entity_content.clone(),
-                                file_path: Some(new_file),
-                                prev_file_path: Some(current_git_file.clone()),
-                            });
-
-                            prev_entity_content = Some(ent.content.clone());
-                            prev_structural_hash = ent.structural_hash.clone();
-                        }
-                        None => {
-                            entries.push(LogEntry {
-                                sha: commit.sha.clone(),
-                                short_sha: commit.short_sha.clone(),
-                                author: commit.author.clone(),
-                                date,
-                                message: msg_first_line,
-                                change_type: EntityChangeType::Deleted,
-                                content: None,
-                                prev_content: prev_entity_content.take(),
-                                file_path: Some(current_git_file.clone()),
-                                prev_file_path: None,
-                            });
-                            prev_structural_hash = None;
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    if !found_at_least_once {
+    let Some(seed) = find_seed_occurrence(
+        &bridge,
+        &registry,
+        &commits,
+        &opts.entity_name,
+        git_file_path.as_deref(),
+    ) else {
         eprintln!(
-            "{} Entity '{}' not found in any commit of {}",
+            "{} Entity '{}' not found in scanned history{}",
             "error:".red().bold(),
             opts.entity_name,
-            file_path
+            git_file_path
+                .as_ref()
+                .map(|path| format!(" of {path}"))
+                .unwrap_or_default()
         );
         std::process::exit(1);
+    };
+
+    let entity_type = seed.entity.entity_type.clone();
+    let mut entries = trace_back_to_origin(&bridge, &registry, &commits, seed.clone());
+    entries.extend(trace_forward_from_seed(&bridge, &registry, &commits, seed));
+    if opts.limit != 0 && entries.len() > opts.limit {
+        let drop_count = entries.len() - opts.limit;
+        entries.drain(0..drop_count);
     }
 
     let first_seen = entries.first().map(|e| e.date.clone()).unwrap_or_default();
@@ -350,23 +214,321 @@ pub fn log_command(opts: LogOptions) {
         .iter()
         .rev()
         .find_map(|e| e.file_path.as_ref())
-        .unwrap_or(&file_path)
-        .clone();
+        .map(String::as_str)
+        .or(git_file_path.as_deref())
+        .unwrap_or("");
     // Check if entity ever moved between files
-    let was_file = entries
-        .iter()
-        .find_map(|e| {
-            if matches!(e.change_type, EntityChangeType::Moved) {
-                e.prev_file_path.as_ref().cloned()
-            } else {
-                None
-            }
-        });
+    let was_file = entries.iter().find_map(|e| {
+        if matches!(e.change_type, EntityChangeType::Moved) {
+            e.prev_file_path.as_ref().cloned()
+        } else {
+            None
+        }
+    });
 
     if opts.json {
-        print_json(&opts.entity_name, &display_file, &entity_type, &entries, opts.verbose);
+        print_json(
+            &opts.entity_name,
+            display_file,
+            &entity_type,
+            &entries,
+            opts.verbose,
+        );
     } else {
-        print_terminal(&opts.entity_name, &display_file, was_file.as_deref(), &entity_type, &entries, total_commits, &first_seen, opts.verbose);
+        print_terminal(
+            &opts.entity_name,
+            display_file,
+            was_file.as_deref(),
+            &entity_type,
+            &entries,
+            total_commits,
+            &first_seen,
+            opts.verbose,
+        );
+    }
+}
+
+fn find_seed_occurrence(
+    bridge: &GitBridge,
+    registry: &ParserRegistry,
+    commits: &[CommitInfo],
+    entity_name: &str,
+    file_path: Option<&str>,
+) -> Option<EntityOccurrence> {
+    for (index, commit) in commits.iter().enumerate().rev() {
+        let paths = match file_path {
+            Some(path) => vec![path.to_string()],
+            None => bridge
+                .get_commit_changed_files(&commit.sha)
+                .unwrap_or_default(),
+        };
+
+        for path in paths {
+            if let Some(entity) =
+                entity_by_name_at_ref(bridge, registry, &commit.sha, &path, entity_name)
+            {
+                return Some(EntityOccurrence {
+                    commit_index: index,
+                    file_path: path,
+                    entity,
+                });
+            }
+        }
+    }
+
+    None
+}
+
+fn trace_back_to_origin(
+    bridge: &GitBridge,
+    registry: &ParserRegistry,
+    commits: &[CommitInfo],
+    seed: EntityOccurrence,
+) -> Vec<LogEntry> {
+    let mut current = seed;
+    let mut entries = Vec::new();
+
+    for child_index in (1..=current.commit_index).rev() {
+        let child_commit = &commits[child_index];
+        let parent_commit = &commits[child_index - 1];
+        let changed_paths = bridge
+            .get_commit_changed_files(&child_commit.sha)
+            .unwrap_or_default();
+
+        let previous = find_related_entity_at_ref(
+            bridge,
+            registry,
+            &parent_commit.sha,
+            &current.file_path,
+            &current.entity.name,
+            current.entity.structural_hash.as_deref(),
+            &changed_paths,
+        );
+
+        let Some(previous) = previous else {
+            entries.push(added_entry(child_commit, &current));
+            entries.reverse();
+            return entries;
+        };
+
+        if let Some(entry) = transition_entry(child_commit, &previous, &current) {
+            entries.push(entry);
+        }
+
+        current = EntityOccurrence {
+            commit_index: child_index - 1,
+            ..previous
+        };
+    }
+
+    entries.push(added_entry(&commits[current.commit_index], &current));
+    entries.reverse();
+    entries
+}
+
+fn trace_forward_from_seed(
+    bridge: &GitBridge,
+    registry: &ParserRegistry,
+    commits: &[CommitInfo],
+    seed: EntityOccurrence,
+) -> Vec<LogEntry> {
+    let mut current = seed;
+    let mut entries = Vec::new();
+
+    for child_index in current.commit_index + 1..commits.len() {
+        let child_commit = &commits[child_index];
+        let changed_paths = bridge
+            .get_commit_changed_files(&child_commit.sha)
+            .unwrap_or_default();
+
+        let next = find_related_entity_at_ref(
+            bridge,
+            registry,
+            &child_commit.sha,
+            &current.file_path,
+            &current.entity.name,
+            current.entity.structural_hash.as_deref(),
+            &changed_paths,
+        );
+
+        let Some(next) = next else {
+            entries.push(deleted_entry(child_commit, &current));
+            break;
+        };
+
+        if let Some(entry) = transition_entry(child_commit, &current, &next) {
+            entries.push(entry);
+        }
+
+        current = EntityOccurrence {
+            commit_index: child_index,
+            ..next
+        };
+    }
+
+    entries
+}
+
+fn find_related_entity_at_ref(
+    bridge: &GitBridge,
+    registry: &ParserRegistry,
+    sha: &str,
+    preferred_file: &str,
+    entity_name: &str,
+    structural_hash: Option<&str>,
+    changed_paths: &[String],
+) -> Option<EntityOccurrence> {
+    let paths = candidate_paths(preferred_file, changed_paths);
+
+    for path in &paths {
+        if let Some(entity) = entity_by_name_at_ref(bridge, registry, sha, path, entity_name) {
+            return Some(EntityOccurrence {
+                commit_index: 0,
+                file_path: path.clone(),
+                entity,
+            });
+        }
+    }
+
+    let structural_hash = structural_hash?;
+    for path in &paths {
+        if let Some(entity) =
+            entity_by_structural_hash_at_ref(bridge, registry, sha, path, structural_hash)
+        {
+            return Some(EntityOccurrence {
+                commit_index: 0,
+                file_path: path.clone(),
+                entity,
+            });
+        }
+    }
+
+    None
+}
+
+fn candidate_paths(preferred_file: &str, changed_paths: &[String]) -> Vec<String> {
+    let mut paths = vec![preferred_file.to_string()];
+    for path in changed_paths {
+        if !paths.iter().any(|existing| existing == path) {
+            paths.push(path.clone());
+        }
+    }
+    paths
+}
+
+fn entity_by_name_at_ref(
+    bridge: &GitBridge,
+    registry: &ParserRegistry,
+    sha: &str,
+    file_path: &str,
+    entity_name: &str,
+) -> Option<SemanticEntity> {
+    entities_at_ref(bridge, registry, sha, file_path)
+        .into_iter()
+        .find(|entity| entity.name == entity_name)
+}
+
+fn entity_by_structural_hash_at_ref(
+    bridge: &GitBridge,
+    registry: &ParserRegistry,
+    sha: &str,
+    file_path: &str,
+    structural_hash: &str,
+) -> Option<SemanticEntity> {
+    entities_at_ref(bridge, registry, sha, file_path)
+        .into_iter()
+        .find(|entity| entity.structural_hash.as_deref() == Some(structural_hash))
+}
+
+fn entities_at_ref(
+    bridge: &GitBridge,
+    registry: &ParserRegistry,
+    sha: &str,
+    file_path: &str,
+) -> Vec<SemanticEntity> {
+    bridge
+        .read_file_at_ref(sha, file_path)
+        .ok()
+        .flatten()
+        .map(|content| registry.extract_entities(file_path, &content))
+        .unwrap_or_default()
+}
+
+fn transition_entry(
+    commit: &CommitInfo,
+    before: &EntityOccurrence,
+    after: &EntityOccurrence,
+) -> Option<LogEntry> {
+    let file_changed = before.file_path != after.file_path;
+    let name_changed = before.entity.name != after.entity.name;
+    let content_changed = before.entity.content_hash != after.entity.content_hash;
+
+    let change_type = if file_changed {
+        EntityChangeType::Moved
+    } else if name_changed {
+        EntityChangeType::Renamed
+    } else if content_changed {
+        if structural_changed(&before.entity, &after.entity) {
+            EntityChangeType::ModifiedLogic
+        } else {
+            EntityChangeType::ModifiedCosmetic
+        }
+    } else {
+        return None;
+    };
+
+    Some(LogEntry {
+        sha: commit.sha.clone(),
+        short_sha: commit.short_sha.clone(),
+        author: commit.author.clone(),
+        date: chrono_lite_format(commit.date.parse::<i64>().unwrap_or(0)),
+        message: commit.message.lines().next().unwrap_or("").to_string(),
+        change_type,
+        content: Some(after.entity.content.clone()),
+        prev_content: Some(before.entity.content.clone()),
+        file_path: Some(after.file_path.clone()),
+        prev_file_path: if file_changed {
+            Some(before.file_path.clone())
+        } else {
+            None
+        },
+    })
+}
+
+fn structural_changed(before: &SemanticEntity, after: &SemanticEntity) -> bool {
+    match (&before.structural_hash, &after.structural_hash) {
+        (Some(before), Some(after)) => before != after,
+        _ => true,
+    }
+}
+
+fn added_entry(commit: &CommitInfo, occurrence: &EntityOccurrence) -> LogEntry {
+    LogEntry {
+        sha: commit.sha.clone(),
+        short_sha: commit.short_sha.clone(),
+        author: commit.author.clone(),
+        date: chrono_lite_format(commit.date.parse::<i64>().unwrap_or(0)),
+        message: commit.message.lines().next().unwrap_or("").to_string(),
+        change_type: EntityChangeType::Added,
+        content: Some(occurrence.entity.content.clone()),
+        prev_content: None,
+        file_path: Some(occurrence.file_path.clone()),
+        prev_file_path: None,
+    }
+}
+
+fn deleted_entry(commit: &CommitInfo, occurrence: &EntityOccurrence) -> LogEntry {
+    LogEntry {
+        sha: commit.sha.clone(),
+        short_sha: commit.short_sha.clone(),
+        author: commit.author.clone(),
+        date: chrono_lite_format(commit.date.parse::<i64>().unwrap_or(0)),
+        message: commit.message.lines().next().unwrap_or("").to_string(),
+        change_type: EntityChangeType::Deleted,
+        content: None,
+        prev_content: Some(occurrence.entity.content.clone()),
+        file_path: Some(occurrence.file_path.clone()),
+        prev_file_path: None,
     }
 }
 
@@ -415,19 +577,13 @@ fn print_terminal(
         // Show file transition for Moved entries
         if matches!(entry.change_type, EntityChangeType::Moved) {
             if let Some(new_fp) = &entry.file_path {
-                println!(
-                    "│    {}",
-                    format!("→ moved to {}", new_fp).blue()
-                );
+                println!("│    {}", format!("→ moved to {}", new_fp).blue());
             }
         }
 
         // Show rename info
         if matches!(entry.change_type, EntityChangeType::Renamed) {
-            println!(
-                "│    {}",
-                "→ entity renamed (structural hash match)".cyan()
-            );
+            println!("│    {}", "→ entity renamed (structural hash match)".cyan());
         }
 
         if verbose {
@@ -532,55 +688,6 @@ fn print_json(
     println!("{}", serde_json::to_string(&output).unwrap());
 }
 
-/// Search for an entity in other files changed by a commit.
-/// First tries matching by name, then falls back to structural_hash (handles renames).
-fn search_entity_cross_file(
-    bridge: &GitBridge,
-    registry: &ParserRegistry,
-    sha: &str,
-    entity_name: &str,
-    prev_structural_hash: Option<&str>,
-    exclude_file: &str,
-) -> Option<(String, SemanticEntity)> {
-    let changed_files = bridge.get_commit_changed_files(sha).ok()?;
-
-    // First pass: match by name
-    for file_path in &changed_files {
-        if file_path == exclude_file {
-            continue;
-        }
-        let content = match bridge.read_file_at_ref(sha, file_path) {
-            Ok(Some(c)) => c,
-            _ => continue,
-        };
-        let entities = registry.extract_entities(file_path, &content);
-        if let Some(ent) = entities.into_iter().find(|e| e.name == entity_name) {
-            return Some((file_path.clone(), ent));
-        }
-    }
-
-    // Second pass: match by structural_hash (handles renames)
-    let prev_hash = prev_structural_hash?;
-    for file_path in &changed_files {
-        if file_path == exclude_file {
-            continue;
-        }
-        let content = match bridge.read_file_at_ref(sha, file_path) {
-            Ok(Some(c)) => c,
-            _ => continue,
-        };
-        let entities = registry.extract_entities(file_path, &content);
-        if let Some(ent) = entities
-            .into_iter()
-            .find(|e| e.structural_hash.as_deref() == Some(prev_hash))
-        {
-            return Some((file_path.clone(), ent));
-        }
-    }
-
-    None
-}
-
 enum FindResult {
     Found(String),
     Ambiguous(Vec<String>),
@@ -652,4 +759,105 @@ fn chrono_lite_format(unix_seconds: i64) -> String {
 
 fn is_leap(y: i64) -> bool {
     (y % 4 == 0 && y % 100 != 0) || y % 400 == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sem_core::parser::plugins::create_default_registry;
+    use std::fs;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    fn git(repo: &TempDir, args: &[&str]) {
+        let status = Command::new("git")
+            .current_dir(repo.path())
+            .args(args)
+            .status()
+            .unwrap();
+        assert!(status.success(), "git {:?} failed", args);
+    }
+
+    fn commit_all(repo: &TempDir, message: &str, timestamp: i64) {
+        git(repo, &["add", "-A"]);
+        let status = Command::new("git")
+            .current_dir(repo.path())
+            .env("GIT_AUTHOR_DATE", format!("@{timestamp}"))
+            .env("GIT_COMMITTER_DATE", format!("@{timestamp}"))
+            .args(["commit", "-q", "-m", message])
+            .status()
+            .unwrap();
+        assert!(status.success(), "git commit failed");
+    }
+
+    fn rename_history_repo() -> TempDir {
+        let repo = TempDir::new().unwrap();
+        git(&repo, &["init", "-q"]);
+        git(&repo, &["config", "user.email", "t@t.com"]);
+        git(&repo, &["config", "user.name", "test"]);
+
+        fs::write(repo.path().join("a.py"), "def original(): return 1\n").unwrap();
+        commit_all(&repo, "v1", 946684800);
+
+        fs::write(repo.path().join("a.py"), "def renamed_func(): return 1\n").unwrap();
+        commit_all(&repo, "v2: rename function", 946771200);
+
+        git(&repo, &["mv", "a.py", "b.py"]);
+        commit_all(&repo, "v3: move file", 946857600);
+
+        fs::write(repo.path().join("b.py"), "def renamed_func(): return 2\n").unwrap();
+        commit_all(&repo, "v4: modify body", 946944000);
+
+        repo
+    }
+
+    fn log_entries(repo: &TempDir, entity_name: &str, file_path: &str) -> Vec<LogEntry> {
+        let bridge = GitBridge::open(repo.path()).unwrap();
+        let registry = create_default_registry();
+        let mut commits = bridge.get_log(0).unwrap();
+        commits.reverse();
+        let seed = find_seed_occurrence(&bridge, &registry, &commits, entity_name, Some(file_path))
+            .unwrap();
+
+        let mut entries = trace_back_to_origin(&bridge, &registry, &commits, seed.clone());
+        entries.extend(trace_forward_from_seed(&bridge, &registry, &commits, seed));
+        entries
+    }
+
+    #[test]
+    fn log_traces_entity_and_file_renames_from_current_name() {
+        let repo = rename_history_repo();
+        let entries = log_entries(&repo, "renamed_func", "b.py");
+        let labels: Vec<_> = entries
+            .iter()
+            .map(|entry| entry.change_type.label())
+            .collect();
+
+        assert_eq!(
+            labels,
+            vec!["added", "renamed", "moved", "modified (logic)"]
+        );
+        assert_eq!(entries[0].file_path.as_deref(), Some("a.py"));
+        assert_eq!(entries[2].prev_file_path.as_deref(), Some("a.py"));
+        assert_eq!(entries[2].file_path.as_deref(), Some("b.py"));
+    }
+
+    #[test]
+    fn log_traces_forward_from_historical_name() {
+        let repo = rename_history_repo();
+        let entries = log_entries(&repo, "original", "a.py");
+        let labels: Vec<_> = entries
+            .iter()
+            .map(|entry| entry.change_type.label())
+            .collect();
+
+        assert_eq!(
+            labels,
+            vec!["added", "renamed", "moved", "modified (logic)"]
+        );
+        assert_eq!(
+            entries.last().and_then(|e| e.file_path.as_deref()),
+            Some("b.py")
+        );
+    }
 }

--- a/crates/sem-cli/tests/blame_cli.rs
+++ b/crates/sem-cli/tests/blame_cli.rs
@@ -1,0 +1,47 @@
+use std::fs;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn git(repo: &TempDir, args: &[&str]) {
+    let status = Command::new("git")
+        .current_dir(repo.path())
+        .args(args)
+        .status()
+        .unwrap();
+    assert!(status.success(), "git {:?} failed", args);
+}
+
+#[test]
+fn blame_json_marks_entity_with_uncommitted_line() {
+    let repo = TempDir::new().unwrap();
+    git(&repo, &["init", "-q"]);
+    git(&repo, &["config", "user.email", "t@t.com"]);
+    git(&repo, &["config", "user.name", "test"]);
+
+    fs::write(repo.path().join("a.py"), "def foo():\n    return 1\n").unwrap();
+    git(&repo, &["add", "a.py"]);
+    let status = Command::new("git")
+        .current_dir(repo.path())
+        .env("GIT_AUTHOR_DATE", "2000-01-01T00:00:00Z")
+        .env("GIT_COMMITTER_DATE", "2000-01-01T00:00:00Z")
+        .args(["commit", "-q", "-m", "init"])
+        .status()
+        .unwrap();
+    assert!(status.success(), "git commit failed");
+
+    fs::write(repo.path().join("a.py"), "def foo():\n    return 2\n").unwrap();
+
+    let sem = env!("CARGO_BIN_EXE_sem");
+    let output = Command::new(sem)
+        .current_dir(repo.path())
+        .args(["blame", "a.py", "--json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json[0]["name"], "foo");
+    assert_eq!(json[0]["author"], "Not Committed Yet");
+    assert!(json[0]["commit"].is_null());
+}

--- a/crates/sem-core/src/git/bridge.rs
+++ b/crates/sem-core/src/git/bridge.rs
@@ -1,12 +1,14 @@
 use std::env;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
+use std::process::Command;
 use std::sync::{Mutex, OnceLock};
 
 use git2::{Blame, Delta, Diff, DiffFindOptions, DiffOptions, ErrorCode, Oid, Repository};
 use thiserror::Error;
 
 use super::types::{CommitInfo, DiffScope, FileChange, FileCommitInfo, FileStatus};
+use super::types::BlameLineInfo;
 
 #[derive(Error, Debug)]
 pub enum GitError {
@@ -54,6 +56,35 @@ impl GitBridge {
 
     pub fn blame_file(&self, file_path: &Path) -> Result<Blame<'_>, GitError> {
         Ok(self.repo.blame_file(file_path, None)?)
+    }
+
+    pub fn blame_file_porcelain(&self, file_path: &Path) -> Result<Vec<BlameLineInfo>, GitError> {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(&self.repo_root)
+            .arg("blame")
+            .arg("--line-porcelain")
+            .arg("--")
+            .arg(file_path)
+            .output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            return Err(git_command_error(if stderr.is_empty() {
+                format!("git blame exited with {}", output.status)
+            } else {
+                stderr
+            }));
+        }
+
+        let parsed = parse_blame_porcelain(&String::from_utf8_lossy(&output.stdout));
+        if parsed.is_empty() && !output.stdout.is_empty() {
+            return Err(git_command_error(
+                "failed to parse git blame porcelain output".to_string(),
+            ));
+        }
+
+        Ok(parsed)
     }
 
     pub fn commit_summary(&self, oid: Oid) -> Option<String> {
@@ -463,7 +494,7 @@ impl GitBridge {
     pub fn get_file_commits(&self, file_path: &str, limit: usize) -> Result<Vec<CommitInfo>, GitError> {
         let mut revwalk = self.repo.revwalk()?;
         revwalk.push_head()?;
-        revwalk.set_sorting(git2::Sort::TIME)?;
+        revwalk.set_sorting(git2::Sort::TOPOLOGICAL | git2::Sort::TIME)?;
 
         let mut commits = Vec::new();
         let path = Path::new(file_path);
@@ -504,7 +535,7 @@ impl GitBridge {
                     message: commit.message().unwrap_or("").to_string(),
                 });
 
-                if commits.len() >= limit {
+                if limit != 0 && commits.len() >= limit {
                     break;
                 }
             }
@@ -522,9 +553,16 @@ impl GitBridge {
         file_path: &str,
         limit: usize,
     ) -> Result<Vec<FileCommitInfo>, GitError> {
+        match self.get_file_commits_follow_renames_cli(file_path, limit) {
+            Ok(commits) if !commits.is_empty() => return Ok(commits),
+            Ok(_) => {}
+            Err(GitError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+
         let mut revwalk = self.repo.revwalk()?;
         revwalk.push_head()?;
-        revwalk.set_sorting(git2::Sort::TIME)?;
+        revwalk.set_sorting(git2::Sort::TOPOLOGICAL | git2::Sort::TIME)?;
 
         let mut results = Vec::new();
         let mut tracked_path = file_path.to_string();
@@ -566,14 +604,16 @@ impl GitBridge {
                     file_path: tracked_path.clone(),
                 });
 
-                if results.len() >= limit {
+                if limit != 0 && results.len() >= limit {
                     break;
                 }
             }
 
-            // If the file is not in this commit's tree, check if it was renamed.
-            // Compute diff between parent and this commit with rename detection.
-            if file_in_commit.is_none() && parent_tree_opt.is_some() {
+            // When walking backward, the rename commit still contains the new
+            // path. Detect that parent-side old path before the next iteration.
+            let should_check_rename =
+                parent_tree_opt.is_some() && (file_in_parent.is_none() || file_in_commit.is_none());
+            if should_check_rename {
                 let mut diff = self.repo.diff_tree_to_tree(
                     parent_tree_opt.as_ref(),
                     Some(&tree),
@@ -608,7 +648,7 @@ impl GitBridge {
                     }
                 }
 
-                if !found_rename {
+                if !found_rename && file_in_commit.is_none() {
                     // File truly deleted, stop tracking
                     break;
                 }
@@ -616,6 +656,88 @@ impl GitBridge {
         }
 
         Ok(results)
+    }
+
+    fn get_file_commits_follow_renames_cli(
+        &self,
+        file_path: &str,
+        limit: usize,
+    ) -> Result<Vec<FileCommitInfo>, GitError> {
+        let mut command = Command::new("git");
+        command
+            .arg("-C")
+            .arg(&self.repo_root)
+            .arg("log")
+            .arg("--follow")
+            .arg("--format=\x1e%H\x1f%an\x1f%at\x1f%s")
+            .arg("--name-status");
+        if limit != 0 {
+            command.arg("-n").arg(limit.to_string());
+        }
+        command.arg("--").arg(file_path);
+
+        let output = command.output()?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            return Err(git_command_error(if stderr.is_empty() {
+                format!("git log exited with {}", output.status)
+            } else {
+                stderr
+            }));
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let mut tracked_path = file_path.to_string();
+        let mut commits = Vec::new();
+
+        for record in stdout.split('\x1e') {
+            let record = record.trim_start_matches('\n');
+            if record.trim().is_empty() {
+                continue;
+            }
+
+            let mut lines = record.lines();
+            let Some(meta) = lines.next() else {
+                continue;
+            };
+            let mut parts = meta.splitn(4, '\x1f');
+            let Some(sha) = parts.next() else {
+                continue;
+            };
+            let Some(author) = parts.next() else {
+                continue;
+            };
+            let Some(date) = parts.next() else {
+                continue;
+            };
+            let message = parts.next().unwrap_or_default();
+
+            let commit_path = tracked_path.clone();
+            let mut previous_path = None;
+            for line in lines {
+                let fields: Vec<&str> = line.split('\t').collect();
+                if fields.len() >= 3 && fields[0].starts_with('R') && fields[2] == tracked_path {
+                    previous_path = Some(fields[1].to_string());
+                }
+            }
+
+            commits.push(FileCommitInfo {
+                commit: CommitInfo {
+                    short_sha: sha[..7.min(sha.len())].to_string(),
+                    sha: sha.to_string(),
+                    author: author.to_string(),
+                    date: date.to_string(),
+                    message: message.to_string(),
+                },
+                file_path: commit_path,
+            });
+
+            if let Some(previous_path) = previous_path {
+                tracked_path = previous_path;
+            }
+        }
+
+        Ok(commits)
     }
 
     /// Get all file paths changed in a single commit (vs its parent).
@@ -651,7 +773,7 @@ impl GitBridge {
 
         let mut commits = Vec::new();
         for (i, oid_result) in revwalk.enumerate() {
-            if i >= limit {
+            if limit != 0 && i >= limit {
                 break;
             }
             let oid = oid_result?;
@@ -668,6 +790,85 @@ impl GitBridge {
 
         Ok(commits)
     }
+}
+
+fn parse_blame_porcelain(output: &str) -> Vec<BlameLineInfo> {
+    let lines: Vec<&str> = output.lines().collect();
+    let mut parsed = Vec::new();
+    let mut index = 0;
+
+    while index < lines.len() {
+        let Some((raw_sha, line_number)) = parse_blame_header(lines[index]) else {
+            index += 1;
+            continue;
+        };
+        index += 1;
+
+        let mut author = String::new();
+        let mut author_time = None;
+        let mut summary = String::new();
+
+        while index < lines.len() {
+            let line = lines[index];
+            index += 1;
+
+            if line.starts_with('\t') {
+                break;
+            } else if let Some(value) = line.strip_prefix("author ") {
+                author = value.to_string();
+            } else if let Some(value) = line.strip_prefix("author-time ") {
+                author_time = value.parse::<i64>().ok();
+            } else if let Some(value) = line.strip_prefix("summary ") {
+                summary = value.to_string();
+            }
+        }
+
+        let sha = raw_sha.trim_start_matches('^');
+        let commit_sha = if sha.chars().all(|c| c == '0') {
+            None
+        } else {
+            Some(sha.to_string())
+        };
+
+        if author.is_empty() {
+            author = if commit_sha.is_none() {
+                "Not Committed Yet".to_string()
+            } else {
+                "unknown".to_string()
+            };
+        }
+
+        parsed.push(BlameLineInfo {
+            line_number,
+            commit_sha,
+            author,
+            author_time,
+            summary,
+        });
+    }
+
+    parsed.sort_by_key(|line| line.line_number);
+    parsed
+}
+
+fn parse_blame_header(line: &str) -> Option<(&str, usize)> {
+    let mut parts = line.split_whitespace();
+    let sha = parts.next()?;
+    if !is_blame_oid(sha) {
+        return None;
+    }
+    parts.next()?;
+    let final_line = parts.next()?.parse().ok()?;
+    Some((sha, final_line))
+}
+
+fn is_blame_oid(value: &str) -> bool {
+    let value = value.strip_prefix('^').unwrap_or(value);
+    value.len() == 40 && value.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+fn git_command_error(message: String) -> GitError {
+    GitError::Git2(git2::Error::from_str(&message))
 }
 
 fn map_git_error(error: git2::Error) -> GitError {
@@ -873,6 +1074,22 @@ mod tests {
                 .commit(Some("HEAD"), &sig, &sig, message, &tree, &[])
                 .unwrap(),
         }
+    }
+
+    #[test]
+    fn porcelain_blame_reports_uncommitted_lines() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path()).unwrap();
+
+        commit_file(&repo, "a.py", "def foo():\n    return 1\n", "init");
+        fs::write(temp.path().join("a.py"), "def foo():\n    return 2\n").unwrap();
+
+        let bridge = GitBridge::open(temp.path()).unwrap();
+        let blame = bridge.blame_file_porcelain(Path::new("a.py")).unwrap();
+
+        assert!(blame[0].commit_sha.is_some());
+        assert_eq!(blame[1].commit_sha, None);
+        assert_eq!(blame[1].author, "Not Committed Yet");
     }
 
     #[test]

--- a/crates/sem-core/src/git/types.rs
+++ b/crates/sem-core/src/git/types.rs
@@ -49,6 +49,15 @@ pub struct FileCommitInfo {
     pub file_path: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlameLineInfo {
+    pub line_number: usize,
+    pub commit_sha: Option<String>,
+    pub author: String,
+    pub author_time: Option<i64>,
+    pub summary: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::{FileChange, FileStatus};

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -1,4 +1,4 @@
-use std::collections::hash_map::DefaultHasher;
+use std::collections::{hash_map::DefaultHasher, HashMap};
 use std::hash::{Hash, Hasher};
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
@@ -11,7 +11,7 @@ use rmcp::model::{CallToolResult, Content, ServerCapabilities, ServerInfo};
 use rmcp::{tool, tool_handler, tool_router, ServerHandler};
 use sem_core::format::json::format_diff_json;
 use sem_core::git::bridge::GitBridge;
-use sem_core::git::types::DiffScope;
+use sem_core::git::types::{BlameLineInfo, CommitInfo, DiffScope};
 use sem_core::model::entity::SemanticEntity;
 use sem_core::parser::differ::compute_semantic_diff;
 use sem_core::parser::graph::EntityGraph;
@@ -480,41 +480,60 @@ impl SemServer {
 
         let blame = ctx
             .git
-            .blame_file(Path::new(&rel_path))
+            .blame_file_porcelain(Path::new(&rel_path))
             .map_err(|e| internal_err(format!("Cannot blame {}: {}", rel_path, e)))?;
+        let blame_by_line: HashMap<usize, BlameLineInfo> = blame
+            .into_iter()
+            .map(|line| (line.line_number, line))
+            .collect();
 
         let mut results: Vec<serde_json::Value> = Vec::new();
 
         for entity in &entities {
-            let mut latest_time: i64 = 0;
-            let mut latest_author = String::new();
-            let mut latest_sha = String::new();
-            let mut latest_summary = String::new();
-            let mut latest_date = String::new();
+            let mut selected: Option<&BlameLineInfo> = None;
 
             for line in entity.start_line..=entity.end_line {
-                if let Some(hunk) = blame.get_line(line) {
-                    let sig = hunk.final_signature();
-                    let time = sig.when().seconds();
-                    if time > latest_time {
-                        latest_time = time;
-                        latest_author = sig.name().unwrap_or("unknown").to_string();
-                        let oid = hunk.final_commit_id();
-                        latest_sha = format!("{}", oid);
-                        latest_summary = ctx.git.commit_summary(oid).unwrap_or_default();
-                        latest_date = chrono_lite_format(sig.when().seconds());
+                if let Some(info) = blame_by_line.get(&line) {
+                    if info.commit_sha.is_none() {
+                        selected = Some(info);
+                        break;
+                    }
+
+                    let is_newer = match (info.author_time, selected.and_then(|s| s.author_time)) {
+                        (Some(current), Some(previous)) => current > previous,
+                        (Some(_), None) => true,
+                        _ => selected.is_none(),
+                    };
+                    if is_newer {
+                        selected = Some(info);
                     }
                 }
             }
+
+            let (author, date, commit_sha, summary) = match selected {
+                Some(info) => (
+                    if info.author.is_empty() {
+                        "unknown".to_string()
+                    } else {
+                        info.author.clone()
+                    },
+                    info.author_time
+                        .map(chrono_lite_format)
+                        .unwrap_or_default(),
+                    info.commit_sha.clone(),
+                    info.summary.clone(),
+                ),
+                None => (String::from("unknown"), String::new(), None, String::new()),
+            };
 
             results.push(serde_json::json!({
                 "name": entity.name,
                 "type": entity.entity_type,
                 "lines": [entity.start_line, entity.end_line],
-                "author": if latest_author.is_empty() { "uncommitted" } else { &latest_author },
-                "date": latest_date,
-                "commit": if latest_sha.is_empty() { "uncommitted" } else { &latest_sha },
-                "summary": latest_summary,
+                "author": author,
+                "date": date,
+                "commit": commit_sha,
+                "summary": summary,
             }));
         }
 
@@ -693,124 +712,68 @@ impl SemServer {
             }
         };
 
-        let plugin = self
-            .registry
-            .get_plugin(&file_path)
-            .ok_or_else(|| internal_err(format!("No parser for file: {}", file_path)))?;
-
         let limit = params.limit.unwrap_or(50);
-        let commits = ctx
+        let use_file_history = ctx
             .git
-            .get_file_commits(&file_path, limit)
-            .map_err(|e| internal_err(format!("Failed to get file history: {}", e)))?;
+            .get_head_sha()
+            .ok()
+            .and_then(|head| {
+                mcp_entity_by_name_at_ref(
+                    &ctx.git,
+                    &self.registry,
+                    &head,
+                    &file_path,
+                    &params.entity_name,
+                )
+            })
+            .is_some();
+
+        let mut commits = if use_file_history {
+            match ctx.git.get_file_commits_follow_renames(&file_path, 0) {
+                Ok(file_commits) if !file_commits.is_empty() => {
+                    file_commits.into_iter().map(|info| info.commit).collect()
+                }
+                Ok(_) => ctx
+                    .git
+                    .get_log(0)
+                    .map_err(|e| internal_err(format!("Failed to get history: {}", e)))?,
+                Err(e) => return Err(internal_err(format!("Failed to get file history: {}", e))),
+            }
+        } else {
+            ctx.git
+                .get_log(0)
+                .map_err(|e| internal_err(format!("Failed to get history: {}", e)))?
+        };
 
         if commits.is_empty() {
             return Err(internal_err(format!("No commits found for {}", file_path)));
         }
+        commits.reverse();
 
-        let mut entries: Vec<serde_json::Value> = Vec::new();
-        let mut prev_entity_content: Option<String> = None;
-        let mut prev_structural_hash: Option<String> = None;
-        let mut entity_type = String::new();
-        let mut found_at_least_once = false;
-
-        // Process oldest to newest
-        for commit in commits.iter().rev() {
-            let content = match ctx.git.read_file_at_ref(&commit.sha, &file_path) {
-                Ok(Some(c)) => c,
-                _ => {
-                    if prev_entity_content.is_some() {
-                        let date = chrono_lite_format(commit.date.parse::<i64>().unwrap_or(0));
-                        entries.push(serde_json::json!({
-                            "commit": commit.sha,
-                            "author": commit.author,
-                            "date": date,
-                            "message": commit.message.lines().next().unwrap_or(""),
-                            "change_type": "deleted",
-                        }));
-                        prev_entity_content = None;
-                        prev_structural_hash = None;
-                    }
-                    continue;
-                }
-            };
-
-            let file_entities = plugin.extract_entities(&content, &file_path);
-            let entity = file_entities.iter().find(|e| e.name == params.entity_name);
-            let date = chrono_lite_format(commit.date.parse::<i64>().unwrap_or(0));
-            let msg = commit.message.lines().next().unwrap_or("").to_string();
-
-            match entity {
-                Some(ent) => {
-                    if !found_at_least_once {
-                        entity_type = ent.entity_type.clone();
-                    }
-
-                    if !found_at_least_once || prev_entity_content.is_none() {
-                        found_at_least_once = true;
-                        entries.push(serde_json::json!({
-                            "commit": commit.sha,
-                            "author": commit.author,
-                            "date": date,
-                            "message": msg,
-                            "change_type": "added",
-                        }));
-                    } else {
-                        let prev_hash = prev_entity_content
-                            .as_ref()
-                            .map(|c| sem_core::utils::hash::content_hash(c));
-                        let content_changed =
-                            prev_hash.as_deref() != Some(ent.content_hash.as_str());
-
-                        if content_changed {
-                            let structural_changed = match (
-                                ent.structural_hash.as_deref(),
-                                prev_structural_hash.as_deref(),
-                            ) {
-                                (Some(cur), Some(prev)) => cur != prev,
-                                _ => true,
-                            };
-
-                            let change_type = if structural_changed {
-                                "modified (logic)"
-                            } else {
-                                "modified (cosmetic)"
-                            };
-
-                            entries.push(serde_json::json!({
-                                "commit": commit.sha,
-                                "author": commit.author,
-                                "date": date,
-                                "message": msg,
-                                "change_type": change_type,
-                            }));
-                        }
-                    }
-
-                    prev_entity_content = Some(ent.content.clone());
-                    prev_structural_hash = ent.structural_hash.clone();
-                }
-                None => {
-                    if prev_entity_content.is_some() {
-                        entries.push(serde_json::json!({
-                            "commit": commit.sha,
-                            "author": commit.author,
-                            "date": date,
-                            "message": msg,
-                            "change_type": "deleted",
-                        }));
-                        prev_entity_content = None;
-                        prev_structural_hash = None;
-                    }
-                }
-            }
-        }
-
-        if !found_at_least_once {
+        let Some(seed) = mcp_find_seed_occurrence(
+            &ctx.git,
+            &self.registry,
+            &commits,
+            &params.entity_name,
+            Some(&file_path),
+        ) else {
             return Err(internal_err(format!(
                 "Entity '{}' not found in any commit of {}",
                 params.entity_name, file_path
             )));
+        };
+
+        let entity_type = seed.entity.entity_type.clone();
+        let mut entries = mcp_trace_back_to_origin(&ctx.git, &self.registry, &commits, seed.clone());
+        entries.extend(mcp_trace_forward_from_seed(
+            &ctx.git,
+            &self.registry,
+            &commits,
+            seed,
+        ));
+        if limit != 0 && entries.len() > limit {
+            let drop_count = entries.len() - limit;
+            entries.drain(0..drop_count);
         }
 
         Ok(CallToolResult::success(vec![Content::text(
@@ -892,7 +855,76 @@ impl ServerHandler for SemServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sem_core::parser::plugins::create_default_registry;
+    use std::fs;
     use std::process::Command;
+    use tempfile::TempDir;
+
+    fn git(repo: &TempDir, args: &[&str]) {
+        let status = Command::new("git")
+            .current_dir(repo.path())
+            .args(args)
+            .status()
+            .unwrap();
+        assert!(status.success(), "git {:?} failed", args);
+    }
+
+    fn commit_all(repo: &TempDir, message: &str, timestamp: i64) {
+        git(repo, &["add", "-A"]);
+        let status = Command::new("git")
+            .current_dir(repo.path())
+            .env("GIT_AUTHOR_DATE", format!("@{timestamp}"))
+            .env("GIT_COMMITTER_DATE", format!("@{timestamp}"))
+            .args(["commit", "-q", "-m", message])
+            .status()
+            .unwrap();
+        assert!(status.success(), "git commit failed");
+    }
+
+    fn rename_history_repo() -> TempDir {
+        let repo = TempDir::new().unwrap();
+        git(&repo, &["init", "-q"]);
+        git(&repo, &["config", "user.email", "t@t.com"]);
+        git(&repo, &["config", "user.name", "test"]);
+        fs::write(repo.path().join("a.py"), "def original(): return 1\n").unwrap();
+        commit_all(&repo, "v1", 946684800);
+        fs::write(repo.path().join("a.py"), "def renamed_func(): return 1\n").unwrap();
+        commit_all(&repo, "v2: rename function", 946771200);
+        git(&repo, &["mv", "a.py", "b.py"]);
+        commit_all(&repo, "v3: move file", 946857600);
+        fs::write(repo.path().join("b.py"), "def renamed_func(): return 2\n").unwrap();
+        commit_all(&repo, "v4: modify body", 946944000);
+        repo
+    }
+
+    fn mcp_log_labels(repo: &TempDir, entity_name: &str, file_path: &str) -> Vec<String> {
+        let git = GitBridge::open(repo.path()).unwrap();
+        let registry = create_default_registry();
+        let mut commits = if git
+            .get_head_sha()
+            .ok()
+            .and_then(|head| mcp_entity_by_name_at_ref(&git, &registry, &head, file_path, entity_name))
+            .is_some()
+        {
+            git.get_file_commits_follow_renames(file_path, 0)
+                .unwrap()
+                .into_iter()
+                .map(|info| info.commit)
+                .collect()
+        } else {
+            git.get_log(0).unwrap()
+        };
+        commits.reverse();
+        let seed =
+            mcp_find_seed_occurrence(&git, &registry, &commits, entity_name, Some(file_path))
+                .unwrap();
+        let mut entries = mcp_trace_back_to_origin(&git, &registry, &commits, seed.clone());
+        entries.extend(mcp_trace_forward_from_seed(&git, &registry, &commits, seed));
+        entries
+            .iter()
+            .map(|entry| entry["change_type"].as_str().unwrap().to_string())
+            .collect()
+    }
 
     #[test]
     fn find_supported_files_returns_walk_errors() {
@@ -978,10 +1010,250 @@ mod tests {
             String::from_utf8_lossy(&output.stderr)
         );
     }
+
+    #[test]
+    fn mcp_log_helpers_trace_current_and_historical_names() {
+        let repo = rename_history_repo();
+        let expected = vec!["added", "renamed", "moved", "modified (logic)"];
+        assert_eq!(mcp_log_labels(&repo, "renamed_func", "b.py"), expected);
+        assert_eq!(mcp_log_labels(&repo, "original", "a.py"), expected);
+    }
 }
 
 fn internal_err(msg: impl ToString) -> rmcp::ErrorData {
     rmcp::ErrorData::internal_error(msg.to_string(), None)
+}
+
+#[derive(Clone)]
+struct McpLogOccurrence {
+    commit_index: usize,
+    file_path: String,
+    entity: SemanticEntity,
+}
+
+fn mcp_find_seed_occurrence(
+    git: &GitBridge,
+    registry: &ParserRegistry,
+    commits: &[CommitInfo],
+    entity_name: &str,
+    file_path: Option<&str>,
+) -> Option<McpLogOccurrence> {
+    for (index, commit) in commits.iter().enumerate().rev() {
+        let paths = match file_path {
+            Some(path) => vec![path.to_string()],
+            None => git.get_commit_changed_files(&commit.sha).unwrap_or_default(),
+        };
+        for path in paths {
+            if let Some(entity) =
+                mcp_entity_by_name_at_ref(git, registry, &commit.sha, &path, entity_name)
+            {
+                return Some(McpLogOccurrence { commit_index: index, file_path: path, entity });
+            }
+        }
+    }
+    None
+}
+
+fn mcp_trace_back_to_origin(
+    git: &GitBridge,
+    registry: &ParserRegistry,
+    commits: &[CommitInfo],
+    seed: McpLogOccurrence,
+) -> Vec<serde_json::Value> {
+    let mut current = seed;
+    let mut entries = Vec::new();
+    for child_index in (1..=current.commit_index).rev() {
+        let child_commit = &commits[child_index];
+        let parent_commit = &commits[child_index - 1];
+        let changed_paths = git.get_commit_changed_files(&child_commit.sha).unwrap_or_default();
+        let previous = mcp_find_related_entity_at_ref(
+            git,
+            registry,
+            &parent_commit.sha,
+            &current.file_path,
+            &current.entity.name,
+            current.entity.structural_hash.as_deref(),
+            &changed_paths,
+        );
+        let Some(previous) = previous else {
+            entries.push(mcp_added_entry(child_commit, &current));
+            entries.reverse();
+            return entries;
+        };
+        if let Some(entry) = mcp_transition_entry(child_commit, &previous, &current) {
+            entries.push(entry);
+        }
+        current = McpLogOccurrence { commit_index: child_index - 1, ..previous };
+    }
+    entries.push(mcp_added_entry(&commits[current.commit_index], &current));
+    entries.reverse();
+    entries
+}
+
+fn mcp_trace_forward_from_seed(
+    git: &GitBridge,
+    registry: &ParserRegistry,
+    commits: &[CommitInfo],
+    seed: McpLogOccurrence,
+) -> Vec<serde_json::Value> {
+    let mut current = seed;
+    let mut entries = Vec::new();
+    for child_index in current.commit_index + 1..commits.len() {
+        let child_commit = &commits[child_index];
+        let changed_paths = git.get_commit_changed_files(&child_commit.sha).unwrap_or_default();
+        let next = mcp_find_related_entity_at_ref(
+            git,
+            registry,
+            &child_commit.sha,
+            &current.file_path,
+            &current.entity.name,
+            current.entity.structural_hash.as_deref(),
+            &changed_paths,
+        );
+        let Some(next) = next else {
+            entries.push(mcp_deleted_entry(child_commit, &current));
+            break;
+        };
+        if let Some(entry) = mcp_transition_entry(child_commit, &current, &next) {
+            entries.push(entry);
+        }
+        current = McpLogOccurrence { commit_index: child_index, ..next };
+    }
+    entries
+}
+
+fn mcp_find_related_entity_at_ref(
+    git: &GitBridge,
+    registry: &ParserRegistry,
+    sha: &str,
+    preferred_file: &str,
+    entity_name: &str,
+    structural_hash: Option<&str>,
+    changed_paths: &[String],
+) -> Option<McpLogOccurrence> {
+    let paths = mcp_candidate_paths(preferred_file, changed_paths);
+    for path in &paths {
+        if let Some(entity) = mcp_entity_by_name_at_ref(git, registry, sha, path, entity_name) {
+            return Some(McpLogOccurrence { commit_index: 0, file_path: path.clone(), entity });
+        }
+    }
+    let structural_hash = structural_hash?;
+    for path in &paths {
+        if let Some(entity) =
+            mcp_entity_by_structural_hash_at_ref(git, registry, sha, path, structural_hash)
+        {
+            return Some(McpLogOccurrence { commit_index: 0, file_path: path.clone(), entity });
+        }
+    }
+    None
+}
+
+fn mcp_candidate_paths(preferred_file: &str, changed_paths: &[String]) -> Vec<String> {
+    let mut paths = vec![preferred_file.to_string()];
+    for path in changed_paths {
+        if !paths.iter().any(|existing| existing == path) {
+            paths.push(path.clone());
+        }
+    }
+    paths
+}
+
+fn mcp_entity_by_name_at_ref(
+    git: &GitBridge,
+    registry: &ParserRegistry,
+    sha: &str,
+    file_path: &str,
+    entity_name: &str,
+) -> Option<SemanticEntity> {
+    mcp_entities_at_ref(git, registry, sha, file_path)
+        .into_iter()
+        .find(|entity| entity.name == entity_name)
+}
+
+fn mcp_entity_by_structural_hash_at_ref(
+    git: &GitBridge,
+    registry: &ParserRegistry,
+    sha: &str,
+    file_path: &str,
+    structural_hash: &str,
+) -> Option<SemanticEntity> {
+    mcp_entities_at_ref(git, registry, sha, file_path)
+        .into_iter()
+        .find(|entity| entity.structural_hash.as_deref() == Some(structural_hash))
+}
+
+fn mcp_entities_at_ref(
+    git: &GitBridge,
+    registry: &ParserRegistry,
+    sha: &str,
+    file_path: &str,
+) -> Vec<SemanticEntity> {
+    git.read_file_at_ref(sha, file_path)
+        .ok()
+        .flatten()
+        .map(|content| registry.extract_entities(file_path, &content))
+        .unwrap_or_default()
+}
+
+fn mcp_transition_entry(
+    commit: &CommitInfo,
+    before: &McpLogOccurrence,
+    after: &McpLogOccurrence,
+) -> Option<serde_json::Value> {
+    let file_changed = before.file_path != after.file_path;
+    let name_changed = before.entity.name != after.entity.name;
+    let content_changed = before.entity.content_hash != after.entity.content_hash;
+    let change_type = if file_changed {
+        "moved"
+    } else if name_changed {
+        "renamed"
+    } else if content_changed {
+        if mcp_structural_changed(&before.entity, &after.entity) {
+            "modified (logic)"
+        } else {
+            "modified (cosmetic)"
+        }
+    } else {
+        return None;
+    };
+    let mut entry = mcp_base_entry(commit, change_type, Some(&after.file_path));
+    if file_changed {
+        entry["prev_file_path"] = serde_json::Value::String(before.file_path.clone());
+    }
+    Some(entry)
+}
+
+fn mcp_structural_changed(before: &SemanticEntity, after: &SemanticEntity) -> bool {
+    match (&before.structural_hash, &after.structural_hash) {
+        (Some(before), Some(after)) => before != after,
+        _ => true,
+    }
+}
+
+fn mcp_added_entry(commit: &CommitInfo, occurrence: &McpLogOccurrence) -> serde_json::Value {
+    mcp_base_entry(commit, "added", Some(&occurrence.file_path))
+}
+
+fn mcp_deleted_entry(commit: &CommitInfo, occurrence: &McpLogOccurrence) -> serde_json::Value {
+    mcp_base_entry(commit, "deleted", Some(&occurrence.file_path))
+}
+
+fn mcp_base_entry(
+    commit: &CommitInfo,
+    change_type: &str,
+    file_path: Option<&str>,
+) -> serde_json::Value {
+    let mut entry = serde_json::json!({
+        "commit": commit.sha,
+        "author": commit.author,
+        "date": chrono_lite_format(commit.date.parse::<i64>().unwrap_or(0)),
+        "message": commit.message.lines().next().unwrap_or(""),
+        "change_type": change_type,
+    });
+    if let Some(file_path) = file_path {
+        entry["file_path"] = serde_json::Value::String(file_path.to_string());
+    }
+    entry
 }
 
 /// Simple timestamp formatting without external deps.


### PR DESCRIPTION
## Summary

- Make `sem log` track entity identity across function renames and file moves, including historical names with `--file`.
- Move blame attribution to one `git blame --line-porcelain` pass and prefer dirty working-tree lines for entity blame.
- Keep MCP `sem_blame` and `sem_log` aligned with the CLI behavior.

Closes #173
Closes #190
Closes #199

## Test plan

- `cargo test --manifest-path crates/Cargo.toml -p sem-core -p sem-cli -p sem-mcp`
- Manual #173 repro: `sem log renamed_func --json` and `sem log original --file a.py --json` both report `added`, `renamed`, `moved`, `modified (logic)`.
- Manual #199 repro: `sem blame a.py --json` reports `author: Not Committed Yet` and `commit: null` for an entity with an uncommitted line edit.
- Tuist validation: `/usr/bin/time -p crates/target/debug/sem blame cli/Sources/TuistEncodable/Encodable+JSON.swift --json` from `~/Developer/oss/tuist` completed in `real 0.10`.