### PR TITLE
Preserve compound semantic diff changes

### DIFF
--- a/crates/sem-cli/src/commands/diff.rs
+++ b/crates/sem-cli/src/commands/diff.rs
@@ -696,10 +696,10 @@ pub fn diff_command(mut opts: DiffOptions) {
         };
 
         // Determine scope from explicit flags, parsed args, or auto-detect
-        let (_scope, file_changes) = if let Some(ref sha) = opts.commit {
+        let file_changes = if let Some(ref sha) = opts.commit {
             let scope = DiffScope::Commit { sha: sha.clone() };
             match git.get_changed_files(&scope, &parsed.pathspecs) {
-                Ok(files) => (scope, files),
+                Ok(files) => files,
                 Err(e) => {
                     eprintln!("\x1b[31mError: {e}\x1b[0m");
                     process::exit(1);
@@ -711,30 +711,38 @@ pub fn diff_command(mut opts: DiffOptions) {
                 to: to.clone(),
             };
             match git.get_changed_files(&scope, &parsed.pathspecs) {
-                Ok(files) => (scope, files),
+                Ok(files) => files,
                 Err(e) => {
                     eprintln!("\x1b[31mError: {e}\x1b[0m");
                     process::exit(1);
                 }
             }
+        } else if let Some(ParsedScope::RefToWorking(refspec)) = parsed.scope.as_ref() {
+            if opts.staged {
+                // git diff --cached <ref> = compare ref to index
+                match git.get_staged_files_with_base_ref(refspec, &parsed.pathspecs) {
+                    Ok(files) => files,
+                    Err(e) => {
+                        eprintln!("\x1b[31mError: {e}\x1b[0m");
+                        process::exit(1);
+                    }
+                }
+            } else {
+                let scope = DiffScope::RefToWorking {
+                    refspec: refspec.clone(),
+                };
+                match git.get_changed_files(&scope, &parsed.pathspecs) {
+                    Ok(files) => files,
+                    Err(e) => {
+                        eprintln!("\x1b[31mError: {e}\x1b[0m");
+                        process::exit(1);
+                    }
+                }
+            }
         } else if let Some(ref parsed_scope) = parsed.scope {
             // Use scope from positional args
             let scope = match parsed_scope {
-                ParsedScope::RefToWorking(refspec) => {
-                    if opts.staged {
-                        // git diff --cached <ref> = compare ref to index
-                        // We approximate this as Range from ref to HEAD (staged view)
-                        // For now, just use the ref as a range base
-                        DiffScope::Range {
-                            from: refspec.clone(),
-                            to: "HEAD".to_string(),
-                        }
-                    } else {
-                        DiffScope::RefToWorking {
-                            refspec: refspec.clone(),
-                        }
-                    }
-                }
+                ParsedScope::RefToWorking(_) => unreachable!(),
                 ParsedScope::Range(from, to) => DiffScope::Range {
                     from: from.clone(),
                     to: to.clone(),
@@ -754,7 +762,7 @@ pub fn diff_command(mut opts: DiffOptions) {
                 ParsedScope::FileCompare { .. } => unreachable!(),
             };
             match git.get_changed_files(&scope, &parsed.pathspecs) {
-                Ok(files) => (scope, files),
+                Ok(files) => files,
                 Err(e) => {
                     eprintln!("\x1b[31mError: {e}\x1b[0m");
                     process::exit(1);
@@ -763,7 +771,7 @@ pub fn diff_command(mut opts: DiffOptions) {
         } else if opts.staged {
             let scope = DiffScope::Staged;
             match git.get_changed_files(&scope, &parsed.pathspecs) {
-                Ok(files) => (scope, files),
+                Ok(files) => files,
                 Err(e) => {
                     eprintln!("\x1b[31mError: {e}\x1b[0m");
                     process::exit(1);
@@ -771,7 +779,7 @@ pub fn diff_command(mut opts: DiffOptions) {
             }
         } else {
             match git.detect_and_get_files(&parsed.pathspecs) {
-                Ok((scope, files)) => (scope, files),
+                Ok((_scope, files)) => files,
                 Err(e) => {
                     eprintln!("\x1b[31mError: {e}\x1b[0m");
                     process::exit(1);
@@ -888,9 +896,23 @@ fn run_diff_pipeline(
 }
 
 fn retain_non_cosmetic_changes(result: &mut DiffResult) {
+    // A move/rename/reorder that also carries a content change is a compound change:
+    // keep it visible under --no-cosmetics, but drop the purely cosmetic content payload.
+    for change in &mut result.changes {
+        if matches!(
+            change.change_type,
+            ChangeType::Moved | ChangeType::Renamed | ChangeType::Reordered
+        ) && change.has_content_change()
+            && change.structural_change == Some(false)
+        {
+            change.before_content = None;
+            change.after_content = None;
+        }
+    }
+    // Drop only purely cosmetic modifications; compound changes are preserved above.
     result
         .changes
-        .retain(|c| c.structural_change != Some(false));
+        .retain(|c| c.change_type != ChangeType::Modified || c.structural_change != Some(false));
     recalculate_diff_summary(result);
 }
 

--- a/crates/sem-cli/src/formatters/markdown.rs
+++ b/crates/sem-cli/src/formatters/markdown.rs
@@ -37,8 +37,11 @@ pub fn format_markdown(result: &DiffResult, verbose: bool) -> String {
                         "Δ"
                     }
                 }
+                ChangeType::Moved if change.has_content_change() => "→ Δ",
                 ChangeType::Moved => "→",
+                ChangeType::Renamed if change.has_content_change() => "↻ Δ",
                 ChangeType::Renamed => "↻",
+                ChangeType::Reordered if change.has_content_change() => "↕ Δ",
                 ChangeType::Reordered => "↕",
             };
 
@@ -77,7 +80,7 @@ pub fn format_markdown(result: &DiffResult, verbose: bool) -> String {
                             post_table.push("```".to_string());
                         }
                     }
-                    ChangeType::Modified | ChangeType::Moved => {
+                    ChangeType::Modified | ChangeType::Moved | ChangeType::Renamed => {
                         if let (Some(before), Some(after)) =
                             (&change.before_content, &change.after_content)
                         {

--- a/crates/sem-cli/src/formatters/plain.rs
+++ b/crates/sem-cli/src/formatters/plain.rs
@@ -26,8 +26,11 @@ pub fn format_plain(result: &DiffResult) -> String {
                 ChangeType::Added => "A".green().to_string(),
                 ChangeType::Modified => "M".yellow().to_string(),
                 ChangeType::Deleted => "D".red().to_string(),
+                ChangeType::Renamed if change.has_content_change() => "RM".cyan().to_string(),
                 ChangeType::Renamed => "R".cyan().to_string(),
+                ChangeType::Moved if change.has_content_change() => ">M".blue().to_string(),
                 ChangeType::Moved => ">".blue().to_string(),
+                ChangeType::Reordered if change.has_content_change() => "OM".magenta().to_string(),
                 ChangeType::Reordered => "O".magenta().to_string(),
             };
 

--- a/crates/sem-cli/src/formatters/terminal.rs
+++ b/crates/sem-cli/src/formatters/terminal.rs
@@ -71,6 +71,15 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
                 continue;
             }
 
+            let content_suffix = if change.has_content_change() {
+                if change.structural_change == Some(false) {
+                    "+cosmetic"
+                } else {
+                    "+modified"
+                }
+            } else {
+                ""
+            };
             let (symbol, tag) = match change.change_type {
                 ChangeType::Added => ("⊕".green().to_string(), "[added]".green().to_string()),
                 ChangeType::Modified => {
@@ -82,11 +91,17 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
                     }
                 }
                 ChangeType::Deleted => ("⊖".red().to_string(), "[deleted]".red().to_string()),
-                ChangeType::Moved => ("→".blue().to_string(), "[moved]".blue().to_string()),
-                ChangeType::Renamed => ("↻".cyan().to_string(), "[renamed]".cyan().to_string()),
+                ChangeType::Moved => (
+                    "→".blue().to_string(),
+                    format!("[moved{content_suffix}]").blue().to_string(),
+                ),
+                ChangeType::Renamed => (
+                    "↻".cyan().to_string(),
+                    format!("[renamed{content_suffix}]").cyan().to_string(),
+                ),
                 ChangeType::Reordered => (
                     "↕".magenta().to_string(),
-                    "[reordered]".magenta().to_string(),
+                    format!("[reordered{content_suffix}]").magenta().to_string(),
                 ),
             };
 

--- a/crates/sem-core/src/git/bridge.rs
+++ b/crates/sem-core/src/git/bridge.rs
@@ -72,10 +72,10 @@ impl GitBridge {
     }
 
     /// Combined detect scope + get files in one call (fast path).
-    /// Matches `git diff` behavior: shows working tree changes by default.
+    /// Shows all changes from HEAD to the current working state by default.
     /// Use `--staged` for staged changes only.
     pub fn detect_and_get_files(&self, pathspecs: &[String]) -> Result<(DiffScope, Vec<FileChange>), GitError> {
-        // Show working tree changes (unstaged), matching git diff behavior
+        // Show the full current working state, including staged changes.
         let mut working_files = self.get_working_diff_files(pathspecs)?;
         if !working_files.is_empty() {
             self.populate_contents(&mut working_files, &DiffScope::Working)?;
@@ -102,6 +102,31 @@ impl GitBridge {
         files.retain(|f| !f.file_path.starts_with(".sem/"));
 
         self.populate_contents(&mut files, scope)?;
+        Ok(files)
+    }
+
+    pub fn get_staged_files_with_base_ref(
+        &self,
+        base: &str,
+        pathspecs: &[String],
+    ) -> Result<Vec<FileChange>, GitError> {
+        let mut files = self.get_staged_diff_files_with_base(base, pathspecs)?;
+        files.retain(|f| !f.file_path.starts_with(".sem/"));
+
+        let base_tree = self.resolve_tree(base)?;
+        for file in files.iter_mut() {
+            if file.status != FileStatus::Deleted {
+                file.after_content = self.read_index_file(&file.file_path);
+            }
+            if file.status != FileStatus::Added {
+                let path = file
+                    .old_file_path
+                    .as_deref()
+                    .unwrap_or(&file.file_path);
+                file.before_content = self.read_blob_from_tree(&base_tree, path);
+            }
+        }
+
         Ok(files)
     }
 
@@ -170,9 +195,26 @@ impl GitBridge {
             Err(_) => None, // No commits yet
         };
 
+        self.get_index_diff_files(head_tree.as_ref(), pathspecs)
+    }
+
+    fn get_staged_diff_files_with_base(
+        &self,
+        base: &str,
+        pathspecs: &[String],
+    ) -> Result<Vec<FileChange>, GitError> {
+        let base_tree = self.resolve_tree(base)?;
+        self.get_index_diff_files(Some(&base_tree), pathspecs)
+    }
+
+    fn get_index_diff_files(
+        &self,
+        base_tree: Option<&git2::Tree<'_>>,
+        pathspecs: &[String],
+    ) -> Result<Vec<FileChange>, GitError> {
         let mut opts = self.make_diff_opts(pathspecs)?;
         let mut diff = self.repo.diff_tree_to_index(
-            head_tree.as_ref(),
+            base_tree,
             Some(&self.repo.index()?),
             Some(&mut opts),
         )?;
@@ -185,9 +227,111 @@ impl GitBridge {
         let mut opts = self.make_diff_opts(pathspecs)?;
         opts.include_untracked(false);
 
-        let mut diff = self.repo.diff_index_to_workdir(None, Some(&mut opts))?;
+        let head_tree = self.resolve_tree("HEAD").ok();
+        let mut diff = match head_tree.as_ref() {
+            Some(head_tree) => self
+                .repo
+                .diff_tree_to_workdir_with_index(Some(head_tree), Some(&mut opts))?,
+            None => self.repo.diff_index_to_workdir(None, Some(&mut opts))?,
+        };
         Self::detect_renames(&mut diff)?;
-        Ok(self.diff_to_file_changes(&diff))
+        self.apply_index_rename_map(
+            self.diff_to_file_changes(&diff),
+            head_tree.as_ref(),
+            pathspecs,
+        )
+    }
+
+    fn apply_index_rename_map(
+        &self,
+        mut files: Vec<FileChange>,
+        base_tree: Option<&git2::Tree<'_>>,
+        pathspecs: &[String],
+    ) -> Result<Vec<FileChange>, GitError> {
+        let Some(base_tree) = base_tree else {
+            return Ok(files);
+        };
+
+        let index_renames: Vec<FileChange> = self
+            .get_index_diff_files(Some(base_tree), pathspecs)?
+            .into_iter()
+            .filter(|file| file.status == FileStatus::Renamed)
+            .collect();
+
+        for rename in index_renames {
+            let Some(old_path) = rename.old_file_path.clone() else {
+                continue;
+            };
+            let target_pos = files
+                .iter()
+                .position(|file| {
+                    matches!(file.status, FileStatus::Added | FileStatus::Renamed)
+                        && file.file_path == rename.file_path
+                });
+            let deleted_pos = files
+                .iter()
+                .position(|file| {
+                    file.status == FileStatus::Deleted && file.file_path == old_path
+                });
+
+            if let (Some(target_pos), Some(deleted_pos)) = (target_pos, deleted_pos) {
+                if files[target_pos].status == FileStatus::Renamed
+                    && files[target_pos].old_file_path.as_deref() == Some(old_path.as_str())
+                {
+                    continue;
+                }
+
+                let target_file = files[target_pos].clone();
+                let deleted_file = files[deleted_pos].clone();
+                let displaced_deleted_path =
+                    if target_file.status == FileStatus::Renamed {
+                        target_file
+                            .old_file_path
+                            .as_ref()
+                            .filter(|path| *path != &old_path)
+                            .cloned()
+                    } else {
+                        None
+                    };
+
+                files = files
+                    .into_iter()
+                    .enumerate()
+                    .filter_map(|(idx, file)| {
+                        if idx == target_pos || idx == deleted_pos {
+                            None
+                        } else {
+                            Some(file)
+                        }
+                    })
+                    .collect();
+                let before_content = deleted_file
+                    .before_content
+                    .or_else(|| self.read_blob_from_tree(base_tree, &old_path));
+                let after_content = target_file
+                    .after_content
+                    .or_else(|| self.read_working_file(&target_file.file_path));
+                files.push(FileChange {
+                    file_path: target_file.file_path,
+                    status: FileStatus::Renamed,
+                    old_file_path: Some(old_path),
+                    before_content,
+                    after_content,
+                });
+                if let Some(file_path) = displaced_deleted_path {
+                    let before_content = self.read_blob_from_tree(base_tree, &file_path);
+                    files.push(FileChange {
+                        file_path,
+                        status: FileStatus::Deleted,
+                        old_file_path: None,
+                        before_content,
+                        after_content: None,
+                    });
+                }
+            }
+        }
+
+        Ok(files)
     }
 
     fn get_commit_diff_files(&self, sha: &str, pathspecs: &[String]) -> Result<Vec<FileChange>, GitError> {
@@ -238,7 +382,7 @@ impl GitBridge {
             Some(&mut opts),
         )?;
         Self::detect_renames(&mut diff)?;
-        Ok(self.diff_to_file_changes(&diff))
+        self.apply_index_rename_map(self.diff_to_file_changes(&diff), Some(&tree), pathspecs)
     }
 
     fn detect_renames(diff: &mut Diff) -> Result<(), GitError> {
@@ -1124,11 +1268,290 @@ export function foo() {
 
         assert_eq!(result.added_count, 0);
         assert_eq!(result.deleted_count, 0);
+        // `foo` is a compound Moved change whose body also changed, so it counts toward
+        // both moved_count and modified_count.
+        assert_eq!(result.modified_count, 1);
         assert_eq!(result.moved_count, 1);
         assert_eq!(result.changes.len(), 1);
         assert_eq!(result.changes[0].change_type, ChangeType::Moved);
         assert_eq!(result.changes[0].entity_name, "foo");
         assert_eq!(result.changes[0].old_file_path.as_deref(), Some("old.ts"));
+        assert_eq!(result.changes[0].structural_change, Some(true));
+    }
+
+    #[test]
+    fn working_diff_preserves_staged_rename_with_unstaged_edit() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path()).unwrap();
+
+        let before = "\
+export function foo(x: number) {
+  return x + 1;
+}
+
+export function bar(y: number) {
+  return y * 2;
+}
+";
+        let after = "\
+export function foo(x: number) {
+  return x + 42;
+}
+
+export function bar(y: number) {
+  return y * 99;
+}
+";
+
+        commit_file(&repo, "a.ts", before, "init");
+
+        fs::rename(temp.path().join("a.ts"), temp.path().join("b.ts")).unwrap();
+        let mut index = repo.index().unwrap();
+        index.remove_path(Path::new("a.ts")).unwrap();
+        index.add_path(Path::new("b.ts")).unwrap();
+        index.write().unwrap();
+
+        fs::write(temp.path().join("b.ts"), after).unwrap();
+
+        let bridge = GitBridge::open(temp.path()).unwrap();
+        let (scope, files) = bridge.detect_and_get_files(&[]).unwrap();
+
+        assert!(matches!(scope, DiffScope::Working));
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].status, FileStatus::Renamed);
+        assert_eq!(files[0].file_path, "b.ts");
+        assert_eq!(files[0].old_file_path.as_deref(), Some("a.ts"));
+        assert_eq!(files[0].before_content.as_deref(), Some(before));
+        assert_eq!(files[0].after_content.as_deref(), Some(after));
+
+        let registry = create_default_registry();
+        let result = compute_semantic_diff(&files, &registry, None, None);
+
+        assert_eq!(result.added_count, 0);
+        assert_eq!(result.deleted_count, 0);
+        assert_eq!(result.modified_count, 2);
+        assert_eq!(result.moved_count, 2);
+        assert_eq!(result.changes.len(), 2);
+        assert!(result
+            .changes
+            .iter()
+            .all(|change| change.change_type == ChangeType::Moved));
+        assert!(result
+            .changes
+            .iter()
+            .all(|change| change.old_file_path.as_deref() == Some("a.ts")));
+        assert!(result
+            .changes
+            .iter()
+            .all(|change| change.structural_change == Some(true)));
+    }
+
+    #[test]
+    fn working_diff_uses_staged_rename_map_after_large_unstaged_rewrite() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path()).unwrap();
+
+        let before_noise = (0..200)
+            .map(|i| format!("// old filler {i} alpha beta gamma"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let after_noise = (0..200)
+            .map(|i| format!("// new filler {i} delta epsilon zeta"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let before = format!(
+            "{before_noise}\nexport function foo(x: number) {{\n  return x + 1;\n}}\n"
+        );
+        let after = format!(
+            "{after_noise}\nexport function foo(x: number) {{\n  return x + 42;\n}}\n"
+        );
+
+        commit_file(&repo, "a.ts", &before, "init");
+
+        fs::rename(temp.path().join("a.ts"), temp.path().join("b.ts")).unwrap();
+        let mut index = repo.index().unwrap();
+        index.remove_path(Path::new("a.ts")).unwrap();
+        index.add_path(Path::new("b.ts")).unwrap();
+        index.write().unwrap();
+
+        fs::write(temp.path().join("b.ts"), &after).unwrap();
+
+        let bridge = GitBridge::open(temp.path()).unwrap();
+        let (scope, files) = bridge.detect_and_get_files(&[]).unwrap();
+
+        assert!(matches!(scope, DiffScope::Working));
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].status, FileStatus::Renamed);
+        assert_eq!(files[0].file_path, "b.ts");
+        assert_eq!(files[0].old_file_path.as_deref(), Some("a.ts"));
+        assert_eq!(files[0].before_content.as_deref(), Some(before.as_str()));
+        assert_eq!(files[0].after_content.as_deref(), Some(after.as_str()));
+
+        let registry = create_default_registry();
+        let result = compute_semantic_diff(&files, &registry, None, None);
+
+        assert_eq!(result.added_count, 0);
+        assert_eq!(result.deleted_count, 0);
+        // Two changes: the rewritten comment block is a Modified orphan, and `foo` is a
+        // compound Moved change whose body also changed, so it counts toward both
+        // moved_count and modified_count.
+        assert_eq!(result.modified_count, 2);
+        assert_eq!(result.moved_count, 1);
+        assert!(result
+            .changes
+            .iter()
+            .any(|change| change.change_type == ChangeType::Moved && change.entity_name == "foo"));
+    }
+
+    #[test]
+    fn explicit_ref_to_working_uses_index_rename_map_after_large_unstaged_rewrite() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path()).unwrap();
+
+        let before_noise = (0..200)
+            .map(|i| format!("// old filler {i} alpha beta gamma"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let after_noise = (0..200)
+            .map(|i| format!("// new filler {i} delta epsilon zeta"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let before = format!(
+            "{before_noise}\nexport function foo(x: number) {{\n  return x + 1;\n}}\n"
+        );
+        let after = format!(
+            "{after_noise}\nexport function foo(x: number) {{\n  return x + 42;\n}}\n"
+        );
+
+        commit_file(&repo, "a.ts", &before, "init");
+
+        fs::rename(temp.path().join("a.ts"), temp.path().join("b.ts")).unwrap();
+        let mut index = repo.index().unwrap();
+        index.remove_path(Path::new("a.ts")).unwrap();
+        index.add_path(Path::new("b.ts")).unwrap();
+        index.write().unwrap();
+
+        fs::write(temp.path().join("b.ts"), &after).unwrap();
+
+        let bridge = GitBridge::open(temp.path()).unwrap();
+        let files = bridge
+            .get_changed_files(
+                &DiffScope::RefToWorking {
+                    refspec: "HEAD".to_string(),
+                },
+                &[],
+            )
+            .unwrap();
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].status, FileStatus::Renamed);
+        assert_eq!(files[0].file_path, "b.ts");
+        assert_eq!(files[0].old_file_path.as_deref(), Some("a.ts"));
+        assert_eq!(files[0].before_content.as_deref(), Some(before.as_str()));
+        assert_eq!(files[0].after_content.as_deref(), Some(after.as_str()));
+
+        let registry = create_default_registry();
+        let result = compute_semantic_diff(&files, &registry, None, None);
+
+        assert_eq!(result.added_count, 0);
+        assert_eq!(result.deleted_count, 0);
+        // Two changes: the rewritten comment block is a Modified orphan, and `foo` is a
+        // compound Moved change whose body also changed, so it counts toward both
+        // moved_count and modified_count.
+        assert_eq!(result.modified_count, 2);
+        assert_eq!(result.moved_count, 1);
+        assert!(result
+            .changes
+            .iter()
+            .any(|change| change.change_type == ChangeType::Moved && change.entity_name == "foo"));
+    }
+
+    #[test]
+    fn staged_rename_map_overrides_wrong_worktree_rename_pairing() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path()).unwrap();
+
+        let a_before = "export function foo(x: number) {\n  return x + 1;\n}\n";
+        let c_before = "export function foo(x: number) {\n  return x + 42;\n}\n";
+
+        commit_file(&repo, "a.ts", a_before, "init a");
+        commit_file(&repo, "c.ts", c_before, "init c");
+
+        fs::rename(temp.path().join("a.ts"), temp.path().join("b.ts")).unwrap();
+        let mut index = repo.index().unwrap();
+        index.remove_path(Path::new("a.ts")).unwrap();
+        index.add_path(Path::new("b.ts")).unwrap();
+        index.write().unwrap();
+
+        fs::remove_file(temp.path().join("c.ts")).unwrap();
+        fs::write(temp.path().join("b.ts"), c_before).unwrap();
+
+        let bridge = GitBridge::open(temp.path()).unwrap();
+        let (scope, files) = bridge.detect_and_get_files(&[]).unwrap();
+
+        assert!(matches!(scope, DiffScope::Working));
+        let renamed = files
+            .iter()
+            .find(|file| {
+                file.status == FileStatus::Renamed
+                    && file.file_path == "b.ts"
+                    && file.old_file_path.as_deref() == Some("a.ts")
+            })
+            .unwrap();
+        assert_eq!(renamed.before_content.as_deref(), Some(a_before));
+        assert_eq!(renamed.after_content.as_deref(), Some(c_before));
+
+        let deleted = files
+            .iter()
+            .find(|file| file.status == FileStatus::Deleted && file.file_path == "c.ts")
+            .unwrap();
+        assert_eq!(deleted.before_content.as_deref(), Some(c_before));
+        assert_eq!(deleted.after_content.as_deref(), None);
+        assert!(!files.iter().any(|file| {
+            file.status == FileStatus::Renamed
+                && file.file_path == "b.ts"
+                && file.old_file_path.as_deref() == Some("c.ts")
+        }));
+    }
+
+    #[test]
+    fn staged_diff_with_base_ref_compares_index_to_that_ref() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path()).unwrap();
+
+        let v1 = "def foo():\n    return 1\n";
+        let v2 = "def foo():\n    return 2\n";
+        let v3 = "def foo():\n    return 3\n";
+        let v4 = "def foo():\n    return 4\n";
+
+        commit_file(&repo, "a.py", v1, "init");
+        commit_file(&repo, "a.py", v2, "second");
+        fs::write(temp.path().join("a.py"), v3).unwrap();
+
+        let mut index = repo.index().unwrap();
+        index.add_path(Path::new("a.py")).unwrap();
+        index.write().unwrap();
+
+        fs::write(temp.path().join("a.py"), v4).unwrap();
+
+        let bridge = GitBridge::open(temp.path()).unwrap();
+        let files = bridge
+            .get_staged_files_with_base_ref("HEAD~1", &[])
+            .unwrap();
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].status, FileStatus::Modified);
+        assert_eq!(files[0].file_path, "a.py");
+        assert_eq!(files[0].before_content.as_deref(), Some(v1));
+        assert_eq!(files[0].after_content.as_deref(), Some(v3));
+
+        let registry = create_default_registry();
+        let result = compute_semantic_diff(&files, &registry, None, None);
+
+        assert_eq!(result.modified_count, 1);
+        assert_eq!(result.changes.len(), 1);
+        assert_eq!(result.changes[0].change_type, ChangeType::Modified);
+        assert_eq!(result.changes[0].entity_name, "foo");
     }
 
     #[test]

--- a/crates/sem-core/src/model/change.rs
+++ b/crates/sem-core/src/model/change.rs
@@ -67,3 +67,12 @@ pub struct SemanticChange {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub structural_change: Option<bool>,
 }
+
+impl SemanticChange {
+    pub fn has_content_change(&self) -> bool {
+        match (&self.before_content, &self.after_content) {
+            (Some(before), Some(after)) => before != after,
+            _ => false,
+        }
+    }
+}

--- a/crates/sem-core/src/model/identity.rs
+++ b/crates/sem-core/src/model/identity.rs
@@ -64,6 +64,17 @@ fn same_signature_across_file_rename(
         && parent_name(before, before_by_id) == parent_name(after, after_by_id)
 }
 
+fn structural_change_between(before: &SemanticEntity, after: &SemanticEntity) -> Option<bool> {
+    if before.content_hash == after.content_hash {
+        return None;
+    }
+
+    match (&before.structural_hash, &after.structural_hash) {
+        (Some(before_hash), Some(after_hash)) => Some(before_hash != after_hash),
+        _ => None,
+    }
+}
+
 fn make_change(
     after_entity: &SemanticEntity,
     change_type: ChangeType,
@@ -84,6 +95,13 @@ fn make_change(
     } else {
         after_entity
     };
+    let structural_change = before_entity.and_then(|before| {
+        if matches!(change_type, ChangeType::Deleted | ChangeType::Reordered) {
+            None
+        } else {
+            structural_change_between(before, after_entity)
+        }
+    });
     SemanticChange {
         id: format!("change::{prefix}{}", primary.id),
         entity_id: primary.id.clone(),
@@ -119,7 +137,7 @@ fn make_change(
         commit_sha: commit_sha.map(String::from),
         author: author.map(String::from),
         timestamp: None,
-        structural_change: None,
+        structural_change,
     }
 }
 
@@ -160,12 +178,14 @@ pub fn match_entities(
             matched_after.insert(id);
 
             if before_entity.content_hash != after_entity.content_hash {
-                let mut change = make_change(after_entity, ChangeType::Modified, Some(before_entity), commit_sha, author, &combined_by_id);
-                change.structural_change = match (&before_entity.structural_hash, &after_entity.structural_hash) {
-                    (Some(before_sh), Some(after_sh)) => Some(before_sh != after_sh),
-                    _ => None,
-                };
-                changes.push(change);
+                changes.push(make_change(
+                    after_entity,
+                    ChangeType::Modified,
+                    Some(before_entity),
+                    commit_sha,
+                    author,
+                    &combined_by_id,
+                ));
             }
         }
     }
@@ -607,6 +627,33 @@ mod tests {
 
     #[test]
     fn test_same_signature_file_rename_with_content_change_is_moved() {
+        let mut before_entity = make_entity(
+            "old.ts::function::foo",
+            "foo",
+            "export function foo() { return alpha + beta + gamma; }",
+            "old.ts",
+        );
+        before_entity.structural_hash = Some("before-structure".to_string());
+        let mut after_entity = make_entity(
+            "new.ts::function::foo",
+            "foo",
+            "export function foo() { return one + two + three; }",
+            "new.ts",
+        );
+        after_entity.structural_hash = Some("after-structure".to_string());
+        let before = vec![before_entity];
+        let after = vec![after_entity];
+
+        let result = match_entities(&before, &after, "new.ts", None, None, None);
+
+        assert_eq!(result.changes.len(), 1);
+        assert_eq!(result.changes[0].change_type, ChangeType::Moved);
+        assert_eq!(result.changes[0].old_file_path.as_deref(), Some("old.ts"));
+        assert_eq!(result.changes[0].structural_change, Some(true));
+    }
+
+    #[test]
+    fn test_moved_content_change_without_structural_hash_is_unknown_structurally() {
         let before = vec![make_entity(
             "old.ts::function::foo",
             "foo",
@@ -625,6 +672,7 @@ mod tests {
         assert_eq!(result.changes.len(), 1);
         assert_eq!(result.changes[0].change_type, ChangeType::Moved);
         assert_eq!(result.changes[0].old_file_path.as_deref(), Some("old.ts"));
+        assert_eq!(result.changes[0].structural_change, None);
     }
 
     #[test]

--- a/crates/sem-core/src/parser/differ.rs
+++ b/crates/sem-core/src/parser/differ.rs
@@ -156,9 +156,24 @@ pub fn compute_semantic_diff(
             ChangeType::Added => added_count += 1,
             ChangeType::Modified => modified_count += 1,
             ChangeType::Deleted => deleted_count += 1,
-            ChangeType::Moved => moved_count += 1,
-            ChangeType::Renamed => renamed_count += 1,
-            ChangeType::Reordered => reordered_count += 1,
+            ChangeType::Moved => {
+                moved_count += 1;
+                if c.has_content_change() {
+                    modified_count += 1;
+                }
+            }
+            ChangeType::Renamed => {
+                renamed_count += 1;
+                if c.has_content_change() {
+                    modified_count += 1;
+                }
+            }
+            ChangeType::Reordered => {
+                reordered_count += 1;
+                if c.has_content_change() {
+                    modified_count += 1;
+                }
+            }
         }
     }
 
@@ -723,10 +738,12 @@ mod tests {
 
         assert_eq!(result.added_count, 0);
         assert_eq!(result.deleted_count, 0);
+        assert_eq!(result.modified_count, 1);
         assert_eq!(result.moved_count, 1);
         assert_eq!(result.changes.len(), 1);
         assert_eq!(result.changes[0].entity_name, "foo");
         assert_eq!(result.changes[0].old_file_path.as_deref(), Some("old.py"));
+        assert_eq!(result.changes[0].structural_change, Some(true));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- surface moved/renamed entities that also changed content as compound modifications
- make default working diffs preserve staged rename mappings across unstaged edits
- make `sem diff --staged <ref>` compare the index against the requested ref

Fixes #175
Fixes #176
Fixes #193

## Test plan
- `cargo test --workspace`
- `cargo build -p sem-cli --bin sem`
- dummy repo checks for moved+modified, staged rename plus unstaged edit, wrong rename pairing, `--staged HEAD`, and compound cosmetic `--no-cosmetics` output