### PR TITLE
Prevent container entities inheriting child call edges

### DIFF
--- a/crates/sem-cli/src/cache.rs
+++ b/crates/sem-cli/src/cache.rs
@@ -737,7 +737,11 @@ mod tests {
 
     #[test]
     fn open_rebuilds_cache_when_schema_version_is_unsupported() {
-        for version in [0, shared_cache::CACHE_SCHEMA_VERSION + 1] {
+        for version in [
+            0,
+            shared_cache::CACHE_SCHEMA_VERSION - 1,
+            shared_cache::CACHE_SCHEMA_VERSION + 1,
+        ] {
             let root = temp_repo_root(&format!("unsupported-{version}"));
             seed_unsupported_cache(&root, version);
 

--- a/crates/sem-core/src/parser/graph.rs
+++ b/crates/sem-core/src/parser/graph.rs
@@ -59,6 +59,107 @@ fn add_scope_reference_words(words: &mut HashSet<String>, reference: &str) {
     }
 }
 
+#[derive(Clone, Copy)]
+struct ChildRange<'a> {
+    file_path: &'a str,
+    start_line: usize,
+    end_line: usize,
+    start_byte: Option<usize>,
+    end_byte: Option<usize>,
+}
+
+fn build_child_ranges_by_parent<'a>(
+    entities: &'a [SemanticEntity],
+) -> HashMap<&'a str, Vec<ChildRange<'a>>> {
+    let entity_by_id: HashMap<&str, &SemanticEntity> =
+        entities.iter().map(|entity| (entity.id.as_str(), entity)).collect();
+    let mut child_ranges_by_parent: HashMap<&'a str, Vec<ChildRange<'a>>> = HashMap::new();
+
+    for child in entities {
+        let Some(parent_id) = child.parent_id.as_deref() else {
+            continue;
+        };
+        let (start_byte, end_byte) = entity_by_id
+            .get(parent_id)
+            .and_then(|parent| child_content_span_in_parent(parent, child))
+            .map_or((None, None), |(start, end)| (Some(start), Some(end)));
+
+        child_ranges_by_parent
+            .entry(parent_id)
+            .or_default()
+            .push(ChildRange {
+                file_path: child.file_path.as_str(),
+                start_line: child.start_line,
+                end_line: child.end_line,
+                start_byte,
+                end_byte,
+            });
+    }
+
+    child_ranges_by_parent
+}
+
+fn child_content_span_in_parent(
+    parent: &SemanticEntity,
+    child: &SemanticEntity,
+) -> Option<(usize, usize)> {
+    if parent.file_path != child.file_path || child.content.is_empty() {
+        return None;
+    }
+
+    let expected_local_line = child.start_line.checked_sub(parent.start_line)? + 1;
+    for (offset, _) in parent.content.match_indices(&child.content) {
+        let local_line = line_for_byte(&parent.content, offset);
+        if local_line == expected_local_line {
+            return Some((offset, offset + child.content.len()));
+        }
+    }
+
+    None
+}
+
+fn entity_owns_content_span(
+    entity_id: &str,
+    file_path: &str,
+    source_line: usize,
+    local_start_byte: Option<usize>,
+    local_end_byte: Option<usize>,
+    child_ranges_by_parent: &HashMap<&str, Vec<ChildRange<'_>>>,
+) -> bool {
+    child_ranges_by_parent
+        .get(entity_id)
+        .map_or(true, |child_ranges| {
+            child_ranges
+                .iter()
+                .all(|child| {
+                    if child.file_path != file_path
+                        || source_line < child.start_line
+                        || source_line > child.end_line
+                    {
+                        return true;
+                    }
+
+                    match (local_start_byte, local_end_byte, child.start_byte, child.end_byte) {
+                        (Some(start), Some(end), Some(child_start), Some(child_end)) => {
+                            end <= child_start || start >= child_end
+                        }
+                        _ => false,
+                    }
+                })
+        })
+}
+
+fn source_line_for_entity_content(entity: &SemanticEntity, local_line: usize) -> usize {
+    entity.start_line + local_line.saturating_sub(1)
+}
+
+fn line_for_byte(content: &str, byte: usize) -> usize {
+    1 + content[..byte]
+        .bytes()
+        .filter(|current| *current == b'\n')
+        .count()
+}
+
 /// A reference from one entity to another.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -168,6 +269,7 @@ impl EntityGraph {
         let mut entity_map: HashMap<String, EntityInfo> = HashMap::with_capacity(all_entities.len());
         let mut parent_child_pairs: HashSet<(&str, &str)> = HashSet::new();
         let mut class_child_names: HashSet<(&str, &str)> = HashSet::new();
+        let child_ranges_by_parent = build_child_ranges_by_parent(&all_entities);
         let mut class_entity_names: HashSet<&str> = HashSet::new();
         let mut class_entity_files: HashSet<(&str, &str)> = HashSet::new();
         let mut id_to_name: HashMap<&str, &str> = HashMap::with_capacity(all_entities.len());
@@ -328,9 +430,19 @@ impl EntityGraph {
                 let stripped = strip_comments_and_strings(&entity.content);
 
                 // Phase 1: Dot-chain resolution
-                let dot_chains = extract_dot_chains(&stripped);
+                let dot_chains = extract_dot_chains_with_positions(&stripped);
 
-                for (receiver, member) in &dot_chains {
+                for (receiver, member, local_line, local_start_byte, local_end_byte) in &dot_chains {
+                    if !entity_owns_content_span(
+                        entity.id.as_str(),
+                        entity.file_path.as_str(),
+                        source_line_for_entity_content(entity, *local_line),
+                        Some(*local_start_byte),
+                        Some(*local_end_byte),
+                        &child_ranges_by_parent,
+                    ) {
+                        continue;
+                    }
                     let edge_count_before = entity_edges.len();
                     if *receiver == "self" || *receiver == "this" {
                         // self.B / this.B: resolve to sibling method in enclosing class
@@ -373,7 +485,21 @@ impl EntityGraph {
 
                 // Phase 2: Bag-of-words resolution (skip words consumed by dot-chains)
                 // Reuse the stripped content to avoid stripping twice
-                let refs = extract_references_with_stripped(&entity.content, &entity.name, &stripped);
+                let refs = extract_references_with_stripped_filtered(
+                    &entity.content,
+                    &entity.name,
+                    &stripped,
+                    |local_line, local_start_byte, local_end_byte| {
+                        entity_owns_content_span(
+                            entity.id.as_str(),
+                            entity.file_path.as_str(),
+                            source_line_for_entity_content(entity, local_line),
+                            Some(local_start_byte),
+                            Some(local_end_byte),
+                            &child_ranges_by_parent,
+                        )
+                    },
+                );
                 for ref_name in refs {
                     if consumed_words.contains(ref_name) {
                         continue;
@@ -677,6 +803,8 @@ impl EntityGraph {
             })
             .collect();
 
+        let child_ranges_by_parent = build_child_ranges_by_parent(&all_entities);
+
         let class_entity_names: HashSet<&str> = all_entities
             .iter()
             .filter(|e| matches!(e.entity_type.as_str(), "class" | "struct" | "interface" | "class_type"))
@@ -766,9 +894,19 @@ impl EntityGraph {
                 let stripped = strip_comments_and_strings(&entity.content);
 
                 // Phase 1: Dot-chain resolution
-                let dot_chains = extract_dot_chains(&stripped);
+                let dot_chains = extract_dot_chains_with_positions(&stripped);
 
-                for (receiver, member) in &dot_chains {
+                for (receiver, member, local_line, local_start_byte, local_end_byte) in &dot_chains {
+                    if !entity_owns_content_span(
+                        entity.id.as_str(),
+                        entity.file_path.as_str(),
+                        source_line_for_entity_content(entity, *local_line),
+                        Some(*local_start_byte),
+                        Some(*local_end_byte),
+                        &child_ranges_by_parent,
+                    ) {
+                        continue;
+                    }
                     let edge_count_before = entity_edges.len();
                     if *receiver == "self" || *receiver == "this" {
                         if let Some(class_name) = enclosing_class.get(entity.id.as_str()) {
@@ -808,7 +946,21 @@ impl EntityGraph {
                 }
 
                 // Phase 2: Bag-of-words resolution (reuse stripped content)
-                let refs = extract_references_with_stripped(&entity.content, &entity.name, &stripped);
+                let refs = extract_references_with_stripped_filtered(
+                    &entity.content,
+                    &entity.name,
+                    &stripped,
+                    |local_line, local_start_byte, local_end_byte| {
+                        entity_owns_content_span(
+                            entity.id.as_str(),
+                            entity.file_path.as_str(),
+                            source_line_for_entity_content(entity, local_line),
+                            Some(local_start_byte),
+                            Some(local_end_byte),
+                            &child_ranges_by_parent,
+                        )
+                    },
+                );
                 for ref_name in refs {
                     if consumed_words.contains(ref_name) {
                         continue;
@@ -1168,10 +1320,11 @@ impl EntityGraph {
 
         // Rebuild the global symbol table from all current entities
         let symbol_table = self.build_symbol_table();
+        let child_ranges_by_parent = build_child_ranges_by_parent(&new_entities);
 
         // Re-resolve references for new entities
         for entity in &new_entities {
-            self.resolve_entity_references(entity, &symbol_table);
+            self.resolve_entity_references(entity, &symbol_table, &child_ranges_by_parent);
         }
 
         // Also re-resolve references for entities in OTHER files that might
@@ -1287,8 +1440,24 @@ impl EntityGraph {
         &mut self,
         entity: &SemanticEntity,
         symbol_table: &HashMap<String, Vec<String>>,
+        child_ranges_by_parent: &HashMap<&str, Vec<ChildRange<'_>>>,
     ) {
-        let refs = extract_references_from_content(&entity.content, &entity.name);
+        let stripped = strip_comments_and_strings(&entity.content);
+        let refs = extract_references_with_stripped_filtered(
+            &entity.content,
+            &entity.name,
+            &stripped,
+            |local_line, local_start_byte, local_end_byte| {
+                entity_owns_content_span(
+                    entity.id.as_str(),
+                    entity.file_path.as_str(),
+                    source_line_for_entity_content(entity, local_line),
+                    Some(local_start_byte),
+                    Some(local_end_byte),
+                    child_ranges_by_parent,
+                )
+            },
+        );
 
         for ref_name in refs {
             if let Some(target_ids) = symbol_table.get(ref_name) {
@@ -1777,19 +1946,23 @@ fn strip_comments_and_strings(content: &str) -> String {
 }
 
 /// Extract dot-chains (receiver.member) from content for precise resolution.
-/// Returns unique (receiver, member) pairs found in the content.
-fn extract_dot_chains<'a>(content: &'a str) -> Vec<(&'a str, &'a str)> {
+/// Returns unique receiver/member pairs with one-based content lines and byte offsets.
+fn extract_dot_chains_with_positions<'a>(
+    content: &'a str,
+) -> Vec<(&'a str, &'a str, usize, usize, usize)> {
     static DOT_CHAIN_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"\b([A-Za-z_]\w*)\.([A-Za-z_]\w*)").unwrap()
     });
 
     let mut chains = Vec::new();
-    let mut seen: HashSet<(&str, &str)> = HashSet::new();
+    let mut seen: HashSet<(&str, &str, usize, usize)> = HashSet::new();
     for cap in DOT_CHAIN_RE.captures_iter(content) {
+        let matched = cap.get(0).unwrap();
+        let line = line_for_byte(content, matched.start());
         let receiver = cap.get(1).unwrap().as_str();
         let member = cap.get(2).unwrap().as_str();
-        if seen.insert((receiver, member)) {
-            chains.push((receiver, member));
+        if seen.insert((receiver, member, line, matched.start())) {
+            chains.push((receiver, member, line, matched.start(), matched.end()));
         }
     }
     chains
@@ -1798,6 +1971,7 @@ fn extract_dot_chains<'a>(content: &'a str) -> Vec<(&'a str, &'a str)> {
 /// Extract identifier references from entity content using simple token analysis.
 /// Strips comments and strings first to avoid false positives from docstrings.
 /// Returns borrowed slices from the stripped content.
+#[cfg(test)]
 fn extract_references_from_content<'a>(content: &'a str, own_name: &str) -> Vec<&'a str> {
     let stripped = strip_comments_and_strings(content);
     extract_references_with_stripped(content, own_name, &stripped)
@@ -1806,43 +1980,110 @@ fn extract_references_from_content<'a>(content: &'a str, own_name: &str) -> Vec<
 /// Extract references using a pre-stripped version of the content.
 /// Use this when you already have the stripped content (e.g. from dot-chain extraction)
 /// to avoid stripping comments/strings twice.
+#[cfg(test)]
 fn extract_references_with_stripped<'a>(content: &'a str, own_name: &str, stripped: &str) -> Vec<&'a str> {
-    let stripped_words: HashSet<&str> = stripped
-        .split(|c: char| !c.is_alphanumeric() && c != '_')
-        .filter(|w| !w.is_empty())
-        .collect();
+    extract_references_with_stripped_filtered(content, own_name, stripped, |_, _, _| true)
+}
 
+fn extract_references_with_stripped_filtered<'a, F>(
+    content: &'a str,
+    own_name: &str,
+    stripped: &str,
+    mut include_token: F,
+) -> Vec<&'a str>
+where
+    F: FnMut(usize, usize, usize) -> bool,
+{
     let mut refs = Vec::new();
     let mut seen: HashSet<&str> = HashSet::new();
+    let mut token_start: Option<usize> = None;
+    let mut line = 1;
 
-    for word in content.split(|c: char| !c.is_alphanumeric() && c != '_') {
-        if word.is_empty() || word == own_name {
+    for (idx, ch) in content.char_indices() {
+        if ch.is_alphanumeric() || ch == '_' {
+            if token_start.is_none() {
+                token_start = Some(idx);
+            }
             continue;
         }
-        if is_keyword(word) || word.len() < 2 {
-            continue;
+
+        if let Some(start) = token_start.take() {
+            maybe_push_reference_token(
+                content,
+                stripped,
+                start,
+                idx,
+                line,
+                own_name,
+                &mut seen,
+                &mut refs,
+                &mut include_token,
+            );
         }
-        // Skip very short lowercase identifiers (likely local vars: i, x, a, ok, id, etc.)
-        if word.starts_with(|c: char| c.is_lowercase()) && word.len() < 3 {
-            continue;
-        }
-        if !word.starts_with(|c: char| c.is_alphabetic() || c == '_') {
-            continue;
-        }
-        // Skip common local variable names that create false graph edges
-        if is_common_local_name(word) {
-            continue;
-        }
-        // Skip words that only appear in comments/strings
-        if !stripped_words.contains(word) {
-            continue;
-        }
-        if seen.insert(word) {
-            refs.push(word);
+
+        if ch == '\n' {
+            line += 1;
         }
     }
 
+    if let Some(start) = token_start {
+        maybe_push_reference_token(
+            content,
+            stripped,
+            start,
+            content.len(),
+            line,
+            own_name,
+            &mut seen,
+            &mut refs,
+            &mut include_token,
+        );
+    }
+
     refs
+}
+
+fn maybe_push_reference_token<'a, F>(
+    content: &'a str,
+    stripped: &str,
+    start: usize,
+    end: usize,
+    line: usize,
+    own_name: &str,
+    seen: &mut HashSet<&'a str>,
+    refs: &mut Vec<&'a str>,
+    include_token: &mut F,
+) where
+    F: FnMut(usize, usize, usize) -> bool,
+{
+    let word = &content[start..end];
+    if word.is_empty() || word == own_name {
+        return;
+    }
+    if is_keyword(word) || word.len() < 2 {
+        return;
+    }
+    // Skip very short lowercase identifiers (likely local vars: i, x, a, ok, id, etc.)
+    if word.starts_with(|c: char| c.is_lowercase()) && word.len() < 3 {
+        return;
+    }
+    if !word.starts_with(|c: char| c.is_alphabetic() || c == '_') {
+        return;
+    }
+    // Skip common local variable names that create false graph edges
+    if is_common_local_name(word) {
+        return;
+    }
+    // Skip words that only appear in comments/strings
+    if stripped.get(start..end) != Some(word) {
+        return;
+    }
+    if !include_token(line, start, end) {
+        return;
+    }
+    if seen.insert(word) {
+        refs.push(word);
+    }
 }
 
 static COMMON_LOCAL_NAMES: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
@@ -2193,6 +2434,42 @@ mod tests {
         assert!(!graph.entities.contains_key("methods.go::type::Service::Run"));
     }
 
+    #[cfg(feature = "lang-go")]
+    #[test]
+    fn test_go_receiver_child_range_does_not_hide_parent_file_edges() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "models.go",
+            "package demo\n\
+             type Dependency struct{}\n\
+             type Service struct { Dependency }\n",
+        );
+        write_file(
+            root,
+            "methods.go",
+            "package demo\n\n\
+             func (s *Service) Run() {}\n",
+        );
+
+        let (graph, _) = EntityGraph::build(
+            root,
+            &["models.go".into(), "methods.go".into()],
+            &registry,
+        );
+
+        assert!(
+            graph.edges.iter().any(|edge| {
+                edge.from_entity == "models.go::type::Service"
+                    && edge.to_entity == "models.go::type::Dependency"
+            }),
+            "Service should keep its Dependency edge. Edges: {:?}",
+            graph.edges
+        );
+    }
+
     #[test]
     fn test_extract_references() {
         let content = "function processData(input) {\n  const result = validateInput(input);\n  return transform(result);\n}";
@@ -2200,6 +2477,167 @@ mod tests {
         assert!(refs.contains(&"validateInput"));
         assert!(refs.contains(&"transform"));
         assert!(!refs.contains(&"processData")); // self excluded
+    }
+
+    #[test]
+    fn test_container_does_not_inherit_child_call_edges() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "app.ts",
+            "export function helper() { return 1; }\n\
+             export class Service {\n\
+               method() { return helper(); }\n\
+             }\n\
+             export class InlineService { method() { return helper(); } }\n",
+        );
+
+        let (graph, _) = EntityGraph::build(root, &["app.ts".into()], &registry);
+        let helper_id = "app.ts::function::helper";
+
+        for (class_id, method_id) in [
+            (
+                "app.ts::class::Service",
+                "app.ts::class::Service::method",
+            ),
+            (
+                "app.ts::class::InlineService",
+                "app.ts::class::InlineService::method",
+            ),
+        ] {
+            assert!(
+                graph.edges.iter().any(|edge| {
+                    edge.from_entity == method_id
+                        && edge.to_entity == helper_id
+                        && edge.ref_type == RefType::Calls
+                }),
+                "{method_id} should call helper. Edges: {:?}",
+                graph.edges
+            );
+            assert!(
+                !graph
+                    .edges
+                    .iter()
+                    .any(|edge| edge.from_entity == class_id && edge.to_entity == helper_id),
+                "{class_id} should not call helper. Edges: {:?}",
+                graph.edges
+            );
+        }
+    }
+
+    #[test]
+    fn test_incremental_container_does_not_inherit_child_call_edges() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "app.ts",
+            "export function helper() { return 1; }\n\
+             export class Service {\n\
+               method() { return helper(); }\n\
+             }\n",
+        );
+        let (initial_graph, initial_entities) =
+            EntityGraph::build(root, &["app.ts".into()], &registry);
+
+        write_file(
+            root,
+            "app.ts",
+            "export function helper() { return 2; }\n\
+             export function extra() { return 3; }\n\
+             export class Service {\n\
+               method() { return helper(); }\n\
+             }\n",
+        );
+
+        let (graph, _) = EntityGraph::build_incremental(
+            root,
+            &["app.ts".into()],
+            &["app.ts".into()],
+            vec![],
+            initial_graph.edges,
+            initial_entities,
+            &registry,
+        );
+
+        let class_id = "app.ts::class::Service";
+        let method_id = "app.ts::class::Service::method";
+        let helper_id = "app.ts::function::helper";
+        assert!(
+            graph.edges.iter().any(|edge| {
+                edge.from_entity == method_id
+                    && edge.to_entity == helper_id
+                    && edge.ref_type == RefType::Calls
+            }),
+            "{method_id} should call helper. Edges: {:?}",
+            graph.edges
+        );
+        assert!(
+            !graph
+                .edges
+                .iter()
+                .any(|edge| edge.from_entity == class_id && edge.to_entity == helper_id),
+            "{class_id} should not call helper. Edges: {:?}",
+            graph.edges
+        );
+    }
+
+    #[test]
+    fn test_same_line_container_and_child_refs_use_byte_spans() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "app.ts",
+            "export function helper() { return 1; }\n\
+             export function other() { return 2; }\n\
+             export class Service { static { helper(); } method() { return other(); } }\n",
+        );
+
+        let (graph, _) = EntityGraph::build(root, &["app.ts".into()], &registry);
+        let class_id = "app.ts::class::Service";
+        let method_id = "app.ts::class::Service::method";
+        let helper_id = "app.ts::function::helper";
+        let other_id = "app.ts::function::other";
+
+        assert!(
+            graph.edges.iter().any(|edge| {
+                edge.from_entity == class_id
+                    && edge.to_entity == helper_id
+                    && edge.ref_type == RefType::Calls
+            }),
+            "{class_id} should own the static-block helper call. Edges: {:?}",
+            graph.edges
+        );
+        assert!(
+            graph.edges.iter().any(|edge| {
+                edge.from_entity == method_id
+                    && edge.to_entity == other_id
+                    && edge.ref_type == RefType::Calls
+            }),
+            "{method_id} should own the method-body other call. Edges: {:?}",
+            graph.edges
+        );
+        assert!(
+            !graph
+                .edges
+                .iter()
+                .any(|edge| edge.from_entity == method_id && edge.to_entity == helper_id),
+            "{method_id} should not inherit the static-block helper call. Edges: {:?}",
+            graph.edges
+        );
+        assert!(
+            !graph
+                .edges
+                .iter()
+                .any(|edge| edge.from_entity == class_id && edge.to_entity == other_id),
+            "{class_id} should not inherit the method-body other call. Edges: {:?}",
+            graph.edges
+        );
     }
 
     #[test]

--- a/crates/sem-core/src/parser/scope_resolve.rs
+++ b/crates/sem-core/src/parser/scope_resolve.rs
@@ -59,6 +59,9 @@ struct AstRef {
     kind: AstRefKind,
     /// Row (0-indexed) where this reference appears in the source
     row: usize,
+    /// Byte range for the referenced syntax node in the file.
+    start_byte: usize,
+    end_byte: usize,
 }
 
 enum AstRefKind {
@@ -66,6 +69,79 @@ enum AstRefKind {
     Call(String),
     /// Attribute call: `x.method()`
     MethodCall { receiver: String, method: String },
+}
+
+#[derive(Clone, Copy)]
+struct SourceSpan {
+    start_byte: usize,
+    end_byte: usize,
+}
+
+fn entity_owns_ref(
+    entity: &SemanticEntity,
+    ast_ref: &AstRef,
+    children_by_parent: &HashMap<&str, Vec<&SemanticEntity>>,
+    entity_spans: &HashMap<&str, SourceSpan>,
+) -> bool {
+    let source_line = ast_ref.row + 1;
+    if let Some(entity_span) = entity_spans.get(entity.id.as_str()) {
+        if ast_ref.end_byte <= entity_span.start_byte || ast_ref.start_byte >= entity_span.end_byte {
+            return false;
+        }
+    }
+
+    children_by_parent
+        .get(entity.id.as_str())
+        .map_or(true, |children| {
+            children
+                .iter()
+                .all(|child| {
+                    if child.file_path != entity.file_path
+                        || source_line < child.start_line
+                        || source_line > child.end_line
+                    {
+                        return true;
+                    }
+
+                    if let Some(child_span) = entity_spans.get(child.id.as_str()) {
+                        ast_ref.end_byte <= child_span.start_byte
+                            || ast_ref.start_byte >= child_span.end_byte
+                    } else {
+                        false
+                    }
+                })
+        })
+}
+
+fn find_entity_source_spans<'a>(
+    entities: &[&'a SemanticEntity],
+    source: &str,
+) -> HashMap<&'a str, SourceSpan> {
+    let mut spans = HashMap::new();
+    for entity in entities {
+        if entity.content.is_empty() {
+            continue;
+        }
+
+        let expected_line = entity.start_line;
+        for (offset, _) in source.match_indices(&entity.content) {
+            let line = 1 + source[..offset]
+                .bytes()
+                .filter(|byte| *byte == b'\n')
+                .count();
+            if line == expected_line {
+                spans.insert(
+                    entity.id.as_str(),
+                    SourceSpan {
+                        start_byte: offset,
+                        end_byte: offset + entity.content.len(),
+                    },
+                );
+                break;
+            }
+        }
+    }
+    spans
 }
 
 /// Result of scope-aware resolution
@@ -343,6 +419,7 @@ pub(crate) fn resolve_with_scopes_full(
                 .map(|v| v.as_slice())
                 .unwrap_or(&[])
                 .to_vec();
+            let entity_spans = find_entity_source_spans(&file_entities, content);
 
             build_scopes_from_ast(
                 tree.root_node(),
@@ -398,7 +475,11 @@ pub(crate) fn resolve_with_scopes_full(
                 let end_row = entity.end_line; // exclusive
 
                 // Filter pre-collected refs to this entity's line range
-                for ast_ref in all_file_refs.iter().filter(|r| r.row >= start_row && r.row < end_row) {
+                for ast_ref in all_file_refs.iter().filter(|r| {
+                    r.row >= start_row
+                        && r.row < end_row
+                        && entity_owns_ref(entity, r, &children_by_parent, &entity_spans)
+                }) {
                     // Skip self-name refs (was previously done during collection)
                     let is_self_ref = match &ast_ref.kind {
                         AstRefKind::Call(name) => name == &entity.name,
@@ -2851,13 +2932,13 @@ fn collect_all_file_refs(
                 CallNodeStyle::FunctionField(field) => {
                     if let Some(func) = node.child_by_field_name(field) {
                         // Pass empty entity_name — self-ref filtering is done at resolution time
-                        extract_call_ref(func, "", "", source, &mut refs, config, node_row);
+                        extract_call_ref(func, node, "", "", source, &mut refs, config);
                     }
                 }
                 CallNodeStyle::FirstChild => {
                     // Swift/Kotlin: callee is the first named child (identifier or navigation_expression)
                     if let Some(func) = node.named_child(0) {
-                        extract_call_ref(func, "", "", source, &mut refs, config, node_row);
+                        extract_call_ref(func, node, "", "", source, &mut refs, config);
                     }
                 }
                 CallNodeStyle::DirectMethod { object_field, method_field } => {
@@ -2871,11 +2952,15 @@ fn collect_all_file_refs(
                             refs.push(AstRef {
                                 kind: AstRefKind::MethodCall { receiver, method: method_name.to_string() },
                                 row: node_row,
+                                start_byte: node.start_byte(),
+                                end_byte: node.end_byte(),
                             });
                         } else {
                             refs.push(AstRef {
                                 kind: AstRefKind::Call(method_name.to_string()),
                                 row: node_row,
+                                start_byte: node.start_byte(),
+                                end_byte: node.end_byte(),
                             });
                         }
                     }
@@ -2896,7 +2981,9 @@ fn collect_all_file_refs(
                 if !macro_name.is_empty() && !is_builtin(macro_name, config) {
                     refs.push(AstRef {
                         kind: AstRefKind::Call(macro_name.to_string()),
-                        row: node_row,
+                        row: macro_node.start_position().row,
+                        start_byte: macro_node.start_byte(),
+                        end_byte: macro_node.end_byte(),
                     });
                 }
             }
@@ -2916,7 +3003,9 @@ fn collect_all_file_refs(
                 if !name.is_empty() && !is_builtin(name, config) {
                     refs.push(AstRef {
                         kind: AstRefKind::Call(name.to_string()),
-                        row: node_row,
+                        row: type_node.start_position().row,
+                        start_byte: type_node.start_byte(),
+                        end_byte: type_node.end_byte(),
                     });
                 }
             }
@@ -2937,7 +3026,9 @@ fn collect_all_file_refs(
                 {
                     refs.push(AstRef {
                         kind: AstRefKind::Call(name.to_string()),
-                        row: node_row,
+                        row: type_node.start_position().row,
+                        start_byte: type_node.start_byte(),
+                        end_byte: type_node.end_byte(),
                     });
                 }
             }
@@ -2956,12 +3047,12 @@ fn collect_all_file_refs(
 /// Extract a call reference from a function/callee node (shared across languages)
 fn extract_call_ref(
     func: tree_sitter::Node,
+    ref_node: tree_sitter::Node,
     _entity_id: &str,
     entity_name: &str,
     source: &[u8],
     refs: &mut Vec<AstRef>,
     config: &ScopeResolveConfig,
-    row: usize,
 ) {
     let func_kind = func.kind();
 
@@ -2970,7 +3061,9 @@ fn extract_call_ref(
         if !name.is_empty() && name != entity_name && !is_builtin(name, config) {
             refs.push(AstRef {
                 kind: AstRefKind::Call(name.to_string()),
-                row,
+                row: ref_node.start_position().row,
+                start_byte: ref_node.start_byte(),
+                end_byte: ref_node.end_byte(),
             });
         }
         return;
@@ -2979,7 +3072,7 @@ fn extract_call_ref(
     // Check config member_access patterns
     for ma in config.member_access {
         if func_kind == ma.node_kind {
-            extract_member_call_ref(func, ma.object_field, ma.property_field, source, refs, row);
+            extract_member_call_ref(func, ref_node, ma.object_field, ma.property_field, source, refs);
             return;
         }
     }
@@ -2998,7 +3091,9 @@ fn extract_call_ref(
                 if !method_name.is_empty() && !is_builtin(method_name, config) {
                     refs.push(AstRef {
                         kind: AstRefKind::Call(method_name.to_string()),
-                        row,
+                        row: ref_node.start_position().row,
+                        start_byte: ref_node.start_byte(),
+                        end_byte: ref_node.end_byte(),
                     });
                 }
             } else {
@@ -3006,14 +3101,18 @@ fn extract_call_ref(
                 if !type_name.is_empty() && !method_name.is_empty() {
                     refs.push(AstRef {
                         kind: AstRefKind::Call(method_name.to_string()),
-                        row,
+                        row: ref_node.start_position().row,
+                        start_byte: ref_node.start_byte(),
+                        end_byte: ref_node.end_byte(),
                     });
                     if type_name.chars().next().map_or(false, |c| c.is_uppercase())
                         && !is_builtin(type_name, config)
                     {
                         refs.push(AstRef {
                             kind: AstRefKind::Call(type_name.to_string()),
-                            row,
+                            row: ref_node.start_position().row,
+                            start_byte: ref_node.start_byte(),
+                            end_byte: ref_node.end_byte(),
                         });
                     }
                 }
@@ -3027,11 +3126,11 @@ fn extract_call_ref(
 /// navigation_expression children don't have field names.
 fn extract_member_call_ref(
     node: tree_sitter::Node,
+    ref_node: tree_sitter::Node,
     object_field: &str,
     attr_field: &str,
     source: &[u8],
     refs: &mut Vec<AstRef>,
-    row: usize,
 ) {
     let obj_text = node
         .child_by_field_name(object_field)
@@ -3048,7 +3147,7 @@ fn extract_member_call_ref(
         .unwrap_or("");
 
     if !obj_text.is_empty() && !attr_text.is_empty() {
-        push_method_call_ref(obj_text, attr_text, refs, row);
+        push_method_call_ref(obj_text, attr_text, refs, ref_node);
         return;
     }
 
@@ -3063,18 +3162,25 @@ fn extract_member_call_ref(
             .and_then(|n| n.utf8_text(source).ok())
             .unwrap_or("");
         if !obj.is_empty() && !attr.is_empty() {
-            push_method_call_ref(obj, attr, refs, row);
+            push_method_call_ref(obj, attr, refs, ref_node);
         }
     }
 }
 
-fn push_method_call_ref(obj: &str, method: &str, refs: &mut Vec<AstRef>, row: usize) {
+fn push_method_call_ref(
+    obj: &str,
+    method: &str,
+    refs: &mut Vec<AstRef>,
+    node: tree_sitter::Node,
+) {
     refs.push(AstRef {
         kind: AstRefKind::MethodCall {
             receiver: obj.to_string(),
             method: method.to_string(),
         },
-        row,
+        row: node.start_position().row,
+        start_byte: node.start_byte(),
+        end_byte: node.end_byte(),
     });
 }
 

--- a/crates/sem-mcp/src/cache.rs
+++ b/crates/sem-mcp/src/cache.rs
@@ -6,7 +6,7 @@ use rusqlite::{params, Connection, Transaction};
 use sem_core::model::entity::SemanticEntity;
 use sem_core::parser::graph::{EntityGraph, EntityInfo, EntityRef, RefType};
 
-pub const CACHE_SCHEMA_VERSION: i32 = 1;
+pub const CACHE_SCHEMA_VERSION: i32 = 2;
 pub const CACHE_INDEXES: &[(&str, &str, &str)] = &[
     ("idx_entities_file_path", "entities", "file_path"),
     ("idx_entities_name", "entities", "name"),
@@ -898,7 +898,7 @@ mod tests {
 
     #[test]
     fn open_rebuilds_cache_when_schema_version_is_unsupported() {
-        for version in [0, CACHE_SCHEMA_VERSION + 1] {
+        for version in [0, CACHE_SCHEMA_VERSION - 1, CACHE_SCHEMA_VERSION + 1] {
             let root = temp_repo_root(&format!("unsupported-{version}"));
             seed_unsupported_cache(&root, version);
 


### PR DESCRIPTION
## Summary

- Attribute graph references to the innermost owning entity so containers do not inherit child method call edges.
- Use byte-span ownership checks to handle parent and child entities that share the same physical source line.
- Bump the shared cache schema version so cached graphs with stale phantom edges are rebuilt.

closes https://github.com/Ataraxy-Labs/sem/issues/195

## Test plan

- `cargo test -p sem-core`
- `cargo test -p sem-cli`
- `cargo test -p sem-mcp`
- `git diff --no-ext-diff --check`
- Fresh dummy git repos for TypeScript, Python, Rust, Go, and cached incremental TypeScript graph behavior
