### PR TITLE
Move SQLite cache outside working trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ If you installed via npm/bun, the binary lives in `node_modules/.bin/sem` and is
 
 Works in any Git repo. No setup required. Also works outside Git for arbitrary file comparison.
 
+sem stores its SQLite entity cache outside the repository, under the OS cache directory by default. Set `SEM_CACHE_DIR=/path/to/cache` to override the cache root; repo-local overrides are ignored so cache files do not dirty the working tree.
+
 ### sem diff
 
 Entity-level diff with rename detection, structural hashing, and word-level inline highlights.

--- a/crates/sem-cli/src/cache.rs
+++ b/crates/sem-cli/src/cache.rs
@@ -21,8 +21,10 @@ pub struct DiskCache {
 
 impl DiskCache {
     pub fn open(repo_root: &Path) -> Result<Self, rusqlite::Error> {
-        let cache_dir = repo_root.join(".sem");
-        std::fs::create_dir_all(&cache_dir).ok();
+        let cache_dir = shared_cache::cache_dir_for_repo(repo_root)
+            .ok_or_else(|| rusqlite::Error::InvalidPath(repo_root.to_path_buf()))?;
+        std::fs::create_dir_all(&cache_dir)
+            .map_err(|_| rusqlite::Error::InvalidPath(cache_dir.clone()))?;
         let db_path = cache_dir.join("cache.db");
         let conn = Connection::open(db_path)?;
 
@@ -506,7 +508,29 @@ impl DiskCache {
 mod tests {
     use super::*;
 
+    fn test_cache_root() -> &'static Path {
+        static CACHE_ROOT: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();
+
+        CACHE_ROOT
+            .get_or_init(|| {
+                let nanos = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos();
+                let root = std::env::temp_dir()
+                    .join(format!("sem-cli-test-cache-{}-{nanos}", std::process::id()));
+                std::fs::create_dir_all(&root).unwrap();
+                root
+            })
+            .as_path()
+    }
+
+    fn configure_test_cache_root() {
+        std::env::set_var("SEM_CACHE_DIR", test_cache_root());
+    }
+
     fn temp_repo_root(test_name: &str) -> std::path::PathBuf {
+        configure_test_cache_root();
         let nanos = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
@@ -530,6 +554,13 @@ mod tests {
     fn sample_files(root: &Path) -> Vec<String> {
         write_file(&root.join("sample.foo"), "export const alpha = () => 1;\n");
         vec!["sample.foo".to_string()]
+    }
+
+    fn cleanup(root: std::path::PathBuf) {
+        let _ = std::fs::remove_dir_all(&root);
+        if let Some(cache_dir) = shared_cache::cache_dir_for_repo(&root) {
+            let _ = std::fs::remove_dir_all(cache_dir);
+        }
     }
 
     fn save_empty_cache(root: &Path, files: &[String]) -> DiskCache {
@@ -594,7 +625,7 @@ mod tests {
     }
 
     fn seed_unsupported_cache(root: &Path, version: i32) {
-        let cache_dir = root.join(".sem");
+        let cache_dir = shared_cache::cache_dir_for_repo(root).unwrap();
         std::fs::create_dir_all(&cache_dir).unwrap();
         let db_path = cache_dir.join("cache.db");
         let conn = Connection::open(&db_path).unwrap();
@@ -654,7 +685,7 @@ mod tests {
         assert!(cache.load_partial(&root, &files).is_none());
 
         drop(cache);
-        let _ = std::fs::remove_dir_all(root);
+        cleanup(root);
     }
 
     #[test]
@@ -671,7 +702,7 @@ mod tests {
         assert!(cache.load_partial(&root, &files).is_none());
 
         drop(cache);
-        let _ = std::fs::remove_dir_all(root);
+        cleanup(root);
     }
 
     #[test]
@@ -688,7 +719,7 @@ mod tests {
         assert!(cache.load_partial(&root, &files).is_none());
 
         drop(cache);
-        let _ = std::fs::remove_dir_all(root);
+        cleanup(root);
     }
 
     #[test]
@@ -704,7 +735,7 @@ mod tests {
         assert!(mcp_cache.load(&cli_to_mcp, &cli_to_mcp_files).is_some());
         drop(mcp_cache);
         drop(cli_cache);
-        let _ = std::fs::remove_dir_all(cli_to_mcp);
+        cleanup(cli_to_mcp);
 
         let mcp_to_cli = temp_repo_root("mcp-to-cli");
         let mcp_to_cli_files = sample_files(&mcp_to_cli);
@@ -717,7 +748,7 @@ mod tests {
         assert!(cli_cache.load(&mcp_to_cli, &mcp_to_cli_files).is_some());
         drop(cli_cache);
         drop(mcp_cache);
-        let _ = std::fs::remove_dir_all(mcp_to_cli);
+        cleanup(mcp_to_cli);
     }
 
     #[test]
@@ -730,9 +761,23 @@ mod tests {
             shared_cache::CACHE_SCHEMA_VERSION
         );
         assert_lookup_indexes(&cache);
+        assert!(shared_cache::cache_db_path(&root).unwrap().exists());
+        assert!(!root.join(".sem").exists());
 
         drop(cache);
-        let _ = std::fs::remove_dir_all(root);
+        cleanup(root);
+    }
+
+    #[test]
+    fn open_uses_shared_external_cache_path() {
+        let root = temp_repo_root("external-path");
+        let cache = DiskCache::open(&root).unwrap();
+
+        assert!(shared_cache::cache_db_path(&root).unwrap().exists());
+        assert!(!root.join(".sem").exists());
+
+        drop(cache);
+        cleanup(root);
     }
 
     #[test]
@@ -753,7 +798,7 @@ mod tests {
             }
 
             drop(cache);
-            let _ = std::fs::remove_dir_all(root);
+            cleanup(root);
         }
     }
 }

--- a/crates/sem-cli/tests/cache_location.rs
+++ b/crates/sem-cli/tests/cache_location.rs
@@ -1,0 +1,132 @@
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use tempfile::TempDir;
+
+fn output_text(output: &Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn assert_success(output: Output, context: &str) -> Output {
+    assert!(
+        output.status.success(),
+        "{context} failed with status {:?}\n{}",
+        output.status.code(),
+        output_text(&output)
+    );
+    output
+}
+
+fn git(repo: &Path, args: &[&str]) -> Output {
+    assert_success(
+        Command::new("git")
+            .current_dir(repo)
+            .args(args)
+            .output()
+            .unwrap(),
+        &format!("git {}", args.join(" ")),
+    )
+}
+
+fn contains_cache_db(path: &Path) -> bool {
+    fs::read_dir(path).unwrap().any(|entry| {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        path.file_name().is_some_and(|name| name == "cache.db")
+            || (path.is_dir() && contains_cache_db(&path))
+    })
+}
+
+fn init_repo(repo: &Path) {
+    git(repo, &["init", "-q"]);
+    git(repo, &["config", "user.email", "t@t.com"]);
+    git(repo, &["config", "user.name", "test"]);
+
+    fs::write(repo.join("a.py"), "def f(a, b):\n    return a + b\n").unwrap();
+    git(repo, &["add", "a.py"]);
+    git(repo, &["commit", "-q", "-m", "init"]);
+}
+
+#[test]
+fn graph_cache_does_not_dirty_the_working_tree() {
+    let repo = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+
+    init_repo(repo.path());
+
+    assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("SEM_CACHE_DIR", cache.path())
+            .args(["graph", "--format", "json"])
+            .output()
+            .unwrap(),
+        "sem graph",
+    );
+
+    let status = git(repo.path(), &["status", "--porcelain"]);
+    assert_eq!(String::from_utf8_lossy(&status.stdout), "");
+    assert!(!repo.path().join(".sem").exists());
+    assert!(contains_cache_db(cache.path()));
+}
+
+#[test]
+fn graph_ignores_repo_local_cache_override() {
+    let repo = TempDir::new().unwrap();
+    let home = TempDir::new().unwrap();
+
+    init_repo(repo.path());
+
+    assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("SEM_CACHE_DIR", ".sem")
+            .env("HOME", home.path())
+            .env("USERPROFILE", home.path())
+            .env_remove("XDG_CACHE_HOME")
+            .env_remove("LOCALAPPDATA")
+            .env_remove("APPDATA")
+            .args(["graph", "--format", "json"])
+            .output()
+            .unwrap(),
+        "sem graph",
+    );
+
+    let status = git(repo.path(), &["status", "--porcelain"]);
+    assert_eq!(String::from_utf8_lossy(&status.stdout), "");
+    assert!(!repo.path().join(".sem").exists());
+    assert!(contains_cache_db(home.path()));
+}
+
+#[test]
+fn graph_ignores_repo_local_xdg_cache_home() {
+    let repo = TempDir::new().unwrap();
+    let home = TempDir::new().unwrap();
+
+    init_repo(repo.path());
+
+    assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("XDG_CACHE_HOME", ".sem")
+            .env("HOME", home.path())
+            .env("USERPROFILE", home.path())
+            .env_remove("SEM_CACHE_DIR")
+            .env_remove("LOCALAPPDATA")
+            .env_remove("APPDATA")
+            .args(["graph", "--format", "json"])
+            .output()
+            .unwrap(),
+        "sem graph",
+    );
+
+    let status = git(repo.path(), &["status", "--porcelain"]);
+    assert_eq!(String::from_utf8_lossy(&status.stdout), "");
+    assert!(!repo.path().join(".sem").exists());
+    assert!(contains_cache_db(home.path()));
+}

--- a/crates/sem-mcp/src/cache.rs
+++ b/crates/sem-mcp/src/cache.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
+use std::env;
+use std::ffi::OsString;
 use std::hash::{Hash, Hasher};
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 use rusqlite::{params, Connection, Transaction};
 use sem_core::model::entity::SemanticEntity;
@@ -76,6 +78,182 @@ pub fn initialize_schema(conn: &Connection) -> Result<(), rusqlite::Error> {
         CACHE_SCHEMA_SQL, index_sql, CACHE_SCHEMA_VERSION
     );
     conn.execute_batch(&schema_sql)
+}
+
+pub fn cache_db_path(repo_root: &Path) -> Option<PathBuf> {
+    Some(cache_dir_for_repo(repo_root)?.join("cache.db"))
+}
+
+pub fn cache_dir_for_repo(repo_root: &Path) -> Option<PathBuf> {
+    Some(cache_root(repo_root)?.join(repo_cache_key(repo_root)))
+}
+
+fn cache_root(repo_root: &Path) -> Option<PathBuf> {
+    let repo_lexical = normalize_lexical(&absolute_path(repo_root));
+    let repo_resolved = canonicalize_existing_prefix(&repo_lexical);
+
+    for candidate in cache_root_candidates() {
+        let lexical = normalize_lexical(&absolute_path(&candidate));
+        let resolved = canonicalize_existing_prefix(&lexical);
+        if path_is_external_to_repo(&lexical, &resolved, &repo_lexical, &repo_resolved) {
+            return Some(resolved);
+        }
+    }
+
+    fallback_external_cache_root(&repo_lexical, &repo_resolved)
+}
+
+fn cache_root_candidates() -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(path) = non_empty_env("SEM_CACHE_DIR") {
+        candidates.push(path);
+    }
+    if cfg!(target_os = "windows") {
+        if let Some(path) = non_empty_env("LOCALAPPDATA").or_else(|| non_empty_env("APPDATA")) {
+            candidates.push(path.join("sem").join("repos"));
+        }
+    } else {
+        if let Some(path) = non_empty_env("XDG_CACHE_HOME") {
+            candidates.push(path.join("sem").join("repos"));
+        }
+
+        if cfg!(target_os = "macos") {
+            if let Some(home) = non_empty_env("HOME") {
+                candidates.push(
+                    home.join("Library")
+                        .join("Caches")
+                        .join("sem")
+                        .join("repos"),
+                );
+            }
+        }
+    }
+
+    if let Some(home) = non_empty_env("HOME").or_else(|| non_empty_env("USERPROFILE")) {
+        candidates.push(home.join(".cache").join("sem").join("repos"));
+    }
+
+    candidates.push(env::temp_dir().join("sem").join("repos"));
+    candidates
+}
+
+fn fallback_external_cache_root(repo_lexical: &Path, repo_resolved: &Path) -> Option<PathBuf> {
+    let mut candidates = Vec::new();
+
+    if let Some(parent) = repo_resolved.parent() {
+        candidates.push(parent.join(".sem-cache").join("repos"));
+    }
+    candidates.push(env::temp_dir().join("sem").join("repos"));
+
+    for candidate in candidates {
+        let lexical = normalize_lexical(&absolute_path(&candidate));
+        let resolved = canonicalize_existing_prefix(&lexical);
+        if path_is_external_to_repo(&lexical, &resolved, repo_lexical, repo_resolved) {
+            return Some(resolved);
+        }
+    }
+
+    None
+}
+
+fn path_is_external_to_repo(
+    candidate_lexical: &Path,
+    candidate_resolved: &Path,
+    repo_lexical: &Path,
+    repo_resolved: &Path,
+) -> bool {
+    let lexical_is_inside =
+        candidate_lexical.starts_with(repo_lexical) || candidate_lexical.starts_with(repo_resolved);
+    let resolved_is_inside = candidate_resolved.starts_with(repo_lexical)
+        || candidate_resolved.starts_with(repo_resolved);
+
+    !lexical_is_inside && !resolved_is_inside
+}
+
+fn canonicalize_existing_prefix(path: &Path) -> PathBuf {
+    let mut missing = Vec::<OsString>::new();
+
+    for ancestor in path.ancestors() {
+        if let Ok(existing) = ancestor.canonicalize() {
+            let mut resolved = normalize_lexical(&existing);
+            for part in missing.iter().rev() {
+                resolved.push(part);
+            }
+            return normalize_lexical(&resolved);
+        }
+
+        if let Some(part) = ancestor.file_name() {
+            missing.push(part.to_os_string());
+        }
+    }
+
+    normalize_lexical(path)
+}
+
+fn normalize_lexical(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    let mut has_prefix = false;
+    let mut has_root = false;
+
+    for component in path.components() {
+        match component {
+            Component::Prefix(_) => {
+                has_prefix = true;
+                normalized.push(component.as_os_str());
+            }
+            Component::RootDir => {
+                has_root = true;
+                normalized.push(component.as_os_str());
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if normalized.as_os_str().is_empty() {
+                    if !has_prefix && !has_root {
+                        normalized.push("..");
+                    }
+                } else if normalized.ends_with("..") {
+                    normalized.push("..");
+                } else if !normalized.pop() {
+                    if !has_prefix && !has_root {
+                        normalized.push("..");
+                    }
+                }
+            }
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+
+    normalized
+}
+
+fn non_empty_env(name: &str) -> Option<PathBuf> {
+    env::var_os(name)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+fn repo_cache_key(repo_root: &Path) -> String {
+    let canonical = repo_root
+        .canonicalize()
+        .unwrap_or_else(|_| absolute_path(repo_root));
+    let mut hash = 0xcbf29ce484222325u64;
+
+    for byte in canonical.to_string_lossy().as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+
+    format!("{hash:016x}")
+}
+
+fn absolute_path(path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+
+    env::current_dir()
+        .map(|cwd| cwd.join(path))
+        .unwrap_or_else(|_| path.to_path_buf())
 }
 
 /// Result of a partial cache load: stale files that need reparsing, plus cached clean data.
@@ -218,8 +396,10 @@ pub struct DiskCache {
 
 impl DiskCache {
     pub fn open(repo_root: &Path) -> Result<Self, rusqlite::Error> {
-        let cache_dir = repo_root.join(".sem");
-        std::fs::create_dir_all(&cache_dir).ok();
+        let cache_dir = cache_dir_for_repo(repo_root)
+            .ok_or_else(|| rusqlite::Error::InvalidPath(repo_root.to_path_buf()))?;
+        std::fs::create_dir_all(&cache_dir)
+            .map_err(|_| rusqlite::Error::InvalidPath(cache_dir.clone()))?;
         let db_path = cache_dir.join("cache.db");
         let conn = Connection::open(db_path)?;
 
@@ -683,7 +863,29 @@ impl DiskCache {
 mod tests {
     use super::*;
 
+    fn test_cache_root() -> &'static Path {
+        static CACHE_ROOT: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();
+
+        CACHE_ROOT
+            .get_or_init(|| {
+                let nanos = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos();
+                let root = std::env::temp_dir()
+                    .join(format!("sem-mcp-test-cache-{}-{nanos}", std::process::id()));
+                std::fs::create_dir_all(&root).unwrap();
+                root
+            })
+            .as_path()
+    }
+
+    fn configure_test_cache_root() {
+        std::env::set_var("SEM_CACHE_DIR", test_cache_root());
+    }
+
     fn temp_repo_root(test_name: &str) -> std::path::PathBuf {
+        configure_test_cache_root();
         let nanos = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
@@ -707,6 +909,13 @@ mod tests {
     fn sample_files(root: &Path) -> Vec<String> {
         write_file(&root.join("sample.foo"), "export const alpha = () => 1;\n");
         vec!["sample.foo".to_string()]
+    }
+
+    fn cleanup(root: std::path::PathBuf) {
+        let _ = std::fs::remove_dir_all(&root);
+        if let Some(cache_dir) = cache_dir_for_repo(&root) {
+            let _ = std::fs::remove_dir_all(cache_dir);
+        }
     }
 
     fn save_empty_cache(root: &Path, files: &[String]) -> DiskCache {
@@ -764,7 +973,7 @@ mod tests {
     }
 
     fn seed_unsupported_cache(root: &Path, version: i32) {
-        let cache_dir = root.join(".sem");
+        let cache_dir = cache_dir_for_repo(root).unwrap();
         std::fs::create_dir_all(&cache_dir).unwrap();
         let db_path = cache_dir.join("cache.db");
         let conn = Connection::open(&db_path).unwrap();
@@ -829,7 +1038,7 @@ mod tests {
         let removed_gitattributes = compute_manifest_hash(&root, &files).unwrap();
         assert_eq!(without_gitattributes, removed_gitattributes);
 
-        let _ = std::fs::remove_dir_all(root);
+        cleanup(root);
     }
 
     #[test]
@@ -847,7 +1056,7 @@ mod tests {
         assert!(cache.load_partial(&root, &files).is_none());
 
         drop(cache);
-        let _ = std::fs::remove_dir_all(root);
+        cleanup(root);
     }
 
     #[test]
@@ -864,7 +1073,7 @@ mod tests {
         assert!(cache.load_partial(&root, &files).is_none());
 
         drop(cache);
-        let _ = std::fs::remove_dir_all(root);
+        cleanup(root);
     }
 
     #[test]
@@ -881,7 +1090,7 @@ mod tests {
         assert!(cache.load_partial(&root, &files).is_none());
 
         drop(cache);
-        let _ = std::fs::remove_dir_all(root);
+        cleanup(root);
     }
 
     #[test]
@@ -891,9 +1100,27 @@ mod tests {
 
         assert_eq!(read_user_version(&cache), CACHE_SCHEMA_VERSION);
         assert_lookup_indexes(&cache);
+        assert!(cache_db_path(&root).unwrap().exists());
+        assert!(!root.join(".sem").exists());
 
         drop(cache);
-        let _ = std::fs::remove_dir_all(root);
+        cleanup(root);
+    }
+
+    #[test]
+    fn cache_path_is_external_and_canonicalized() {
+        let root = temp_repo_root("external-path");
+        let cache_dir = cache_dir_for_repo(&root).unwrap();
+
+        assert_eq!(cache_dir, cache_dir_for_repo(&root.join(".")).unwrap());
+        assert!(!cache_dir.starts_with(&root));
+
+        let cache = DiskCache::open(&root).unwrap();
+        assert!(cache_db_path(&root).unwrap().exists());
+        assert!(!root.join(".sem").exists());
+
+        drop(cache);
+        cleanup(root);
     }
 
     #[test]
@@ -911,7 +1138,7 @@ mod tests {
             }
 
             drop(cache);
-            let _ = std::fs::remove_dir_all(root);
+            cleanup(root);
         }
     }
 }

--- a/docs/benchmarks.html
+++ b/docs/benchmarks.html
@@ -512,7 +512,7 @@
       </div>
 
       <div class="insight">
-        Two cache layers: in-memory (keyed by file manifest hash) and SQLite at <code style="color:var(--green)">.sem/cache.db</code>.
+        Two cache layers: in-memory (keyed by file manifest hash) and SQLite under the OS cache directory or <code style="color:var(--green)">SEM_CACHE_DIR</code>.
         Memory cache serves sequential calls in the same session. SQLite cache survives process restarts.
         If any file's mtime changes, the cache is invalidated and the graph rebuilds.
       </div>


### PR DESCRIPTION
## Summary
- move CLI and MCP SQLite graph caches out of repo-local .sem directories into per-repo external cache roots
- ignore cache-root candidates that resolve inside the target repository, including repo-local SEM_CACHE_DIR overrides
- add regression coverage for clean git status after cache-building commands and document SEM_CACHE_DIR

Closes #251

## Test plan
- rustfmt --check sem-mcp/src/cache.rs sem-cli/src/cache.rs sem-cli/tests/cache_location.rs
- cargo test -p sem-mcp cache::tests
- cargo test -p sem-cli cache::tests
- cargo test -p sem-cli --test cache_location
- manual dummy repos: graph/impact/context/verify with external SEM_CACHE_DIR and graph with SEM_CACHE_DIR=.sem, verifying clean git status and no repo-local .sem

## Notes
- cargo clippy -p sem-mcp -p sem-cli --all-targets -- -D warnings currently fails on existing sem-core lints unrelated to this change.