### PR TITLE
Normalize empty diff JSON output

### DIFF
--- a/crates/sem-cli/src/commands/diff.rs
+++ b/crates/sem-cli/src/commands/diff.rs
@@ -1026,7 +1026,7 @@ fn run_diff_pipeline(
     if file_changes.is_empty() {
         match opts.format {
             OutputFormat::Json => {
-                println!("{{\"summary\":{{\"fileCount\":0,\"added\":0,\"modified\":0,\"deleted\":0,\"moved\":0,\"renamed\":0,\"reordered\":0,\"orphan\":0,\"total\":0}},\"changes\":[]}}");
+                println!("{}", format_json(&DiffResult::default()));
             }
             _ => {
                 println!("\x1b[2mNo semantic changes detected.\x1b[0m");

--- a/crates/sem-cli/tests/diff_patch.rs
+++ b/crates/sem-cli/tests/diff_patch.rs
@@ -137,6 +137,24 @@ fn patch_mode_rejects_truncated_git_binary_patch() {
 }
 
 #[test]
+fn json_empty_result_shape_matches_when_clean_or_filtered_empty() {
+    let repo = TempRepo::new();
+    std::fs::write(repo.path.join("app.py"), "def foo():\n    return 1\n").expect("write app");
+    run_git(&repo.path, &["add", "app.py"]);
+    run_git(&repo.path, &["commit", "-qm", "init"]);
+
+    let clean = run_sem(&["diff", "--json"], &[], Some(&repo.path));
+    assert!(clean.status.success());
+
+    std::fs::write(repo.path.join("app.py"), "def foo():\n        return 1\n").expect("edit app");
+
+    let filtered = run_sem(&["diff", "--json", "--no-cosmetics"], &[], Some(&repo.path));
+    assert!(filtered.status.success());
+
+    assert_eq!(clean.stdout, filtered.stdout);
+}
+
+#[test]
 fn patch_mode_warns_for_malformed_hunk_without_content_resolution_warning() {
     let output = run_diff_patch(
         "diff --git a/a.ts b/a.ts\n\

--- a/crates/sem-core/src/parser/differ.rs
+++ b/crates/sem-core/src/parser/differ.rs
@@ -22,7 +22,7 @@ use crate::model::identity::match_entities;
 use crate::parser::registry::ParserRegistry;
 use std::collections::{HashMap, HashSet};
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DiffResult {
     pub changes: Vec<SemanticChange>,


### PR DESCRIPTION
## Summary

- route the no-file-change `sem diff --json` fast path through the shared JSON formatter
- add a regression test comparing clean-repo JSON with a `--no-cosmetics` filtered-empty result

Closes #274

## Test plan

- `cargo test -p sem-cli --test diff_patch json_empty_result_shape_matches_when_clean_or_filtered_empty`
- `cargo test -p sem-cli --test diff_patch`
- `cargo test -p sem-core format::json`
- `cargo test -p sem-cli --bin sem formatters::json`
- `cargo test -p sem-cli`
- Manual disposable git repos: compared clean, filtered-empty, pathspec-empty, and second clean-repo `sem diff --json` output byte-for-byte
