### PR TITLE
Align patch pathspec matching with Git

### DIFF
--- a/crates/sem-cli/src/commands/diff.rs
+++ b/crates/sem-cli/src/commands/diff.rs
@@ -78,12 +78,84 @@ fn split_on_separator(args: Vec<String>) -> (Vec<String>, Vec<String>) {
     }
 }
 
-/// Simple glob matching for pathspecs. Supports `*` (any chars except `/`),
-/// `**` (any chars including `/`), and `?` (one non-`/` char).
+/// Simple glob matching for pathspecs. Supports `*`, `**`, `?`, and bracket classes.
 fn glob_match(pattern: &str, path: &str) -> bool {
     let pat: Vec<char> = pattern.chars().collect();
     let text: Vec<char> = path.chars().collect();
     glob_match_inner(&pat, &text)
+}
+
+fn posix_bracket_class_matches(name: &str, ch: char) -> Option<bool> {
+    match name {
+        "alnum" => Some(ch.is_ascii_alphanumeric()),
+        "alpha" => Some(ch.is_ascii_alphabetic()),
+        "blank" => Some(ch == ' ' || ch == '\t'),
+        "cntrl" => Some(ch.is_ascii_control()),
+        "digit" => Some(ch.is_ascii_digit()),
+        "graph" => Some(ch.is_ascii_graphic()),
+        "lower" => Some(ch.is_ascii_lowercase()),
+        "print" => Some(ch.is_ascii_graphic() || ch == ' '),
+        "punct" => Some(ch.is_ascii_punctuation()),
+        "space" => Some(ch.is_ascii_whitespace()),
+        "upper" => Some(ch.is_ascii_uppercase()),
+        "xdigit" => Some(ch.is_ascii_hexdigit()),
+        _ => None,
+    }
+}
+
+fn match_posix_bracket_class(pat: &[char], ch: char) -> Option<(bool, usize)> {
+    if !matches!((pat.first(), pat.get(1)), (Some(&'['), Some(&':'))) {
+        return None;
+    }
+
+    for idx in 2..pat.len().saturating_sub(1) {
+        if pat[idx] == ':' && pat[idx + 1] == ']' {
+            let name: String = pat[2..idx].iter().collect();
+            return posix_bracket_class_matches(&name, ch).map(|matched| (matched, idx + 2));
+        }
+    }
+
+    None
+}
+
+fn match_bracket_class(pat: &[char], ch: char) -> Option<(bool, usize)> {
+    if pat.first() != Some(&'[') {
+        return None;
+    }
+
+    let mut idx = 1;
+    let negated = matches!(pat.get(idx), Some('!' | '^'));
+    if negated {
+        idx += 1;
+    }
+
+    let class_start = idx;
+    let mut matched = false;
+
+    while idx < pat.len() {
+        if pat[idx] == ']' && idx > class_start {
+            return Some((matched != negated, idx + 1));
+        }
+
+        if let Some((posix_matched, consumed)) = match_posix_bracket_class(&pat[idx..], ch) {
+            matched |= posix_matched;
+            idx += consumed;
+        } else if idx + 2 < pat.len() && pat[idx + 1] == '-' && pat[idx + 2] != ']' {
+            let start = pat[idx];
+            let end = pat[idx + 2];
+            if start <= ch && ch <= end {
+                matched = true;
+            }
+            idx += 3;
+        } else {
+            if pat[idx] == ch {
+                matched = true;
+            }
+            idx += 1;
+        }
+    }
+
+    None
 }
 
 fn glob_match_inner(pat: &[char], text: &[char]) -> bool {
@@ -91,14 +163,22 @@ fn glob_match_inner(pat: &[char], text: &[char]) -> bool {
         return text.is_empty();
     }
 
-    // Handle ** (matches any chars including /)
+    // Handle ** (matches any chars, with **/ advancing on path boundaries)
     if pat.len() >= 2 && pat[0] == '*' && pat[1] == '*' {
-        let rest = if pat.len() > 2 && pat[2] == '/' {
-            &pat[3..]
-        } else {
-            &pat[2..]
-        };
-        // Try matching ** against 0..n chars
+        if pat.len() > 2 && pat[2] == '/' {
+            let rest = &pat[3..];
+            if glob_match_inner(rest, text) {
+                return true;
+            }
+            for i in 0..text.len() {
+                if text[i] == '/' && glob_match_inner(rest, &text[i + 1..]) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        let rest = &pat[2..];
         for i in 0..=text.len() {
             if glob_match_inner(rest, &text[i..]) {
                 return true;
@@ -107,12 +187,9 @@ fn glob_match_inner(pat: &[char], text: &[char]) -> bool {
         return false;
     }
 
-    // Handle * (matches any chars except /)
+    // Handle * (matches any chars)
     if pat[0] == '*' {
         for i in 0..=text.len() {
-            if i > 0 && text[i - 1] == '/' {
-                break;
-            }
             if glob_match_inner(&pat[1..], &text[i..]) {
                 return true;
             }
@@ -120,23 +197,42 @@ fn glob_match_inner(pat: &[char], text: &[char]) -> bool {
         return false;
     }
 
-    // Handle ? (matches one non-/ char)
+    // Handle ? (matches one char)
     if pat[0] == '?' {
-        return !text.is_empty() && text[0] != '/' && glob_match_inner(&pat[1..], &text[1..]);
+        return !text.is_empty() && glob_match_inner(&pat[1..], &text[1..]);
+    }
+
+    // Handle bracket character classes.
+    if pat[0] == '[' {
+        if let Some((class_matches, consumed)) = text
+            .first()
+            .and_then(|ch| match_bracket_class(pat, *ch))
+        {
+            return class_matches && glob_match_inner(&pat[consumed..], &text[1..]);
+        }
     }
 
     // Literal character
     !text.is_empty() && pat[0] == text[0] && glob_match_inner(&pat[1..], &text[1..])
 }
 
-/// Check if a file path matches a pathspec (supports prefix matching and basic globs).
-fn path_matches_spec(file_path: &str, spec: &str) -> bool {
-    if spec.contains('*') || spec.contains('?') || spec.contains('[') {
-        glob_match(spec, file_path)
-    } else if spec.ends_with('/') {
-        file_path.starts_with(spec.trim_end_matches('/'))
+fn literal_pathspec_matches(file_path: &str, spec: &str) -> bool {
+    if spec.ends_with('/') {
+        let dir = spec.trim_end_matches('/');
+        file_path.starts_with(&format!("{dir}/"))
     } else {
         file_path == spec || file_path.starts_with(&format!("{spec}/"))
+    }
+}
+
+/// Check if a file path matches a pathspec (supports prefix matching and basic globs).
+fn path_matches_spec(file_path: &str, spec: &str) -> bool {
+    if literal_pathspec_matches(file_path, spec) {
+        true
+    } else if spec.contains('*') || spec.contains('?') || spec.contains('[') {
+        glob_match(spec, file_path)
+    } else {
+        false
     }
 }
 
@@ -1239,6 +1335,39 @@ mod tests {
         assert!(!is_unified_hunk_header("@@ NOTAHUNK @@"));
         assert!(!is_unified_hunk_header("@@ -1 +1@@"));
         assert!(!is_unified_hunk_header("@@ -1, +1 @@"));
+    }
+
+    #[test]
+    fn pathspec_matching_respects_directory_boundaries() {
+        assert!(!path_matches_spec("src", "src/"));
+        assert!(path_matches_spec("src/a.py", "src/"));
+        assert!(path_matches_spec("src/nested/a.py", "src/"));
+        assert!(!path_matches_spec("src2/a.py", "src/"));
+        assert!(path_matches_spec("a[12].py", "a[12].py"));
+        assert!(path_matches_spec("a[12].py/nested.py", "a[12].py"));
+    }
+
+    #[test]
+    fn glob_matching_supports_bracket_classes() {
+        assert!(glob_match("a[12].py", "a1.py"));
+        assert!(glob_match("a[12].py", "a2.py"));
+        assert!(!glob_match("a[12].py", "a3.py"));
+        assert!(glob_match("a[1-3].py", "a2.py"));
+        assert!(glob_match("a[!3].py", "a2.py"));
+        assert!(!glob_match("a[!3].py", "a3.py"));
+        assert!(glob_match("a[^3].py", "a2.py"));
+        assert!(glob_match("a[[:digit:]].py", "a2.py"));
+        assert!(!glob_match("a[[:digit:]].py", "aa.py"));
+        assert!(glob_match("a[![:digit:]].py", "aa.py"));
+        assert!(!glob_match("a[![:digit:]].py", "a2.py"));
+        assert!(glob_match("a[ab].py", "aa.py"));
+        assert!(glob_match("a?b.py", "a/b.py"));
+        assert!(glob_match("a[/]b.py", "a/b.py"));
+        assert!(glob_match("*.py", "src/nested/a.py"));
+        assert!(glob_match("**/a.py", "src/nested/a.py"));
+        assert!(glob_match("**/a.py", "a.py"));
+        assert!(!glob_match("**/a.py", "nested-a.py"));
+        assert!(glob_match("a[12.py", "a[12.py"));
     }
 
     #[test]

--- a/crates/sem-cli/tests/diff_patch.rs
+++ b/crates/sem-cli/tests/diff_patch.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
@@ -72,6 +73,24 @@ fn run_sem(args: &[&str], input: &[u8], cwd: Option<&Path>) -> Output {
 
 fn run_diff_patch(input: &str) -> Output {
     run_sem(&["diff", "--patch"], input.as_bytes(), None)
+}
+
+fn json_file_paths(output: &Output) -> BTreeSet<String> {
+    assert!(
+        output.status.success(),
+        "sem failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be json");
+    json["changes"]
+        .as_array()
+        .expect("changes should be an array")
+        .iter()
+        .filter_map(|change| change["filePath"].as_str().map(str::to_owned))
+        .collect()
 }
 
 fn changed_app_patch() -> (TempRepo, Vec<u8>) {
@@ -248,4 +267,135 @@ fn patch_mode_pathspec_matches_renamed_old_path() {
     assert!(output.status.success());
     assert!(stdout.contains("greet"));
     assert!(!stdout.contains("No semantic changes detected."));
+}
+
+#[test]
+fn patch_mode_directory_pathspec_does_not_match_sibling_prefixes() {
+    let repo = TempRepo::new();
+    std::fs::create_dir(repo.path.join("src")).expect("create src");
+    std::fs::create_dir(repo.path.join("src2")).expect("create src2");
+    std::fs::write(repo.path.join("src/a.py"), "def a():\n    return 1\n").expect("write src file");
+    std::fs::write(repo.path.join("src2/a.py"), "def b():\n    return 1\n")
+        .expect("write src2 file");
+    run_git(&repo.path, &["add", "."]);
+    run_git(&repo.path, &["commit", "-qm", "init"]);
+
+    std::fs::write(repo.path.join("src/a.py"), "def a():\n    return 2\n")
+        .expect("change src file");
+    std::fs::write(repo.path.join("src2/a.py"), "def b():\n    return 2\n")
+        .expect("change src2 file");
+
+    let patch = run_git(&repo.path, &["diff"]).stdout;
+    let output = run_sem(
+        &["diff", "--patch", "--json", "--", "src/"],
+        &patch,
+        Some(&repo.path),
+    );
+
+    let paths = json_file_paths(&output);
+    assert_eq!(paths, BTreeSet::from(["src/a.py".to_string()]));
+}
+
+#[test]
+fn patch_mode_pathspec_matches_bracket_character_classes() {
+    let repo = TempRepo::new();
+    std::fs::write(repo.path.join("a1.py"), "def f():\n    return 1\n").expect("write a1");
+    std::fs::write(repo.path.join("a2.py"), "def g():\n    return 1\n").expect("write a2");
+    std::fs::write(repo.path.join("a3.py"), "def h():\n    return 1\n").expect("write a3");
+    std::fs::write(repo.path.join("a[12].py"), "def literal():\n    return 1\n")
+        .expect("write literal bracket path");
+    run_git(&repo.path, &["add", "."]);
+    run_git(&repo.path, &["commit", "-qm", "init"]);
+
+    std::fs::write(repo.path.join("a1.py"), "def f():\n    return 2\n").expect("change a1");
+    std::fs::write(repo.path.join("a2.py"), "def g():\n    return 2\n").expect("change a2");
+    std::fs::write(repo.path.join("a3.py"), "def h():\n    return 2\n").expect("change a3");
+    std::fs::write(repo.path.join("a[12].py"), "def literal():\n    return 2\n")
+        .expect("change literal bracket path");
+    run_git(&repo.path, &["add", "."]);
+
+    let patch = run_git(&repo.path, &["diff", "--cached"]).stdout;
+    let output = run_sem(
+        &["diff", "--patch", "--json", "--", "a[12].py"],
+        &patch,
+        Some(&repo.path),
+    );
+
+    let paths = json_file_paths(&output);
+    assert_eq!(
+        paths,
+        BTreeSet::from([
+            "a1.py".to_string(),
+            "a2.py".to_string(),
+            "a[12].py".to_string(),
+        ])
+    );
+}
+
+#[test]
+fn patch_mode_pathspec_matches_posix_bracket_classes() {
+    let repo = TempRepo::new();
+    std::fs::write(repo.path.join("a1.py"), "def f():\n    return 1\n").expect("write a1");
+    std::fs::write(repo.path.join("a2.py"), "def g():\n    return 1\n").expect("write a2");
+    std::fs::write(repo.path.join("aa.py"), "def h():\n    return 1\n").expect("write aa");
+    run_git(&repo.path, &["add", "."]);
+    run_git(&repo.path, &["commit", "-qm", "init"]);
+
+    std::fs::write(repo.path.join("a1.py"), "def f():\n    return 2\n").expect("change a1");
+    std::fs::write(repo.path.join("a2.py"), "def g():\n    return 2\n").expect("change a2");
+    std::fs::write(repo.path.join("aa.py"), "def h():\n    return 2\n").expect("change aa");
+    run_git(&repo.path, &["add", "."]);
+
+    let patch = run_git(&repo.path, &["diff", "--cached"]).stdout;
+    let output = run_sem(
+        &["diff", "--patch", "--json", "--", "a[[:digit:]].py"],
+        &patch,
+        Some(&repo.path),
+    );
+
+    let paths = json_file_paths(&output);
+    assert_eq!(
+        paths,
+        BTreeSet::from(["a1.py".to_string(), "a2.py".to_string()])
+    );
+}
+
+#[test]
+fn patch_mode_pathspec_wildcards_match_nested_paths_like_git() {
+    let repo = TempRepo::new();
+    std::fs::create_dir_all(repo.path.join("src/nested")).expect("create nested dir");
+    std::fs::write(repo.path.join("root.py"), "def root():\n    return 1\n")
+        .expect("write root");
+    std::fs::write(
+        repo.path.join("src/nested/child.py"),
+        "def child():\n    return 1\n",
+    )
+    .expect("write child");
+    run_git(&repo.path, &["add", "."]);
+    run_git(&repo.path, &["commit", "-qm", "init"]);
+
+    std::fs::write(repo.path.join("root.py"), "def root():\n    return 2\n")
+        .expect("change root");
+    std::fs::write(
+        repo.path.join("src/nested/child.py"),
+        "def child():\n    return 2\n",
+    )
+    .expect("change child");
+    run_git(&repo.path, &["add", "."]);
+
+    let patch = run_git(&repo.path, &["diff", "--cached"]).stdout;
+    let output = run_sem(
+        &["diff", "--patch", "--json", "--", "*.py"],
+        &patch,
+        Some(&repo.path),
+    );
+
+    let paths = json_file_paths(&output);
+    assert_eq!(
+        paths,
+        BTreeSet::from([
+            "root.py".to_string(),
+            "src/nested/child.py".to_string(),
+        ])
+    );
 }


### PR DESCRIPTION
## Summary

- Fix `sem diff --patch` directory pathspec filtering so `src/` does not match sibling prefixes like `src2/`.
- Add bracket-class pathspec matching, including ranges, negation, POSIX classes, and exact literal paths containing brackets.
- Align patch-mode wildcard matching with Git default pathspec behavior for nested paths.

Closes #269

## Test plan

- `cargo test -p sem-cli --test diff_patch`
- `cargo test -p sem-cli glob_matching_supports_bracket_classes && cargo test -p sem-cli pathspec_matching_respects_directory_boundaries`
- `cargo test -p sem-cli`
- Manual temp-repo parity checks comparing `git diff --name-only -- <pathspec>` with `git diff | sem diff --patch --json -- <pathspec>` for `src/`, `*.py`, `a[12].py`, and `a[[:digit:]].py`