### PR TITLE
Gate Swift scope resolution benchmark

### DIFF
--- a/crates/sem-core/src/parser/scope_resolve.rs
+++ b/crates/sem-core/src/parser/scope_resolve.rs
@@ -1857,25 +1857,47 @@ fn scan_swift_property_declaration(
     source: &[u8],
     instance_attr_types: &mut HashMap<(String, String), String>,
 ) {
-    // Swift property_declaration has a "name" (via pattern binding) and type annotation
+    let mut pending_names: Vec<String> = Vec::new();
     let mut cursor = node.walk();
+
     for child in node.named_children(&mut cursor) {
-        if child.kind() == "pattern" || child.kind() == "simple_identifier" || child.kind() == "identifier" {
-            let field_name = child.utf8_text(source).unwrap_or("");
-            if let Some(type_ann) = node.child_by_field_name("type") {
-                let type_text = extract_base_type(type_ann, source);
-                if !field_name.is_empty()
-                    && !type_text.is_empty()
-                    && type_text.chars().next().map_or(false, |c| c.is_uppercase())
-                {
-                    instance_attr_types.insert(
-                        (class_name.to_string(), field_name.to_string()),
-                        type_text,
-                    );
+        match child.kind() {
+            "pattern" | "simple_identifier" | "identifier" => {
+                if let Some(name) = swift_property_pattern_name(child, source) {
+                    pending_names.push(name);
                 }
             }
+            "type_annotation" | "user_type" | "type_identifier" => {
+                let type_text = extract_base_type(child, source);
+                let field_names = std::mem::take(&mut pending_names);
+                if !type_text.is_empty()
+                    && type_text.chars().next().map_or(false, |c| c.is_uppercase())
+                {
+                    for field_name in field_names {
+                        instance_attr_types.insert(
+                            (class_name.to_string(), field_name),
+                            type_text.clone(),
+                        );
+                    }
+                }
+            }
+            _ => {}
         }
     }
+}
+
+fn swift_property_pattern_name(node: tree_sitter::Node, source: &[u8]) -> Option<String> {
+    if node.kind() == "simple_identifier" || node.kind() == "identifier" {
+        return node.utf8_text(source).ok().map(str::to_string);
+    }
+
+    let mut cursor = node.walk();
+    let found = node
+        .named_children(&mut cursor)
+        .find(|child| matches!(child.kind(), "simple_identifier" | "identifier"))
+        .and_then(|child| child.utf8_text(source).ok())
+        .map(str::to_string);
+    found
 }
 
 /// Kotlin: extract typed property declarations `val conn: Connection`
@@ -3204,6 +3226,37 @@ fn resolve_ref(
                 if let Some(members) = class_members.get(class_name.as_str()) {
                     if let Some((_, mid)) = members.iter().find(|(n, _)| n == method) {
                         return Some((mid.clone(), RefType::Calls, "type_tracking"));
+                    }
+                }
+            }
+
+            // Inside class methods, unqualified property receivers resolve
+            // against the enclosing instance when no local binding shadows them.
+            let from_entity_is_container_type = entity_map.get(from_entity_id).map_or(false, |entity| {
+                matches!(
+                    entity.entity_type.as_str(),
+                    "class"
+                        | "struct"
+                        | "interface"
+                        | "enum"
+                        | "protocol_declaration"
+                        | "object_declaration"
+                        | "companion_object"
+                )
+            });
+
+            if !from_entity_is_container_type
+                && !is_local_binding_in_scopes(scope_idx, scopes, receiver)
+            {
+                if let Some(class_name) = find_enclosing_class(scope_idx, scopes, entity_map) {
+                    if let Some(attr_type) =
+                        instance_attr_types.get(&(class_name, receiver.to_string()))
+                    {
+                        if let Some(members) = class_members.get(attr_type.as_str()) {
+                            if let Some((_, mid)) = members.iter().find(|(n, _)| n == method) {
+                                return Some((mid.clone(), RefType::Calls, "type_tracking"));
+                            }
+                        }
                     }
                 }
             }

--- a/crates/sem-core/tests/fixtures/scope_test/swift/database.swift
+++ b/crates/sem-core/tests/fixtures/scope_test/swift/database.swift
@@ -8,6 +8,10 @@ class Connection {
     func close() {}
 }
 
+class Logger {
+    func record(message: String) {}
+}
+
 class Transaction {
     var conn: Connection
 
@@ -24,6 +28,34 @@ class Transaction {
     }
 
     func rollback() {}
+}
+
+class Replicator {
+    var primary, backup: Connection
+
+    init(primary: Connection, backup: Connection) {
+        self.primary = primary
+        self.backup = backup
+    }
+
+    func sync() {
+        primary.execute(query: "SELECT 1")
+        backup.commit()
+    }
+}
+
+class AuditedTransaction {
+    var conn: Connection, logger: Logger
+
+    init(conn: Connection, logger: Logger) {
+        self.conn = conn
+        self.logger = logger
+    }
+
+    func write() {
+        conn.commit()
+        logger.record(message: "done")
+    }
 }
 
 func getConnection() -> Connection {

--- a/crates/sem-core/tests/scope_resolve_bench.rs
+++ b/crates/sem-core/tests/scope_resolve_bench.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use sem_core::model::entity::SemanticEntity;
-use sem_core::parser::graph::{EntityGraph, EntityInfo, RefType};
+use sem_core::parser::graph::{EntityGraph, EntityInfo};
 use sem_core::parser::plugins::create_default_registry;
 use sem_core::parser::scope_resolve;
 
@@ -796,6 +796,20 @@ fn run_scope_resolve_for_lang(
     if new_edges.is_empty() && !old_edges.is_empty() {
         eprintln!("  NOTE [{}]: Scope resolver produced 0 edges (config may need tuning)", lang_name);
     }
+
+    // Languages with complete expected coverage gate CI on the scored result.
+    if lang_name == "swift" {
+        assert_eq!(
+            new_fn, 0,
+            "{} scope resolver missed {} expected edges; see MISSED lines above",
+            lang_name, new_fn
+        );
+        assert_eq!(
+            new_fp, 0,
+            "{} scope resolver produced {} forbidden edges; see FALSE POSITIVE lines above",
+            lang_name, new_fp
+        );
+    }
 }
 
 #[test]
@@ -1126,6 +1140,10 @@ fn get_swift_expected_edges() -> Vec<(&'static str, &'static str, &'static str)>
         // database.swift internal
         ("Transaction::execute", "execute", "Transaction.execute calls conn.execute"),
         ("Transaction::commit", "commit", "Transaction.commit calls conn.commit"),
+        ("Replicator::sync", "execute", "Replicator.sync calls primary.execute"),
+        ("Replicator::sync", "commit", "Replicator.sync calls backup.commit"),
+        ("AuditedTransaction::write", "commit", "AuditedTransaction.write calls conn.commit"),
+        ("AuditedTransaction::write", "record", "AuditedTransaction.write calls logger.record"),
     ]
 }
 


### PR DESCRIPTION
## Summary

- resolve Swift stored-property receiver calls inside class methods, such as `conn.execute()` on `Transaction.conn`
- make the Swift scope-resolution benchmark fail when expected Swift edges are missed or forbidden edges are produced
- leave other language scope benchmarks informational because they still have known expected misses

Fixes #261

## Test plan

- `cargo test -q -p sem-core --test scope_resolve_bench scope_resolve_swift -- --nocapture`
- `cargo test -q -p sem-core --test scope_resolve_bench`
- `cargo test -q -p sem-core`
- `cargo build -q -p sem-cli`
- `cargo test -q -p sem-cli --test diff_file_compare`
- dummy Swift git repo: verified `Transaction.execute -> Connection.execute` and `Transaction.commit -> Connection.commit` via `sem graph --json --no-cache --file-exts .swift`
- dummy Swift git repo: verified a local `conn = Logger()` receiver resolves to `Logger.execute` and does not fall back to `Connection.execute`