### PR TITLE
Bound sem log history scans

### DIFF
--- a/crates/sem-cli/src/commands/log.rs
+++ b/crates/sem-cli/src/commands/log.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::Path;
 
 use colored::Colorize;
@@ -138,21 +139,14 @@ pub fn log_command(opts: LogOptions) {
         }
     }
 
-    let use_file_history = git_file_path.as_deref().is_some_and(|path| {
-        bridge
-            .get_head_sha()
-            .ok()
-            .and_then(|head| entity_by_name_at_ref(&bridge, &registry, &head, path, &opts.entity_name))
-            .is_some()
-    });
-
-    let mut commits = if use_file_history {
+    let history_limit = history_limit_with_baseline(opts.limit);
+    let mut commits = if git_file_path.is_some() {
         let path = git_file_path.as_deref().unwrap();
-        match bridge.get_file_commits_follow_renames(path, 0) {
+        match bridge.get_file_commits_follow_renames(path, history_limit) {
             Ok(file_commits) if !file_commits.is_empty() => {
                 file_commits.into_iter().map(|info| info.commit).collect()
             }
-            Ok(_) => match bridge.get_log(0) {
+            Ok(_) => match bridge.get_log(history_limit) {
                 Ok(c) => c,
                 Err(e) => {
                     eprintln!("{} Failed to get history: {}", "error:".red().bold(), e);
@@ -160,12 +154,16 @@ pub fn log_command(opts: LogOptions) {
                 }
             },
             Err(e) => {
-                eprintln!("{} Failed to get file history: {}", "error:".red().bold(), e);
+                eprintln!(
+                    "{} Failed to get file history: {}",
+                    "error:".red().bold(),
+                    e
+                );
                 std::process::exit(1);
             }
         }
     } else {
-        match bridge.get_log(0) {
+        match bridge.get_log(history_limit) {
             Ok(c) => c,
             Err(e) => {
                 eprintln!("{} Failed to get history: {}", "error:".red().bold(), e);
@@ -180,7 +178,8 @@ pub fn log_command(opts: LogOptions) {
     }
     commits.reverse();
 
-    let total_commits = commits.len();
+    let total_commits = scanned_commit_count(commits.len(), opts.limit);
+    let scanned_commits = scanned_commit_shas(&commits, opts.limit);
     let Some(seed) = find_seed_occurrence(
         &bridge,
         &registry,
@@ -203,9 +202,8 @@ pub fn log_command(opts: LogOptions) {
     let entity_type = seed.entity.entity_type.clone();
     let mut entries = trace_back_to_origin(&bridge, &registry, &commits, seed.clone());
     entries.extend(trace_forward_from_seed(&bridge, &registry, &commits, seed));
-    if opts.limit != 0 && entries.len() > opts.limit {
-        let drop_count = entries.len() - opts.limit;
-        entries.drain(0..drop_count);
+    if let Some(scanned_commits) = &scanned_commits {
+        entries.retain(|entry| scanned_commits.contains(&entry.sha));
     }
 
     let first_seen = entries.first().map(|e| e.date.clone()).unwrap_or_default();
@@ -246,6 +244,35 @@ pub fn log_command(opts: LogOptions) {
             opts.verbose,
         );
     }
+}
+
+fn history_limit_with_baseline(limit: usize) -> usize {
+    if limit == 0 {
+        0
+    } else {
+        limit.saturating_add(1)
+    }
+}
+
+fn scanned_commit_count(commit_count: usize, limit: usize) -> usize {
+    if limit == 0 {
+        commit_count
+    } else {
+        commit_count.min(limit)
+    }
+}
+
+fn scanned_commit_shas(commits: &[CommitInfo], limit: usize) -> Option<HashSet<String>> {
+    if limit == 0 || commits.len() <= limit {
+        return None;
+    }
+
+    Some(
+        commits[commits.len() - limit..]
+            .iter()
+            .map(|commit| commit.sha.clone())
+            .collect(),
+    )
 }
 
 fn find_seed_occurrence(

--- a/crates/sem-cli/src/main.rs
+++ b/crates/sem-cli/src/main.rs
@@ -206,7 +206,7 @@ enum Commands {
         #[arg(long)]
         file: Option<String>,
 
-        /// Maximum number of commits to scan
+        /// Maximum number of commits to scan (0 = unlimited)
         #[arg(long, default_value = "50")]
         limit: usize,
 

--- a/crates/sem-cli/tests/log_cli.rs
+++ b/crates/sem-cli/tests/log_cli.rs
@@ -1,0 +1,113 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn git(repo: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .current_dir(repo)
+        .args(args)
+        .output()
+        .expect("run git");
+
+    assert!(
+        output.status.success(),
+        "git {args:?} failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn commit_all(repo: &Path, message: &str) {
+    git(repo, &["add", "-A"]);
+    git(repo, &["commit", "-q", "-m", message]);
+}
+
+fn init_repo() -> TempDir {
+    let repo = TempDir::new().expect("create temporary repo");
+    git(repo.path(), &["init", "-q"]);
+    git(repo.path(), &["config", "user.email", "test@example.com"]);
+    git(repo.path(), &["config", "user.name", "Test User"]);
+    git(repo.path(), &["config", "commit.gpgsign", "false"]);
+    repo
+}
+
+fn sem_log_json(repo: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_sem"))
+        .current_dir(repo)
+        .args(["log"])
+        .args(args)
+        .args(["--json"])
+        .output()
+        .expect("run sem log")
+}
+
+#[test]
+fn log_limit_bounds_history_scan_for_deleted_entities() {
+    let repo = init_repo();
+
+    fs::write(repo.path().join("a.py"), "def foo():\n    return 1\n").expect("write a.py");
+    commit_all(repo.path(), "add foo");
+
+    fs::write(repo.path().join("a.py"), "def foo():\n    return 2\n").expect("modify a.py");
+    commit_all(repo.path(), "modify foo");
+
+    fs::write(repo.path().join("a.py"), "").expect("delete foo");
+    commit_all(repo.path(), "delete foo");
+
+    fs::write(repo.path().join("b.py"), "def bar():\n    return 1\n").expect("write b.py");
+    commit_all(repo.path(), "add bar");
+
+    fs::write(repo.path().join("c.py"), "def baz():\n    return 1\n").expect("write c.py");
+    commit_all(repo.path(), "add baz");
+
+    let output = sem_log_json(repo.path(), &["foo", "--file", "a.py", "--limit", "2"]);
+    assert!(
+        output.status.success(),
+        "sem log failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("parse json");
+    let changes = json["changes"].as_array().expect("changes array");
+    assert_eq!(changes.len(), 2);
+    assert_eq!(changes[0]["change_type"], "modified (logic)");
+    assert_eq!(changes[0]["commit"]["message"], "modify foo");
+    assert_eq!(changes[1]["change_type"], "deleted");
+    assert_eq!(changes[1]["commit"]["message"], "delete foo");
+}
+
+#[test]
+fn log_limit_is_not_applied_as_result_entry_truncation() {
+    let repo = init_repo();
+
+    fs::write(repo.path().join("a.py"), "def foo():\n    return 1\n").expect("write a.py");
+    commit_all(repo.path(), "v1");
+
+    fs::write(repo.path().join("a.py"), "def foo():\n    return 2\n").expect("modify a.py");
+    commit_all(repo.path(), "v2");
+
+    fs::write(repo.path().join("a.py"), "def foo():\n    return 3\n").expect("modify a.py");
+    commit_all(repo.path(), "v3");
+
+    fs::write(repo.path().join("a.py"), "def foo():\n    return 4\n").expect("modify a.py");
+    commit_all(repo.path(), "v4");
+
+    let output = sem_log_json(repo.path(), &["foo", "--file", "a.py", "--limit", "2"]);
+    assert!(
+        output.status.success(),
+        "sem log failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("parse json");
+    let changes = json["changes"].as_array().expect("changes array");
+    assert_eq!(changes.len(), 2);
+    assert_eq!(changes[0]["change_type"], "modified (logic)");
+    assert_eq!(changes[0]["commit"]["message"], "v3");
+    assert_eq!(changes[1]["change_type"], "modified (logic)");
+    assert_eq!(changes[1]["commit"]["message"], "v4");
+}


### PR DESCRIPTION
Closes #275\n\n## Summary\n- pass the sem log limit into history collection instead of scanning all commits\n- keep one baseline commit for accurate oldest-window change classification\n- use file history for explicit file lookups, including deleted entities\n- add CLI integration tests with dummy Git repositories\n\n## Test plan\n- cargo test --manifest-path crates/sem-cli/Cargo.toml --test log_cli\n- cargo test --manifest-path crates/sem-cli/Cargo.toml\n- cargo test --manifest-path crates/Cargo.toml --workspace --no-run\n- manual dummy Git repo checks for deleted entities, current entities, and --limit 0