### PR TITLE
Parse diff ref path arguments

### DIFF
--- a/crates/sem-cli/src/commands/diff.rs
+++ b/crates/sem-cli/src/commands/diff.rs
@@ -78,6 +78,22 @@ fn split_on_separator(args: Vec<String>) -> (Vec<String>, Vec<String>) {
     }
 }
 
+fn looks_like_pathspec(arg: &str) -> bool {
+    arg.starts_with(':') || arg.contains('*') || arg.contains('?') || arg.contains('[')
+}
+
+fn get_git_bridge<'a>(git: &'a mut Option<Option<GitBridge>>, cwd: &str) -> Option<&'a GitBridge> {
+    if git.is_none() {
+        *git = Some(GitBridge::open(Path::new(cwd)).ok());
+    }
+
+    git.as_ref().and_then(|git| git.as_ref())
+}
+
+fn is_valid_git_rev(git: &mut Option<Option<GitBridge>>, cwd: &str, arg: &str) -> bool {
+    get_git_bridge(git, cwd).is_some_and(|git| git.is_valid_rev(arg))
+}
+
 /// Simple glob matching for pathspecs. Supports `*` (any chars except `/`),
 /// `**` (any chars including `/`), and `?` (one non-`/` char).
 fn glob_match(pattern: &str, path: &str) -> bool {
@@ -232,9 +248,9 @@ fn normalize_trailing_output_format(opts: &mut DiffOptions) {
     opts.args = args;
 }
 
-
 fn parse_args(args: Vec<String>, cwd: &str) -> ParsedArgs {
     let (refs, pathspecs) = split_on_separator(args);
+    let mut git = None;
 
     if refs.is_empty() {
         return ParsedArgs {
@@ -275,6 +291,11 @@ fn parse_args(args: Vec<String>, cwd: &str) -> ParsedArgs {
 
         // If it exists as a file or directory on disk, treat as pathspec
         if Path::new(cwd).join(arg).exists() {
+            if is_valid_git_rev(&mut git, cwd, arg) {
+                eprintln!(
+                    "warning: '{arg}' is both a git revision and a path; treating it as a pathspec"
+                );
+            }
             let mut pathspecs = pathspecs;
             pathspecs.push(arg.clone());
             return ParsedArgs {
@@ -284,7 +305,7 @@ fn parse_args(args: Vec<String>, cwd: &str) -> ParsedArgs {
         }
 
         // If the arg contains glob meta-characters, treat as pathspec
-        if arg.contains('*') || arg.contains('?') || arg.contains('[') {
+        if looks_like_pathspec(arg) {
             let mut pathspecs = pathspecs;
             pathspecs.push(arg.clone());
             return ParsedArgs {
@@ -303,6 +324,23 @@ fn parse_args(args: Vec<String>, cwd: &str) -> ParsedArgs {
     if refs.len() == 2 {
         let a = &refs[0];
         let b = &refs[1];
+        let b_exists = Path::new(cwd).join(b).exists();
+        let b_looks_like_pathspec = b_exists || looks_like_pathspec(b);
+
+        // git diff <ref> <path> treats the second positional argument as a
+        // pathspec when only the first argument resolves as a revision.
+        if pathspecs.is_empty() && b_looks_like_pathspec {
+            let a_is_rev = is_valid_git_rev(&mut git, cwd, a);
+            let b_is_rev = is_valid_git_rev(&mut git, cwd, b);
+            if a_is_rev && !b_is_rev {
+                let mut pathspecs = pathspecs;
+                pathspecs.push(b.clone());
+                return ParsedArgs {
+                    scope: Some(ParsedScope::RefToWorking(a.clone())),
+                    pathspecs,
+                };
+            }
+        }
 
         // If both exist as files on disk and no pathspecs, treat as file comparison
         if pathspecs.is_empty()
@@ -426,7 +464,6 @@ fn is_git_binary_payload_line(line: &str) -> bool {
 
 fn parse_unified_diff(patch: &str, cwd: &str) -> Result<Vec<FileChange>, PatchParseError> {
     use sem_core::git::types::FileStatus;
-
 
     struct PatchEntry {
         file_path: String,
@@ -871,9 +908,10 @@ pub fn diff_command(mut opts: DiffOptions) {
             changes
                 .into_iter()
                 .filter(|fc| {
-                    parsed.pathspecs.iter().any(|spec| {
-                        file_change_matches_spec(fc, spec)
-                    })
+                    parsed
+                        .pathspecs
+                        .iter()
+                        .any(|spec| file_change_matches_spec(fc, spec))
                 })
                 .collect()
         };

--- a/crates/sem-cli/tests/diff_file_compare.rs
+++ b/crates/sem-cli/tests/diff_file_compare.rs
@@ -22,6 +22,193 @@ fn run_sem_json(dir: &PathBuf, home: &PathBuf, args: &[&str]) -> std::process::O
         .expect("sem should run")
 }
 
+fn run_git(dir: &PathBuf, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("git should run");
+    assert!(
+        output.status.success(),
+        "git {} failed\nstdout: {}\nstderr: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn init_git_repo(dir: &PathBuf) {
+    run_git(dir, &["init", "-q"]);
+    run_git(dir, &["config", "user.email", "a@b.co"]);
+    run_git(dir, &["config", "user.name", "a"]);
+}
+
+#[test]
+fn ref_plus_path_positional_arg_filters_to_pathspec() {
+    let dir = temp_dir("ref-plus-path-positional");
+    let home = temp_dir("ref-plus-path-positional-home");
+    init_git_repo(&dir);
+    fs::write(dir.join("app.py"), "def foo():\n    return 1\n")
+        .expect("source file should be written");
+    fs::write(dir.join("other.py"), "def bar():\n    return 1\n")
+        .expect("source file should be written");
+    run_git(&dir, &["add", "."]);
+    run_git(&dir, &["commit", "-qm", "c1"]);
+
+    fs::write(dir.join("app.py"), "def foo():\n    return 2\n")
+        .expect("source file should be written");
+    fs::write(dir.join("other.py"), "def bar():\n    return 2\n")
+        .expect("source file should be written");
+
+    let output = run_sem_json(&dir, &home, &["diff", "HEAD", "app.py", "--format", "json"]);
+    assert!(
+        output.status.success(),
+        "sem failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be json");
+    let changes = json["changes"]
+        .as_array()
+        .expect("changes should be an array");
+    assert!(!changes.is_empty(), "{json:?}");
+    assert!(
+        changes
+            .iter()
+            .all(|change| change["filePath"].as_str() == Some("app.py")),
+        "{changes:?}"
+    );
+
+    let _ = fs::remove_dir_all(dir);
+    let _ = fs::remove_dir_all(home);
+}
+
+#[test]
+fn ref_plus_missing_path_reports_an_error() {
+    let dir = temp_dir("ref-plus-missing-path");
+    let home = temp_dir("ref-plus-missing-path-home");
+    init_git_repo(&dir);
+    fs::write(dir.join("app.py"), "def foo():\n    return 1\n")
+        .expect("source file should be written");
+    run_git(&dir, &["add", "."]);
+    run_git(&dir, &["commit", "-qm", "c1"]);
+
+    let output = run_sem_json(
+        &dir,
+        &home,
+        &["diff", "HEAD", "missing.py", "--format", "json"],
+    );
+    assert!(
+        !output.status.success(),
+        "sem unexpectedly succeeded\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("missing.py"), "{stderr}");
+
+    let _ = fs::remove_dir_all(dir);
+    let _ = fs::remove_dir_all(home);
+}
+
+#[test]
+fn two_ref_positional_args_remain_range() {
+    let dir = temp_dir("two-ref-positional-range");
+    let home = temp_dir("two-ref-positional-range-home");
+    init_git_repo(&dir);
+    fs::write(dir.join("app.py"), "def foo():\n    return 1\n")
+        .expect("source file should be written");
+    run_git(&dir, &["add", "."]);
+    run_git(&dir, &["commit", "-qm", "c1"]);
+    fs::write(dir.join("app.py"), "def foo():\n    return 2\n")
+        .expect("source file should be written");
+    run_git(&dir, &["commit", "-qam", "c2"]);
+    fs::write(dir.join("app.py"), "def foo():\n    return 3\n")
+        .expect("source file should be written");
+
+    let output = run_sem_json(&dir, &home, &["diff", "HEAD~1", "HEAD", "--format", "json"]);
+    assert!(
+        output.status.success(),
+        "sem failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be json");
+    let changes = json["changes"]
+        .as_array()
+        .expect("changes should be an array");
+    let change = changes
+        .iter()
+        .find(|change| change["filePath"].as_str() == Some("app.py"))
+        .expect("app.py change should be present");
+    assert!(
+        change["afterContent"]
+            .as_str()
+            .is_some_and(|content| content.contains("return 2")),
+        "{change:?}"
+    );
+    assert!(
+        !change["afterContent"]
+            .as_str()
+            .is_some_and(|content| content.contains("return 3")),
+        "{change:?}"
+    );
+
+    let _ = fs::remove_dir_all(dir);
+    let _ = fs::remove_dir_all(home);
+}
+
+#[test]
+fn ambiguous_single_name_warns_and_uses_pathspec() {
+    let dir = temp_dir("ambiguous-single-name");
+    let home = temp_dir("ambiguous-single-name-home");
+    init_git_repo(&dir);
+    fs::write(dir.join("app.py"), "def foo():\n    return 1\n")
+        .expect("source file should be written");
+    run_git(&dir, &["add", "."]);
+    run_git(&dir, &["commit", "-qm", "c1"]);
+    fs::write(dir.join("app.py"), "def foo():\n    return 2\n")
+        .expect("source file should be written");
+    run_git(&dir, &["commit", "-qam", "c2"]);
+    run_git(&dir, &["branch", "app.py", "HEAD~1"]);
+    fs::write(dir.join("app.py"), "def foo():\n    return 3\n")
+        .expect("source file should be written");
+
+    let output = run_sem_json(&dir, &home, &["diff", "app.py", "--format", "json"]);
+    assert!(
+        output.status.success(),
+        "sem failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("both a git revision and a path")
+            && stderr.contains("treating it as a pathspec"),
+        "{stderr}"
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be json");
+    let changes = json["changes"]
+        .as_array()
+        .expect("changes should be an array");
+    assert!(!changes.is_empty(), "{json:?}");
+    assert!(
+        changes
+            .iter()
+            .all(|change| change["filePath"].as_str() == Some("app.py")),
+        "{changes:?}"
+    );
+
+    let _ = fs::remove_dir_all(dir);
+    let _ = fs::remove_dir_all(home);
+}
+
 #[test]
 fn cross_language_file_compare_uses_each_side_path() {
     let dir = temp_dir("cross-language-file-compare");


### PR DESCRIPTION
Closes #270

## Summary
- Parse `sem diff <ref> <path>` as a ref-to-working-tree diff filtered by the pathspec when the first positional argument is a revision and the second is an existing path or explicit pathspec.
- Warn when a single positional argument is both an on-disk path and a Git revision, while continuing to treat it as a pathspec.
- Preserve missing-path errors and two-revision range parsing.

## Test plan
- `rustfmt --check crates/sem-cli/src/commands/diff.rs crates/sem-cli/tests/diff_file_compare.rs`
- `cargo test -p sem-cli --test diff_file_compare`
- `cargo test -p sem-cli`
- Manual dummy Git repos validating `sem diff HEAD app.py`, `sem diff HEAD missing.py`, `sem diff HEAD~1 HEAD`, and the branch/file ambiguity warning.