### PR TITLE
Suppress Swift local property entities

### DIFF
--- a/crates/sem-core/src/parser/graph.rs
+++ b/crates/sem-core/src/parser/graph.rs
@@ -2304,6 +2304,59 @@ class UserService {
     }
 
     #[test]
+    fn test_swift_local_bindings_do_not_become_graph_nodes() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "Mini.swift", "\
+func connect() -> Int { return 0 }
+func conn() -> Int { return 1 }
+
+func build() -> Int {
+    let conn = { 2 }
+    return conn() + connect()
+}
+");
+
+        let (graph, _) = EntityGraph::build(root, &["Mini.swift".into()], &registry);
+        let names: Vec<&str> = graph.entities.values().map(|entity| entity.name.as_str()).collect();
+
+        assert!(names.contains(&"connect"), "got: {:?}", names);
+        assert!(names.contains(&"conn"), "got: {:?}", names);
+        assert!(names.contains(&"build"), "got: {:?}", names);
+
+        let connect_id = graph
+            .entities
+            .values()
+            .find(|entity| entity.name == "connect")
+            .map(|entity| entity.id.clone())
+            .expect("connect entity should exist");
+        let dependents = graph.get_dependents(&connect_id);
+        let dependent_names: Vec<&str> = dependents.iter().map(|entity| entity.name.as_str()).collect();
+
+        assert!(dependent_names.contains(&"build"), "got: {:?}", dependent_names);
+        assert!(!dependent_names.contains(&"conn"), "got: {:?}", dependent_names);
+        assert!(
+            graph.edges.iter().all(|edge| !edge.from_entity.ends_with("::conn")),
+            "local binding should not create edges. Edges: {:?}",
+            graph.edges
+        );
+
+        let conn_id = graph
+            .entities
+            .values()
+            .find(|entity| entity.name == "conn")
+            .map(|entity| entity.id.clone())
+            .expect("conn entity should exist");
+        let conn_dependents = graph.get_dependents(&conn_id);
+        assert!(
+            conn_dependents.is_empty(),
+            "local binding should not depend on same-named function. Dependents: {:?}",
+            conn_dependents.iter().map(|entity| &entity.name).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
     fn test_dot_chain_class_static() {
         let (dir, registry) = create_test_repo();
         let root = dir.path();

--- a/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
+++ b/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
@@ -1172,14 +1172,22 @@ fn find_declarator_name_range(mut node: Node) -> Option<(usize, usize)> {
 }
 
 fn extract_name(node: Node, source: &[u8]) -> Option<String> {
+    let node_type = node.kind();
+
+    if node_type == "deinit_declaration" {
+        return Some("deinit".to_string());
+    }
+
+    if node_type == "subscript_declaration" {
+        return Some("subscript".to_string());
+    }
+
     // Try 'name' field first (works for most languages)
     if let Some(name_node) = node.child_by_field_name("name") {
         return Some(node_text(name_node, source).to_string());
     }
 
     // For variable/lexical declarations, try to get the declarator name
-    let node_type = node.kind();
-
     // For Rust impl blocks, construct unique name from trait + type
     // e.g. "impl Display for Foo" -> "Display for Foo", "impl Foo" -> "Foo"
     if node_type == "impl_item" {

--- a/crates/sem-core/src/parser/plugins/code/languages.rs
+++ b/crates/sem-core/src/parser/plugins/code/languages.rs
@@ -405,6 +405,32 @@ const CPP_SUPPRESSED_NESTED: &[SuppressedNestedEntity] = &[
 
 const CPP_SCOPE_BOUNDARIES: &[&str] = &["lambda_expression"];
 
+/// Inside Swift body-bearing declarations, suppress local `let`/`var`
+/// bindings so they remain part of the enclosing entity instead of becoming
+/// addressable property entities.
+const SWIFT_SUPPRESSED_NESTED: &[SuppressedNestedEntity] = &[
+    SuppressedNestedEntity {
+        parent_entity_node_type: "function_declaration",
+        child_entity_node_type: "property_declaration",
+    },
+    SuppressedNestedEntity {
+        parent_entity_node_type: "init_declaration",
+        child_entity_node_type: "property_declaration",
+    },
+    SuppressedNestedEntity {
+        parent_entity_node_type: "deinit_declaration",
+        child_entity_node_type: "property_declaration",
+    },
+    SuppressedNestedEntity {
+        parent_entity_node_type: "subscript_declaration",
+        child_entity_node_type: "property_declaration",
+    },
+    SuppressedNestedEntity {
+        parent_entity_node_type: "property_declaration",
+        child_entity_node_type: "property_declaration",
+    },
+];
+
 #[cfg(feature = "lang-typescript")]
 static TYPESCRIPT_CONFIG: LanguageConfig = LanguageConfig {
     id: "typescript",
@@ -707,9 +733,9 @@ static SWIFT_CONFIG: LanguageConfig = LanguageConfig {
         "operator_declaration",
         "associatedtype_declaration",
     ],
-    container_node_types: &["class_body", "protocol_body", "enum_class_body", "struct_body", "function_body"],
+    container_node_types: &["class_body", "protocol_body", "enum_class_body", "struct_body", "function_body", "computed_property"],
     call_entity_identifiers: &[],
-    suppressed_nested_entities: &[],
+    suppressed_nested_entities: SWIFT_SUPPRESSED_NESTED,
     scope_boundary_types: &[],
     get_language: get_swift,
     scope_resolve: Some(&SWIFT_SCOPE_CONFIG),
@@ -1421,13 +1447,13 @@ static PHP_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
 static SWIFT_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     class_scope_nodes: &["class_declaration", "protocol_declaration", "struct_declaration", "enum_declaration"],
     impl_scope_nodes: &["extension_declaration"],
-    function_scope_nodes: &["function_declaration", "init_declaration"],
+    function_scope_nodes: &["function_declaration", "init_declaration", "deinit_declaration", "subscript_declaration", "property_declaration"],
     class_name_field: ClassNameField::Simple("name"),
 
     assignment_rules: &[
         AssignmentRule { node_kind: "property_declaration", strategy: AssignmentStrategy::Declarators },
     ],
-    assignment_recurse_into: &["function_body", "code_block", "statements"],
+    assignment_recurse_into: &["function_body", "computed_property", "code_block", "statements"],
 
     param_rules: &[
         ParamRule { node_kind: "parameter", name_field: ParamNameField::Simple("name"), type_field: "type", skip_names: &[] },

--- a/crates/sem-core/src/parser/plugins/code/mod.rs
+++ b/crates/sem-core/src/parser/plugins/code/mod.rs
@@ -343,6 +343,91 @@ func helper(x: Int) -> Int {
     }
 
     #[test]
+    fn test_swift_body_locals_not_extracted_as_properties() {
+        let code = r#"
+class Cache {
+    var stored: Int
+
+    var computed: Int {
+        let computedLocal = stored + 1
+        func computedNested() -> Int {
+            return computedLocal
+        }
+        return computedNested()
+    }
+
+    var explicit: Int {
+        get {
+            let getterLocal = stored
+            func getterNested() -> Int {
+                return getterLocal
+            }
+            return getterNested()
+        }
+    }
+
+    init(seed: Int) {
+        let initial = seed
+        self.stored = initial
+    }
+
+    func value() -> Int {
+        let doubled = stored * 2
+        var offset = doubled + 1
+        func nested() -> Int {
+            let insideNested = offset
+            return insideNested
+        }
+        return nested()
+    }
+
+    subscript(index: Int) -> Int {
+        let shifted = index + stored
+        func subscriptNested() -> Int {
+            return shifted
+        }
+        return subscriptNested()
+    }
+
+    deinit {
+        let closing = stored
+        _ = closing
+    }
+}
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "Cache.swift");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+
+        assert!(names.contains(&"Cache"), "got: {:?}", names);
+        assert!(names.contains(&"stored"), "got: {:?}", names);
+        assert!(names.contains(&"computed"), "got: {:?}", names);
+        assert!(names.contains(&"explicit"), "got: {:?}", names);
+        assert!(names.contains(&"init"), "got: {:?}", names);
+        assert!(names.contains(&"value"), "got: {:?}", names);
+        assert!(names.contains(&"computedNested"), "got: {:?}", names);
+        assert!(names.contains(&"getterNested"), "got: {:?}", names);
+        assert!(names.contains(&"nested"), "got: {:?}", names);
+        assert!(names.contains(&"subscriptNested"), "got: {:?}", names);
+        assert!(names.contains(&"subscript"), "got: {:?}", names);
+        assert!(names.contains(&"deinit"), "got: {:?}", names);
+        assert!(!names.contains(&"Int"), "got: {:?}", names);
+
+        for local in [
+            "computedLocal",
+            "getterLocal",
+            "initial",
+            "doubled",
+            "offset",
+            "insideNested",
+            "shifted",
+            "closing",
+        ] {
+            assert!(!names.contains(&local), "{local} should not be an entity. Got: {:?}", names);
+        }
+    }
+
+    #[test]
     fn test_swift_conditional_compilation_inside_struct() {
         let code = r#"
 import ArgumentParser

--- a/crates/sem-core/src/parser/scope_resolve.rs
+++ b/crates/sem-core/src/parser/scope_resolve.rs
@@ -80,7 +80,7 @@ pub struct ResolutionEntry {
     pub from_entity: String,
     pub reference: String,
     pub resolved_to: Option<String>,
-    pub method: &'static str, // "scope_chain", "type_tracking", "import", "unresolved"
+    pub method: &'static str, // "scope_chain", "type_tracking", "import", "unresolved", "local_binding"
 }
 
 /// Resolve references using tree-sitter scope analysis.
@@ -397,6 +397,15 @@ pub(crate) fn resolve_with_scopes_full(
                 let start_row = entity.start_line.saturating_sub(1); // 1-indexed to 0-indexed
                 let end_row = entity.end_line; // exclusive
 
+                for binding in local_bindings_in_scope_chain(scope_idx, &scopes) {
+                    file_log.push(ResolutionEntry {
+                        from_entity: entity.id.clone(),
+                        reference: binding,
+                        resolved_to: None,
+                        method: "local_binding",
+                    });
+                }
+
                 // Filter pre-collected refs to this entity's line range
                 for ast_ref in all_file_refs.iter().filter(|r| r.row >= start_row && r.row < end_row) {
                     // Skip self-name refs (was previously done during collection)
@@ -677,9 +686,7 @@ fn build_scopes_from_ast(
         let is_function_like = config.function_scope_nodes.contains(&kind);
 
         if is_function_like {
-            let func_name = node.child_by_field_name("name")
-                .and_then(|n| n.utf8_text(source).ok())
-                .unwrap_or("");
+            let func_name = scope_entity_name(node, source);
 
             let parent_scope = if config.external_method && kind == "method_declaration" {
                 let receiver_type = node.utf8_text(source).ok()
@@ -765,6 +772,30 @@ fn build_scopes_from_ast(
             worklist.push((child, current_scope));
         }
     }
+}
+
+fn scope_entity_name(node: tree_sitter::Node, source: &[u8]) -> String {
+    match node.kind() {
+        "deinit_declaration" => "deinit".to_string(),
+        "subscript_declaration" => "subscript".to_string(),
+        _ => node.child_by_field_name("name")
+            .and_then(|n| n.utf8_text(source).ok())
+            .unwrap_or("")
+            .to_string(),
+    }
+}
+
+fn local_bindings_in_scope_chain(start_scope: usize, scopes: &[Scope]) -> Vec<String> {
+    let mut bindings = HashSet::new();
+    let mut idx = Some(start_scope);
+    while let Some(scope_idx) = idx {
+        bindings.extend(scopes[scope_idx].bindings.iter().cloned());
+        idx = scopes[scope_idx].parent;
+    }
+
+    let mut bindings: Vec<_> = bindings.into_iter().collect();
+    bindings.sort();
+    bindings
 }
 
 /// Scan for variable assignments and record type bindings.
@@ -1035,6 +1066,8 @@ fn scan_ts_var_declaration(
         };
 
         if !var_name.is_empty() {
+            scopes[scope_idx].bindings.insert(var_name.clone());
+
             // Check for type annotation
             if let Some(type_ann) = node.child_by_field_name("type") {
                 let type_text = extract_base_type(type_ann, source);


### PR DESCRIPTION
Fixes #254

## Summary
- suppress Swift local `let`/`var` property declarations inside function-like bodies so they do not become semantic entities
- add stable extraction/scope names for Swift `deinit` and `subscript` declarations
- preserve nested declarations in Swift computed property, getter, and subscript bodies while suppressing local bindings
- consume scope-local bindings before graph fallback resolution to avoid false edges to same-named entities

## Test plan
- `cargo test -p sem-core swift -- --nocapture`
- `cargo test -p sem-core`
- dummy Swift git repos validated `sem entities`, `sem graph --no-cache --json --file-exts .swift`, and `sem impact ... --no-cache --json --file-exts .swift`

## Review
- independent code reviewer findings addressed
- `claude -p` reviewer was launched twice but produced no output and hung; both processes were terminated cleanly
