### PR TITLE
Extract JavaScript object literal method entities

### DIFF
--- a/crates/sem-core/src/parser/differ.rs
+++ b/crates/sem-core/src/parser/differ.rs
@@ -213,6 +213,7 @@ fn suppress_redundant_parents(
         "export",
         "package",
         "field",
+        "variable",
         "svelte_instance_script",
         "svelte_module_script",
         "object",
@@ -339,22 +340,68 @@ fn strip_children_content(
     parent_start_line: usize,
     children: &[&SemanticEntity],
 ) -> String {
-    let lines: Vec<&str> = content.lines().collect();
-    let mut excluded: HashSet<usize> = HashSet::new();
+    let mut line_starts = vec![0];
+    for (idx, ch) in content.char_indices() {
+        if ch == '\n' {
+            line_starts.push(idx + ch.len_utf8());
+        }
+    }
+
+    let mut excluded_ranges: Vec<(usize, usize)> = Vec::new();
     for child in children {
         let start_idx = child.start_line.saturating_sub(parent_start_line);
         let end_idx = child.end_line.saturating_sub(parent_start_line);
-        for i in start_idx..=end_idx.max(start_idx) {
-            if i < lines.len() {
-                excluded.insert(i);
+        let search_start = line_starts.get(start_idx).copied().unwrap_or(0);
+        let search_end = line_starts
+            .get(end_idx.saturating_add(1))
+            .copied()
+            .unwrap_or(content.len())
+            .min(content.len());
+
+        if !child.content.is_empty() && search_start <= search_end {
+            if let Some(relative_start) = content[search_start..search_end].find(&child.content) {
+                let start = search_start + relative_start;
+                excluded_ranges.push((start, start + child.content.len()));
+                continue;
             }
         }
     }
-    lines
-        .iter()
-        .enumerate()
-        .filter(|(i, _)| !excluded.contains(i))
-        .map(|(_, l)| l.trim())
+
+    if excluded_ranges.is_empty() {
+        return normalize_content_for_parent_suppression(content);
+    }
+
+    excluded_ranges.sort_unstable();
+    let mut merged_ranges: Vec<(usize, usize)> = Vec::new();
+    for (start, end) in excluded_ranges {
+        if let Some((_, merged_end)) = merged_ranges.last_mut() {
+            if start <= *merged_end {
+                *merged_end = (*merged_end).max(end);
+                continue;
+            }
+        }
+        merged_ranges.push((start, end));
+    }
+
+    let mut stripped = String::with_capacity(content.len());
+    let mut cursor = 0;
+    for (start, end) in merged_ranges {
+        if cursor < start {
+            stripped.push_str(&content[cursor..start]);
+        }
+        cursor = end.max(cursor);
+    }
+    if cursor < content.len() {
+        stripped.push_str(&content[cursor..]);
+    }
+
+    normalize_content_for_parent_suppression(&stripped)
+}
+
+fn normalize_content_for_parent_suppression(content: &str) -> String {
+    content
+        .lines()
+        .map(|l| l.trim())
         .filter(|l| !l.is_empty())
         .collect::<Vec<_>>()
         .join(" ")
@@ -770,6 +817,131 @@ mod tests {
         assert!(
             !result.changes.iter().any(|c| c.entity_type == "field"),
             "field containers should be suppressed when only a nested method changed, got: {changes:?}"
+        );
+    }
+
+    #[test]
+    fn test_nested_typescript_object_literal_diff_reports_leaf_method() {
+        let before = r#"export const svc = {
+  open(): number { return 1; },
+  close(): number { return 0; },
+};
+"#;
+        let after = r#"export const svc = {
+  open(): number { return 2; },
+  close(): number { return 0; },
+};
+"#;
+
+        let registry = create_default_registry();
+        let result = compute_semantic_diff(
+            &[modified_file("service.ts", before, after)],
+            &registry,
+            None,
+            None,
+        );
+
+        let changes: Vec<_> = result
+            .changes
+            .iter()
+            .map(|c| (c.entity_name.as_str(), c.entity_type.as_str()))
+            .collect();
+        assert!(
+            result
+                .changes
+                .iter()
+                .any(|c| c.entity_id == "service.ts::variable::svc::open"),
+            "expected object-literal method leaf change, got: {changes:?}"
+        );
+        assert!(
+            !result
+                .changes
+                .iter()
+                .any(|c| c.entity_name == "svc" && c.entity_type == "variable"),
+            "variable container should be suppressed when only a nested method changed, got: {changes:?}"
+        );
+    }
+
+    #[test]
+    fn test_nested_typescript_object_literal_pair_diff_reports_leaf_methods() {
+        let before = r#"export const svc = {
+  reset: () => 1,
+  flush: function() { return 0; },
+};
+"#;
+        let after = r#"export const svc = {
+  reset: () => 2,
+  flush: function() { return 3; },
+};
+"#;
+
+        let registry = create_default_registry();
+        let result = compute_semantic_diff(
+            &[modified_file("service.ts", before, after)],
+            &registry,
+            None,
+            None,
+        );
+
+        let changes: Vec<_> = result
+            .changes
+            .iter()
+            .map(|c| (c.entity_name.as_str(), c.entity_type.as_str()))
+            .collect();
+        assert!(
+            result
+                .changes
+                .iter()
+                .any(|c| c.entity_id == "service.ts::variable::svc::reset"),
+            "expected arrow-valued object method change, got: {changes:?}"
+        );
+        assert!(
+            result
+                .changes
+                .iter()
+                .any(|c| c.entity_id == "service.ts::variable::svc::flush"),
+            "expected function-valued object method change, got: {changes:?}"
+        );
+        assert!(
+            !result
+                .changes
+                .iter()
+                .any(|c| c.entity_name == "svc" && c.entity_type == "variable"),
+            "variable container should be suppressed when only nested function-valued properties changed, got: {changes:?}"
+        );
+    }
+
+    #[test]
+    fn test_inline_typescript_object_literal_keeps_parent_variable_changes() {
+        let before = "export const svc = { open() { return 1; }, enabled: true };\n";
+        let after = "export let svc = { open() { return 2; }, enabled: false };\n";
+
+        let registry = create_default_registry();
+        let result = compute_semantic_diff(
+            &[modified_file("service.ts", before, after)],
+            &registry,
+            None,
+            None,
+        );
+
+        let changes: Vec<_> = result
+            .changes
+            .iter()
+            .map(|c| (c.entity_name.as_str(), c.entity_type.as_str()))
+            .collect();
+        assert!(
+            result
+                .changes
+                .iter()
+                .any(|c| c.entity_id == "service.ts::variable::svc::open"),
+            "expected nested method change, got: {changes:?}"
+        );
+        assert!(
+            result
+                .changes
+                .iter()
+                .any(|c| c.entity_name == "svc" && c.entity_type == "variable"),
+            "parent variable change should remain visible, got: {changes:?}"
         );
     }
 

--- a/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
+++ b/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
@@ -268,11 +268,11 @@ fn visit_node(
                     // their own, so their initializer is traversed under the
                     // surrounding parent, matching the single-declarator path.
                     let initializer_parent = emitted_entity_id.as_deref().or(parent_id);
-                    if let Some(initializer_child) =
-                        js_ts_initializer_child(config, *declarator, initializer_parent)
-                    {
-                        initializer_children.push(initializer_child);
-                    }
+                    initializer_children.extend(js_ts_initializer_children(
+                        config,
+                        *declarator,
+                        initializer_parent,
+                    ));
                 }
                 // The worklist is LIFO; push in reverse so initializers are
                 // visited in source order.
@@ -381,6 +381,31 @@ fn visit_node(
                 }
                 continue;
             }
+        }
+
+        if let Some((name, value)) =
+            extract_js_ts_object_function_pair(node, config, source, suppression_context)
+        {
+            let content = node_text(node, source).to_string();
+            let struct_hash = compute_structural_hash(node, source);
+            let entity = SemanticEntity {
+                id: build_entity_id(file_path, "method", &name, parent_id),
+                file_path: file_path.to_string(),
+                entity_type: "method".to_string(),
+                name,
+                parent_id: parent_id.map(String::from),
+                content_hash: content_hash(&content),
+                structural_hash: Some(struct_hash),
+                content,
+                start_line: node.start_position().row + 1,
+                end_line: node.end_position().row + 1,
+                metadata: None,
+            };
+
+            let entity_id = entity.id.clone();
+            entities.push(entity);
+            worklist.push((value, Some(entity_id), Some(value.kind().to_string())));
+            continue;
         }
 
         if config.entity_node_types.contains(&node_type) {
@@ -1074,6 +1099,14 @@ fn find_name_byte_range(node: Node, _source: &[u8]) -> Option<(usize, usize)> {
         for child in node.named_children(&mut cursor) {
             if child.kind() == "module_type_name" {
                 return Some((child.start_byte(), child.end_byte()));
+            }
+        }
+    }
+
+    if node_type == "pair" {
+        if let Some(key) = node.child_by_field_name("key") {
+            if js_ts_object_key_name(key, _source).is_some() {
+                return Some((key.start_byte(), key.end_byte()));
             }
         }
     }
@@ -1898,26 +1931,63 @@ fn push_js_ts_initializer_children<'tree>(
     node: Node<'tree>,
     entity_id: &str,
 ) {
-    if let Some(initializer_child) = js_ts_initializer_child(config, node, Some(entity_id)) {
+    let initializer_children = js_ts_initializer_children(config, node, Some(entity_id));
+    for initializer_child in initializer_children.into_iter().rev() {
         worklist.push(initializer_child);
     }
 }
 
-fn js_ts_initializer_child<'tree>(
+fn js_ts_initializer_children<'tree>(
     config: &LanguageConfig,
     node: Node<'tree>,
     parent_id: Option<&str>,
-) -> Option<(Node<'tree>, Option<String>, Option<String>)> {
+) -> Vec<(Node<'tree>, Option<String>, Option<String>)> {
     if !matches!(config.id, "typescript" | "tsx" | "javascript") {
-        return None;
+        return Vec::new();
     }
 
-    let value = js_ts_initializer_value(config, node)?;
-    Some((
+    let Some(value) = js_ts_initializer_value(config, node) else {
+        return Vec::new();
+    };
+
+    if value.kind() == "object" {
+        return js_ts_object_initializer_children(value, parent_id);
+    }
+
+    vec![(
         value,
         parent_id.map(String::from),
         Some(value.kind().to_string()),
-    ))
+    )]
+}
+
+fn js_ts_object_initializer_children<'tree>(
+    object: Node<'tree>,
+    parent_id: Option<&str>,
+) -> Vec<(Node<'tree>, Option<String>, Option<String>)> {
+    let mut cursor = object.walk();
+    object
+        .named_children(&mut cursor)
+        .filter_map(|child| {
+            let suppression_context = if child.kind() == "method_definition" {
+                Some(child.kind().to_string())
+            } else if js_ts_pair_function_value(child).is_some() {
+                Some("object".to_string())
+            } else {
+                None
+            };
+
+            if let Some(suppression_context) = suppression_context {
+                Some((
+                    child,
+                    parent_id.map(String::from),
+                    Some(suppression_context),
+                ))
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 fn js_ts_initializer_value<'tree>(
@@ -1940,7 +2010,59 @@ fn js_ts_initializer_value<'tree>(
 }
 
 fn is_js_ts_initializer_node(config: &LanguageConfig, node: Node) -> bool {
-    config.scope_boundary_types.contains(&node.kind()) || node.kind() == "class"
+    config.scope_boundary_types.contains(&node.kind()) || matches!(node.kind(), "class" | "object")
+}
+
+fn extract_js_ts_object_function_pair<'tree>(
+    node: Node<'tree>,
+    config: &LanguageConfig,
+    source: &[u8],
+    suppression_context: Option<&str>,
+) -> Option<(String, Node<'tree>)> {
+    if !matches!(config.id, "typescript" | "tsx" | "javascript")
+        || suppression_context != Some("object")
+    {
+        return None;
+    }
+
+    let value = js_ts_pair_function_value(node)?;
+    let key = node.child_by_field_name("key")?;
+    Some((js_ts_object_key_name(key, source)?, value))
+}
+
+fn js_ts_pair_function_value(node: Node) -> Option<Node> {
+    if node.kind() != "pair" {
+        return None;
+    }
+
+    let value = node.child_by_field_name("value")?;
+    matches!(
+        value.kind(),
+        "arrow_function" | "function_expression" | "generator_function"
+    )
+    .then_some(value)
+}
+
+fn js_ts_object_key_name(key: Node, source: &[u8]) -> Option<String> {
+    let text = node_text(key, source).trim();
+    if text.is_empty() || text.starts_with('[') {
+        return None;
+    }
+
+    let name = match key.kind() {
+        "string" | "template_string" => text
+            .trim_matches('"')
+            .trim_matches('\'')
+            .trim_matches('`')
+            .to_string(),
+        _ => text.to_string(),
+    };
+
+    if name.is_empty() || (key.kind() == "template_string" && name.contains("${")) {
+        return None;
+    }
+
+    Some(name)
 }
 
 /// Dart constructor signatures use `field("name", seq(identifier, optional(".", identifier)))`,

--- a/crates/sem-core/src/parser/plugins/code/mod.rs
+++ b/crates/sem-core/src/parser/plugins/code/mod.rs
@@ -649,6 +649,68 @@ class L1 {
     }
 
     #[test]
+    fn test_typescript_object_literal_methods_are_nested_under_variable() {
+        let code = r#"
+export const svc = {
+  open(): void {},
+  close(): void {},
+  reset: () => {
+    class ResetJob {}
+    return new ResetJob();
+  },
+  flush: function() {
+    return true;
+  },
+  "key${x}": () => true,
+  "": () => false,
+  [Symbol.iterator]: function() {},
+  value: 1,
+};
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "service.ts");
+        let find = |name: &str| {
+            entities.iter().find(|e| e.name == name).unwrap_or_else(|| {
+                panic!(
+                    "missing {name}; got: {:?}",
+                    entities
+                        .iter()
+                        .map(|e| (&e.name, &e.entity_type, &e.parent_id))
+                        .collect::<Vec<_>>()
+                )
+            })
+        };
+
+        let svc = find("svc");
+        assert_eq!(svc.entity_type, "variable");
+        let svc_id = svc.id.clone();
+
+        for name in ["open", "close", "reset", "flush", "key${x}"] {
+            let method = find(name);
+            assert_eq!(method.entity_type, "method");
+            assert_eq!(method.parent_id.as_deref(), Some(svc_id.as_str()));
+        }
+
+        let reset = find("reset");
+        let reset_job = find("ResetJob");
+        assert_eq!(reset_job.entity_type, "class");
+        assert_eq!(reset_job.parent_id.as_deref(), Some(reset.id.as_str()));
+        assert_eq!(find("open").id, "service.ts::variable::svc::open");
+        assert!(
+            entities.iter().all(|e| e.name != "value"),
+            "non-function object properties should not become entities"
+        );
+        assert!(
+            entities.iter().all(|e| !e.name.is_empty()),
+            "empty object keys should not become entities"
+        );
+        assert!(
+            entities.iter().all(|e| e.name != "[Symbol.iterator]"),
+            "computed object keys should not become entities"
+        );
+    }
+
+    #[test]
     fn test_nested_functions_python() {
         let code = "def outer():\n    def inner():\n        return 42\n    return inner()\n";
         let plugin = CodeParserPlugin;


### PR DESCRIPTION
## Summary
- Extract JS/TS object-literal shorthand methods and function-valued properties under variable/field initializer entities
- Preserve nested diff granularity for object-literal methods while avoiding redundant variable container changes
- Tighten parent suppression to remove exact child content ranges so same-line parent/sibling changes remain visible

Fixes #266

## Test plan
- cargo test -p sem-core
- cargo test -p sem-cli
- Built target/debug/sem and validated sem entities / sem diff against disposable git repos for shorthand methods, arrow/function-valued object properties, ignored empty/computed keys, and inline parent/sibling changes

## Review
- Independent code_reviewer subagent reviewed the patch; addressed same-line suppression and missing pair-diff coverage findings
- claude -p reviewed the patch; addressed duplicate fallback and empty/dynamic object key hardening findings
