### PR TITLE
Harden diff output escaping

### DIFF
--- a/crates/sem-cli/src/formatters/markdown.rs
+++ b/crates/sem-cli/src/formatters/markdown.rs
@@ -4,6 +4,37 @@ use sem_core::parser::differ::DiffResult;
 use similar::{ChangeTag, TextDiff};
 use std::collections::BTreeMap;
 
+fn longest_backtick_run(input: &str) -> usize {
+    let mut longest = 0;
+    let mut current = 0;
+
+    for ch in input.chars() {
+        if ch == '`' {
+            current += 1;
+            longest = longest.max(current);
+        } else {
+            current = 0;
+        }
+    }
+
+    longest
+}
+
+fn push_diff_block(lines: &mut Vec<String>, diff_lines: Vec<String>) {
+    let fence_len = diff_lines
+        .iter()
+        .map(|line| longest_backtick_run(line))
+        .max()
+        .unwrap_or(0)
+        .saturating_add(1)
+        .max(3);
+    let fence = "`".repeat(fence_len);
+
+    lines.push(format!("{fence}diff"));
+    lines.extend(diff_lines);
+    lines.push(fence);
+}
+
 pub fn format_markdown(result: &DiffResult, verbose: bool) -> String {
     if result.changes.is_empty() {
         return "No semantic changes detected.".to_string();
@@ -62,22 +93,20 @@ pub fn format_markdown(result: &DiffResult, verbose: bool) -> String {
                         if let Some(ref content) = change.after_content {
                             post_table.push(String::new());
                             post_table.push(format!("**`{}`**", change.entity_name));
-                            post_table.push("```diff".to_string());
-                            for line in content.lines() {
-                                post_table.push(format!("+ {line}"));
-                            }
-                            post_table.push("```".to_string());
+                            push_diff_block(
+                                &mut post_table,
+                                content.lines().map(|line| format!("+ {line}")).collect(),
+                            );
                         }
                     }
                     ChangeType::Deleted => {
                         if let Some(ref content) = change.before_content {
                             post_table.push(String::new());
                             post_table.push(format!("**`{}`**", change.entity_name));
-                            post_table.push("```diff".to_string());
-                            for line in content.lines() {
-                                post_table.push(format!("- {line}"));
-                            }
-                            post_table.push("```".to_string());
+                            push_diff_block(
+                                &mut post_table,
+                                content.lines().map(|line| format!("- {line}")).collect(),
+                            );
                         }
                     }
                     ChangeType::Modified | ChangeType::Moved | ChangeType::Renamed => {
@@ -86,10 +115,10 @@ pub fn format_markdown(result: &DiffResult, verbose: bool) -> String {
                         {
                             post_table.push(String::new());
                             post_table.push(format!("**`{}`**", change.entity_name));
-                            post_table.push("```diff".to_string());
+                            let mut diff_lines = Vec::new();
                             let diff = TextDiff::from_lines(before.as_str(), after.as_str());
                             for hunk in diff.unified_diff().context_radius(2).iter_hunks() {
-                                post_table.push(hunk.header().to_string());
+                                diff_lines.push(hunk.header().to_string());
                                 for op in hunk.ops() {
                                     let mut deletes: Vec<String> = Vec::new();
                                     let mut inserts: Vec<String> = Vec::new();
@@ -100,25 +129,25 @@ pub fn format_markdown(result: &DiffResult, verbose: bool) -> String {
                                             ChangeTag::Delete => deletes.push(line.to_string()),
                                             ChangeTag::Insert => inserts.push(line.to_string()),
                                             ChangeTag::Equal => {
-                                                post_table.push(format!("  {line}"))
+                                                diff_lines.push(format!("  {line}"))
                                             }
                                         }
                                     }
 
                                     let paired = deletes.len().min(inserts.len());
                                     for i in 0..paired {
-                                        post_table.push(format!("- {}", deletes[i]));
-                                        post_table.push(format!("+ {}", inserts[i]));
+                                        diff_lines.push(format!("- {}", deletes[i]));
+                                        diff_lines.push(format!("+ {}", inserts[i]));
                                     }
                                     for d in &deletes[paired..] {
-                                        post_table.push(format!("- {d}"));
+                                        diff_lines.push(format!("- {d}"));
                                     }
                                     for i in &inserts[paired..] {
-                                        post_table.push(format!("+ {i}"));
+                                        diff_lines.push(format!("+ {i}"));
                                     }
                                 }
                             }
-                            post_table.push("```".to_string());
+                            push_diff_block(&mut post_table, diff_lines);
                         }
                     }
                     _ => {}
@@ -132,14 +161,12 @@ pub fn format_markdown(result: &DiffResult, verbose: bool) -> String {
                     if before_lines.len() <= 3 && after_lines.len() <= 3 {
                         post_table.push(String::new());
                         post_table.push(format!("**`{}`**", change.entity_name));
-                        post_table.push("```diff".to_string());
-                        for line in &before_lines {
-                            post_table.push(format!("- {}", line.trim()));
-                        }
-                        for line in &after_lines {
-                            post_table.push(format!("+ {}", line.trim()));
-                        }
-                        post_table.push("```".to_string());
+                        let diff_lines = before_lines
+                            .iter()
+                            .map(|line| format!("- {}", line.trim()))
+                            .chain(after_lines.iter().map(|line| format!("+ {}", line.trim())))
+                            .collect();
+                        push_diff_block(&mut post_table, diff_lines);
                     }
                 }
             }
@@ -201,4 +228,60 @@ pub fn format_markdown(result: &DiffResult, verbose: bool) -> String {
     ));
 
     lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sem_core::model::change::SemanticChange;
+
+    fn diff_result(change: SemanticChange) -> DiffResult {
+        DiffResult {
+            changes: vec![change],
+            file_count: 1,
+            added_count: 0,
+            modified_count: 1,
+            deleted_count: 0,
+            moved_count: 0,
+            renamed_count: 0,
+            reordered_count: 0,
+            orphan_count: 0,
+            total_entities_before: 1,
+            total_entities_after: 1,
+        }
+    }
+
+    #[test]
+    fn markdown_diff_fence_is_longer_than_embedded_backticks() {
+        let change: SemanticChange = serde_json::from_value(serde_json::json!({
+            "id": "change::app.py::function::foo",
+            "entityId": "app.py::function::foo",
+            "changeType": "modified",
+            "entityType": "function",
+            "entityName": "foo",
+            "entityLine": 1,
+            "filePath": "app.py",
+            "beforeContent": "def foo():\n    return \"plain\"\n",
+            "afterContent": "def foo():\n    return \"````\"\n",
+            "structuralChange": true
+        }))
+        .unwrap();
+
+        let output = format_markdown(&diff_result(change), true);
+        let lines: Vec<&str> = output.lines().collect();
+        let opening = lines
+            .iter()
+            .position(|line| *line == "`````diff")
+            .expect("diff block should open with a 5-backtick fence");
+        let closing = lines[opening + 1..]
+            .iter()
+            .position(|line| *line == "`````")
+            .map(|offset| opening + 1 + offset)
+            .expect("diff block should close with a matching 5-backtick fence");
+
+        assert!(lines[opening + 1..closing]
+            .iter()
+            .any(|line| line.contains("````")));
+        assert!(!lines.iter().any(|line| *line == "````diff"));
+    }
 }

--- a/crates/sem-cli/src/formatters/terminal.rs
+++ b/crates/sem-cli/src/formatters/terminal.rs
@@ -5,6 +5,22 @@ use sem_core::parser::differ::DiffResult;
 use similar::{ChangeTag, TextDiff};
 use std::collections::BTreeMap;
 
+fn sanitize_terminal_text(input: &str) -> String {
+    if !input.chars().any(char::is_control) {
+        return input.to_string();
+    }
+
+    let mut output = String::with_capacity(input.len());
+    for ch in input.chars() {
+        if ch.is_control() {
+            output.extend(ch.escape_debug());
+        } else {
+            output.push(ch);
+        }
+    }
+    output
+}
+
 /// Runs word-level diff on two lines and returns (delete_line, insert_line)
 /// with changed words highlighted (strikethrough+red / bold+green).
 fn render_inline_diff(old_line: &str, new_line: &str) -> (String, String) {
@@ -13,7 +29,7 @@ fn render_inline_diff(old_line: &str, new_line: &str) -> (String, String) {
     let mut ins = String::new();
 
     for change in diff.iter_all_changes() {
-        let val = change.value();
+        let val = sanitize_terminal_text(change.value());
         match change.tag() {
             ChangeTag::Equal => {
                 del.push_str(&val.dimmed().to_string());
@@ -54,7 +70,7 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
             continue;
         }
 
-        let header = format!("─ {file_path} ");
+        let header = format!("─ {} ", sanitize_terminal_text(file_path));
         let pad_len = 55usize.saturating_sub(header.len());
         lines.push(
             format!("┌{header}{}", "─".repeat(pad_len))
@@ -105,14 +121,18 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
                 ),
             };
 
-            let type_label = format!("{:<10}", change.entity_type);
+            let type_label = format!("{:<10}", sanitize_terminal_text(&change.entity_type));
             let base_name = if let Some(ref old_name) = change.old_entity_name {
-                format!("{old_name} -> {}", change.entity_name)
+                format!(
+                    "{} -> {}",
+                    sanitize_terminal_text(old_name),
+                    sanitize_terminal_text(&change.entity_name)
+                )
             } else {
-                change.entity_name.clone()
+                sanitize_terminal_text(&change.entity_name)
             };
             let display_name = match &change.parent_name {
-                Some(p) => format!("{p}::{base_name}"),
+                Some(p) => format!("{}::{base_name}", sanitize_terminal_text(p)),
                 None => base_name,
             };
             let name_label = format!("{:<25}", display_name);
@@ -132,6 +152,7 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
                     ChangeType::Added => {
                         if let Some(ref content) = change.after_content {
                             for line in content.lines() {
+                                let line = sanitize_terminal_text(line);
                                 lines.push(format!(
                                     "{}    {}",
                                     "│".dimmed(),
@@ -143,6 +164,7 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
                     ChangeType::Deleted => {
                         if let Some(ref content) = change.before_content {
                             for line in content.lines() {
+                                let line = sanitize_terminal_text(line);
                                 lines.push(format!(
                                     "{}    {}",
                                     "│".dimmed(),
@@ -167,10 +189,12 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
                                     let mut inserts: Vec<String> = Vec::new();
 
                                     for diff_change in diff.iter_changes(op) {
-                                        let line = diff_change.value().trim_end_matches('\n');
+                                        let line = sanitize_terminal_text(
+                                            diff_change.value().trim_end_matches('\n'),
+                                        );
                                         match diff_change.tag() {
-                                            ChangeTag::Delete => deletes.push(line.to_string()),
-                                            ChangeTag::Insert => inserts.push(line.to_string()),
+                                            ChangeTag::Delete => deletes.push(line),
+                                            ChangeTag::Insert => inserts.push(line),
                                             ChangeTag::Equal => {
                                                 lines.push(format!(
                                                     "{}    {}",
@@ -226,17 +250,19 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
 
                     if before_lines.len() <= 3 && after_lines.len() <= 3 {
                         for line in &before_lines {
+                            let line = sanitize_terminal_text(line.trim());
                             lines.push(format!(
                                 "{}    {}",
                                 "│".dimmed(),
-                                format!("- {}", line.trim()).red(),
+                                format!("- {line}").red(),
                             ));
                         }
                         for line in &after_lines {
+                            let line = sanitize_terminal_text(line.trim());
                             lines.push(format!(
                                 "{}    {}",
                                 "│".dimmed(),
-                                format!("+ {}", line.trim()).green(),
+                                format!("+ {line}").green(),
                             ));
                         }
                     }
@@ -249,7 +275,7 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
                     lines.push(format!(
                         "{}    {}",
                         "│".dimmed(),
-                        format!("from {old_path}").dimmed(),
+                        format!("from {}", sanitize_terminal_text(old_path)).dimmed(),
                     ));
                 } else if let Some(ref old_parent) = change.old_parent_id {
                     // Intra-file move: extract parent name from entity ID
@@ -257,7 +283,7 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
                     lines.push(format!(
                         "{}    {}",
                         "│".dimmed(),
-                        format!("moved from {parent_name}").dimmed(),
+                        format!("moved from {}", sanitize_terminal_text(parent_name)).dimmed(),
                     ));
                 }
             }
@@ -348,11 +374,11 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
     }
 
     // Warn if fallback chunking was used (unsupported file extension)
-    let chunk_files: Vec<&str> = result
+    let chunk_files: Vec<String> = result
         .changes
         .iter()
         .filter(|c| c.entity_type == "chunk")
-        .map(|c| c.file_path.as_str())
+        .map(|c| sanitize_terminal_text(&c.file_path))
         .collect::<std::collections::BTreeSet<_>>()
         .into_iter()
         .collect();
@@ -374,4 +400,61 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
     }
 
     lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sem_core::model::change::SemanticChange;
+
+    #[test]
+    fn terminal_source_content_escapes_control_characters() {
+        let output = sanitize_terminal_text("\u{1b}[31mRED\u{1b}[0m\t\r\n");
+
+        assert!(!output.contains('\u{1b}'));
+        assert!(output.contains("\\u{1b}[31mRED\\u{1b}[0m"));
+        assert!(output.contains("\\t\\r\\n"));
+    }
+
+    #[test]
+    fn terminal_chunk_warning_escapes_file_path_control_characters() {
+        colored::control::set_override(false);
+        let change: SemanticChange = serde_json::from_value(serde_json::json!({
+            "id": "change::bad.txt::chunk::1",
+            "entityId": "bad.txt::chunk::1",
+            "changeType": "modified",
+            "entityType": "chunk",
+            "entityName": "chunk 1",
+            "entityLine": 1,
+            "startLine": 1,
+            "endLine": 2,
+            "filePath": "bad\u{1b}[31m.txt",
+            "beforeContent": "alpha\nbeta\n",
+            "afterContent": "alpha\nchanged\n",
+            "structuralChange": true
+        }))
+        .unwrap();
+        let result = DiffResult {
+            changes: vec![change],
+            file_count: 1,
+            added_count: 0,
+            modified_count: 1,
+            deleted_count: 0,
+            moved_count: 0,
+            renamed_count: 0,
+            reordered_count: 0,
+            orphan_count: 0,
+            total_entities_before: 1,
+            total_entities_after: 1,
+        };
+
+        let output = format_terminal(&result, true);
+
+        assert!(!output.contains('\u{1b}'), "{output}");
+        assert!(output.contains("bad\\u{1b}[31m.txt"), "{output}");
+        assert!(
+            output.contains("used line-based chunking (unsupported file extension)"),
+            "{output}"
+        );
+    }
 }

--- a/crates/sem-cli/tests/diff_output_hardening.rs
+++ b/crates/sem-cli/tests/diff_output_hardening.rs
@@ -1,0 +1,149 @@
+use std::path::Path;
+use std::process::{Command, Output};
+
+struct TempRepo {
+    repo: tempfile::TempDir,
+    home: tempfile::TempDir,
+}
+
+impl TempRepo {
+    fn new() -> Self {
+        let repo = tempfile::tempdir().expect("create temp repo");
+        let home = tempfile::tempdir().expect("create temp home");
+
+        run_git(repo.path(), &["init", "-q"]);
+        run_git(repo.path(), &["config", "user.name", "Test"]);
+        run_git(repo.path(), &["config", "user.email", "test@example.com"]);
+
+        Self { repo, home }
+    }
+
+    fn path(&self) -> &Path {
+        self.repo.path()
+    }
+
+    fn run_sem(&self, args: &[&str]) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .args(args)
+            .current_dir(self.repo.path())
+            .env("HOME", self.home.path())
+            .output()
+            .expect("run sem")
+    }
+}
+
+fn run_git(repo: &Path, args: &[&str]) -> Output {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn commit_file(repo: &TempRepo, path: &str, content: &str) {
+    std::fs::write(repo.path().join(path), content).expect("write file");
+    run_git(repo.path(), &["add", path]);
+    run_git(repo.path(), &["commit", "-qm", "init"]);
+}
+
+#[test]
+fn markdown_verbose_diff_uses_fence_longer_than_source_backticks() {
+    let repo = TempRepo::new();
+    commit_file(
+        &repo,
+        "app.py",
+        "def foo():\n    s = \"plain\"\n    return s\n",
+    );
+    std::fs::write(
+        repo.path().join("app.py"),
+        "def foo():\n    s = \"X``` Y ``` Z\"\n    return s\n",
+    )
+    .expect("write modified file");
+
+    let output = repo.run_sem(&["diff", "--format", "markdown", "-v"]);
+    assert!(
+        output.status.success(),
+        "sem failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf-8");
+    let lines: Vec<&str> = stdout.lines().collect();
+    let opening = lines
+        .iter()
+        .position(|line| *line == "````diff")
+        .expect("diff block should open with a 4-backtick fence");
+    let closing = lines[opening + 1..]
+        .iter()
+        .position(|line| *line == "````")
+        .map(|offset| opening + 1 + offset)
+        .expect("diff block should close with a matching 4-backtick fence");
+
+    assert!(lines[opening + 1..closing]
+        .iter()
+        .any(|line| line.contains("```")));
+    assert!(!lines.iter().any(|line| *line == "```diff"), "{stdout}");
+}
+
+#[test]
+fn terminal_verbose_diff_escapes_source_control_bytes_with_color_never() {
+    let repo = TempRepo::new();
+    commit_file(&repo, "app.py", "def foo():\n    return 1\n");
+    std::fs::write(
+        repo.path().join("app.py"),
+        "def foo():\n    s = \"\u{1b}[31mRED\u{1b}[0m\"\n    return s\n",
+    )
+    .expect("write modified file");
+
+    let output = repo.run_sem(&["diff", "-v", "--color", "never"]);
+    assert!(
+        output.status.success(),
+        "sem failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        !output.stdout.contains(&0x1b),
+        "stdout contains raw ESC bytes: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf-8");
+    assert!(stdout.contains("\\u{1b}[31mRED\\u{1b}[0m"), "{stdout}");
+}
+
+#[test]
+#[cfg(not(windows))]
+fn terminal_unsupported_file_warning_escapes_file_path_control_bytes() {
+    let repo = TempRepo::new();
+    let file_name = "bad\u{1b}[31m.txt";
+    commit_file(&repo, file_name, "alpha\nbeta\n");
+    std::fs::write(repo.path().join(file_name), "alpha\nchanged\n").expect("write modified file");
+
+    let output = repo.run_sem(&["diff", "-v", "--color", "never"]);
+    assert!(
+        output.status.success(),
+        "sem failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        !output.stdout.contains(&0x1b),
+        "stdout contains raw ESC bytes: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf-8");
+    assert!(stdout.contains("bad\\u{1b}[31m.txt"), "{stdout}");
+    assert!(
+        stdout.contains("used line-based chunking (unsupported file extension)"),
+        "{stdout}"
+    );
+}


### PR DESCRIPTION
## Summary
- use markdown code fences that grow beyond embedded source backtick runs
- escape source-derived terminal control characters before applying CLI colors
- cover source content and unsupported-file warning paths with dummy git repo regressions

Closes #273

## Test plan
- cargo test -p sem-cli --test diff_output_hardening
- cargo test -p sem-cli
- cargo test
- manual disposable git repos for markdown backticks and terminal ESC filename/content hardening