### PR TITLE
Fix subdirectory path resolution in CLI commands

### DIFF
--- a/crates/sem-cli/src/commands/context.rs
+++ b/crates/sem-cli/src/commands/context.rs
@@ -34,7 +34,16 @@ pub fn context_command(opts: ContextOptions) {
     );
     let (graph, all_entities) = super::graph::get_or_build_graph(root, &file_paths, &registry, opts.no_cache);
 
-    let entity = find_entity(&graph, opts.entity_name.as_deref(), opts.entity_id.as_deref(), opts.file_path.as_deref());
+    let file_path = opts
+        .file_path
+        .as_deref()
+        .map(|file| super::normalize_repo_relative_path(Path::new(&opts.cwd), root, file));
+    let entity = find_entity(
+        &graph,
+        opts.entity_name.as_deref(),
+        opts.entity_id.as_deref(),
+        file_path.as_deref(),
+    );
     let context_result = build_context_result(&graph, &entity.id, &all_entities, opts.budget);
 
     if opts.json {

--- a/crates/sem-cli/src/commands/diff.rs
+++ b/crates/sem-cli/src/commands/diff.rs
@@ -131,7 +131,9 @@ fn glob_match_inner(pat: &[char], text: &[char]) -> bool {
 
 /// Check if a file path matches a pathspec (supports prefix matching and basic globs).
 fn path_matches_spec(file_path: &str, spec: &str) -> bool {
-    if spec.contains('*') || spec.contains('?') || spec.contains('[') {
+    if spec == "." {
+        true
+    } else if spec.contains('*') || spec.contains('?') || spec.contains('[') {
         glob_match(spec, file_path)
     } else if spec.ends_with('/') {
         file_path.starts_with(spec.trim_end_matches('/'))
@@ -231,7 +233,6 @@ fn normalize_trailing_output_format(opts: &mut DiffOptions) {
 
     opts.args = args;
 }
-
 
 fn parse_args(args: Vec<String>, cwd: &str) -> ParsedArgs {
     let (refs, pathspecs) = split_on_separator(args);
@@ -424,9 +425,11 @@ fn is_git_binary_payload_line(line: &str) -> bool {
         && !line.starts_with("+++ ")
 }
 
-fn parse_unified_diff(patch: &str, cwd: &str) -> Result<Vec<FileChange>, PatchParseError> {
+fn parse_unified_diff(
+    patch: &str,
+    worktree_root: &Path,
+) -> Result<Vec<FileChange>, PatchParseError> {
     use sem_core::git::types::FileStatus;
-
 
     struct PatchEntry {
         file_path: String,
@@ -587,7 +590,7 @@ fn parse_unified_diff(patch: &str, cwd: &str) -> Result<Vec<FileChange>, PatchPa
     let git_show = |sha: &str| -> Option<String> {
         let output = process::Command::new("git")
             .args(["show", sha])
-            .current_dir(cwd)
+            .current_dir(worktree_root)
             .output()
             .ok()?;
         if output.status.success() {
@@ -606,7 +609,7 @@ fn parse_unified_diff(patch: &str, cwd: &str) -> Result<Vec<FileChange>, PatchPa
             // Fallback: if git show fails for the new SHA (e.g. unstaged working
             // tree changes where the blob doesn't exist yet), read from disk.
             if after_content.is_none() && e.new_sha.is_some() {
-                let file = Path::new(cwd).join(&e.file_path);
+                let file = worktree_root.join(&e.file_path);
                 after_content = std::fs::read_to_string(&file).ok();
             }
 
@@ -754,6 +757,18 @@ pub fn diff_command(mut opts: DiffOptions) {
     } else {
         parse_args(raw_args, &opts.cwd)
     };
+    let patch_worktree_root = if opts.patch {
+        Some(super::repo_root_or_cwd(&opts.cwd))
+    } else {
+        None
+    };
+    if let Some(root) = patch_worktree_root.as_deref() {
+        parsed.pathspecs = parsed
+            .pathspecs
+            .iter()
+            .map(|spec| super::normalize_repo_relative_path(Path::new(&opts.cwd), root, spec))
+            .collect();
+    }
 
     // Resolve jj revsets to git SHAs if we're in a jj repo
     let root = Path::new(&opts.cwd);
@@ -861,7 +876,10 @@ pub fn diff_command(mut opts: DiffOptions) {
                 eprintln!("\x1b[31mError reading stdin: {e}\x1b[0m");
                 process::exit(1);
             });
-        let changes = parse_unified_diff(&input, &opts.cwd).unwrap_or_else(|e| {
+        let worktree_root = patch_worktree_root
+            .as_deref()
+            .expect("patch worktree root is initialized when --patch is set");
+        let changes = parse_unified_diff(&input, worktree_root).unwrap_or_else(|e| {
             eprintln!("error: {}", e.message());
             process::exit(1);
         });
@@ -871,9 +889,10 @@ pub fn diff_command(mut opts: DiffOptions) {
             changes
                 .into_iter()
                 .filter(|fc| {
-                    parsed.pathspecs.iter().any(|spec| {
-                        file_change_matches_spec(fc, spec)
-                    })
+                    parsed
+                        .pathspecs
+                        .iter()
+                        .any(|spec| file_change_matches_spec(fc, spec))
                 })
                 .collect()
         };
@@ -1244,23 +1263,29 @@ mod tests {
     #[test]
     fn parse_unified_diff_rejects_empty_input() {
         assert_eq!(
-            parse_unified_diff("", ".").unwrap_err(),
+            parse_unified_diff("", Path::new(".")).unwrap_err(),
             PatchParseError::EmptyInput
         );
         assert_eq!(
-            parse_unified_diff("\n\t ", ".").unwrap_err(),
+            parse_unified_diff("\n\t ", Path::new(".")).unwrap_err(),
             PatchParseError::EmptyInput
         );
     }
 
     #[test]
+    fn path_matches_spec_requires_normalized_dot_for_whole_repo() {
+        assert!(path_matches_spec("src/lib.rs", "."));
+        assert!(!path_matches_spec("src/lib.rs", ""));
+    }
+
+    #[test]
     fn parse_unified_diff_rejects_non_diff_input() {
         assert_eq!(
-            parse_unified_diff("this is not a diff\n", ".").unwrap_err(),
+            parse_unified_diff("this is not a diff\n", Path::new(".")).unwrap_err(),
             PatchParseError::NoRecognizableHunks
         );
         assert_eq!(
-            parse_unified_diff("diff --git a/a.ts b/a.ts\n", ".").unwrap_err(),
+            parse_unified_diff("diff --git a/a.ts b/a.ts\n", Path::new(".")).unwrap_err(),
             PatchParseError::NoRecognizableHunks
         );
     }
@@ -1274,7 +1299,7 @@ mod tests {
                      -foo\n\
                      +bar\n";
 
-        let changes = parse_unified_diff(patch, ".").unwrap();
+        let changes = parse_unified_diff(patch, Path::new(".")).unwrap();
         assert!(changes.is_empty());
     }
 
@@ -1287,7 +1312,7 @@ mod tests {
                      -foo\n\
                      +bar\n";
 
-        let changes = parse_unified_diff(patch, ".").unwrap();
+        let changes = parse_unified_diff(patch, Path::new(".")).unwrap();
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].file_path, "a.ts");
     }
@@ -1299,7 +1324,7 @@ mod tests {
                      rename from old.py\n\
                      rename to new.py\n";
 
-        let changes = parse_unified_diff(patch, ".").unwrap();
+        let changes = parse_unified_diff(patch, Path::new(".")).unwrap();
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].old_file_path.as_deref(), Some("old.py"));
         assert_eq!(changes[0].file_path, "new.py");
@@ -1314,7 +1339,7 @@ mod tests {
                      literal 0\n\
                      HcmV?d00001\n";
 
-        let changes = parse_unified_diff(patch, ".").unwrap();
+        let changes = parse_unified_diff(patch, Path::new(".")).unwrap();
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].file_path, "blob.bin");
     }
@@ -1329,7 +1354,7 @@ mod tests {
                      delta 1\n\
                      def\n";
 
-        let changes = parse_unified_diff(patch, ".").unwrap();
+        let changes = parse_unified_diff(patch, Path::new(".")).unwrap();
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].file_path, "blob.bin");
     }
@@ -1340,7 +1365,7 @@ mod tests {
                      index 1111111..2222222 100644\n\
                      Binary files a/blob.bin and b/blob.bin differ\n";
 
-        let changes = parse_unified_diff(patch, ".").unwrap();
+        let changes = parse_unified_diff(patch, Path::new(".")).unwrap();
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].file_path, "blob.bin");
     }
@@ -1360,7 +1385,7 @@ mod tests {
             "diff --git a/blob.bin b/blob.bin\nindex 1111111..2222222 100644\nGIT binary patch\nliteral 1\nabc\ndelta 1\n",
         ] {
             assert_eq!(
-                parse_unified_diff(patch, ".").unwrap_err(),
+                parse_unified_diff(patch, Path::new(".")).unwrap_err(),
                 PatchParseError::NoRecognizableHunks
             );
         }

--- a/crates/sem-cli/src/commands/impact.rs
+++ b/crates/sem-cli/src/commands/impact.rs
@@ -41,7 +41,16 @@ pub fn impact_command(opts: ImpactOptions) {
     );
     let (graph, all_entities) = super::graph::get_or_build_graph(root, &file_paths, &registry, opts.no_cache);
 
-    let entity = find_entity(&graph, opts.entity_name.as_deref(), opts.entity_id.as_deref(), opts.file_hint.as_deref());
+    let file_hint = opts
+        .file_hint
+        .as_deref()
+        .map(|file| super::normalize_repo_relative_path(Path::new(&opts.cwd), root, file));
+    let entity = find_entity(
+        &graph,
+        opts.entity_name.as_deref(),
+        opts.entity_id.as_deref(),
+        file_hint.as_deref(),
+    );
 
     match opts.mode {
         ImpactMode::Deps => print_deps(&graph, entity, opts.json),

--- a/crates/sem-cli/src/commands/mod.rs
+++ b/crates/sem-cli/src/commands/mod.rs
@@ -12,7 +12,9 @@ pub mod verify;
 
 use sem_core::parser::plugins::create_default_registry;
 use sem_core::parser::registry::ParserRegistry;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
+
+use sem_core::git::bridge::GitBridge;
 
 /// Create a parser registry with extension mappings loaded from `cwd`.
 /// Loads `.semrc` first (takes priority), then `.gitattributes` as fallback.
@@ -22,6 +24,84 @@ pub fn create_registry(cwd: &str) -> ParserRegistry {
     registry.load_semrc(root);
     registry.load_gitattributes(root);
     registry
+}
+
+pub fn repo_root_or_cwd(cwd: &str) -> PathBuf {
+    GitBridge::open(Path::new(cwd))
+        .map(|git| git.repo_root().to_path_buf())
+        .unwrap_or_else(|_| Path::new(cwd).to_path_buf())
+}
+
+pub fn normalize_repo_relative_path(cwd: &Path, repo_root: &Path, path: &str) -> String {
+    if path.is_empty() {
+        return ".".to_string();
+    }
+    if path.starts_with(':') {
+        return path.to_string();
+    }
+
+    let path = Path::new(path);
+    let cwd_base = normalize_existing_prefix(cwd).unwrap_or_else(|| normalize_lexical(cwd));
+    let repo_root_base =
+        normalize_existing_prefix(repo_root).unwrap_or_else(|| normalize_lexical(repo_root));
+    let absolute = if path.is_absolute() {
+        normalize_lexical(path)
+    } else {
+        normalize_lexical(&cwd_base.join(path))
+    };
+
+    let repo_root = normalize_lexical(&repo_root_base);
+    let Ok(relative) = absolute.strip_prefix(&repo_root) else {
+        return absolute.to_string_lossy().replace('\\', "/");
+    };
+
+    if relative.as_os_str().is_empty() {
+        ".".to_string()
+    } else {
+        relative.to_string_lossy().replace('\\', "/")
+    }
+}
+
+fn normalize_lexical(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+
+    normalized
+}
+
+fn normalize_existing_prefix(path: &Path) -> Option<PathBuf> {
+    if let Ok(canonical) = std::fs::canonicalize(path) {
+        return Some(canonical);
+    }
+
+    let mut missing = Vec::new();
+    let mut current = path;
+
+    while let Some(parent) = current.parent() {
+        if let Some(name) = current.file_name() {
+            missing.push(name.to_os_string());
+        }
+        if let Ok(mut canonical) = std::fs::canonicalize(parent) {
+            for component in missing.iter().rev() {
+                canonical.push(component);
+            }
+            return Some(normalize_lexical(&canonical));
+        }
+        current = parent;
+    }
+
+    None
 }
 
 /// Truncate a string to `max_chars` Unicode scalar values (codepoints), appending "..." if
@@ -61,7 +141,8 @@ pub fn truncate_str(s: &str, max_chars: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::truncate_str;
+    use super::{normalize_existing_prefix, normalize_lexical, normalize_repo_relative_path, truncate_str};
+    use std::path::Path;
 
     #[test]
     fn ascii_short_string_unchanged() {
@@ -140,5 +221,141 @@ mod tests {
     fn max_chars_four_triggers_ellipsis() {
         // max_chars == 4, string is longer → take 1 char + "..."
         assert_eq!(truncate_str("hello", 4), "h...");
+    }
+
+    #[test]
+    fn normalize_repo_relative_path_handles_absolute_paths() {
+        let cwd = Path::new("/repo/sub");
+        let repo_root = Path::new("/repo");
+
+        let normalized = normalize_repo_relative_path(cwd, repo_root, "/repo/sub/foo.py");
+
+        assert_eq!(normalized, "sub/foo.py");
+    }
+
+    #[test]
+    fn normalize_repo_relative_path_handles_parent_components() {
+        let cwd = Path::new("/repo/sub/nested");
+        let repo_root = Path::new("/repo");
+
+        let normalized = normalize_repo_relative_path(cwd, repo_root, "../foo.py");
+
+        assert_eq!(normalized, "sub/foo.py");
+    }
+
+    #[test]
+    fn normalize_repo_relative_path_keeps_repo_root_dot_as_all_paths() {
+        let cwd = Path::new("/repo");
+        let repo_root = Path::new("/repo");
+
+        let normalized = normalize_repo_relative_path(cwd, repo_root, ".");
+
+        assert_eq!(normalized, ".");
+    }
+
+    #[test]
+    fn normalize_repo_relative_path_treats_empty_path_as_dot() {
+        let cwd = Path::new("/repo/sub");
+        let repo_root = Path::new("/repo");
+
+        let normalized = normalize_repo_relative_path(cwd, repo_root, "");
+
+        assert_eq!(normalized, ".");
+    }
+
+    #[test]
+    fn normalize_repo_relative_path_converts_subdir_dot_to_subdir() {
+        let cwd = Path::new("/repo/sub");
+        let repo_root = Path::new("/repo");
+
+        let normalized = normalize_repo_relative_path(cwd, repo_root, ".");
+
+        assert_eq!(normalized, "sub");
+    }
+
+    #[test]
+    fn normalize_repo_relative_path_leaves_magic_pathspecs_unchanged() {
+        let cwd = Path::new("/repo/sub");
+        let repo_root = Path::new("/repo");
+
+        let normalized = normalize_repo_relative_path(cwd, repo_root, ":(glob)**/*.py");
+
+        assert_eq!(normalized, ":(glob)**/*.py");
+    }
+
+    #[test]
+    fn normalize_repo_relative_path_returns_normalized_absolute_path_outside_repo() {
+        use std::fs;
+
+        let repo_root = std::env::temp_dir().join(format!(
+            "sem-normalize-outside-test-{}",
+            std::process::id()
+        ));
+        let cwd = repo_root.join("sub");
+        fs::create_dir_all(&cwd).expect("create cwd");
+        let outside_path = cwd.join("../../outside.py");
+        let expected = normalize_existing_prefix(&outside_path)
+            .unwrap_or_else(|| normalize_lexical(&outside_path))
+            .to_string_lossy()
+            .replace('\\', "/");
+
+        let normalized = normalize_repo_relative_path(&cwd, &repo_root, "../../outside.py");
+
+        assert_eq!(normalized, expected);
+        fs::remove_dir_all(repo_root).expect("remove temp dir");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn normalize_repo_relative_path_handles_symlinked_cwd() {
+        use std::fs;
+        use std::os::unix::fs::symlink;
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let id = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        let temp = std::env::temp_dir().join(format!(
+            "sem-normalize-repo-relative-test-{}-{id}",
+            std::process::id()
+        ));
+        let repo_root = temp.join("repo");
+        let real_subdir = repo_root.join("sub");
+        let symlinked_cwd = temp.join("linked-sub");
+        fs::create_dir_all(&real_subdir).expect("create real cwd");
+        symlink(&real_subdir, &symlinked_cwd).expect("create symlinked cwd");
+
+        let normalized = normalize_repo_relative_path(&symlinked_cwd, &repo_root, "foo.py");
+
+        assert_eq!(normalized, "sub/foo.py");
+        fs::remove_dir_all(temp).expect("remove temp dir");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn normalize_repo_relative_path_resolves_missing_cwd_through_symlinked_repo_root() {
+        use std::fs;
+        use std::os::unix::fs::symlink;
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let id = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        let temp = std::env::temp_dir().join(format!(
+            "sem-normalize-missing-cwd-test-{}-{id}",
+            std::process::id()
+        ));
+        let repo_root = temp.join("repo");
+        let symlinked_repo_root = temp.join("linked-repo");
+        fs::create_dir_all(&repo_root).expect("create repo root");
+        symlink(&repo_root, &symlinked_repo_root).expect("create symlinked repo root");
+        let missing_cwd = symlinked_repo_root.join("missing");
+
+        let normalized = normalize_repo_relative_path(&missing_cwd, &repo_root, "foo.py");
+
+        assert_eq!(normalized, "missing/foo.py");
+        fs::remove_dir_all(temp).expect("remove temp dir");
     }
 }

--- a/crates/sem-cli/src/commands/verify.rs
+++ b/crates/sem-cli/src/commands/verify.rs
@@ -12,8 +12,9 @@ pub struct VerifyOptions {
 }
 
 pub fn verify_command(opts: VerifyOptions) {
-    let root = Path::new(&opts.cwd);
-    let registry = super::create_registry(&opts.cwd);
+    let root = super::repo_root_or_cwd(&opts.cwd);
+    let root = root.as_path();
+    let registry = super::create_registry(&root.to_string_lossy());
 
     let ext_filter = super::graph::normalize_exts(&opts.file_exts);
     let file_paths = super::graph::find_supported_files_with_options(

--- a/crates/sem-cli/tests/cwd_resolution.rs
+++ b/crates/sem-cli/tests/cwd_resolution.rs
@@ -1,0 +1,178 @@
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static TEMP_REPO_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+struct TempRepo {
+    path: PathBuf,
+}
+
+impl TempRepo {
+    fn new() -> Self {
+        let id = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        let counter = TEMP_REPO_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "sem-cwd-resolution-test-{}-{id}-{counter}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&path).expect("create temp repo");
+        run_git(&path, &["init", "-q"]);
+        run_git(&path, &["config", "user.name", "Test"]);
+        run_git(&path, &["config", "user.email", "test@example.com"]);
+        Self { path }
+    }
+
+    fn subdir(&self) -> PathBuf {
+        self.path.join("sub")
+    }
+}
+
+impl Drop for TempRepo {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn run_git(cwd: &Path, args: &[&str]) -> Output {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {:?} failed in {}: {}",
+        args,
+        cwd.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn run_sem(args: &[&str], input: &[u8], cwd: &Path) -> Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_sem"))
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .current_dir(cwd)
+        .spawn()
+        .expect("spawn sem");
+
+    child
+        .stdin
+        .take()
+        .expect("open stdin")
+        .write_all(input)
+        .expect("write stdin");
+
+    child.wait_with_output().expect("wait for sem")
+}
+
+fn write_sub_file(repo: &TempRepo, contents: &str) {
+    std::fs::create_dir_all(repo.subdir()).expect("create subdir");
+    std::fs::write(repo.subdir().join("foo.py"), contents).expect("write foo.py");
+}
+
+fn commit_sub_file(repo: &TempRepo) {
+    run_git(&repo.path, &["add", "sub/foo.py"]);
+    run_git(&repo.path, &["commit", "-qm", "init"]);
+}
+
+#[test]
+fn verify_diff_finds_broken_callers_from_subdirectory() {
+    let repo = TempRepo::new();
+    write_sub_file(
+        &repo,
+        "def f(x, y):\n    return x + y\n\ndef g():\n    return f(1, 2)\n",
+    );
+    commit_sub_file(&repo);
+    write_sub_file(
+        &repo,
+        "def f(x):\n    return x\n\ndef g():\n    return f(1, 2)\n",
+    );
+
+    let output = run_sem(&["verify", "--diff", "--json"], &[], &repo.subdir());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert_eq!(output.status.code(), Some(1), "{stdout}");
+    let mismatches: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+    assert_eq!(mismatches[0]["callee"], "f");
+    assert_eq!(mismatches[0]["caller"], "g");
+    assert_eq!(mismatches[0]["file"], "sub/foo.py");
+}
+
+#[test]
+fn diff_patch_reads_worktree_contents_from_repo_root() {
+    let repo = TempRepo::new();
+    write_sub_file(&repo, "def foo():\n    return 1\n");
+    commit_sub_file(&repo);
+    write_sub_file(&repo, "def foo():\n    return 2\n");
+
+    let patch = run_git(&repo.subdir(), &["diff"]).stdout;
+    let output = run_sem(&["diff", "--patch", "--json"], &patch, &repo.subdir());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{stdout}");
+    let diff: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+    assert_eq!(diff["summary"]["modified"], 1);
+    assert_eq!(diff["summary"]["deleted"], 0);
+}
+
+#[test]
+fn diff_patch_pathspecs_are_relative_to_invocation_directory() {
+    let repo = TempRepo::new();
+    write_sub_file(&repo, "def foo():\n    return 1\n");
+    commit_sub_file(&repo);
+    write_sub_file(&repo, "def foo():\n    return 2\n");
+
+    let patch = run_git(&repo.subdir(), &["diff"]).stdout;
+    let output = run_sem(
+        &["diff", "--patch", "--json", "--", "foo.py"],
+        &patch,
+        &repo.subdir(),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{stdout}");
+    let diff: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+    assert_eq!(diff["summary"]["fileCount"], 1);
+    assert_eq!(diff["changes"][0]["filePath"], "sub/foo.py");
+}
+
+#[test]
+fn impact_and_context_file_hints_are_relative_to_invocation_directory() {
+    let repo = TempRepo::new();
+    write_sub_file(
+        &repo,
+        "def f():\n    return 1\n\ndef g():\n    return f()\n",
+    );
+    commit_sub_file(&repo);
+
+    let impact = run_sem(
+        &["impact", "f", "--file", "foo.py", "--json", "--no-cache"],
+        &[],
+        &repo.subdir(),
+    );
+    let impact_stdout = String::from_utf8_lossy(&impact.stdout);
+    assert!(impact.status.success(), "{impact_stdout}");
+    let impact_json: serde_json::Value = serde_json::from_str(&impact_stdout).expect("valid json");
+    assert_eq!(impact_json["entity"]["file"], "sub/foo.py");
+
+    let context = run_sem(
+        &["context", "f", "--file", "foo.py", "--json", "--no-cache"],
+        &[],
+        &repo.subdir(),
+    );
+    let context_stdout = String::from_utf8_lossy(&context.stdout);
+    assert!(context.status.success(), "{context_stdout}");
+    let context_json: serde_json::Value =
+        serde_json::from_str(&context_stdout).expect("valid json");
+    assert_eq!(context_json["entries"][0]["file"], "sub/foo.py");
+}


### PR DESCRIPTION
## Summary

- Normalize cwd-relative file hints and patch pathspecs to repo-root-relative paths.
- Resolve `verify` and `diff --patch` content lookups from the worktree root when invoked from subdirectories.
- Add dummy-repo regression coverage for the affected subdirectory workflows and unit coverage for path normalization edge cases.

Closes #268

## Test Plan

- `cargo test -p sem-cli`
- `cargo test --workspace`
- Manual dummy git repo validation for `verify --diff`, `diff --patch`, `diff --patch -- foo.py`, `impact --file foo.py`, and `context --file foo.py` from a subdirectory.