### PR TITLE
Make verify cache bypassable and consistent

### DIFF
--- a/crates/sem-cli/src/cache.rs
+++ b/crates/sem-cli/src/cache.rs
@@ -386,13 +386,8 @@ impl DiskCache {
             .iter()
             .filter(|file| !shared_cache::is_manifest_file_name(file))
             .collect();
-        let stale_set: HashSet<&str> = source_stale_files
-            .iter()
-            .map(|file| file.as_str())
-            .collect();
 
         let tx = self.conn.unchecked_transaction()?;
-        let mut deleted_cached_files = Vec::new();
 
         // Delete stale file entries
         {
@@ -420,7 +415,6 @@ impl DiskCache {
                     && !current_set.contains(path.as_str())
                 {
                     del_files.execute(params![path])?;
-                    deleted_cached_files.push(path.clone());
                 }
             }
         }
@@ -440,42 +434,31 @@ impl DiskCache {
 
         shared_cache::refresh_manifest_entries(&tx, root)?;
 
-        // Delete entities for stale files
-        {
-            let mut del = tx.prepare("DELETE FROM entities WHERE file_path = ?1")?;
-            for f in &source_stale_files {
-                del.execute(params![f])?;
-            }
-            for f in &deleted_cached_files {
-                del.execute(params![f])?;
-            }
-        }
-
-        // Insert new entities for stale files
+        // Rewrite entity rows as a complete snapshot; graph repair can change
+        // entity IDs in files whose source bytes are still cached.
+        tx.execute("DELETE FROM entities", [])?;
         {
             let mut ins = tx.prepare(
                 "INSERT OR REPLACE INTO entities (id, name, entity_type, file_path, start_line, end_line, content, content_hash, structural_hash, parent_id, metadata_json) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
             )?;
             for e in entities {
-                if stale_set.contains(e.file_path.as_str()) {
-                    let metadata_json = e
-                        .metadata
-                        .as_ref()
-                        .and_then(|m| serde_json::to_string(m).ok());
-                    ins.execute(params![
-                        e.id,
-                        e.name,
-                        e.entity_type,
-                        e.file_path,
-                        e.start_line as i64,
-                        e.end_line as i64,
-                        e.content,
-                        e.content_hash,
-                        e.structural_hash,
-                        e.parent_id,
-                        metadata_json,
-                    ])?;
-                }
+                let metadata_json = e
+                    .metadata
+                    .as_ref()
+                    .and_then(|m| serde_json::to_string(m).ok());
+                ins.execute(params![
+                    e.id,
+                    e.name,
+                    e.entity_type,
+                    e.file_path,
+                    e.start_line as i64,
+                    e.end_line as i64,
+                    e.content,
+                    e.content_hash,
+                    e.structural_hash,
+                    e.parent_id,
+                    metadata_json,
+                ])?;
             }
         }
 
@@ -737,7 +720,11 @@ mod tests {
 
     #[test]
     fn open_rebuilds_cache_when_schema_version_is_unsupported() {
-        for version in [0, shared_cache::CACHE_SCHEMA_VERSION + 1] {
+        for version in [
+            0,
+            shared_cache::CACHE_SCHEMA_VERSION - 1,
+            shared_cache::CACHE_SCHEMA_VERSION + 1,
+        ] {
             let root = temp_repo_root(&format!("unsupported-{version}"));
             seed_unsupported_cache(&root, version);
 

--- a/crates/sem-cli/src/commands/verify.rs
+++ b/crates/sem-cli/src/commands/verify.rs
@@ -8,6 +8,7 @@ pub struct VerifyOptions {
     pub json: bool,
     pub diff: bool,
     pub file_exts: Vec<String>,
+    pub no_cache: bool,
     pub no_default_excludes: bool,
 }
 
@@ -23,7 +24,7 @@ pub fn verify_command(opts: VerifyOptions) {
         opts.no_default_excludes,
     );
     let (graph, all_entities) =
-        super::graph::get_or_build_graph(root, &file_paths, &registry, false);
+        super::graph::get_or_build_graph(root, &file_paths, &registry, opts.no_cache);
 
     if opts.diff {
         verify_diff(

--- a/crates/sem-cli/src/main.rs
+++ b/crates/sem-cli/src/main.rs
@@ -296,6 +296,10 @@ enum Commands {
         #[arg(long, num_args = 1..)]
         file_exts: Vec<String>,
 
+        /// Skip the SQLite entity cache (rebuild from scratch)
+        #[arg(long)]
+        no_cache: bool,
+
         /// Include directories and generated files that are excluded by default
         #[arg(long)]
         no_default_excludes: bool,
@@ -536,6 +540,7 @@ fn main() {
             json,
             diff,
             file_exts,
+            no_cache,
             no_default_excludes,
         }) => {
             verify_command(VerifyOptions {
@@ -546,6 +551,7 @@ fn main() {
                 json: resolve_json(format, json),
                 diff,
                 file_exts,
+                no_cache,
                 no_default_excludes,
             });
         }

--- a/crates/sem-cli/tests/verify_cli.rs
+++ b/crates/sem-cli/tests/verify_cli.rs
@@ -1,0 +1,248 @@
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use rusqlite::{params, Connection};
+use sem_mcp::cache::CACHE_SCHEMA_VERSION;
+
+const PREVIOUS_CACHE_SCHEMA_VERSION: i32 = 1;
+
+fn sem_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_sem")
+}
+
+fn output_text(output: &Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn assert_success(output: Output, context: &str) -> Output {
+    assert!(
+        output.status.success(),
+        "{context} failed with status {:?}\n{}",
+        output.status.code(),
+        output_text(&output)
+    );
+    output
+}
+
+fn assert_failure(output: Output, context: &str) -> Output {
+    assert!(
+        !output.status.success(),
+        "{context} unexpectedly succeeded\n{}",
+        output_text(&output)
+    );
+    output
+}
+
+fn run_git(repo: &Path, args: &[&str]) -> Output {
+    assert_success(
+        Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .unwrap(),
+        &format!("git {}", args.join(" ")),
+    )
+}
+
+fn run_sem(repo: &Path, args: &[&str]) -> Output {
+    let mut command = Command::new(sem_bin());
+    command.args(args).current_dir(repo).env("NO_COLOR", "1");
+    command.output().unwrap()
+}
+
+fn init_repo(repo: &Path) {
+    assert_success(
+        Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(repo)
+            .output()
+            .unwrap(),
+        "git init",
+    );
+    run_git(repo, &["config", "user.email", "t@t.com"]);
+    run_git(repo, &["config", "user.name", "test"]);
+}
+
+fn rewrite_after_mtime_tick(path: &Path, content: &str) {
+    let before = fs::metadata(path).unwrap().modified().unwrap();
+
+    for _ in 0..200 {
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        fs::write(path, content).unwrap();
+        if fs::metadata(path).unwrap().modified().unwrap() != before {
+            return;
+        }
+    }
+
+    panic!("mtime did not change for {}", path.display());
+}
+
+fn assert_verify_reports_target_mismatch(output: &Output) {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(r#""caller": "use_it""#), "{stdout}");
+    assert!(stdout.contains(r#""callee": "target""#), "{stdout}");
+    assert!(stdout.contains(r#""expected_min": 1"#), "{stdout}");
+    assert!(stdout.contains(r#""expected_max": 1"#), "{stdout}");
+    assert!(stdout.contains(r#""actual_args": 3"#), "{stdout}");
+}
+
+fn file_mtime_parts(path: &Path) -> (i64, i64) {
+    let mtime = fs::metadata(path).unwrap().modified().unwrap();
+    let dur = mtime
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    (dur.as_secs() as i64, dur.subsec_nanos() as i64)
+}
+
+fn seed_v1_bad_full_cache(repo: &Path) {
+    assert!(CACHE_SCHEMA_VERSION > PREVIOUS_CACHE_SCHEMA_VERSION);
+
+    let cache_dir = repo.join(".sem");
+    fs::create_dir_all(&cache_dir).unwrap();
+    let conn = Connection::open(cache_dir.join("cache.db")).unwrap();
+    conn.execute_batch(&format!(
+        "PRAGMA user_version = {PREVIOUS_CACHE_SCHEMA_VERSION};
+         CREATE TABLE files (
+             path TEXT PRIMARY KEY,
+             mtime_secs INTEGER NOT NULL,
+             mtime_nanos INTEGER NOT NULL
+         );
+         CREATE TABLE entities (
+             id TEXT PRIMARY KEY,
+             name TEXT NOT NULL,
+             entity_type TEXT NOT NULL,
+             file_path TEXT NOT NULL,
+             start_line INTEGER NOT NULL,
+             end_line INTEGER NOT NULL,
+             content TEXT NOT NULL,
+             content_hash TEXT NOT NULL,
+             structural_hash TEXT,
+             parent_id TEXT,
+             metadata_json TEXT
+         );
+         CREATE TABLE edges (
+             from_entity TEXT NOT NULL,
+             to_entity TEXT NOT NULL,
+             ref_type TEXT NOT NULL
+         );"
+    ))
+    .unwrap();
+
+    let mut files = conn
+        .prepare("INSERT INTO files (path, mtime_secs, mtime_nanos) VALUES (?1, ?2, ?3)")
+        .unwrap();
+    for file in ["a.py", "b.py"] {
+        let (secs, nanos) = file_mtime_parts(&repo.join(file));
+        files.execute(params![file, secs, nanos]).unwrap();
+    }
+    drop(files);
+
+    let mut entities = conn
+        .prepare(
+            "INSERT INTO entities (
+                id, name, entity_type, file_path, start_line, end_line,
+                content, content_hash, structural_hash, parent_id, metadata_json
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, NULL, NULL)",
+        )
+        .unwrap();
+    entities
+        .execute(params![
+            "a.py::function::use_it",
+            "use_it",
+            "function",
+            "a.py",
+            1_i64,
+            2_i64,
+            "def use_it():\n    return target(1, 2, 3)\n",
+            "old-use-it"
+        ])
+        .unwrap();
+    entities
+        .execute(params![
+            "b.py::function::other",
+            "other",
+            "function",
+            "b.py",
+            1_i64,
+            2_i64,
+            "def other():\n    return 0\n",
+            "old-other"
+        ])
+        .unwrap();
+    entities
+        .execute(params![
+            "b.py::function::target",
+            "target",
+            "function",
+            "b.py",
+            4_i64,
+            5_i64,
+            "def target(a):\n    return a\n",
+            "old-target"
+        ])
+        .unwrap();
+}
+
+#[test]
+fn verify_incremental_cache_rechecks_clean_callers_for_new_callees() {
+    let temp = tempfile::tempdir().unwrap();
+    let repo = temp.path();
+
+    init_repo(repo);
+
+    fs::write(repo.join("b.py"), "def other():\n    return 0\n").unwrap();
+    fs::write(
+        repo.join("a.py"),
+        "def use_it():\n    return target(1, 2, 3)\n",
+    )
+    .unwrap();
+    run_git(repo, &["add", "a.py", "b.py"]);
+    run_git(repo, &["commit", "-q", "-m", "init"]);
+
+    assert_success(run_sem(repo, &["graph", "--json"]), "sem graph");
+
+    rewrite_after_mtime_tick(
+        &repo.join("b.py"),
+        "def other():\n    return 0\n\n\ndef target(a):\n    return a\n",
+    );
+
+    let cached = assert_failure(run_sem(repo, &["verify", "--json"]), "sem verify --json");
+    assert_verify_reports_target_mismatch(&cached);
+
+    let uncached = assert_failure(
+        run_sem(repo, &["verify", "--json", "--no-cache"]),
+        "sem verify --json --no-cache",
+    );
+    assert_verify_reports_target_mismatch(&uncached);
+}
+
+#[test]
+fn verify_rebuilds_v1_full_cache_hits() {
+    let temp = tempfile::tempdir().unwrap();
+    let repo = temp.path();
+
+    init_repo(repo);
+
+    fs::write(
+        repo.join("a.py"),
+        "def use_it():\n    return target(1, 2, 3)\n",
+    )
+    .unwrap();
+    fs::write(
+        repo.join("b.py"),
+        "def other():\n    return 0\n\n\ndef target(a):\n    return a\n",
+    )
+    .unwrap();
+    run_git(repo, &["add", "a.py", "b.py"]);
+    run_git(repo, &["commit", "-q", "-m", "init"]);
+
+    seed_v1_bad_full_cache(repo);
+
+    let output = assert_failure(run_sem(repo, &["verify", "--json"]), "sem verify --json");
+    assert_verify_reports_target_mismatch(&output);
+}

--- a/crates/sem-core/src/parser/graph.rs
+++ b/crates/sem-core/src/parser/graph.rs
@@ -585,6 +585,51 @@ impl EntityGraph {
             }
         }
 
+        let mut affected_target_names: HashSet<&str> = all_entities
+            .iter()
+            .filter(|entity| {
+                truly_changed_ids.contains(&entity.id)
+                    || parent_repaired_ids.contains(entity.id.as_str())
+            })
+            .map(|entity| entity.name.as_str())
+            .collect();
+        affected_target_names.extend(
+            stale_file_cached_entities
+                .iter()
+                .filter(|entity| deleted_ids.contains(entity.id.as_str()))
+                .map(|entity| entity.name.as_str()),
+        );
+
+        // Clean entities can gain edges to names introduced by stale files even when
+        // no cached edge existed.
+        if !affected_target_names.is_empty() {
+            for entity in &all_entities {
+                if stale_set.contains(entity.file_path.as_str())
+                    || affected_clean_ids.contains(&entity.id)
+                {
+                    continue;
+                }
+
+                let ext = entity
+                    .file_path
+                    .rfind('.')
+                    .map(|i| &entity.file_path[i..])
+                    .unwrap_or("");
+                if crate::parser::plugins::code::languages::get_language_config(ext).is_none() {
+                    continue;
+                }
+
+                if !text_mentions_any_name(&entity.content, &affected_target_names) {
+                    continue;
+                }
+
+                let stripped = strip_comments_and_strings(&entity.content);
+                if text_mentions_any_name(&stripped, &affected_target_names) {
+                    affected_clean_ids.insert(entity.id.clone());
+                }
+            }
+        }
+
         // Collect all stale entity IDs (for edge filtering)
         let stale_entity_ids: HashSet<&str> = all_entities
             .iter()
@@ -1801,6 +1846,12 @@ fn extract_dot_chains<'a>(content: &'a str) -> Vec<(&'a str, &'a str)> {
 fn extract_references_from_content<'a>(content: &'a str, own_name: &str) -> Vec<&'a str> {
     let stripped = strip_comments_and_strings(content);
     extract_references_with_stripped(content, own_name, &stripped)
+}
+
+fn text_mentions_any_name(text: &str, names: &HashSet<&str>) -> bool {
+    text
+        .split(|c: char| !c.is_alphanumeric() && c != '_')
+        .any(|word| names.contains(word))
 }
 
 /// Extract references using a pre-stripped version of the content.

--- a/crates/sem-mcp/src/cache.rs
+++ b/crates/sem-mcp/src/cache.rs
@@ -6,7 +6,7 @@ use rusqlite::{params, Connection, Transaction};
 use sem_core::model::entity::SemanticEntity;
 use sem_core::parser::graph::{EntityGraph, EntityInfo, EntityRef, RefType};
 
-pub const CACHE_SCHEMA_VERSION: i32 = 1;
+pub const CACHE_SCHEMA_VERSION: i32 = 2;
 pub const CACHE_INDEXES: &[(&str, &str, &str)] = &[
     ("idx_entities_file_path", "entities", "file_path"),
     ("idx_entities_name", "entities", "name"),
@@ -573,13 +573,8 @@ impl DiskCache {
             .iter()
             .filter(|file| !is_manifest_file_name(file))
             .collect();
-        let stale_set: HashSet<&str> = source_stale_files
-            .iter()
-            .map(|file| file.as_str())
-            .collect();
 
         let tx = self.conn.unchecked_transaction()?;
-        let mut deleted_cached_files = Vec::new();
 
         {
             let mut del_files = tx.prepare("DELETE FROM files WHERE path = ?1")?;
@@ -603,7 +598,6 @@ impl DiskCache {
             for path in &cached_paths {
                 if !is_cache_manifest_key(path) && !current_set.contains(path.as_str()) {
                     del_files.execute(params![path])?;
-                    deleted_cached_files.push(path.clone());
                 }
             }
         }
@@ -622,40 +616,31 @@ impl DiskCache {
 
         refresh_manifest_entries(&tx, root)?;
 
-        {
-            let mut del = tx.prepare("DELETE FROM entities WHERE file_path = ?1")?;
-            for f in &source_stale_files {
-                del.execute(params![f])?;
-            }
-            for f in &deleted_cached_files {
-                del.execute(params![f])?;
-            }
-        }
-
+        // Rewrite entity rows as a complete snapshot; graph repair can change
+        // entity IDs in files whose source bytes are still cached.
+        tx.execute("DELETE FROM entities", [])?;
         {
             let mut ins = tx.prepare(
                 "INSERT OR REPLACE INTO entities (id, name, entity_type, file_path, start_line, end_line, content, content_hash, structural_hash, parent_id, metadata_json) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
             )?;
             for e in entities {
-                if stale_set.contains(e.file_path.as_str()) {
-                    let metadata_json = e
-                        .metadata
-                        .as_ref()
-                        .and_then(|m| serde_json::to_string(m).ok());
-                    ins.execute(params![
-                        e.id,
-                        e.name,
-                        e.entity_type,
-                        e.file_path,
-                        e.start_line as i64,
-                        e.end_line as i64,
-                        e.content,
-                        e.content_hash,
-                        e.structural_hash,
-                        e.parent_id,
-                        metadata_json,
-                    ])?;
-                }
+                let metadata_json = e
+                    .metadata
+                    .as_ref()
+                    .and_then(|m| serde_json::to_string(m).ok());
+                ins.execute(params![
+                    e.id,
+                    e.name,
+                    e.entity_type,
+                    e.file_path,
+                    e.start_line as i64,
+                    e.end_line as i64,
+                    e.content,
+                    e.content_hash,
+                    e.structural_hash,
+                    e.parent_id,
+                    metadata_json,
+                ])?;
             }
         }
 
@@ -898,7 +883,7 @@ mod tests {
 
     #[test]
     fn open_rebuilds_cache_when_schema_version_is_unsupported() {
-        for version in [0, CACHE_SCHEMA_VERSION + 1] {
+        for version in [0, CACHE_SCHEMA_VERSION - 1, CACHE_SCHEMA_VERSION + 1] {
             let root = temp_repo_root(&format!("unsupported-{version}"));
             seed_unsupported_cache(&root, version);
 


### PR DESCRIPTION
## Summary
- Add `--no-cache` support to `sem verify`.
- Re-resolve clean callers that mention changed stale-file callees so incremental graph rebuilds can add previously missing call edges.
- Bump the shared SQLite cache schema version to invalidate pre-fix graph snapshots.
- Persist complete entity snapshots during incremental cache saves so rewritten edges cannot point at repaired clean entity IDs missing from the cache.

Fixes #250

## Test plan
- `cargo test --manifest-path crates/Cargo.toml -p sem-cli --test verify_cli -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p sem-cli cache::tests::open_rebuilds_cache_when_schema_version_is_unsupported -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p sem-mcp cache::tests::open_rebuilds_cache_when_schema_version_is_unsupported -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml --workspace -- --nocapture`
- Manual dummy git repos covering incremental stale-cache verification and seeded v1 bad full-cache invalidation.
