### PR TITLE
Filter cosmetic orphan changes from semantic diff

### DIFF
--- a/crates/sem-cli/src/commands/diff.rs
+++ b/crates/sem-cli/src/commands/diff.rs
@@ -1104,16 +1104,20 @@ fn retain_non_cosmetic_changes(result: &mut DiffResult) {
             change.after_content = None;
         }
     }
-    // Drop only purely cosmetic modifications; compound changes are preserved above.
-    result
-        .changes
-        .retain(|c| c.change_type != ChangeType::Modified || c.structural_change != Some(false));
+    // Drop purely cosmetic changes; compound moves/renames/reorders are preserved above.
+    result.changes.retain(|c| {
+        c.structural_change != Some(false)
+            || matches!(
+                c.change_type,
+                ChangeType::Moved | ChangeType::Renamed | ChangeType::Reordered
+            )
+    });
     recalculate_diff_summary(result);
 }
 
 fn recalculate_diff_summary(result: &mut DiffResult) {
-    // Mirrors compute_semantic_diff: any retained change, including an orphan,
-    // marks its file as changed. Orphans only skip the entity change-type buckets.
+    // Mirrors compute_semantic_diff: orphan_count is cross-cutting metadata,
+    // while retained orphans still contribute to change-type buckets.
     result.file_count = result
         .changes
         .iter()
@@ -1132,16 +1136,30 @@ fn recalculate_diff_summary(result: &mut DiffResult) {
     for change in &result.changes {
         if change.entity_type == "orphan" {
             orphan_count += 1;
-            continue;
         }
 
         match change.change_type {
             ChangeType::Added => added_count += 1,
             ChangeType::Modified => modified_count += 1,
             ChangeType::Deleted => deleted_count += 1,
-            ChangeType::Moved => moved_count += 1,
-            ChangeType::Renamed => renamed_count += 1,
-            ChangeType::Reordered => reordered_count += 1,
+            ChangeType::Moved => {
+                moved_count += 1;
+                if change.has_content_change() {
+                    modified_count += 1;
+                }
+            }
+            ChangeType::Renamed => {
+                renamed_count += 1;
+                if change.has_content_change() {
+                    modified_count += 1;
+                }
+            }
+            ChangeType::Reordered => {
+                reordered_count += 1;
+                if change.has_content_change() {
+                    modified_count += 1;
+                }
+            }
         }
     }
 
@@ -1222,12 +1240,27 @@ mod tests {
         assert_eq!(result.changes.len(), 3);
         assert_eq!(result.file_count, 2);
         assert_eq!(result.added_count, 1);
-        assert_eq!(result.modified_count, 1);
+        assert_eq!(result.modified_count, 2);
         assert_eq!(result.deleted_count, 0);
         assert_eq!(result.moved_count, 0);
         assert_eq!(result.renamed_count, 0);
         assert_eq!(result.reordered_count, 0);
         assert_eq!(result.orphan_count, 1);
+    }
+
+    #[test]
+    fn no_cosmetics_filter_drops_cosmetic_orphan_addition() {
+        let mut orphan = change("src/orphan.rs", ChangeType::Added, Some(false));
+        orphan.entity_type = "orphan".to_string();
+
+        let mut result = diff_result(vec![orphan]);
+
+        retain_non_cosmetic_changes(&mut result);
+
+        assert!(result.changes.is_empty());
+        assert_eq!(result.file_count, 0);
+        assert_eq!(result.added_count, 0);
+        assert_eq!(result.orphan_count, 0);
     }
 
     #[test]

--- a/crates/sem-cli/tests/diff_no_cosmetics.rs
+++ b/crates/sem-cli/tests/diff_no_cosmetics.rs
@@ -1,0 +1,197 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+struct TestRepo {
+    path: PathBuf,
+    home: PathBuf,
+}
+
+impl TestRepo {
+    fn new(name: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after UNIX epoch")
+            .as_nanos();
+        let path =
+            std::env::temp_dir().join(format!("sem-cli-{name}-{}-{nonce}", std::process::id()));
+        let home = std::env::temp_dir().join(format!(
+            "sem-cli-{name}-home-{}-{nonce}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path).expect("create temporary repo");
+        fs::create_dir_all(&home).expect("create temporary home");
+
+        git(&path, &["init", "-q"]);
+        git(&path, &["config", "user.email", "test@example.com"]);
+        git(&path, &["config", "user.name", "Test User"]);
+        git(&path, &["config", "commit.gpgsign", "false"]);
+
+        Self { path, home }
+    }
+}
+
+impl Drop for TestRepo {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+        let _ = fs::remove_dir_all(&self.home);
+    }
+}
+
+fn git(repo: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .expect("run git");
+
+    assert!(
+        output.status.success(),
+        "git {args:?} failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn sem(repo: &TestRepo, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_sem"))
+        .args(args)
+        .current_dir(&repo.path)
+        .env("HOME", &repo.home)
+        .output()
+        .expect("run sem")
+}
+
+#[test]
+fn no_cosmetics_hides_comment_only_orphan_change() {
+    let repo = TestRepo::new("diff-no-cosmetics-comment-orphan");
+    fs::write(
+        repo.path.join("app.py"),
+        "# original comment\ndef foo():\n    return 1\n",
+    )
+    .expect("write initial source");
+    git(&repo.path, &["add", "-A"]);
+    git(&repo.path, &["commit", "-q", "-m", "initial"]);
+
+    fs::write(
+        repo.path.join("app.py"),
+        "# changed comment text\ndef foo():\n    return 1\n",
+    )
+    .expect("write changed source");
+
+    let output = sem(&repo, &["diff", "--no-cosmetics", "--json"]);
+    assert!(
+        output.status.success(),
+        "sem diff failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be json");
+    assert_eq!(json["changes"].as_array().map(Vec::len), Some(0));
+    assert_eq!(json["summary"]["fileCount"], 0);
+    assert_eq!(json["summary"]["total"], 0);
+    assert_eq!(json["summary"]["orphan"], 0);
+}
+
+#[test]
+fn no_cosmetics_hides_added_comment_only_orphan() {
+    let repo = TestRepo::new("diff-no-cosmetics-added-comment-orphan");
+    fs::write(repo.path.join("app.py"), "def foo():\n    return 1\n")
+        .expect("write initial source");
+    git(&repo.path, &["add", "-A"]);
+    git(&repo.path, &["commit", "-q", "-m", "initial"]);
+
+    fs::write(
+        repo.path.join("app.py"),
+        "# added comment\ndef foo():\n    return 1\n",
+    )
+    .expect("write changed source");
+
+    let output = sem(&repo, &["diff", "--no-cosmetics", "--json"]);
+    assert!(
+        output.status.success(),
+        "sem diff failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be json");
+    assert_eq!(json["changes"].as_array().map(Vec::len), Some(0));
+    assert_eq!(json["summary"]["total"], 0);
+    assert_eq!(json["summary"]["orphan"], 0);
+}
+
+#[test]
+fn no_cosmetics_keeps_orphan_code_addition_in_summary_bucket() {
+    let repo = TestRepo::new("diff-no-cosmetics-code-orphan");
+    fs::write(repo.path.join("app.py"), "def foo():\n    return 1\n")
+        .expect("write initial source");
+    git(&repo.path, &["add", "-A"]);
+    git(&repo.path, &["commit", "-q", "-m", "initial"]);
+
+    fs::write(
+        repo.path.join("app.py"),
+        "import sys\n\ndef foo():\n    return 1\n",
+    )
+    .expect("write changed source");
+
+    let output = sem(&repo, &["diff", "--no-cosmetics", "--json"]);
+    assert!(
+        output.status.success(),
+        "sem diff failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be json");
+    assert_eq!(json["changes"].as_array().map(Vec::len), Some(1));
+    assert_eq!(json["changes"][0]["entityType"], "orphan");
+    assert_eq!(json["changes"][0]["changeType"], "added");
+    assert_eq!(json["changes"][0]["structuralChange"], true);
+    assert_eq!(json["summary"]["added"], 1);
+    assert_eq!(json["summary"]["total"], 1);
+    assert_eq!(json["summary"]["orphan"], 1);
+}
+
+#[test]
+fn no_cosmetics_keeps_shebang_change() {
+    let repo = TestRepo::new("diff-no-cosmetics-shebang");
+    fs::write(
+        repo.path.join("script"),
+        "#!/usr/bin/env python3\ndef foo():\n    return 1\n",
+    )
+    .expect("write initial source");
+    git(&repo.path, &["add", "-A"]);
+    git(&repo.path, &["commit", "-q", "-m", "initial"]);
+
+    fs::write(
+        repo.path.join("script"),
+        "#!/usr/bin/env python\ndef foo():\n    return 1\n",
+    )
+    .expect("write changed source");
+
+    let output = sem(&repo, &["diff", "--no-cosmetics", "--json"]);
+    assert!(
+        output.status.success(),
+        "sem diff failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be json");
+    assert_eq!(json["changes"].as_array().map(Vec::len), Some(1));
+    assert_eq!(json["changes"][0]["entityType"], "orphan");
+    assert_eq!(json["changes"][0]["changeType"], "modified");
+    assert_eq!(json["changes"][0]["structuralChange"], true);
+    assert_eq!(json["summary"]["modified"], 1);
+    assert_eq!(json["summary"]["total"], 1);
+    assert_eq!(json["summary"]["orphan"], 1);
+}

--- a/crates/sem-core/src/parser/differ.rs
+++ b/crates/sem-core/src/parser/differ.rs
@@ -19,6 +19,7 @@ macro_rules! maybe_par_iter {
 use crate::model::change::{ChangeType, SemanticChange};
 use crate::model::entity::SemanticEntity;
 use crate::model::identity::match_entities;
+use crate::parser::plugin::SemanticParserPlugin;
 use crate::parser::registry::ParserRegistry;
 use std::collections::{HashMap, HashSet};
 
@@ -107,6 +108,8 @@ pub fn compute_semantic_diff(
                     file,
                     &before_entities,
                     &after_entities,
+                    Some(plugin),
+                    detection_path,
                     commit_sha,
                     author,
                 );
@@ -367,6 +370,8 @@ fn detect_orphan_changes(
     file: &FileChange,
     before_entities: &[SemanticEntity],
     after_entities: &[SemanticEntity],
+    plugin: Option<&dyn SemanticParserPlugin>,
+    detection_path: &str,
     commit_sha: Option<&str>,
     author: Option<&str>,
 ) -> Vec<SemanticChange> {
@@ -448,11 +453,31 @@ fn detect_orphan_changes(
             commit_sha: commit_sha.map(String::from),
             author: author.map(String::from),
             timestamp: None,
-            structural_change: Some(true),
+            structural_change: orphan_structural_change(
+                before_content,
+                after_content,
+                plugin,
+                detection_path,
+            ),
         });
     }
 
     changes
+}
+
+fn orphan_structural_change(
+    before_content: Option<&str>,
+    after_content: Option<&str>,
+    plugin: Option<&dyn SemanticParserPlugin>,
+    detection_path: &str,
+) -> Option<bool> {
+    let plugin = plugin?;
+    let before_hash =
+        plugin.structural_hash_content(before_content.unwrap_or_default(), detection_path)?;
+    let after_hash =
+        plugin.structural_hash_content(after_content.unwrap_or_default(), detection_path)?;
+
+    Some(before_hash != after_hash)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -660,6 +685,45 @@ mod tests {
         assert_eq!(result.modified_count, 1);
         assert_eq!(result.changes[0].entity_type, "orphan");
         assert_eq!(result.changes[0].change_type, ChangeType::Modified);
+        assert_eq!(result.changes[0].structural_change, Some(false));
+    }
+
+    #[test]
+    fn orphan_code_change_is_structural() {
+        let before = "import os\n\ndef value():\n    return 1\n";
+        let after = "import sys\n\ndef value():\n    return 1\n";
+
+        let registry = create_default_registry();
+        let result = compute_semantic_diff(
+            &[modified_file("app.py", before, after)],
+            &registry,
+            None,
+            None,
+        );
+
+        assert_eq!(result.changes.len(), 1);
+        assert_eq!(result.changes[0].entity_type, "orphan");
+        assert_eq!(result.changes[0].change_type, ChangeType::Modified);
+        assert_eq!(result.changes[0].structural_change, Some(true));
+    }
+
+    #[test]
+    fn orphan_shebang_change_is_structural() {
+        let before = "#!/usr/bin/env python3\ndef value():\n    return 1\n";
+        let after = "#!/usr/bin/env python\ndef value():\n    return 1\n";
+
+        let registry = create_default_registry();
+        let result = compute_semantic_diff(
+            &[modified_file("script", before, after)],
+            &registry,
+            None,
+            None,
+        );
+
+        assert_eq!(result.changes.len(), 1);
+        assert_eq!(result.changes[0].entity_type, "orphan");
+        assert_eq!(result.changes[0].change_type, ChangeType::Modified);
+        assert_eq!(result.changes[0].structural_change, Some(true));
     }
 
     #[test]
@@ -849,6 +913,11 @@ mod tests {
             .changes
             .iter()
             .any(|c| c.entity_type == "orphan" && c.change_type == ChangeType::Added));
+        assert!(result.changes.iter().any(|c| {
+            c.entity_type == "orphan"
+                && c.change_type == ChangeType::Added
+                && c.structural_change == Some(false)
+        }));
 
         let named_bucket_total = result.added_count
             + result.modified_count
@@ -868,7 +937,7 @@ mod tests {
         );
         let entities = vec![entity_span("foo", 2, 2), entity_span("bar", 4, 4)];
 
-        let changes = detect_orphan_changes(&file, &entities, &entities, None, None);
+        let changes = detect_orphan_changes(&file, &entities, &entities, None, "a.rs", None, None);
 
         assert_eq!(changes.len(), 2);
         assert_eq!(changes[0].start_line, 1);
@@ -891,8 +960,15 @@ mod tests {
         let before_entities = vec![entity_span("foo", 1, 1)];
         let after_entities = vec![entity_span("foo", 2, 2)];
 
-        let changes =
-            detect_orphan_changes(&file, &before_entities, &after_entities, None, None);
+        let changes = detect_orphan_changes(
+            &file,
+            &before_entities,
+            &after_entities,
+            None,
+            "a.rs",
+            None,
+            None,
+        );
 
         assert!(changes.is_empty());
     }
@@ -907,8 +983,15 @@ mod tests {
         let before_entities = vec![entity_span("foo", 1, 1), entity_span("bar", 3, 3)];
         let after_entities = vec![entity_span("foo", 2, 2), entity_span("bar", 4, 4)];
 
-        let changes =
-            detect_orphan_changes(&file, &before_entities, &after_entities, None, None);
+        let changes = detect_orphan_changes(
+            &file,
+            &before_entities,
+            &after_entities,
+            None,
+            "a.rs",
+            None,
+            None,
+        );
 
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].change_type, ChangeType::Added);
@@ -938,8 +1021,15 @@ mod tests {
             entity_span("bar", 8, 8),
         ];
 
-        let changes =
-            detect_orphan_changes(&file, &before_entities, &after_entities, None, None);
+        let changes = detect_orphan_changes(
+            &file,
+            &before_entities,
+            &after_entities,
+            None,
+            "a.rs",
+            None,
+            None,
+        );
 
         assert_eq!(changes.len(), 3);
         assert_eq!(changes[0].change_type, ChangeType::Deleted);

--- a/crates/sem-core/src/parser/plugin.rs
+++ b/crates/sem-core/src/parser/plugin.rs
@@ -13,6 +13,9 @@ pub trait SemanticParserPlugin: Send + Sync {
     ) -> (Vec<SemanticEntity>, Option<tree_sitter::Tree>) {
         (self.extract_entities(content, file_path), None)
     }
+    fn structural_hash_content(&self, _content: &str, _file_path: &str) -> Option<String> {
+        None
+    }
     fn compute_similarity(&self, a: &SemanticEntity, b: &SemanticEntity) -> f64 {
         crate::model::identity::default_similarity(a, b)
     }

--- a/crates/sem-core/src/parser/plugins/code/mod.rs
+++ b/crates/sem-core/src/parser/plugins/code/mod.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 
 use crate::model::entity::SemanticEntity;
 use crate::parser::plugin::SemanticParserPlugin;
+use crate::utils::hash::{content_hash, structural_hash};
 use languages::{get_all_code_extensions, get_language_config};
 use entity_extractor::extract_entities;
 
@@ -15,6 +16,81 @@ pub struct CodeParserPlugin;
 // Avoids creating a new Parser for every file during parallel graph builds.
 thread_local! {
     static PARSER_CACHE: RefCell<HashMap<&'static str, tree_sitter::Parser>> = RefCell::new(HashMap::new());
+}
+
+fn language_config_for_content(
+    content: &str,
+    file_path: &str,
+) -> Option<&'static languages::LanguageConfig> {
+    let ext = std::path::Path::new(file_path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| format!(".{}", e.to_lowercase()))
+        .unwrap_or_default();
+
+    get_language_config(&ext).or_else(|| {
+        detect_ext_from_content(content).and_then(|shebang_ext| get_language_config(&shebang_ext))
+    })
+}
+
+fn parse_tree(
+    config: &'static languages::LanguageConfig,
+    content: &str,
+) -> Option<tree_sitter::Tree> {
+    let language = (config.get_language)()?;
+
+    PARSER_CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        let parser = cache.entry(config.id).or_insert_with(|| {
+            let mut p = tree_sitter::Parser::new();
+            let _ = p.set_language(&language);
+            p
+        });
+
+        parser.parse(content.as_bytes(), None)
+    })
+}
+
+fn has_non_comment_content(node: tree_sitter::Node, source: &[u8]) -> bool {
+    let mut worklist = Vec::new();
+    let mut cursor = node.walk();
+    worklist.extend(node.children(&mut cursor));
+
+    while let Some(node) = worklist.pop() {
+        if is_comment_node(node.kind()) {
+            continue;
+        }
+
+        if node.child_count() == 0 {
+            let start = node.start_byte();
+            let end = node.end_byte();
+            if start < end
+                && end <= source.len()
+                && source[start..end].iter().any(|b| !b.is_ascii_whitespace())
+            {
+                return true;
+            }
+            continue;
+        }
+
+        let mut cursor = node.walk();
+        worklist.extend(node.children(&mut cursor));
+    }
+
+    false
+}
+
+fn is_comment_node(kind: &str) -> bool {
+    matches!(
+        kind,
+        "comment" | "line_comment" | "block_comment" | "doc_comment" | "tag_comment"
+    )
+}
+
+fn shebang_line(content: &str) -> Option<&str> {
+    content
+        .strip_prefix("#!")
+        .map(|rest| rest.lines().next().unwrap_or(""))
 }
 
 impl SemanticParserPlugin for CodeParserPlugin {
@@ -35,46 +111,30 @@ impl SemanticParserPlugin for CodeParserPlugin {
         content: &str,
         file_path: &str,
     ) -> (Vec<SemanticEntity>, Option<tree_sitter::Tree>) {
-        let ext = std::path::Path::new(file_path)
-            .extension()
-            .and_then(|e| e.to_str())
-            .map(|e| format!(".{}", e.to_lowercase()))
-            .unwrap_or_default();
-
-        let config = match get_language_config(&ext) {
-            Some(c) => c,
-            None => {
-                // Try shebang detection for extensionless files
-                match detect_ext_from_content(content)
-                    .and_then(|se| get_language_config(&se))
-                {
-                    Some(c) => c,
-                    None => return (Vec::new(), None),
-                }
-            }
+        let Some(config) = language_config_for_content(content, file_path) else {
+            return (Vec::new(), None);
         };
 
-        let language = match (config.get_language)() {
-            Some(lang) => lang,
-            None => return (Vec::new(), None),
+        let Some(tree) = parse_tree(config, content) else {
+            return (Vec::new(), None);
         };
 
-        PARSER_CACHE.with(|cache| {
-            let mut cache = cache.borrow_mut();
-            let parser = cache.entry(config.id).or_insert_with(|| {
-                let mut p = tree_sitter::Parser::new();
-                let _ = p.set_language(&language);
-                p
-            });
+        let entities = extract_entities(&tree, file_path, config, content);
+        (entities, Some(tree))
+    }
 
-            let tree = match parser.parse(content.as_bytes(), None) {
-                Some(t) => t,
-                None => return (Vec::new(), None),
-            };
-
-            let entities = extract_entities(&tree, file_path, config, content);
-            (entities, Some(tree))
-        })
+    fn structural_hash_content(&self, content: &str, file_path: &str) -> Option<String> {
+        let config = language_config_for_content(content, file_path)?;
+        let tree = parse_tree(config, content)?;
+        let shebang = shebang_line(content);
+        if shebang.is_none() && !has_non_comment_content(tree.root_node(), content.as_bytes()) {
+            return Some(String::new());
+        }
+        let structural = structural_hash(tree.root_node(), content.as_bytes());
+        match shebang {
+            Some(shebang) => Some(content_hash(&format!("shebang:{shebang}\n{structural}"))),
+            None => Some(structural),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- classify orphan changes with parser structural hashes so comment-only orphan edits are cosmetic
- keep real orphan code changes visible under `--no-cosmetics` and preserve their summary buckets
- treat shebang edits as structural executable metadata

Fixes #272

## Test plan
- `cargo test --workspace`
- dummy Git repos covering comment-only edits, added comments, added imports, modified imports, and shebang edits
- independent subagent review completed; actionable findings fixed
- `claude -p` reviewer launched twice; final embedded-diff run exited successfully but produced no review text