### PR TITLE
Prevent fallback graph edges after scoped misses

### DIFF
--- a/crates/sem-core/src/parser/graph.rs
+++ b/crates/sem-core/src/parser/graph.rs
@@ -7,6 +7,7 @@
 //!
 //! This enables impact analysis: "if I change entity X, what else is affected?"
 
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::{Arc, LazyLock};
@@ -54,9 +55,85 @@ fn add_scope_reference_words(words: &mut HashSet<String>, reference: &str) {
         if !member.is_empty() {
             words.insert(member.to_string());
         }
+    } else if reference.contains("::") {
+        for part in reference.split("::").filter(|part| !part.is_empty()) {
+            words.insert(part.to_string());
+        }
     } else if !reference.is_empty() {
         words.insert(reference.to_string());
     }
+}
+
+fn build_descendant_ranges_by_entity(
+    entity_map: &HashMap<String, EntityInfo>,
+) -> HashMap<String, Vec<(usize, usize)>> {
+    let mut ranges_by_entity: HashMap<String, Vec<(usize, usize)>> = HashMap::new();
+
+    let mut entities_by_file: HashMap<&str, Vec<(&str, &EntityInfo)>> = HashMap::new();
+    for (id, entity) in entity_map {
+        entities_by_file
+            .entry(entity.file_path.as_str())
+            .or_default()
+            .push((id.as_str(), entity));
+    }
+
+    for file_entities in entities_by_file.values() {
+        for (child_id, child) in file_entities {
+            for (candidate_id, candidate) in file_entities {
+                if child_id == candidate_id {
+                    continue;
+                }
+                if is_strict_enclosing_entity(candidate, child) {
+                    ranges_by_entity
+                        .entry((*candidate_id).to_string())
+                        .or_default()
+                        .push((child.start_line, child.end_line));
+                }
+            }
+        }
+    }
+    for ranges in ranges_by_entity.values_mut() {
+        ranges.sort_unstable();
+        ranges.dedup();
+    }
+
+    ranges_by_entity
+}
+
+fn is_strict_enclosing_entity(candidate: &EntityInfo, child: &EntityInfo) -> bool {
+    candidate.start_line <= child.start_line
+        && child.end_line <= candidate.end_line
+        && (candidate.start_line < child.start_line || child.end_line < candidate.end_line)
+}
+
+fn content_without_descendant_ranges<'a>(
+    content: &'a str,
+    entity_id: &str,
+    start_line: usize,
+    descendant_ranges_by_entity: &HashMap<String, Vec<(usize, usize)>>,
+) -> Cow<'a, str> {
+    let Some(ranges) = descendant_ranges_by_entity.get(entity_id) else {
+        return Cow::Borrowed(content);
+    };
+    if ranges.is_empty() {
+        return Cow::Borrowed(content);
+    }
+
+    let mut masked = String::with_capacity(content.len());
+    for (line_offset, line) in content.lines().enumerate() {
+        let line_number = start_line + line_offset;
+        if ranges
+            .iter()
+            .any(|(range_start, range_end)| line_number >= *range_start && line_number <= *range_end)
+        {
+            masked.push('\n');
+        } else {
+            masked.push_str(line);
+            masked.push('\n');
+        }
+    }
+
+    Cow::Owned(masked)
 }
 
 /// A reference from one entity to another.
@@ -303,6 +380,7 @@ impl EntityGraph {
         } else {
             (vec![], HashMap::new())
         };
+        let descendant_ranges_by_entity = build_descendant_ranges_by_entity(&entity_map);
 
         // Pass 2: Extract references in parallel, then resolve against symbol table
         // Phase 1: Dot-chain resolution (precise self.X, this.X, ClassName.X)
@@ -324,8 +402,16 @@ impl EntityGraph {
                     .cloned()
                     .unwrap_or_default();
 
+                let fallback_content = content_without_descendant_ranges(
+                    &entity.content,
+                    &entity.id,
+                    entity.start_line,
+                    &descendant_ranges_by_entity,
+                );
+                let fallback_content = fallback_content.as_ref();
+
                 // Strip comments/strings once, reuse for both dot-chain and bag-of-words
-                let stripped = strip_comments_and_strings(&entity.content);
+                let stripped = strip_comments_and_strings(fallback_content);
 
                 // Phase 1: Dot-chain resolution
                 let dot_chains = extract_dot_chains(&stripped);
@@ -373,7 +459,7 @@ impl EntityGraph {
 
                 // Phase 2: Bag-of-words resolution (skip words consumed by dot-chains)
                 // Reuse the stripped content to avoid stripping twice
-                let refs = extract_references_with_stripped(&entity.content, &entity.name, &stripped);
+                let refs = extract_references_with_stripped(fallback_content, &entity.name, &stripped);
                 for ref_name in refs {
                     if consumed_words.contains(ref_name) {
                         continue;
@@ -392,7 +478,7 @@ impl EntityGraph {
                             && !parent_child_pairs.contains(&(entity.id.as_str(), import_target_id.as_str()))
                             && !parent_child_pairs.contains(&(import_target_id.as_str(), entity.id.as_str()))
                         {
-                            let ref_type = infer_ref_type(&entity.content, &ref_name);
+                            let ref_type = infer_ref_type(fallback_content, &ref_name);
                             entity_edges.push((
                                 entity.id.clone(),
                                 import_target_id.clone(),
@@ -421,7 +507,7 @@ impl EntityGraph {
                             {
                                 continue;
                             }
-                            let ref_type = infer_ref_type(&entity.content, &ref_name);
+                            let ref_type = infer_ref_type(fallback_content, &ref_name);
                             entity_edges.push((
                                 entity.id.clone(),
                                 target_id.clone(),
@@ -745,6 +831,7 @@ impl EntityGraph {
         } else {
             (vec![], HashMap::new())
         };
+        let descendant_ranges_by_entity = build_descendant_ranges_by_entity(&entity_map);
 
         // Resolve references only for entities in needs_resolution
         let resolved_refs: Vec<(String, String, RefType)> = maybe_par_iter!(all_entities)
@@ -762,8 +849,16 @@ impl EntityGraph {
                     .cloned()
                     .unwrap_or_default();
 
+                let fallback_content = content_without_descendant_ranges(
+                    &entity.content,
+                    &entity.id,
+                    entity.start_line,
+                    &descendant_ranges_by_entity,
+                );
+                let fallback_content = fallback_content.as_ref();
+
                 // Strip comments/strings once, reuse for both dot-chain and bag-of-words
-                let stripped = strip_comments_and_strings(&entity.content);
+                let stripped = strip_comments_and_strings(fallback_content);
 
                 // Phase 1: Dot-chain resolution
                 let dot_chains = extract_dot_chains(&stripped);
@@ -808,7 +903,7 @@ impl EntityGraph {
                 }
 
                 // Phase 2: Bag-of-words resolution (reuse stripped content)
-                let refs = extract_references_with_stripped(&entity.content, &entity.name, &stripped);
+                let refs = extract_references_with_stripped(fallback_content, &entity.name, &stripped);
                 for ref_name in refs {
                     if consumed_words.contains(ref_name) {
                         continue;
@@ -823,7 +918,7 @@ impl EntityGraph {
                             && !parent_child_pairs.contains(&(entity.id.as_str(), import_target_id.as_str()))
                             && !parent_child_pairs.contains(&(import_target_id.as_str(), entity.id.as_str()))
                         {
-                            let ref_type = infer_ref_type(&entity.content, &ref_name);
+                            let ref_type = infer_ref_type(fallback_content, &ref_name);
                             entity_edges.push((
                                 entity.id.clone(),
                                 import_target_id.clone(),
@@ -849,7 +944,7 @@ impl EntityGraph {
                             {
                                 continue;
                             }
-                            let ref_type = infer_ref_type(&entity.content, &ref_name);
+                            let ref_type = infer_ref_type(fallback_content, &ref_name);
                             entity_edges.push((
                                 entity.id.clone(),
                                 target_id.clone(),
@@ -2740,6 +2835,183 @@ export function caller(foo) { return foo(); }
         assert!(
             !deps.iter().any(|d| d.name == "foo" && d.file_path == "lib.ts"),
             "local parameter foo should shadow named import. Deps: {:?}",
+            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_nested_local_binding_does_not_hide_parent_reference() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "lib.ts", "\
+export const answer = 42;
+");
+        write_file(root, "main.ts", "\
+import { answer } from './lib';
+export function outer() {
+    const value = answer;
+    function inner() {
+        const answer = 0;
+        return answer;
+    }
+    return value;
+}
+");
+
+        let (graph, _) = EntityGraph::build(
+            root,
+            &["lib.ts".into(), "main.ts".into()],
+            &registry,
+        );
+
+        let outer_id = graph.entities.iter()
+            .find(|(_, entity)| entity.name == "outer")
+            .map(|(id, _)| id)
+            .expect("outer entity should exist");
+        let outer_deps = graph.get_dependencies(outer_id);
+        assert!(
+            outer_deps.iter().any(|d| d.name == "answer" && d.file_path == "lib.ts"),
+            "parent bare reference to imported answer should remain resolved. Deps: {:?}",
+            outer_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+
+        let inner_id = graph.entities.iter()
+            .find(|(_, entity)| entity.name == "inner")
+            .map(|(id, _)| id)
+            .expect("inner entity should exist");
+        let inner_deps = graph.get_dependencies(inner_id);
+        assert!(
+            !inner_deps.iter().any(|d| d.name == "answer" && d.file_path == "lib.ts"),
+            "nested local binding answer should not resolve to imported answer. Deps: {:?}",
+            inner_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_python_local_binding_shadows_same_file_function() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "b.py", "\
+def total(items):
+    return sum(items)
+
+def report():
+    total = 0
+    for i in range(10):
+        total = total + i
+    return total
+");
+
+        let (graph, _) = EntityGraph::build(root, &["b.py".into()], &registry);
+
+        let report_id = graph.entities.iter()
+            .find(|(_, entity)| entity.name == "report")
+            .map(|(id, _)| id)
+            .expect("report entity should exist");
+        let deps = graph.get_dependencies(report_id);
+        assert!(
+            !deps.iter().any(|d| d.name == "total"),
+            "local variable total should not resolve to same-file function total. Deps: {:?}",
+            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_rust_impl_container_does_not_inherit_child_build_call() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "graph.rs", "\
+pub struct EntityGraph;
+
+impl EntityGraph {
+    pub fn build(a: i32, b: i32, c: i32) -> i32 {
+        a + b + c
+    }
+}
+");
+        write_file(root, "server.rs", "\
+use crate::graph::EntityGraph;
+
+struct SemServer;
+
+impl SemServer {
+    fn find_supported_files() {
+        let mut builder = ignore::WalkBuilder::new(\".\");
+        let walker = builder.build();
+    }
+
+    fn get_or_build_graph() {
+        let _ = EntityGraph::build(1, 2, 3);
+    }
+}
+
+impl SemServer {
+    fn metadata(&self) -> i32 {
+        1
+    }
+}
+");
+
+        let (graph, _) = EntityGraph::build(
+            root,
+            &["graph.rs".into(), "server.rs".into()],
+            &registry,
+        );
+
+        let sem_server_impls: Vec<_> = graph.entities.iter()
+            .filter(|(_, entity)| entity.entity_type == "impl" && entity.name == "SemServer")
+            .collect();
+        assert!(
+            sem_server_impls.len() >= 2,
+            "test fixture should produce duplicate SemServer impl entities"
+        );
+        for (impl_id, _) in sem_server_impls {
+            let impl_deps = graph.get_dependencies(impl_id);
+            assert!(
+                !impl_deps.iter().any(|d| d.name == "build" && d.file_path == "graph.rs"),
+                "impl container should not inherit child build calls. Deps: {:?}",
+                impl_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+            );
+        }
+
+        let method_id = graph.entities.iter()
+            .find(|(_, entity)| entity.name == "get_or_build_graph")
+            .map(|(id, _)| id)
+            .expect("get_or_build_graph entity should exist");
+        let method_deps = graph.get_dependencies(method_id);
+        assert!(
+            method_deps.iter().any(|d| d.name == "build" && d.file_path == "graph.rs"),
+            "direct EntityGraph::build call should remain resolved. Deps: {:?}",
+            method_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_rust_lowercase_scoped_path_does_not_fallback_to_local_function() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "main.rs", "\
+fn baz() {}
+
+fn caller() {
+    foo::bar::baz();
+}
+");
+
+        let (graph, _) = EntityGraph::build(root, &["main.rs".into()], &registry);
+
+        let caller_id = graph.entities.iter()
+            .find(|(_, entity)| entity.name == "caller")
+            .map(|(id, _)| id)
+            .expect("caller entity should exist");
+        let deps = graph.get_dependencies(caller_id);
+        assert!(
+            !deps.iter().any(|d| d.name == "baz"),
+            "lowercase scoped path should not fall back to local baz function. Deps: {:?}",
             deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
         );
     }

--- a/crates/sem-core/src/parser/scope_resolve.rs
+++ b/crates/sem-core/src/parser/scope_resolve.rs
@@ -42,6 +42,8 @@ pub struct Scope {
     defs: HashMap<String, String>,
     /// Local bindings that shadow outer names but are not graph entities.
     bindings: HashSet<String>,
+    /// Binding declaration rows keyed by name.
+    binding_rows: HashMap<String, Vec<usize>>,
     /// Variable type bindings: var_name -> class_name (from `x = Foo()`)
     types: HashMap<String, String>,
     /// Unresolved call assignments: var_name -> function_name (from `x = func()`)
@@ -64,6 +66,8 @@ struct AstRef {
 enum AstRefKind {
     /// Bare name call: `foo()`
     Call(String),
+    /// Qualified path call: `module::function()`
+    ScopedCall { path: String, name: String },
     /// Attribute call: `x.method()`
     MethodCall { receiver: String, method: String },
 }
@@ -318,6 +322,7 @@ pub(crate) fn resolve_with_scopes_full(
                 parent: None,
                 defs: HashMap::new(),
                 bindings: HashSet::new(),
+                binding_rows: HashMap::new(),
                 types: HashMap::new(),
                 pending_call_types: HashMap::new(),
                 owner_id: None,
@@ -386,6 +391,8 @@ pub(crate) fn resolve_with_scopes_full(
 
             // Walk the AST once for the entire file, collecting all refs with row positions
             let all_file_refs = collect_all_file_refs(tree.root_node(), source, config);
+            let descendant_ranges_by_entity =
+                build_descendant_ranges_by_entity(&file_entities, entity_map);
 
             for entity in &file_entities {
                 let scope_idx = entity_inner_scope
@@ -393,15 +400,31 @@ pub(crate) fn resolve_with_scopes_full(
                     .or_else(|| entity_scope_map.get(&entity.id))
                     .copied()
                     .unwrap_or(0);
-
                 let start_row = entity.start_line.saturating_sub(1); // 1-indexed to 0-indexed
                 let end_row = entity.end_line; // exclusive
+                log_scope_bindings(
+                    &mut file_log,
+                    &entity.id,
+                    &scopes[scope_idx],
+                    start_row,
+                    end_row,
+                    &descendant_ranges_by_entity,
+                );
 
                 // Filter pre-collected refs to this entity's line range
                 for ast_ref in all_file_refs.iter().filter(|r| r.row >= start_row && r.row < end_row) {
+                    if row_belongs_to_descendant(
+                        &descendant_ranges_by_entity,
+                        &entity.id,
+                        ast_ref.row,
+                    ) {
+                        continue;
+                    }
+
                     // Skip self-name refs (was previously done during collection)
                     let is_self_ref = match &ast_ref.kind {
                         AstRefKind::Call(name) => name == &entity.name,
+                        AstRefKind::ScopedCall { .. } => false,
                         AstRefKind::MethodCall { .. } => false,
                     };
                     if is_self_ref {
@@ -488,8 +511,101 @@ pub(crate) fn resolve_with_scopes_full(
 fn ref_description(ast_ref: &AstRef) -> String {
     match &ast_ref.kind {
         AstRefKind::Call(name) => format!("{}()", name),
+        AstRefKind::ScopedCall { path, name } => format!("{}::{}()", path, name),
         AstRefKind::MethodCall { receiver, method } => format!("{}.{}()", receiver, method),
     }
+}
+
+fn log_scope_bindings(
+    file_log: &mut Vec<ResolutionEntry>,
+    from_entity: &str,
+    scope: &Scope,
+    start_row: usize,
+    end_row: usize,
+    descendant_ranges_by_entity: &HashMap<String, Vec<(usize, usize)>>,
+) {
+    let mut bindings: Vec<&String> = scope.bindings.iter().collect();
+    bindings.sort();
+    for binding in bindings {
+        let belongs_to_entity = scope
+            .binding_rows
+            .get(binding)
+            .map_or(false, |rows| {
+                rows.iter().any(|row| {
+                    *row >= start_row
+                        && *row < end_row
+                        && !row_belongs_to_descendant(
+                            descendant_ranges_by_entity,
+                            from_entity,
+                            *row,
+                        )
+                })
+            });
+        if !belongs_to_entity {
+            continue;
+        }
+        file_log.push(ResolutionEntry {
+            from_entity: from_entity.to_string(),
+            reference: binding.clone(),
+            resolved_to: None,
+            method: "local_binding",
+        });
+    }
+}
+
+fn build_descendant_ranges_by_entity(
+    file_entities: &[&SemanticEntity],
+    entity_map: &HashMap<String, EntityInfo>,
+) -> HashMap<String, Vec<(usize, usize)>> {
+    let mut ranges_by_entity: HashMap<String, Vec<(usize, usize)>> = HashMap::new();
+    for entity in file_entities {
+        let child_range = (entity.start_line.saturating_sub(1), entity.end_line);
+        let mut current = entity.parent_id.as_deref();
+        let mut visited = HashSet::new();
+        while let Some(parent_id) = current {
+            if !visited.insert(parent_id.to_string()) {
+                break;
+            }
+            ranges_by_entity
+                .entry(parent_id.to_string())
+                .or_default()
+                .push(child_range);
+            current = entity_map
+                .get(parent_id)
+                .and_then(|parent| parent.parent_id.as_deref());
+        }
+
+        for candidate in file_entities {
+            if candidate.id != entity.id && is_strict_enclosing_range(candidate, entity) {
+                ranges_by_entity
+                    .entry(candidate.id.clone())
+                    .or_default()
+                    .push(child_range);
+            }
+        }
+    }
+    for ranges in ranges_by_entity.values_mut() {
+        ranges.sort_unstable();
+        ranges.dedup();
+    }
+    ranges_by_entity
+}
+
+fn is_strict_enclosing_range(candidate: &SemanticEntity, child: &SemanticEntity) -> bool {
+    candidate.file_path == child.file_path
+        && candidate.start_line <= child.start_line
+        && child.end_line <= candidate.end_line
+        && (candidate.start_line < child.start_line || child.end_line < candidate.end_line)
+}
+
+fn row_belongs_to_descendant(
+    descendant_ranges_by_entity: &HashMap<String, Vec<(usize, usize)>>,
+    entity_id: &str,
+    row: usize,
+) -> bool {
+    descendant_ranges_by_entity
+        .get(entity_id)
+        .map_or(false, |ranges| ranges.iter().any(|(start, end)| row >= *start && row < *end))
 }
 
 /// Build scope tree by walking the AST.
@@ -576,6 +692,7 @@ fn build_scopes_from_ast(
                         parent: Some(current_scope),
                         defs: HashMap::new(),
                         bindings: HashSet::new(),
+                        binding_rows: HashMap::new(),
                         types: HashMap::new(),
                         pending_call_types: HashMap::new(),
                         owner_id: Some(ce.id.clone()),
@@ -607,6 +724,7 @@ fn build_scopes_from_ast(
                     parent: Some(current_scope),
                     defs: HashMap::new(),
                     bindings: HashSet::new(),
+                    binding_rows: HashMap::new(),
                     types: HashMap::new(),
                     pending_call_types: HashMap::new(),
                     owner_id: None,
@@ -633,6 +751,7 @@ fn build_scopes_from_ast(
                 parent: Some(current_scope),
                 defs: HashMap::new(),
                 bindings: HashSet::new(),
+                binding_rows: HashMap::new(),
                 types: HashMap::new(),
                 pending_call_types: HashMap::new(),
                 owner_id: None,
@@ -703,6 +822,7 @@ fn build_scopes_from_ast(
                 parent: Some(parent_scope),
                 defs: HashMap::new(),
                 bindings: HashSet::new(),
+                binding_rows: HashMap::new(),
                 types: HashMap::new(),
                 pending_call_types: HashMap::new(),
                 owner_id: None,
@@ -812,6 +932,15 @@ fn scan_assignments(
     }
 }
 
+fn record_binding(scopes: &mut [Scope], scope_idx: usize, name: &str, row: usize) {
+    scopes[scope_idx].bindings.insert(name.to_string());
+    scopes[scope_idx]
+        .binding_rows
+        .entry(name.to_string())
+        .or_default()
+        .push(row);
+}
+
 /// Scan function parameter type annotations and add them as type bindings.
 /// e.g. `def foo(shelter: Shelter)` -> types["shelter"] = "Shelter"
 fn scan_function_params(
@@ -897,7 +1026,7 @@ fn scan_function_params(
             if param_name.is_empty() || rule.skip_names.contains(&param_name) {
                 continue;
             }
-            scopes[scope_idx].bindings.insert(param_name.to_string());
+            record_binding(scopes, scope_idx, param_name, child.start_position().row);
 
             // Try the configured type field first, then fall back to child type nodes
             // (Swift parameters have user_type children instead of a "type" field)
@@ -959,7 +1088,7 @@ fn scan_single_assignment(
         Ok(n) => n.to_string(),
         Err(_) => return,
     };
-    scopes[scope_idx].bindings.insert(var_name.clone());
+    record_binding(scopes, scope_idx, &var_name, left.start_position().row);
 
     record_type_from_rhs(right, &var_name, scope_idx, scopes, source);
 }
@@ -983,7 +1112,11 @@ fn scan_ts_var_declaration(
             if var_name.is_empty() {
                 continue;
             }
-            scopes[scope_idx].bindings.insert(var_name.clone());
+            let binding_row = child
+                .child_by_field_name("name")
+                .map(|n| n.start_position().row)
+                .unwrap_or_else(|| child.start_position().row);
+            record_binding(scopes, scope_idx, &var_name, binding_row);
 
             // Check for explicit type annotation: `const x: Foo = ...`
             if let Some(type_ann) = child.child_by_field_name("type") {
@@ -1123,7 +1256,7 @@ fn scan_rust_let_declaration(
     if var_name.is_empty() {
         return;
     }
-    scopes[scope_idx].bindings.insert(var_name.clone());
+    record_binding(scopes, scope_idx, &var_name, node.start_position().row);
 
     // Check for explicit type annotation: `let x: Connection = ...`
     if let Some(type_node) = node.child_by_field_name("type") {
@@ -1173,7 +1306,7 @@ fn scan_go_short_var(
     if var_name.is_empty() {
         return;
     }
-    scopes[scope_idx].bindings.insert(var_name.clone());
+    record_binding(scopes, scope_idx, &var_name, left.start_position().row);
 
     let rhs = if right.kind() == "expression_list" {
         match right.named_child(0) {
@@ -1208,7 +1341,7 @@ fn scan_go_var_declaration(
                     if first.kind() == "identifier" {
                         let name = first.utf8_text(source).unwrap_or("").to_string();
                         if !name.is_empty() {
-                            scopes[scope_idx].bindings.insert(name.clone());
+                            record_binding(scopes, scope_idx, &name, first.start_position().row);
                             // Check for type child
                             if let Some(type_node) = child.child_by_field_name("type") {
                                 let type_text = extract_base_type(type_node, source);
@@ -1223,7 +1356,11 @@ fn scan_go_var_declaration(
                 }
                 continue;
             }
-            scopes[scope_idx].bindings.insert(var_name.clone());
+            let binding_row = child
+                .child_by_field_name("name")
+                .map(|n| n.start_position().row)
+                .unwrap_or_else(|| child.start_position().row);
+            record_binding(scopes, scope_idx, &var_name, binding_row);
 
             // Check for explicit type
             if let Some(type_node) = child.child_by_field_name("type") {
@@ -2994,7 +3131,7 @@ fn extract_call_ref(
             let is_path_prefix =
                 parts[0] == "super" || parts[0] == "self" || parts[0] == "crate";
             let method_name = parts[parts.len() - 1];
-            if is_path_prefix {
+            if is_path_prefix && parts.len() == 2 {
                 if !method_name.is_empty() && !is_builtin(method_name, config) {
                     refs.push(AstRef {
                         kind: AstRefKind::Call(method_name.to_string()),
@@ -3002,17 +3139,26 @@ fn extract_call_ref(
                     });
                 }
             } else {
-                let type_name = parts[parts.len() - 2];
-                if !type_name.is_empty() && !method_name.is_empty() {
-                    refs.push(AstRef {
-                        kind: AstRefKind::Call(method_name.to_string()),
-                        row,
-                    });
-                    if type_name.chars().next().map_or(false, |c| c.is_uppercase())
-                        && !is_builtin(type_name, config)
+                let receiver = parts[..parts.len() - 1].join("::");
+                let receiver_base = parts[parts.len() - 2];
+                if !receiver.is_empty() && !method_name.is_empty() {
+                    if parts.len() == 2
+                        && receiver_base.chars().next().map_or(false, |c| c.is_uppercase())
+                        && !is_builtin(receiver_base, config)
                     {
                         refs.push(AstRef {
-                            kind: AstRefKind::Call(type_name.to_string()),
+                            kind: AstRefKind::MethodCall {
+                                receiver: receiver_base.to_string(),
+                                method: method_name.to_string(),
+                            },
+                            row,
+                        });
+                    } else if !is_builtin(method_name, config) {
+                        refs.push(AstRef {
+                            kind: AstRefKind::ScopedCall {
+                                path: receiver,
+                                name: method_name.to_string(),
+                            },
                             row,
                         });
                     }
@@ -3140,6 +3286,8 @@ fn resolve_ref(
 
             None
         }
+
+        AstRefKind::ScopedCall { .. } => None,
 
         AstRefKind::MethodCall { receiver: raw_receiver, method } => {
             // Strip prefix operators like ! (Swift: `!dog.validate()`)


### PR DESCRIPTION
Closes #248

## Summary
- skip descendant entity bodies when graph fallback extracts dot-chain and bag-of-words references for enclosing entities
- record local binding rows in scope resolution so scoped misses only consume fallback words for the entity that owns the binding
- preserve scoped `Type::method` resolution for Rust while avoiding unresolved receiver fallbacks to unrelated same-name methods

## Test plan
- `cargo test -p sem-core`
- `cargo test -p sem-cli`
- dummy Python git repo: `total` local variable in `report()` does not create a fallback edge to same-file `total()`
- dummy Rust git repo: `builder.build()` inside `run()` does not create an edge to sibling `Thing::build`, while explicit `Builder::new` references still resolve
- `sem verify --json` on this repo returns `[]`
- `sem graph --no-cache --json` on this repo only reports real `SemServer::get_or_build_graph -> EntityGraph::build*` edges for the original issue shape
