### PR TITLE
Normalize Swift declaration entities

### DIFF
--- a/crates/sem-core/src/parser/differ.rs
+++ b/crates/sem-core/src/parser/differ.rs
@@ -207,6 +207,7 @@ fn suppress_redundant_parents(
         "module",
         "class",
         "interface",
+        "protocol",
         "mixin",
         "extension",
         "namespace",
@@ -690,6 +691,74 @@ mod tests {
                 .iter()
                 .any(|c| c.entity_name == "UserService" && c.change_type == ChangeType::Modified),
             "class should be suppressed when only the method body changed, got: {names:?}"
+        );
+    }
+
+    #[test]
+    fn test_protocol_parent_suppressed_when_only_associatedtype_renamed() {
+        let before = "protocol Repository {\n    associatedtype Item\n}\n";
+        let after = "protocol Repository {\n    associatedtype Canvas\n}\n";
+
+        let registry = create_default_registry();
+        let result = compute_semantic_diff(
+            &[modified_file("Repository.swift", before, after)],
+            &registry,
+            None,
+            None,
+        );
+
+        let names: Vec<&str> = result
+            .changes
+            .iter()
+            .map(|c| c.entity_name.as_str())
+            .collect();
+        assert!(
+            result
+                .changes
+                .iter()
+                .any(|c| c.entity_type == "associatedtype"),
+            "expected associatedtype change, got: {names:?}"
+        );
+        assert!(
+            !result
+                .changes
+                .iter()
+                .any(|c| c.entity_name == "Repository" && c.change_type == ChangeType::Modified),
+            "protocol should be suppressed when only the associatedtype changed, got: {names:?}"
+        );
+    }
+
+    #[test]
+    fn test_protocol_parent_not_suppressed_when_own_declaration_changes() {
+        let before = "protocol Repository {\n    associatedtype Item\n}\n";
+        let after = "protocol Repository: Sendable {\n    associatedtype Canvas\n}\n";
+
+        let registry = create_default_registry();
+        let result = compute_semantic_diff(
+            &[modified_file("Repository.swift", before, after)],
+            &registry,
+            None,
+            None,
+        );
+
+        let names: Vec<&str> = result
+            .changes
+            .iter()
+            .map(|c| c.entity_name.as_str())
+            .collect();
+        assert!(
+            result
+                .changes
+                .iter()
+                .any(|c| c.entity_type == "associatedtype"),
+            "expected associatedtype change, got: {names:?}"
+        );
+        assert!(
+            result
+                .changes
+                .iter()
+                .any(|c| c.entity_name == "Repository" && c.change_type == ChangeType::Modified),
+            "protocol should remain Modified when its own declaration changed, got: {names:?}"
         );
     }
 

--- a/crates/sem-core/src/parser/graph.rs
+++ b/crates/sem-core/src/parser/graph.rs
@@ -197,7 +197,7 @@ impl EntityGraph {
                 class_child_names.insert((pid.as_str(), entity.name.as_str()));
             }
 
-            if matches!(entity.entity_type.as_str(), "class" | "struct" | "interface" | "class_type") {
+            if is_nominal_member_container(entity.entity_type.as_str()) {
                 class_entity_names.insert(entity.name.as_str());
                 class_entity_files.insert((entity.name.as_str(), entity.file_path.as_str()));
             }
@@ -227,7 +227,7 @@ impl EntityGraph {
                 }
                 // scope_class_members for scope resolver (checks entity_type of parent)
                 if let Some(parent) = entity_map.get(pid.as_str()) {
-                    if matches!(parent.entity_type.as_str(), "class" | "struct" | "interface" | "impl") {
+                    if is_scope_member_container(parent.entity_type.as_str()) {
                         scope_class_members.entry(parent.name.clone()).or_default()
                             .push((entity.name.clone(), entity.id.clone()));
                     }
@@ -679,12 +679,12 @@ impl EntityGraph {
 
         let class_entity_names: HashSet<&str> = all_entities
             .iter()
-            .filter(|e| matches!(e.entity_type.as_str(), "class" | "struct" | "interface" | "class_type"))
+            .filter(|e| is_nominal_member_container(e.entity_type.as_str()))
             .map(|e| e.name.as_str())
             .collect();
         let class_entity_files: HashSet<(&str, &str)> = all_entities
             .iter()
-            .filter(|e| matches!(e.entity_type.as_str(), "class" | "struct" | "interface" | "class_type"))
+            .filter(|e| is_nominal_member_container(e.entity_type.as_str()))
             .map(|e| (e.name.as_str(), e.file_path.as_str()))
             .collect();
 
@@ -1322,6 +1322,27 @@ impl EntityGraph {
             }
         }
     }
+}
+
+fn is_nominal_member_container(entity_type: &str) -> bool {
+    matches!(
+        entity_type,
+        "class" | "struct" | "interface" | "class_type" | "enum" | "protocol"
+    )
+}
+
+fn is_scope_member_container(entity_type: &str) -> bool {
+    matches!(
+        entity_type,
+        "class"
+            | "struct"
+            | "interface"
+            | "impl"
+            | "enum"
+            | "protocol"
+            | "object_declaration"
+            | "companion_object"
+    )
 }
 
 /// Check if an entity looks like a test based on name, file path, and content patterns.
@@ -2326,6 +2347,12 @@ function caller() { return MathUtils.compute(); }
             "caller should depend on compute via MathUtils.compute(). Deps: {:?}",
             deps.iter().map(|d| &d.name).collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn test_protocols_are_member_containers() {
+        assert!(is_nominal_member_container("protocol"));
+        assert!(is_scope_member_container("protocol"));
     }
 
     #[test]

--- a/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
+++ b/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
@@ -745,7 +745,7 @@ fn swift_declaration_keyword_type(keyword: &str) -> Option<&'static str> {
         "class" => Some("class"),
         "enum" => Some("enum"),
         "extension" => Some("extension"),
-        "protocol" => Some("protocol_declaration"),
+        "protocol" => Some("protocol"),
         "struct" => Some("struct"),
         _ => None,
     }
@@ -952,12 +952,25 @@ fn compute_structural_hash(node: Node, source: &[u8]) -> String {
 /// Find the byte range of the name node, mirroring extract_name() logic.
 /// Returns (start_byte, end_byte) of the name token to exclude from hashing.
 fn find_name_byte_range(node: Node, _source: &[u8]) -> Option<(usize, usize)> {
+    let node_type = node.kind();
+
+    if node_type == "operator_declaration" {
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            if child.kind() == "custom_operator" || child.kind() == "simple_identifier" {
+                return Some((child.start_byte(), child.end_byte()));
+            }
+        }
+    }
+
+    if node_type == "subscript_declaration" || node_type == "deinit_declaration" {
+        return None;
+    }
+
     // Try 'name' field first (works for most languages)
     if let Some(name_node) = node.child_by_field_name("name") {
         return Some((name_node.start_byte(), name_node.end_byte()));
     }
-
-    let node_type = node.kind();
 
     // Variable/lexical declarations: name is inside variable_declarator
     if node_type == "lexical_declaration" || node_type == "variable_declaration" {
@@ -1172,14 +1185,31 @@ fn find_declarator_name_range(mut node: Node) -> Option<(usize, usize)> {
 }
 
 fn extract_name(node: Node, source: &[u8]) -> Option<String> {
+    let node_type = node.kind();
+
+    if node_type == "subscript_declaration" {
+        return Some("subscript".to_string());
+    }
+
+    if node_type == "deinit_declaration" {
+        return Some("deinit".to_string());
+    }
+
+    if node_type == "operator_declaration" {
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            if child.kind() == "custom_operator" || child.kind() == "simple_identifier" {
+                return Some(node_text(child, source).to_string());
+            }
+        }
+    }
+
     // Try 'name' field first (works for most languages)
     if let Some(name_node) = node.child_by_field_name("name") {
         return Some(node_text(name_node, source).to_string());
     }
 
     // For variable/lexical declarations, try to get the declarator name
-    let node_type = node.kind();
-
     // For Rust impl blocks, construct unique name from trait + type
     // e.g. "impl Display for Foo" -> "Display for Foo", "impl Foo" -> "Foo"
     if node_type == "impl_item" {
@@ -1554,7 +1584,13 @@ fn map_node_type(tree_sitter_type: &str) -> &str {
         | "method_signature" | "operator_signature" => "method",
         "class_declaration" | "class_definition" | "class_specifier" => "class",
         "interface_declaration" => "interface",
-        "type_alias_declaration" | "type_declaration" | "type_item" | "type_definition" | "type_alias" => "type",
+        "protocol_declaration" => "protocol",
+        "init_declaration" => "init",
+        "deinit_declaration" => "deinit",
+        "subscript_declaration" => "subscript",
+        "type_alias_declaration" | "typealias_declaration" | "type_declaration" | "type_item" | "type_definition" | "type_alias" => "type",
+        "associatedtype_declaration" => "associatedtype",
+        "operator_declaration" => "operator",
         "enum_declaration" | "enum_item" | "enum_specifier" | "enum_definition" => "enum",
         "mixin_declaration" => "mixin",
         "extension_declaration" | "extension_type_declaration" => "extension",

--- a/crates/sem-core/src/parser/plugins/code/mod.rs
+++ b/crates/sem-core/src/parser/plugins/code/mod.rs
@@ -291,11 +291,19 @@ int main() {
         let code = r#"
 import Foundation
 
+typealias Handler = (Int) -> Void
+
+prefix operator ~~~
+
 class UserService {
     var name: String
 
     init(name: String) {
         self.name = name
+    }
+
+    deinit {
+        print("freed")
     }
 
     func getUsers() -> [User] {
@@ -306,6 +314,10 @@ class UserService {
 struct Point {
     var x: Double
     var y: Double
+
+    subscript(index: Int) -> Double {
+        return x + y + Double(index)
+    }
 }
 
 enum Status {
@@ -315,9 +327,9 @@ enum Status {
 }
 
 protocol Repository {
-    associatedtype Item
-    func findById(id: String) -> Item?
-    func findAll() -> [Item]
+    associatedtype Canvas
+    func findById(id: String) -> Canvas?
+    func findAll() -> [Canvas]
 }
 
 func helper(x: Int) -> Int {
@@ -333,13 +345,63 @@ func helper(x: Int) -> Int {
         assert!(names.contains(&"Point"), "Should find struct Point, got: {:?}", names);
         assert!(names.contains(&"Status"), "Should find enum Status, got: {:?}", names);
         assert!(names.contains(&"Repository"), "Should find protocol Repository, got: {:?}", names);
+        assert!(names.contains(&"Canvas"), "Should find associatedtype Canvas, got: {:?}", names);
+        assert!(names.contains(&"Handler"), "Should find typealias Handler, got: {:?}", names);
+        assert!(names.contains(&"~~~"), "Should find custom operator ~~~, got: {:?}", names);
+        assert!(names.contains(&"init"), "Should find initializer init, got: {:?}", names);
+        assert!(names.contains(&"deinit"), "Should find deinitializer deinit, got: {:?}", names);
+        assert!(names.contains(&"subscript"), "Should find subscript, got: {:?}", names);
         assert!(names.contains(&"helper"), "Should find function helper, got: {:?}", names);
+
+        let handler = entities.iter().find(|e| e.name == "Handler").unwrap();
+        assert_eq!(handler.entity_type, "type");
+        assert!(handler.parent_id.is_none());
+
+        let operator = entities.iter().find(|e| e.name == "~~~").unwrap();
+        assert_eq!(operator.entity_type, "operator");
+        assert!(operator.parent_id.is_none());
+
+        let user_service = entities.iter().find(|e| e.name == "UserService").unwrap();
+        assert_eq!(user_service.entity_type, "class");
+
+        let initializer = entities.iter().find(|e| e.name == "init").unwrap();
+        assert_eq!(initializer.entity_type, "init");
+        assert_eq!(initializer.parent_id.as_deref(), Some(user_service.id.as_str()));
+        assert_eq!(initializer.id, "UserService.swift::class::UserService::init");
+
+        let deinitializer = entities.iter().find(|e| e.name == "deinit").unwrap();
+        assert_eq!(deinitializer.entity_type, "deinit");
+        assert_eq!(deinitializer.parent_id.as_deref(), Some(user_service.id.as_str()));
+        assert_eq!(
+            deinitializer.id,
+            "UserService.swift::class::UserService::deinit"
+        );
 
         let point = entities.iter().find(|e| e.name == "Point").unwrap();
         assert_eq!(point.entity_type, "struct");
 
+        let subscript = entities.iter().find(|e| e.name == "subscript").unwrap();
+        assert_eq!(subscript.entity_type, "subscript");
+        assert_eq!(subscript.parent_id.as_deref(), Some(point.id.as_str()));
+        assert_eq!(
+            subscript.id,
+            "UserService.swift::struct::Point::subscript"
+        );
+
         let status = entities.iter().find(|e| e.name == "Status").unwrap();
         assert_eq!(status.entity_type, "enum");
+
+        let repository = entities.iter().find(|e| e.name == "Repository").unwrap();
+        assert_eq!(repository.entity_type, "protocol");
+        assert_eq!(repository.id, "UserService.swift::protocol::Repository");
+
+        let canvas = entities.iter().find(|e| e.name == "Canvas").unwrap();
+        assert_eq!(canvas.entity_type, "associatedtype");
+        assert_eq!(canvas.parent_id.as_deref(), Some(repository.id.as_str()));
+        assert_eq!(
+            canvas.id,
+            "UserService.swift::protocol::Repository::Canvas"
+        );
     }
 
     #[test]
@@ -748,6 +810,69 @@ impl Greeting for Cat {
             entities_a[0].content_hash, entities_b[0].content_hash,
             "Content hash should differ since raw content includes the name"
         );
+    }
+
+    #[test]
+    fn test_swift_renamed_operator_same_structural_hash() {
+        let plugin = CodeParserPlugin;
+        let entities_a = plugin.extract_entities("prefix operator ~~~\n", "a.swift");
+        let entities_b = plugin.extract_entities("prefix operator !!!\n", "b.swift");
+
+        assert_eq!(entities_a.len(), 1, "Should find one entity in a");
+        assert_eq!(entities_b.len(), 1, "Should find one entity in b");
+        assert_eq!(entities_a[0].name, "~~~");
+        assert_eq!(entities_b[0].name, "!!!");
+        assert_eq!(entities_a[0].entity_type, "operator");
+        assert_eq!(entities_b[0].entity_type, "operator");
+        assert_eq!(
+            entities_a[0].structural_hash, entities_b[0].structural_hash,
+            "Renamed operator with otherwise identical declaration should have same structural_hash"
+        );
+        assert_ne!(
+            entities_a[0].content_hash, entities_b[0].content_hash,
+            "Content hash should differ since raw content includes the operator token"
+        );
+    }
+
+    #[test]
+    fn test_swift_synthesized_names_disambiguate_overloads() {
+        let plugin = CodeParserPlugin;
+        let code = r#"
+struct Matrix {
+    subscript(row: Int) -> Double {
+        return Double(row)
+    }
+
+    subscript(row: Int, column: Int) -> Double {
+        return Double(row + column)
+    }
+}
+
+class Builder {
+    init(value: Int) {}
+    init(text: String) {}
+}
+"#;
+
+        let entities = plugin.extract_entities(code, "Overloads.swift");
+
+        let subscript_ids: Vec<&str> = entities
+            .iter()
+            .filter(|e| e.entity_type == "subscript")
+            .map(|e| e.id.as_str())
+            .collect();
+        assert_eq!(subscript_ids.len(), 2);
+        assert_ne!(subscript_ids[0], subscript_ids[1]);
+        assert!(subscript_ids.iter().all(|id| id.contains("@L")));
+
+        let init_ids: Vec<&str> = entities
+            .iter()
+            .filter(|e| e.entity_type == "init")
+            .map(|e| e.id.as_str())
+            .collect();
+        assert_eq!(init_ids.len(), 2);
+        assert_ne!(init_ids[0], init_ids[1]);
+        assert!(init_ids.iter().all(|id| id.contains("@L")));
     }
 
     #[test]

--- a/crates/sem-core/src/parser/scope_resolve.rs
+++ b/crates/sem-core/src/parser/scope_resolve.rs
@@ -143,7 +143,7 @@ pub(crate) fn resolve_with_scopes_full(
                     if matches!(
                         parent.entity_type.as_str(),
                         "class" | "struct" | "interface" | "impl"
-                            | "enum" | "protocol_declaration"
+                            | "enum" | "protocol"
                             | "object_declaration" | "companion_object"
                     ) {
                         class_members
@@ -560,7 +560,7 @@ fn build_scopes_from_ast(
                     && matches!(
                         e.entity_type.as_str(),
                         "class" | "struct" | "interface"
-                            | "enum" | "protocol_declaration"
+                            | "enum" | "protocol"
                             | "object_declaration" | "companion_object"
                     )
             }).copied();


### PR DESCRIPTION
## Summary
- Normalize Swift declaration AST nodes to semantic entity types for protocols, initializers, deinitializers, subscripts, typealiases, associated types, and operators.
- Fix Swift subscript/deinit/operator names and operator structural hashes so renames are detected correctly.
- Treat protocols consistently as containers in diff suppression, scope resolution, and graph member indexing.

Fixes #258

## Test Plan
- cargo test -p sem-core
- cargo test -p sem-cli
- Dummy git repos covering sem entities, sem graph, sem impact, sem context, and sem diff for Swift declarations, operator renames, protocol associatedtype renames, and overload disambiguation.