### PR TITLE
Resolve Swift bare property method call graph edges

### DIFF
--- a/crates/sem-core/src/parser/graph.rs
+++ b/crates/sem-core/src/parser/graph.rs
@@ -2303,6 +2303,281 @@ class UserService {
         );
     }
 
+    #[cfg(feature = "lang-swift")]
+    #[test]
+    fn test_swift_bare_instance_property_receiver_resolution() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "Example.swift", "\
+class Connection {
+    func execute(query: String) {}
+    func commit() {}
+}
+
+class Transaction {
+    let conn: Connection
+    init(conn: Connection) { self.conn = conn }
+
+    func execute(query: String) {
+        conn.execute(query: query)
+    }
+
+    func commit() {
+        conn.commit()
+    }
+}
+");
+
+        let (graph, _) = EntityGraph::build(root, &["Example.swift".into()], &registry);
+
+        let transaction_execute_id = graph
+            .entities
+            .iter()
+            .find(|(id, info)| info.name == "execute" && id.contains("Transaction"))
+            .map(|(id, _)| id.clone())
+            .expect("Transaction.execute entity should exist");
+        let execute_deps = graph.get_dependencies(&transaction_execute_id);
+        assert!(
+            execute_deps.iter().any(|d| {
+                d.name == "execute"
+                    && d.parent_id
+                        .as_deref()
+                        .map_or(false, |parent| parent.contains("Connection"))
+            }),
+            "Transaction.execute should depend on Connection.execute. Deps: {:?}",
+            execute_deps
+                .iter()
+                .map(|d| (&d.name, &d.parent_id))
+                .collect::<Vec<_>>()
+        );
+
+        let transaction_commit_id = graph
+            .entities
+            .iter()
+            .find(|(id, info)| info.name == "commit" && id.contains("Transaction"))
+            .map(|(id, _)| id.clone())
+            .expect("Transaction.commit entity should exist");
+        let commit_deps = graph.get_dependencies(&transaction_commit_id);
+        assert!(
+            commit_deps.iter().any(|d| {
+                d.name == "commit"
+                    && d.parent_id
+                        .as_deref()
+                        .map_or(false, |parent| parent.contains("Connection"))
+            }),
+            "Transaction.commit should depend on Connection.commit. Deps: {:?}",
+            commit_deps
+                .iter()
+                .map(|d| (&d.name, &d.parent_id))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[cfg(feature = "lang-swift")]
+    #[test]
+    fn test_swift_static_method_does_not_resolve_instance_property_receiver() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "Example.swift", "\
+class Connection {
+    func execute(query: String) {}
+}
+
+class Transaction {
+    let conn: Connection
+
+    static func run() {
+        conn.execute(query: \"SELECT 1\")
+    }
+}
+");
+
+        let (graph, _) = EntityGraph::build(root, &["Example.swift".into()], &registry);
+
+        let run_id = graph.entities.keys()
+            .find(|id| id.contains("Transaction") && id.contains("run"))
+            .expect("Transaction.run entity should exist");
+        let deps = graph.get_dependencies(run_id);
+        assert!(
+            !deps.iter().any(|d| {
+                d.name == "execute"
+                    && d.parent_id
+                        .as_deref()
+                        .map_or(false, |parent| parent.contains("Connection"))
+            }),
+            "static Transaction.run should not depend on Connection.execute via instance property. Deps: {:?}",
+            deps.iter()
+                .map(|d| (&d.name, &d.parent_id))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[cfg(feature = "lang-swift")]
+    #[test]
+    fn test_swift_multi_binding_property_receivers_resolve() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "Example.swift", "\
+class PrimaryConnection {
+    func execute(query: String) {}
+}
+
+class BackupConnection {
+    func flush() {}
+}
+
+class Transaction {
+    let conn: PrimaryConnection, backup: BackupConnection
+
+    func run(query: String) {
+        conn.execute(query: query)
+        backup.flush()
+    }
+}
+");
+
+        let (graph, _) = EntityGraph::build(root, &["Example.swift".into()], &registry);
+
+        let run_id = graph.entities.keys()
+            .find(|id| id.contains("Transaction") && id.contains("run"))
+            .expect("Transaction.run entity should exist");
+        let deps = graph.get_dependencies(run_id);
+        assert!(
+            deps.iter().any(|d| {
+                d.name == "execute"
+                    && d.parent_id
+                        .as_deref()
+                        .map_or(false, |parent| parent.contains("PrimaryConnection"))
+            }),
+            "conn.execute should resolve to PrimaryConnection.execute. Deps: {:?}",
+            deps.iter()
+                .map(|d| (&d.name, &d.parent_id))
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            deps.iter().any(|d| {
+                d.name == "flush"
+                    && d.parent_id
+                        .as_deref()
+                        .map_or(false, |parent| parent.contains("BackupConnection"))
+            }),
+            "backup.flush should resolve to BackupConnection.flush. Deps: {:?}",
+            deps.iter()
+                .map(|d| (&d.name, &d.parent_id))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[cfg(feature = "lang-swift")]
+    #[test]
+    fn test_swift_nested_local_binding_shadows_instance_property_receiver() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "Example.swift", "\
+class Connection {
+    func execute(query: String) {}
+}
+
+class MockConnection {
+    func execute(query: String) {}
+}
+
+class Transaction {
+    let conn: Connection
+    init(conn: Connection) { self.conn = conn }
+
+    func execute(query: String, useMock: Bool) {
+        if useMock {
+            let conn = MockConnection()
+            conn.execute(query: query)
+        }
+    }
+}
+");
+
+        let (graph, _) = EntityGraph::build(root, &["Example.swift".into()], &registry);
+
+        let transaction_execute_id = graph
+            .entities
+            .iter()
+            .find(|(id, info)| info.name == "execute" && id.contains("Transaction"))
+            .map(|(id, _)| id.clone())
+            .expect("Transaction.execute entity should exist");
+        let deps = graph.get_dependencies(&transaction_execute_id);
+        assert!(
+            deps.iter().any(|d| {
+                d.name == "execute"
+                    && d.parent_id
+                        .as_deref()
+                        .map_or(false, |parent| parent.contains("MockConnection"))
+            }),
+            "nested local conn should resolve to MockConnection.execute. Deps: {:?}",
+            deps.iter()
+                .map(|d| (&d.name, &d.parent_id))
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            !deps.iter().any(|d| {
+                d.name == "execute"
+                    && d.parent_id
+                        .as_deref()
+                        .map_or(false, |parent| parent.contains("Connection") && !parent.contains("MockConnection"))
+            }),
+            "nested local conn should shadow Transaction.conn. Deps: {:?}",
+            deps.iter()
+                .map(|d| (&d.name, &d.parent_id))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_typescript_bare_identifier_does_not_resolve_instance_property() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "service.ts", "\
+class Connection {
+    execute() {
+        return true;
+    }
+}
+
+class Transaction {
+    conn: Connection;
+    constructor(conn: Connection) {
+        this.conn = conn;
+    }
+
+    run() {
+        return conn.execute();
+    }
+}
+");
+
+        let (graph, _) = EntityGraph::build(root, &["service.ts".into()], &registry);
+
+        let run_id = graph.entities.keys()
+            .find(|id| id.contains("Transaction") && id.contains("run"))
+            .expect("Transaction.run entity should exist");
+        let deps = graph.get_dependencies(run_id);
+        assert!(
+            !deps.iter().any(|d| {
+                d.name == "execute"
+                    && d.parent_id
+                        .as_deref()
+                        .map_or(false, |parent| parent.contains("Connection"))
+            }),
+            "bare conn.execute() should not resolve through a TypeScript instance property. Deps: {:?}",
+            deps.iter()
+                .map(|d| (&d.name, &d.parent_id))
+                .collect::<Vec<_>>()
+        );
+    }
+
     #[test]
     fn test_dot_chain_class_static() {
         let (dir, registry) = create_test_repo();

--- a/crates/sem-core/src/parser/plugins/code/languages.rs
+++ b/crates/sem-core/src/parser/plugins/code/languages.rs
@@ -1427,7 +1427,17 @@ static SWIFT_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     assignment_rules: &[
         AssignmentRule { node_kind: "property_declaration", strategy: AssignmentStrategy::Declarators },
     ],
-    assignment_recurse_into: &["function_body", "code_block", "statements"],
+    assignment_recurse_into: &[
+        "function_body",
+        "code_block",
+        "statements",
+        "if_statement",
+        "guard_statement",
+        "for_statement",
+        "while_statement",
+        "repeat_while_statement",
+        "switch_statement",
+    ],
 
     param_rules: &[
         ParamRule { node_kind: "parameter", name_field: ParamNameField::Simple("name"), type_field: "type", skip_names: &[] },

--- a/crates/sem-core/src/parser/scope_resolve.rs
+++ b/crates/sem-core/src/parser/scope_resolve.rs
@@ -411,6 +411,12 @@ pub(crate) fn resolve_with_scopes_full(
                     // Languages without per-symbol imports (e.g. Swift, Kotlin)
                     // allow cross-file resolution for lowercase function names.
                     let allow_cross_file = config.import_extractor.is_none();
+                    let allow_implicit_instance_member_receiver =
+                        allows_implicit_instance_member_receiver(
+                            file_path,
+                            &entity.entity_type,
+                            &entity.content,
+                        );
                     let resolution = resolve_ref(
                         ast_ref,
                         scope_idx,
@@ -423,6 +429,7 @@ pub(crate) fn resolve_with_scopes_full(
                         file_path,
                         &entity.id,
                         allow_cross_file,
+                        allow_implicit_instance_member_receiver,
                     );
 
                     if let Some((target_id, ref_type, method)) = resolution {
@@ -1818,6 +1825,7 @@ fn scan_swift_init_body(
                             .unwrap_or("");
                         let prop = left.child_by_field_name("suffix")
                             .and_then(|n| n.utf8_text(source).ok())
+                            .map(|text| text.strip_prefix('.').unwrap_or(text))
                             .unwrap_or("");
                         if obj == "self" && !prop.is_empty() {
                             if let Some(right) = child.child_by_field_name("right").or_else(|| child.named_child(1)) {
@@ -1857,25 +1865,123 @@ fn scan_swift_property_declaration(
     source: &[u8],
     instance_attr_types: &mut HashMap<(String, String), String>,
 ) {
-    // Swift property_declaration has a "name" (via pattern binding) and type annotation
+    let mut processed_pattern_binding = false;
+
     let mut cursor = node.walk();
     for child in node.named_children(&mut cursor) {
-        if child.kind() == "pattern" || child.kind() == "simple_identifier" || child.kind() == "identifier" {
-            let field_name = child.utf8_text(source).unwrap_or("");
-            if let Some(type_ann) = node.child_by_field_name("type") {
-                let type_text = extract_base_type(type_ann, source);
-                if !field_name.is_empty()
-                    && !type_text.is_empty()
-                    && type_text.chars().next().map_or(false, |c| c.is_uppercase())
-                {
-                    instance_attr_types.insert(
-                        (class_name.to_string(), field_name.to_string()),
-                        type_text,
-                    );
-                }
-            }
+        if child.kind() == "pattern_binding" {
+            processed_pattern_binding = true;
+            scan_swift_property_binding(
+                child,
+                class_name,
+                source,
+                instance_attr_types,
+            );
         }
     }
+    if processed_pattern_binding {
+        return;
+    }
+
+    // Swift property_declaration nodes vary by grammar version. Some expose
+    // pattern/type_annotation pairs directly instead of pattern_binding nodes.
+    let mut pending_names = Vec::new();
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        match child.kind() {
+            "pattern" | "simple_identifier" | "identifier" => {
+                if let Some(name) = extract_swift_property_pattern_name(child, source) {
+                    pending_names.push(name);
+                }
+            }
+            "type_annotation" => {
+                let type_text = extract_base_type(child, source);
+                if type_text.chars().next().map_or(false, |c| c.is_uppercase()) {
+                    for name in pending_names.drain(..) {
+                        instance_attr_types.insert(
+                            (class_name.to_string(), name),
+                            type_text.clone(),
+                        );
+                    }
+                }
+            }
+            "call_expression" | "new_expression" | "value_argument" => pending_names.clear(),
+            _ => {}
+        }
+    }
+}
+
+fn scan_swift_property_binding(
+    node: tree_sitter::Node,
+    class_name: &str,
+    source: &[u8],
+    instance_attr_types: &mut HashMap<(String, String), String>,
+) {
+    let mut field_names = Vec::new();
+    let mut field_type = node
+        .child_by_field_name("type")
+        .and_then(|type_node| {
+            let type_text = extract_base_type(type_node, source);
+            if type_text.is_empty() {
+                None
+            } else {
+                Some(type_text)
+            }
+        });
+
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        match child.kind() {
+            "pattern" | "simple_identifier" | "identifier" => {
+                if let Some(name) = extract_swift_property_pattern_name(child, source) {
+                    field_names.push(name);
+                }
+            }
+            "type_annotation" => {
+                if field_type.is_none() {
+                    let type_text = extract_base_type(child, source);
+                    if !type_text.is_empty() {
+                        field_type = Some(type_text);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let Some(type_text) = field_type else {
+        return;
+    };
+    if !type_text.chars().next().map_or(false, |c| c.is_uppercase()) {
+        return;
+    }
+
+    for field_name in field_names {
+        instance_attr_types.insert((class_name.to_string(), field_name), type_text.clone());
+    }
+}
+
+fn extract_swift_property_pattern_name(
+    node: tree_sitter::Node,
+    source: &[u8],
+) -> Option<String> {
+    if matches!(node.kind(), "simple_identifier" | "identifier") {
+        let name = node.utf8_text(source).ok()?.trim();
+        return (!name.is_empty()).then(|| name.to_string());
+    }
+
+    if let Some(name_node) = node.child_by_field_name("name") {
+        return extract_swift_property_pattern_name(name_node, source);
+    }
+
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        if matches!(child.kind(), "simple_identifier" | "identifier") {
+            return extract_swift_property_pattern_name(child, source);
+        }
+    }
+
+    None
 }
 
 /// Kotlin: extract typed property declarations `val conn: Connection`
@@ -3091,6 +3197,7 @@ fn resolve_ref(
     file_path: &str,
     from_entity_id: &str,
     allow_cross_file_calls: bool,
+    allow_implicit_instance_member_receiver: bool,
 ) -> Option<(String, RefType, &'static str)> {
     match &ast_ref.kind {
         AstRefKind::Call(name) => {
@@ -3198,7 +3305,23 @@ fn resolve_ref(
             }
 
             // receiver.method() -> look up receiver type, then resolve method
-            let receiver_type = lookup_type_in_scopes(scope_idx, scopes, receiver);
+            let receiver_type = if let Some(receiver_type) =
+                lookup_type_in_scopes(scope_idx, scopes, receiver)
+            {
+                Some(receiver_type)
+            } else if allow_implicit_instance_member_receiver
+                && is_simple_identifier_name(receiver)
+                && !is_local_binding_in_scopes(scope_idx, scopes, receiver)
+            {
+                match find_enclosing_class(scope_idx, scopes, entity_map) {
+                    Some(class_name) => instance_attr_types
+                        .get(&(class_name, receiver.to_string()))
+                        .cloned(),
+                    None => None,
+                }
+            } else {
+                None
+            };
 
             if let Some(class_name) = receiver_type {
                 if let Some(members) = class_members.get(class_name.as_str()) {
@@ -3266,6 +3389,111 @@ fn resolve_ref(
             None
         }
     }
+}
+
+fn allows_implicit_instance_member_receiver(
+    file_path: &str,
+    entity_type: &str,
+    entity_content: &str,
+) -> bool {
+    let ext = file_path.rsplit('.').next().unwrap_or("");
+    let supports_implicit_receiver = matches!(
+        ext,
+        "swift"
+            | "kt"
+            | "kts"
+            | "java"
+            | "cs"
+            | "cpp"
+            | "cc"
+            | "cxx"
+            | "hpp"
+            | "hh"
+            | "hxx"
+            | "h"
+            | "scala"
+            | "dart"
+    );
+
+    supports_implicit_receiver
+        && matches!(
+            entity_type,
+            "function" | "method" | "init_declaration" | "constructor_declaration"
+        )
+        && !has_static_member_modifier(ext, entity_content)
+}
+
+fn has_static_member_modifier(ext: &str, entity_content: &str) -> bool {
+    let header = entity_content
+        .split(|ch| ch == '{' || ch == '=')
+        .next()
+        .unwrap_or(entity_content);
+    let header_without_comments = strip_member_header_comments(header);
+    let tokens = header_without_comments
+        .split(|ch: char| !ch.is_alphanumeric() && ch != '_')
+        .filter(|token| !token.is_empty())
+        .collect::<Vec<_>>();
+    let declaration_start = tokens
+        .iter()
+        .position(|token| {
+            matches!(
+                *token,
+                "func" | "function" | "fn" | "constructor" | "init" | "var" | "let" | "subscript"
+            )
+        })
+        .unwrap_or(tokens.len());
+
+    tokens[..declaration_start]
+        .iter()
+        .any(|token| *token == "static" || (ext == "swift" && *token == "class"))
+}
+
+fn strip_member_header_comments(header: &str) -> String {
+    let mut output = String::with_capacity(header.len());
+    let mut chars = header.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch != '/' {
+            output.push(ch);
+            continue;
+        }
+
+        match chars.peek().copied() {
+            Some('/') => {
+                chars.next();
+                for next in chars.by_ref() {
+                    if next == '\n' {
+                        output.push(' ');
+                        break;
+                    }
+                }
+            }
+            Some('*') => {
+                chars.next();
+                let mut previous = '\0';
+                for next in chars.by_ref() {
+                    if previous == '*' && next == '/' {
+                        break;
+                    }
+                    previous = next;
+                }
+                output.push(' ');
+            }
+            _ => output.push(ch),
+        }
+    }
+
+    output
+}
+
+fn is_simple_identifier_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+
+    (first == '_' || first.is_alphabetic())
+        && chars.all(|ch| ch == '_' || ch.is_alphanumeric())
 }
 
 /// Find the class name for the enclosing class scope.


### PR DESCRIPTION
Closes #256

## Summary
- Resolve bare Swift stored-property method calls through the enclosing instance property type when the receiver is not a local binding.
- Extract Swift typed stored properties from `type_annotation` nodes so property receiver types are available to scope resolution.
- Avoid false positives for Swift static/type methods, nested local shadowing, and TypeScript bare identifiers.

## Test plan
- `cargo test -p sem-core`
- `cargo build -p sem-cli`
- Dummy Swift git repos under `/tmp/sem-issue-256-*` validating positive graph/impact edges, local shadowing, nested local shadowing, and static-method non-resolution with `sem graph` / `sem impact --no-cache`
