### PR TITLE
Extract Swift multi-binding properties

### DIFF
--- a/crates/sem-core/src/model/identity.rs
+++ b/crates/sem-core/src/model/identity.rs
@@ -452,10 +452,21 @@ fn detect_reorders(
     // Collect unchanged entities: matched by ID with same content_hash
     let before_by_id: HashMap<&str, &SemanticEntity> =
         before.iter().map(|e| (e.id.as_str(), e)).collect();
+    let before_positions: HashMap<&str, usize> = before
+        .iter()
+        .enumerate()
+        .map(|(i, e)| (e.id.as_str(), i))
+        .collect();
+    let after_positions: HashMap<&str, usize> = after
+        .iter()
+        .enumerate()
+        .map(|(i, e)| (e.id.as_str(), i))
+        .collect();
 
     // Group by file. For each file, collect unchanged entities in their
     // before-order, then look up their after-positions.
-    let mut by_file: HashMap<&str, Vec<(&SemanticEntity, &SemanticEntity)>> = HashMap::new();
+    let mut by_file: HashMap<&str, Vec<(usize, usize, &SemanticEntity, &SemanticEntity)>> =
+        HashMap::new();
     for after_entity in after {
         if !matched_after.contains(after_entity.id.as_str()) {
             continue;
@@ -472,10 +483,16 @@ fn detect_reorders(
             if before_entity.file_path != after_entity.file_path {
                 continue;
             }
+            let Some(before_position) = before_positions.get(before_entity.id.as_str()) else {
+                continue;
+            };
+            let Some(after_position) = after_positions.get(after_entity.id.as_str()) else {
+                continue;
+            };
             by_file
                 .entry(after_entity.file_path.as_str())
                 .or_default()
-                .push((before_entity, after_entity));
+                .push((*before_position, *after_position, before_entity, after_entity));
         }
     }
 
@@ -484,21 +501,32 @@ fn detect_reorders(
             continue;
         }
 
-        // Sort by before start_line to get the "before" ordering
-        pairs.sort_by_key(|(b, _)| b.start_line);
+        // Line numbers alone are not enough because a file can contain
+        // multiple entities on one line.
+        pairs.sort_by_key(|(before_position, _, _, _)| *before_position);
 
-        // Map to after start_lines in before-order
-        let after_lines: Vec<usize> = pairs.iter().map(|(_, a)| a.start_line).collect();
+        // Map to after positions in before-order
+        let after_positions: Vec<usize> = pairs
+            .iter()
+            .map(|(_, after_position, _, _)| *after_position)
+            .collect();
 
         // Find LIS indices (entities that stayed in relative order)
-        let lis_set = longest_increasing_subsequence_indices(&after_lines);
+        let lis_set = longest_increasing_subsequence_indices(&after_positions);
 
         // Entities NOT in LIS were reordered
-        for (i, (before_entity, after_entity)) in pairs.iter().enumerate() {
+        for (i, (_, _, before_entity, after_entity)) in pairs.iter().enumerate() {
             if lis_set.contains(&i) {
                 continue;
             }
-            changes.push(make_change(after_entity, ChangeType::Reordered, Some(before_entity), commit_sha, author, by_id));
+            changes.push(make_change(
+                after_entity,
+                ChangeType::Reordered,
+                Some(before_entity),
+                commit_sha,
+                author,
+                by_id,
+            ));
         }
     }
 }
@@ -915,6 +943,43 @@ mod tests {
         let result = match_entities(&before, &after, "a.rs", None, None, None);
         // Lines shifted but relative order is same, no reorder
         assert_eq!(result.changes.len(), 0);
+    }
+
+    #[test]
+    fn test_no_reorder_for_same_line_entities_when_order_preserved() {
+        let before = vec![
+            make_entity_at("a::f::alpha", "alpha", "let alpha = 1", "a.rs", 1),
+            make_entity_at("a::f::beta", "beta", "let beta = 2", "a.rs", 1),
+            make_entity_at("a::f::gamma", "gamma", "let gamma = 3", "a.rs", 2),
+        ];
+        let after = vec![
+            make_entity_at("a::f::alpha", "alpha", "let alpha = 1", "a.rs", 1),
+            make_entity_at("a::f::beta", "beta", "let beta = 2", "a.rs", 1),
+            make_entity_at("a::f::gamma", "gamma", "let gamma = 3", "a.rs", 2),
+        ];
+        let result = match_entities(&before, &after, "a.rs", None, None, None);
+        assert_eq!(result.changes.len(), 0);
+    }
+
+    #[test]
+    fn test_reorder_for_same_line_entities_when_order_changes() {
+        let before = vec![
+            make_entity_at("a::f::alpha", "alpha", "let alpha = 1", "a.rs", 1),
+            make_entity_at("a::f::beta", "beta", "let beta = 2", "a.rs", 1),
+            make_entity_at("a::f::gamma", "gamma", "let gamma = 3", "a.rs", 2),
+        ];
+        let after = vec![
+            make_entity_at("a::f::beta", "beta", "let beta = 2", "a.rs", 1),
+            make_entity_at("a::f::alpha", "alpha", "let alpha = 1", "a.rs", 1),
+            make_entity_at("a::f::gamma", "gamma", "let gamma = 3", "a.rs", 2),
+        ];
+        let result = match_entities(&before, &after, "a.rs", None, None, None);
+        assert_eq!(result.changes.len(), 1);
+        assert_eq!(result.changes[0].change_type, ChangeType::Reordered);
+        assert!(
+            result.changes[0].entity_name == "alpha"
+                || result.changes[0].entity_name == "beta"
+        );
     }
 
     #[test]

--- a/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
+++ b/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
@@ -287,6 +287,35 @@ fn visit_node(
             }
         }
 
+        if node_type == "property_declaration"
+            && config.id == "swift"
+            && config.entity_node_types.contains(&node_type)
+        {
+            let bindings = extract_swift_property_bindings(node, source);
+            if bindings.len() > 1 {
+                let should_skip = should_skip_entity(config, suppression_context, node_type);
+                if !should_skip {
+                    for binding in bindings {
+                        let entity_type = map_entity_type(node, config);
+                        entities.push(SemanticEntity {
+                            id: build_entity_id(file_path, entity_type, &binding.name, parent_id),
+                            file_path: file_path.to_string(),
+                            entity_type: entity_type.to_string(),
+                            name: binding.name,
+                            parent_id: parent_id.map(String::from),
+                            content_hash: content_hash(&binding.content),
+                            structural_hash: Some(binding.structural_hash),
+                            content: binding.content,
+                            start_line: binding.start_line,
+                            end_line: binding.end_line,
+                            metadata: None,
+                        });
+                    }
+                }
+                continue;
+            }
+        }
+
         // Go grouped declarations: `var ( a = 1; b = 2 )` should produce
         // one entity per spec instead of collapsing to the first (#149).
         if (node_type == "var_declaration"
@@ -1540,6 +1569,171 @@ fn extract_declarator_name(mut node: Node, source: &[u8]) -> Option<String> {
 
 fn node_text<'a>(node: Node, source: &'a [u8]) -> &'a str {
     node.utf8_text(source).unwrap_or("")
+}
+
+struct SwiftPropertyBinding {
+    name: String,
+    content: String,
+    structural_hash: String,
+    start_line: usize,
+    end_line: usize,
+}
+
+struct SwiftRawPropertyBinding {
+    name: String,
+    segment_start_byte: usize,
+    segment_end_byte: usize,
+    has_type: bool,
+    has_value: bool,
+    type_text: Option<String>,
+}
+
+fn extract_swift_property_bindings(node: Node, source: &[u8]) -> Vec<SwiftPropertyBinding> {
+    let mut cursor = node.walk();
+    let children: Vec<Node> = node.children(&mut cursor).collect();
+    let prefix_end = children
+        .iter()
+        .find(|child| child.kind() == "value_binding_pattern")
+        .map(|child| child.end_byte())
+        .unwrap_or(node.start_byte());
+    let prefix = source
+        .get(node.start_byte()..prefix_end)
+        .and_then(|bytes| std::str::from_utf8(bytes).ok())
+        .unwrap_or("")
+        .trim();
+
+    let mut name_nodes = Vec::new();
+    for index in 0..node.child_count() {
+        if node.field_name_for_child(index as u32) == Some("name") {
+            if let Some(child) = node.child(index as u32) {
+                name_nodes.push(child);
+            }
+        }
+    }
+
+    if name_nodes.len() <= 1 {
+        return Vec::new();
+    }
+
+    let mut raw_bindings = Vec::new();
+    for (index, name_node) in name_nodes.iter().enumerate() {
+        let next_name_start = name_nodes.get(index + 1).map(|next| next.start_byte());
+        let segment_end_byte = next_name_start
+            .and_then(|next_start| {
+                children
+                    .iter()
+                    .find(|child| {
+                        child.kind() == ","
+                            && child.start_byte() >= name_node.end_byte()
+                            && child.start_byte() < next_start
+                    })
+                    .map(|child| child.start_byte())
+            })
+            .unwrap_or_else(|| {
+                if let Some(next_start) = next_name_start {
+                    next_start
+                } else {
+                    let mut end_byte = name_node.end_byte();
+                    for child_index in 0..node.child_count() {
+                        let Some(child) = node.child(child_index as u32) else {
+                            continue;
+                        };
+                        if child.start_byte() < name_node.end_byte() {
+                            continue;
+                        }
+                        let field_name = node.field_name_for_child(child_index as u32);
+                        if field_name == Some("type")
+                            || matches!(field_name, Some("value") | Some("computed_value"))
+                            || child.kind() == "type_annotation"
+                        {
+                            end_byte = end_byte.max(child.end_byte());
+                        }
+                    }
+                    end_byte
+                }
+            });
+
+        let mut has_type = false;
+        let mut has_value = false;
+        let mut type_text = None;
+        for child_index in 0..node.child_count() {
+            let Some(child) = node.child(child_index as u32) else {
+                continue;
+            };
+            if child.start_byte() < name_node.end_byte()
+                || child.start_byte() >= segment_end_byte
+            {
+                continue;
+            }
+            let field_name = node.field_name_for_child(child_index as u32);
+            if field_name == Some("type") || child.kind() == "type_annotation" {
+                has_type = true;
+                let text = node_text(child, source).trim();
+                if !text.is_empty() {
+                    type_text = Some(text.to_string());
+                }
+            }
+            if matches!(field_name, Some("value") | Some("computed_value")) {
+                has_value = true;
+            }
+        }
+
+        raw_bindings.push(SwiftRawPropertyBinding {
+            name: node_text(*name_node, source).to_string(),
+            segment_start_byte: name_node.start_byte(),
+            segment_end_byte,
+            has_type,
+            has_value,
+            type_text,
+        });
+    }
+
+    raw_bindings
+        .iter()
+        .enumerate()
+        .map(|(index, binding)| {
+            let mut segment = source
+                .get(binding.segment_start_byte..binding.segment_end_byte)
+                .and_then(|bytes| std::str::from_utf8(bytes).ok())
+                .unwrap_or("")
+                .trim()
+                .to_string();
+
+            if !binding.has_type && !binding.has_value {
+                // A trailing Swift type annotation applies to preceding
+                // comma-separated patterns.
+                if let Some(type_text) = raw_bindings
+                    .iter()
+                    .skip(index + 1)
+                    .find_map(|next| next.type_text.as_deref())
+                {
+                    segment.push_str(type_text);
+                }
+            }
+
+            let mut content = prefix.to_string();
+            if !content.is_empty() && !segment.is_empty() {
+                content.push(' ');
+            }
+            // Each segment starts at its binding's name node, so the first
+            // bytes of the segment identify the portion masked for renames.
+            let name_offset = content.len();
+            content.push_str(&segment);
+            let name_end_offset = name_offset + binding.name.len();
+
+            SwiftPropertyBinding {
+                name: binding.name.clone(),
+                structural_hash: recovered_swift_structural_hash(
+                    &content,
+                    name_offset,
+                    name_end_offset,
+                ),
+                content,
+                start_line: line_number_for_byte(source, node.start_byte()),
+                end_line: line_number_for_byte(source, binding.segment_end_byte),
+            }
+        })
+        .collect()
 }
 
 fn map_node_type(tree_sitter_type: &str) -> &str {

--- a/crates/sem-core/src/parser/plugins/code/mod.rs
+++ b/crates/sem-core/src/parser/plugins/code/mod.rs
@@ -343,6 +343,126 @@ func helper(x: Int) -> Int {
     }
 
     #[test]
+    fn test_swift_multi_binding_property_extraction() {
+        let code = r#"
+struct Point {
+    var x, y: Int
+}
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "Point.swift");
+        let point = entities.iter().find(|e| e.name == "Point").unwrap();
+        let properties: Vec<_> = entities
+            .iter()
+            .filter(|e| e.entity_type == "property")
+            .collect();
+
+        assert_eq!(
+            properties.iter().map(|e| e.name.as_str()).collect::<Vec<_>>(),
+            vec!["x", "y"]
+        );
+        assert!(properties
+            .iter()
+            .all(|property| property.parent_id.as_deref() == Some(point.id.as_str())));
+        assert_eq!(properties[0].content, "var x: Int");
+        assert_eq!(properties[1].content, "var y: Int");
+    }
+
+    #[test]
+    fn test_swift_multi_binding_property_content_is_per_binding() {
+        let typed_code = r#"
+struct Types {
+    var x: Int, y: String
+}
+"#;
+        let plugin = CodeParserPlugin;
+        let typed_entities = plugin.extract_entities(typed_code, "Types.swift");
+        let typed_properties: Vec<_> = typed_entities
+            .iter()
+            .filter(|e| e.entity_type == "property")
+            .collect();
+        assert_eq!(typed_properties[0].content, "var x: Int");
+        assert_eq!(typed_properties[1].content, "var y: String");
+
+        let mixed_code = r#"
+struct Mixed {
+    var x, y: Int, z: String
+}
+"#;
+        let mixed_entities = plugin.extract_entities(mixed_code, "Mixed.swift");
+        let mixed_properties: Vec<_> = mixed_entities
+            .iter()
+            .filter(|e| e.entity_type == "property")
+            .collect();
+        assert_eq!(mixed_properties[0].content, "var x: Int");
+        assert_eq!(mixed_properties[1].content, "var y: Int");
+        assert_eq!(mixed_properties[2].content, "var z: String");
+
+        let generic_code = r#"
+struct GenericTypes {
+    var lookup: Dictionary<String, Int>, count: Int
+}
+"#;
+        let generic_entities = plugin.extract_entities(generic_code, "GenericTypes.swift");
+        let generic_properties: Vec<_> = generic_entities
+            .iter()
+            .filter(|e| e.entity_type == "property")
+            .collect();
+        assert_eq!(
+            generic_properties[0].content,
+            "var lookup: Dictionary<String, Int>"
+        );
+        assert_eq!(generic_properties[1].content, "var count: Int");
+
+        let initializer_code = r#"
+struct Initializers {
+    var a = Foo(), b = Bar()
+}
+"#;
+        let initializer_entities = plugin.extract_entities(initializer_code, "Initializers.swift");
+        let initializer_properties: Vec<_> = initializer_entities
+            .iter()
+            .filter(|e| e.entity_type == "property")
+            .collect();
+        assert!(initializer_properties[0].content.contains("Foo()"));
+        assert!(!initializer_properties[0].content.contains("Bar()"));
+        assert!(initializer_properties[1].content.contains("Bar()"));
+        assert!(!initializer_properties[1].content.contains("Foo()"));
+
+        let constants_code = r#"
+struct Constants {
+    let first, second, third: Int
+}
+"#;
+        let constants_entities = plugin.extract_entities(constants_code, "Constants.swift");
+        let constants_properties: Vec<_> = constants_entities
+            .iter()
+            .filter(|e| e.entity_type == "property")
+            .collect();
+        assert_eq!(
+            constants_properties.iter().map(|e| e.name.as_str()).collect::<Vec<_>>(),
+            vec!["first", "second", "third"]
+        );
+        assert_eq!(constants_properties[0].content, "let first: Int");
+        assert_eq!(constants_properties[1].content, "let second: Int");
+        assert_eq!(constants_properties[2].content, "let third: Int");
+
+        let semicolon_code = r#"
+struct Semicolons {
+    var left, right: Int; var next: Int
+}
+"#;
+        let semicolon_entities = plugin.extract_entities(semicolon_code, "Semicolons.swift");
+        let semicolon_properties: Vec<_> = semicolon_entities
+            .iter()
+            .filter(|e| e.entity_type == "property")
+            .collect();
+        assert_eq!(semicolon_properties[0].content, "var left: Int");
+        assert_eq!(semicolon_properties[1].content, "var right: Int");
+        assert_eq!(semicolon_properties[2].content, "var next: Int");
+    }
+
+    #[test]
     fn test_swift_conditional_compilation_inside_struct() {
         let code = r#"
 import ArgumentParser


### PR DESCRIPTION
## Summary
- emit one Swift property entity per binding for declarations like `var x, y: Int`
- synthesize per-binding content for shared type annotations, explicit per-binding types, initializers, and `let` declarations
- use extractor sequence positions for reorder detection so same-line entities do not produce false reorders

Fixes #260

## Test plan
- `cargo test -p sem-core swift_multi_binding --features lang-swift -- --nocapture`
- `cargo test -p sem-core reorder --features lang-swift -- --nocapture`
- `cargo test -p sem-core --features lang-swift`
- `cargo test -p sem-cli`
- `cargo build -p sem-cli`
- disposable Swift git repo validating `sem entities`, `sem context`, `sem impact`, `sem blame`, and `sem diff --format json`