### PR TITLE
Fix TypeScript import resolution gaps

### DIFF
--- a/crates/sem-core/src/parser/graph.rs
+++ b/crates/sem-core/src/parser/graph.rs
@@ -28,7 +28,10 @@ macro_rules! maybe_par_iter {
 
 use crate::git::types::{FileChange, FileStatus};
 use crate::model::entity::SemanticEntity;
-use crate::parser::import_resolution::find_import_target;
+use crate::parser::import_resolution::{
+    find_import_file, find_import_target, is_js_ts_file, sort_import_candidate_files,
+    JS_TS_EXTENSIONS,
+};
 use crate::parser::registry::{resolve_go_method_parent_ids, ParserRegistry};
 use crate::parser::scope_resolve;
 
@@ -434,8 +437,11 @@ impl EntityGraph {
             })
             .collect();
 
+        let export_edges = build_export_alias_edges(&all_entities, &import_table);
+
         // Merge scope edges with bag-of-words edges, deduplicating
         let mut combined: Vec<(String, String, RefType)> = scope_edges;
+        combined.extend(export_edges);
         combined.extend(resolved_refs);
         let mut seen_edges: HashSet<(String, String)> = HashSet::with_capacity(combined.len());
         let mut all_resolved: Vec<(String, String, RefType)> = Vec::with_capacity(combined.len());
@@ -862,8 +868,11 @@ impl EntityGraph {
             })
             .collect();
 
+        let export_edges = build_export_alias_edges(&all_entities, &import_table);
+
         // Merge scope edges + bag-of-words edges + kept cached edges
         let mut combined: Vec<(String, String, RefType)> = scope_edges;
+        combined.extend(export_edges);
         combined.extend(resolved_refs);
         let mut seen_edges: HashSet<(String, String)> = HashSet::with_capacity(combined.len());
         let mut all_resolved: Vec<(String, String, RefType)> = Vec::with_capacity(combined.len());
@@ -1361,6 +1370,146 @@ fn is_test_entity(entity: &crate::model::entity::SemanticEntity) -> bool {
     in_test_file && has_test_marker
 }
 
+fn build_export_alias_edges(
+    all_entities: &[SemanticEntity],
+    import_table: &HashMap<(String, String), String>,
+) -> Vec<(String, String, RefType)> {
+    all_entities
+        .iter()
+        .filter(|entity| entity.entity_type == "export")
+        .filter_map(|entity| {
+            let key = (entity.file_path.clone(), entity.name.clone());
+            let target_id = import_table.get(&key)?;
+            if target_id == &entity.id {
+                return None;
+            }
+            Some((entity.id.clone(), target_id.clone(), RefType::Imports))
+        })
+        .collect()
+}
+
+fn build_ts_default_export_table(
+    root: &Path,
+    file_paths: &[String],
+    symbol_table: &HashMap<String, Vec<String>>,
+    entity_map: &HashMap<String, EntityInfo>,
+    content_map: &HashMap<&str, &str>,
+) -> HashMap<String, String> {
+    let mut default_exports = HashMap::new();
+
+    for file_path in file_paths {
+        if !is_js_ts_file(file_path) {
+            continue;
+        }
+
+        let owned_content;
+        let content = if let Some(content) = content_map.get(file_path.as_str()) {
+            *content
+        } else {
+            let full_path = root.join(file_path);
+            owned_content = match std::fs::read_to_string(&full_path) {
+                Ok(content) => content,
+                Err(_) => continue,
+            };
+            owned_content.as_str()
+        };
+
+        for name in default_export_names_from_content(content) {
+            let Some(target_ids) = symbol_table.get(name.as_str()) else {
+                continue;
+            };
+            let target = target_ids.iter().find(|id| {
+                entity_map.get(*id).map_or(false, |entity| {
+                    entity.file_path == *file_path && entity.parent_id.is_none()
+                })
+            });
+            if let Some(target_id) = target {
+                default_exports.insert(file_path.clone(), target_id.clone());
+            }
+        }
+    }
+
+    default_exports
+}
+
+fn default_export_names_from_content(content: &str) -> Vec<String> {
+    static DEFAULT_FUNCTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"\bexport\s+default\s+(?:async\s+)?function\s*\*?\s+([A-Za-z_$][\w$]*)")
+            .unwrap()
+    });
+    static DEFAULT_CLASS_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"\bexport\s+default\s+class\s+([A-Za-z_$][\w$]*)").unwrap()
+    });
+    static DEFAULT_IDENTIFIER_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?m)\bexport\s+default\s+([A-Za-z_$][\w$]*)\s*(?:;|$)").unwrap()
+    });
+    static DEFAULT_SPECIFIER_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r#"export\s+(?:type\s+)?\{([^}]+)\}\s*;?"#).unwrap()
+    });
+
+    let mut names = Vec::new();
+    for cap in DEFAULT_FUNCTION_RE.captures_iter(content) {
+        names.push(cap.get(1).unwrap().as_str().to_string());
+    }
+    for cap in DEFAULT_CLASS_RE.captures_iter(content) {
+        names.push(cap.get(1).unwrap().as_str().to_string());
+    }
+    for cap in DEFAULT_IDENTIFIER_RE.captures_iter(content) {
+        names.push(cap.get(1).unwrap().as_str().to_string());
+    }
+    for cap in DEFAULT_SPECIFIER_RE.captures_iter(content) {
+        let rest = content[cap.get(0).unwrap().end()..].trim_start();
+        if rest.starts_with("from ") {
+            continue;
+        }
+        let names_str = cap.get(1).unwrap().as_str();
+        for name_part in names_str.split(',') {
+            let Some((original_name, local_name)) = parse_js_ts_import_specifier(name_part) else {
+                continue;
+            };
+            if local_name == "default" {
+                names.push(original_name.to_string());
+            }
+        }
+    }
+
+    names
+}
+
+fn resolve_default_export_target(
+    default_exports: &HashMap<String, String>,
+    module_path: &str,
+    file_path: &str,
+) -> Option<String> {
+    let mut default_export_files: Vec<&str> = default_exports.keys().map(String::as_str).collect();
+    sort_import_candidate_files(&mut default_export_files, JS_TS_EXTENSIONS);
+    let target_file = find_import_file(&default_export_files, module_path, file_path, JS_TS_EXTENSIONS)?;
+    default_exports.get(target_file).cloned()
+}
+
+fn parse_js_ts_import_specifier(name_part: &str) -> Option<(&str, &str)> {
+    let name_part = name_part.trim();
+    if name_part.is_empty() {
+        return None;
+    }
+
+    let (original, local) = if let Some(pos) = name_part.find(" as ") {
+        let original = name_part[..pos].trim();
+        let local = name_part[pos + 4..].trim();
+        (original, local)
+    } else {
+        (name_part, name_part)
+    };
+
+    let original = original.strip_prefix("type ").unwrap_or(original).trim();
+    let local = local.strip_prefix("type ").unwrap_or(local).trim();
+    if original.is_empty() || local.is_empty() {
+        return None;
+    }
+
+    Some((original, local))
+}
+
 /// Build import table: maps (file_path, imported_name) → target entity ID.
 ///
 /// Parses `from X import Y` / `import X` / `use X` style statements from entity content
@@ -1378,6 +1527,8 @@ fn build_import_table(
             files.iter().map(|(fp, content, _)| (fp.as_str(), content.as_str())).collect()
         })
         .unwrap_or_default();
+    let ts_default_exports =
+        build_ts_default_export_table(root, file_paths, symbol_table, entity_map, &content_map);
 
     // Go imports are handled entirely by the scope resolver (which uses an indexed approach).
     // We no longer need a go_pkg_index here since Go files are skipped below.
@@ -1487,15 +1638,24 @@ fn build_import_table(
 
             // JS/TS imports: import { foo, bar as baz } from './module'
             //                import Foo from './module'
-            let is_js_ts = file_path.ends_with(".js") || file_path.ends_with(".ts")
-                || file_path.ends_with(".jsx") || file_path.ends_with(".tsx");
+            let is_js_ts = is_js_ts_file(file_path);
 
             if is_js_ts {
                 static JS_NAMED_RE: LazyLock<Regex> = LazyLock::new(|| {
-                    Regex::new(r#"import\s*\{([^}]+)\}\s*from\s*['"]([^'"]+)['"]"#).unwrap()
+                    Regex::new(
+                        r#"import\s+(?:type\s+)?(?:[A-Za-z_$][\w$]*\s*,\s*)?\{([^}]+)\}\s*from\s*['"]([^'"]+)['"]"#,
+                    )
+                    .unwrap()
                 });
                 static JS_DEFAULT_RE: LazyLock<Regex> = LazyLock::new(|| {
-                    Regex::new(r#"import\s+(?:type\s+)?([A-Za-z_]\w*)\s+from\s*['"]([^'"]+)['"]"#).unwrap()
+                    Regex::new(
+                        r#"import\s+(?:type\s+)?([A-Za-z_$][\w$]*)(?:\s*,\s*\{[^}]*\})?\s*from\s*['"]([^'"]+)['"]"#,
+                    )
+                    .unwrap()
+                });
+                static JS_REEXPORT_RE: LazyLock<Regex> = LazyLock::new(|| {
+                    Regex::new(r#"export\s+(?:type\s+)?\{([^}]+)\}\s*from\s*['"]([^'"]+)['"]"#)
+                        .unwrap()
                 });
 
                 for cap in JS_NAMED_RE.captures_iter(content) {
@@ -1503,28 +1663,18 @@ fn build_import_table(
                     let module_path = cap.get(2).unwrap().as_str();
 
                     for name_part in names_str.split(',') {
-                        let name_part = name_part.trim();
-                        if name_part.is_empty() { continue; }
-
-                        // Handle "foo as bar" aliases and "type foo" prefixes
-                        let (original_name, local_name) = if let Some(pos) = name_part.find(" as ") {
-                            let orig = name_part[..pos].trim();
-                            let local = name_part[pos + 4..].trim();
-                            let orig = orig.strip_prefix("type ").unwrap_or(orig);
-                            (orig, local)
-                        } else {
-                            let name = name_part.strip_prefix("type ").unwrap_or(name_part);
-                            (name, name)
+                        let Some((original_name, local_name)) =
+                            parse_js_ts_import_specifier(name_part)
+                        else {
+                            continue;
                         };
-
-                        if original_name.is_empty() || local_name.is_empty() { continue; }
 
                         if let Some(target_ids) = symbol_table.get(original_name) {
                             let target = find_import_target(
                                 target_ids,
                                 module_path,
                                 file_path,
-                                &[".ts", ".tsx", ".js", ".jsx"],
+                                JS_TS_EXTENSIONS,
                                 entity_map,
                             );
                             if let Some(target_id) = target {
@@ -1541,18 +1691,50 @@ fn build_import_table(
                     let local_name = cap.get(1).unwrap().as_str();
                     let module_path = cap.get(2).unwrap().as_str();
 
-                    if let Some(target_ids) = symbol_table.get(local_name) {
-                        let target = find_import_target(
-                            target_ids,
-                            module_path,
-                            file_path,
-                            &[".ts", ".tsx", ".js", ".jsx"],
-                            entity_map,
-                        );
-                        if let Some(target_id) = target {
+                    if let Some(target_id) =
+                        resolve_default_export_target(&ts_default_exports, module_path, file_path)
+                    {
+                        local_imports.push((
+                            (file_path.clone(), local_name.to_string()),
+                            target_id,
+                        ));
+                    }
+                }
+
+                for cap in JS_REEXPORT_RE.captures_iter(content) {
+                    let names_str = cap.get(1).unwrap().as_str();
+                    let module_path = cap.get(2).unwrap().as_str();
+
+                    for name_part in names_str.split(',') {
+                        let Some((original_name, local_name)) =
+                            parse_js_ts_import_specifier(name_part)
+                        else {
+                            continue;
+                        };
+
+                        let target_id = if original_name == "default" {
+                            resolve_default_export_target(
+                                &ts_default_exports,
+                                module_path,
+                                file_path,
+                            )
+                        } else {
+                            symbol_table.get(original_name).and_then(|target_ids| {
+                                find_import_target(
+                                    target_ids,
+                                    module_path,
+                                    file_path,
+                                    JS_TS_EXTENSIONS,
+                                    entity_map,
+                                )
+                                .cloned()
+                            })
+                        };
+
+                        if let Some(target_id) = target_id {
                             local_imports.push((
                                 (file_path.clone(), local_name.to_string()),
-                                target_id.clone(),
+                                target_id,
                             ));
                         }
                     }
@@ -1689,9 +1871,13 @@ fn resolve_rust_import(
 /// Strip common file extensions from a filename.
 fn strip_file_ext(s: &str) -> &str {
     s.strip_suffix(".py")
+        .or_else(|| s.strip_suffix(".mts"))
+        .or_else(|| s.strip_suffix(".cts"))
         .or_else(|| s.strip_suffix(".ts"))
-        .or_else(|| s.strip_suffix(".js"))
         .or_else(|| s.strip_suffix(".tsx"))
+        .or_else(|| s.strip_suffix(".mjs"))
+        .or_else(|| s.strip_suffix(".cjs"))
+        .or_else(|| s.strip_suffix(".js"))
         .or_else(|| s.strip_suffix(".jsx"))
         .or_else(|| s.strip_suffix(".rs"))
         .unwrap_or(s)
@@ -2432,6 +2618,365 @@ export function caller() { return helper(); }
             "caller should not resolve explicit ./util.ts to src/util.js. Deps: {:?}",
             deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn test_js_ts_default_import_resolves_default_export() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "lib.ts", "\
+export default function makeThing(): string { return 'ok'; }
+export function namedThing(): string { return 'named'; }
+");
+        write_file(root, "consumer.ts", "\
+import build, { namedThing as aliasNamed } from './lib';
+export function useDefault(): string { return build(); }
+export function useNamed(): string { return aliasNamed(); }
+");
+
+        let (graph, _) = EntityGraph::build(
+            root,
+            &["lib.ts".into(), "consumer.ts".into()],
+            &registry,
+        );
+
+        let use_default_id = graph.entities.keys()
+            .find(|id| id.contains("useDefault"))
+            .expect("useDefault entity should exist");
+        let default_deps = graph.get_dependencies(use_default_id);
+        assert!(
+            default_deps.iter().any(|d| d.name == "makeThing" && d.file_path == "lib.ts"),
+            "useDefault should resolve default import alias to makeThing. Deps: {:?}",
+            default_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+
+        let use_named_id = graph.entities.keys()
+            .find(|id| id.contains("useNamed"))
+            .expect("useNamed entity should exist");
+        let named_deps = graph.get_dependencies(use_named_id);
+        assert!(
+            named_deps.iter().any(|d| d.name == "namedThing" && d.file_path == "lib.ts"),
+            "useNamed should still resolve aliased named import. Deps: {:?}",
+            named_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_js_ts_default_import_resolves_default_export_specifier() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "lib.ts", "\
+function makeThing(): string { return 'ok'; }
+export { makeThing as default };
+");
+        write_file(root, "consumer.ts", "\
+import build from './lib';
+export function useDefault(): string { return build(); }
+");
+
+        let (graph, _) = EntityGraph::build(
+            root,
+            &["lib.ts".into(), "consumer.ts".into()],
+            &registry,
+        );
+
+        let use_default_id = graph.entities.keys()
+            .find(|id| id.contains("useDefault"))
+            .expect("useDefault entity should exist");
+        let default_deps = graph.get_dependencies(use_default_id);
+        assert!(
+            default_deps.iter().any(|d| d.name == "makeThing" && d.file_path == "lib.ts"),
+            "useDefault should resolve export specifier default to makeThing. Deps: {:?}",
+            default_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_js_ts_default_import_resolves_bare_identifier_export() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "lib.ts", "\
+function makeThing(): string { return 'ok'; }
+export default makeThing; // default alias
+");
+        write_file(root, "consumer.ts", "\
+import build from './lib';
+export function useDefault(): string { return build(); }
+");
+
+        let (graph, _) = EntityGraph::build(
+            root,
+            &["lib.ts".into(), "consumer.ts".into()],
+            &registry,
+        );
+
+        let use_default_id = graph.entities.keys()
+            .find(|id| id.contains("useDefault"))
+            .expect("useDefault entity should exist");
+        let default_deps = graph.get_dependencies(use_default_id);
+        assert!(
+            default_deps.iter().any(|d| d.name == "makeThing" && d.file_path == "lib.ts"),
+            "useDefault should resolve bare identifier default export to makeThing. Deps: {:?}",
+            default_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_js_ts_default_import_ignores_complex_expression_export() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "lib.ts", "\
+export function foo(): string { return 'foo'; }
+export default foo.bar;
+");
+        write_file(root, "consumer.ts", "\
+import value from './lib';
+export function useDefault(): unknown { return value(); }
+");
+
+        let (graph, _) = EntityGraph::build(
+            root,
+            &["lib.ts".into(), "consumer.ts".into()],
+            &registry,
+        );
+
+        let use_default_id = graph.entities.keys()
+            .find(|id| id.contains("useDefault"))
+            .expect("useDefault entity should exist");
+        let default_deps = graph.get_dependencies(use_default_id);
+        assert!(
+            !default_deps.iter().any(|d| d.name == "foo" && d.file_path == "lib.ts"),
+            "useDefault should not guess that foo.bar resolves to foo. Deps: {:?}",
+            default_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_js_ts_default_import_prefers_ordered_module_variant() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "lib.ts", "\
+export default function tsThing(): string { return 'ts'; }
+");
+        write_file(root, "lib.js", "\
+export default function jsThing() { return 'js'; }
+");
+        write_file(root, "consumer.ts", "\
+import build from './lib';
+export function useDefault(): string { return build(); }
+");
+
+        let (graph, _) = EntityGraph::build(
+            root,
+            &["lib.ts".into(), "lib.js".into(), "consumer.ts".into()],
+            &registry,
+        );
+
+        let use_default_id = graph.entities.keys()
+            .find(|id| id.contains("useDefault"))
+            .expect("useDefault entity should exist");
+        let default_deps = graph.get_dependencies(use_default_id);
+        assert!(
+            default_deps.iter().any(|d| d.name == "tsThing" && d.file_path == "lib.ts"),
+            "extensionless default import should follow JS_TS_EXTENSIONS order. Deps: {:?}",
+            default_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+        assert!(
+            !default_deps.iter().any(|d| d.name == "jsThing" && d.file_path == "lib.js"),
+            "extensionless default import should not depend on later lib.js variant. Deps: {:?}",
+            default_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_js_ts_default_import_bare_specifier_prefers_ordered_module_variant() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "lib.ts", "\
+export default function tsThing(): string { return 'ts'; }
+");
+        write_file(root, "lib.js", "\
+export default function jsThing() { return 'js'; }
+");
+        write_file(root, "consumer.ts", "\
+import build from 'lib';
+export function useDefault(): string { return build(); }
+");
+
+        let (graph, _) = EntityGraph::build(
+            root,
+            &["lib.ts".into(), "lib.js".into(), "consumer.ts".into()],
+            &registry,
+        );
+
+        let use_default_id = graph.entities.keys()
+            .find(|id| id.contains("useDefault"))
+            .expect("useDefault entity should exist");
+        let default_deps = graph.get_dependencies(use_default_id);
+        assert!(
+            default_deps.iter().any(|d| d.name == "tsThing" && d.file_path == "lib.ts"),
+            "bare default import should follow JS_TS_EXTENSIONS order. Deps: {:?}",
+            default_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+        assert!(
+            !default_deps.iter().any(|d| d.name == "jsThing" && d.file_path == "lib.js"),
+            "bare default import should not depend on later lib.js variant. Deps: {:?}",
+            default_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_js_ts_re_export_alias_resolves_through_barrel() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "lib.ts", "\
+export function core(): string { return 'core'; }
+");
+        write_file(root, "barrel.ts", "\
+export { core as publicCore } from './lib';
+");
+        write_file(root, "consumer.ts", "\
+import { publicCore } from './barrel';
+export function usePublicCore(): string { return publicCore(); }
+");
+
+        let (graph, _) = EntityGraph::build(
+            root,
+            &["lib.ts".into(), "barrel.ts".into(), "consumer.ts".into()],
+            &registry,
+        );
+
+        let public_core = graph.entities.values()
+            .find(|entity| {
+                entity.name == "publicCore"
+                    && entity.file_path == "barrel.ts"
+                    && entity.entity_type == "export"
+            })
+            .expect("barrel export alias entity should exist");
+        let alias_deps = graph.get_dependencies(&public_core.id);
+        assert!(
+            alias_deps.iter().any(|d| d.name == "core" && d.file_path == "lib.ts"),
+            "publicCore alias should depend on lib.ts core. Deps: {:?}",
+            alias_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+
+        let use_public_core_id = graph.entities.keys()
+            .find(|id| id.contains("usePublicCore"))
+            .expect("usePublicCore entity should exist");
+        let consumer_deps = graph.get_dependencies(use_public_core_id);
+        assert!(
+            consumer_deps.iter().any(|d| d.name == "publicCore" && d.file_path == "barrel.ts"),
+            "consumer should resolve publicCore through the barrel alias. Deps: {:?}",
+            consumer_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+
+        let core = graph.entities.values()
+            .find(|entity| entity.name == "core" && entity.file_path == "lib.ts")
+            .expect("lib core entity should exist");
+        let impact = graph.impact_analysis(&core.id);
+        assert!(
+            impact.iter().any(|entity| entity.name == "usePublicCore"),
+            "core impact should include usePublicCore through publicCore. Impact: {:?}",
+            impact.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_js_ts_direct_re_export_resolves_through_barrel() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(root, "lib.ts", "\
+export function core(): string { return 'core'; }
+");
+        write_file(root, "barrel.ts", "\
+export { core } from './lib';
+");
+        write_file(root, "consumer.ts", "\
+import { core } from './barrel';
+export function useCore(): string { return core(); }
+");
+
+        let (graph, _) = EntityGraph::build(
+            root,
+            &["lib.ts".into(), "barrel.ts".into(), "consumer.ts".into()],
+            &registry,
+        );
+
+        let barrel_core = graph.entities.values()
+            .find(|entity| {
+                entity.name == "core"
+                    && entity.file_path == "barrel.ts"
+                    && entity.entity_type == "export"
+            })
+            .expect("direct barrel export entity should exist");
+        let alias_deps = graph.get_dependencies(&barrel_core.id);
+        assert!(
+            alias_deps.iter().any(|d| d.name == "core" && d.file_path == "lib.ts"),
+            "barrel core export should depend on lib.ts core. Deps: {:?}",
+            alias_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+
+        let use_core_id = graph.entities.keys()
+            .find(|id| id.contains("useCore"))
+            .expect("useCore entity should exist");
+        let consumer_deps = graph.get_dependencies(use_core_id);
+        assert!(
+            consumer_deps.iter().any(|d| d.name == "core" && d.file_path == "barrel.ts"),
+            "consumer should resolve core through the direct barrel export. Deps: {:?}",
+            consumer_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_js_ts_module_variant_import_resolves_exact_file() {
+        for (extension, target_content) in [
+            (".mts", "export function loadConfig(): string { return 'deep'; }\n"),
+            (".cts", "export function loadConfig(): string { return 'deep'; }\n"),
+            (".mjs", "export function loadConfig() { return 'deep'; }\n"),
+            (".cjs", "export function loadConfig() { return 'deep'; }\n"),
+        ] {
+            let (dir, registry) = create_test_repo();
+            let root = dir.path();
+
+            let target_path = format!("deep/config{extension}");
+            write_file(root, &target_path, target_content);
+            write_file(root, "config.ts", "\
+export function loadConfig(): string { return 'sibling'; }
+");
+            write_file(root, "app.ts", &format!("\
+import {{ loadConfig }} from './deep/config{extension}';
+export function start(): string {{ return loadConfig(); }}
+"));
+
+            let (graph, _) = EntityGraph::build(
+                root,
+                &[target_path.clone(), "config.ts".into(), "app.ts".into()],
+                &registry,
+            );
+
+            let start_id = graph.entities.keys()
+                .find(|id| id.contains("start"))
+                .expect("start entity should exist");
+            let deps = graph.get_dependencies(start_id);
+            assert!(
+                deps.iter().any(|d| d.name == "loadConfig" && d.file_path == target_path),
+                "start should resolve loadConfig to {target_path}. Deps: {:?}",
+                deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+            );
+            assert!(
+                !deps.iter().any(|d| d.name == "loadConfig" && d.file_path == "config.ts"),
+                "start should not resolve loadConfig to config.ts for {extension}. Deps: {:?}",
+                deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+            );
+        }
     }
 
     #[test]

--- a/crates/sem-core/src/parser/import_resolution.rs
+++ b/crates/sem-core/src/parser/import_resolution.rs
@@ -3,6 +3,29 @@ use std::path::{Component, Path, PathBuf};
 
 use crate::parser::graph::EntityInfo;
 
+pub(crate) const JS_TS_EXTENSIONS: &[&str] = &[
+    ".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs",
+];
+
+pub(crate) fn is_js_ts_file(file_path: &str) -> bool {
+    JS_TS_EXTENSIONS.iter().any(|extension| file_path.ends_with(extension))
+}
+
+pub(crate) fn sort_import_candidate_files(paths: &mut [&str], extensions: &[&str]) {
+    paths.sort_by(|left, right| {
+        extension_priority(left, extensions)
+            .cmp(&extension_priority(right, extensions))
+            .then_with(|| left.cmp(right))
+    });
+}
+
+fn extension_priority(file_path: &str, extensions: &[&str]) -> usize {
+    extensions
+        .iter()
+        .position(|extension| file_path.ends_with(extension))
+        .unwrap_or(extensions.len())
+}
+
 pub(crate) fn find_import_target<'a>(
     target_ids: &'a [String],
     source_path: &str,
@@ -10,22 +33,39 @@ pub(crate) fn find_import_target<'a>(
     extensions: &[&str],
     entity_map: &HashMap<String, EntityInfo>,
 ) -> Option<&'a String> {
+    let target_files: Vec<&str> = target_ids
+        .iter()
+        .filter_map(|id| entity_map.get(id).map(|entity| entity.file_path.as_str()))
+        .collect();
+    let target_file = find_import_file(&target_files, source_path, file_path, extensions)?;
+
+    target_ids.iter().find(|id| {
+        entity_map
+            .get(*id)
+            .map_or(false, |entity| entity.file_path == target_file)
+    })
+}
+
+pub(crate) fn find_import_file<'a>(
+    candidate_file_paths: &[&'a str],
+    source_path: &str,
+    file_path: &str,
+    extensions: &[&str],
+) -> Option<&'a str> {
     if let Some(candidates) = import_file_candidates(file_path, source_path, extensions) {
         return candidates.iter().find_map(|candidate_path| {
-            target_ids.iter().find(|id| {
-                entity_map
-                    .get(*id)
-                    .map_or(false, |e| e.file_path == *candidate_path)
-            })
+            candidate_file_paths
+                .iter()
+                .copied()
+                .find(|path| *path == candidate_path)
         });
     }
 
     let source_module = import_stem(source_path);
-    target_ids.iter().find(|id| {
-        entity_map
-            .get(*id)
-            .map_or(false, |e| file_stem(&e.file_path) == source_module)
-    })
+    candidate_file_paths
+        .iter()
+        .copied()
+        .find(|path| file_stem(path) == source_module)
 }
 
 pub(crate) fn import_source_matches_file(
@@ -143,8 +183,12 @@ fn file_stem(file_path: &str) -> &str {
     file_name
         .strip_suffix(".py")
         .or_else(|| file_name.strip_suffix(".rs"))
+        .or_else(|| file_name.strip_suffix(".mts"))
+        .or_else(|| file_name.strip_suffix(".cts"))
         .or_else(|| file_name.strip_suffix(".ts"))
         .or_else(|| file_name.strip_suffix(".tsx"))
+        .or_else(|| file_name.strip_suffix(".mjs"))
+        .or_else(|| file_name.strip_suffix(".cjs"))
         .or_else(|| file_name.strip_suffix(".js"))
         .or_else(|| file_name.strip_suffix(".jsx"))
         .or_else(|| file_name.strip_suffix(".go"))
@@ -182,7 +226,7 @@ mod tests {
             &ids,
             "./util.ts",
             "src/main.ts",
-            &[".ts", ".tsx", ".js", ".jsx"],
+            JS_TS_EXTENSIONS,
             &entity_map,
         );
 
@@ -198,7 +242,7 @@ mod tests {
             &ids,
             "./util.ts",
             "src/main.ts",
-            &[".ts", ".tsx", ".js", ".jsx"],
+            JS_TS_EXTENSIONS,
             &entity_map,
         );
 
@@ -230,10 +274,34 @@ mod tests {
             &ids,
             "util.ts",
             "src/main.ts",
-            &[".ts", ".tsx", ".js", ".jsx"],
+            JS_TS_EXTENSIONS,
             &entity_map,
         );
 
         assert_eq!(target, Some(&ids[0]));
+    }
+
+    #[test]
+    fn explicit_relative_import_resolves_module_variants_before_same_named_ts() {
+        for extension in [".mts", ".cts", ".mjs", ".cjs"] {
+            let ids = vec![
+                "src/config.ts::function::helper".to_string(),
+                format!("src/deep/config{extension}::function::helper"),
+            ];
+            let entity_map = HashMap::from([
+                (ids[0].clone(), entity("src/config.ts")),
+                (ids[1].clone(), entity(&format!("src/deep/config{extension}"))),
+            ]);
+
+            let target = find_import_target(
+                &ids,
+                &format!("./deep/config{extension}"),
+                "src/main.ts",
+                JS_TS_EXTENSIONS,
+                &entity_map,
+            );
+
+            assert_eq!(target, Some(&ids[1]), "extension: {extension}");
+        }
     }
 }

--- a/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
+++ b/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
@@ -483,6 +483,15 @@ fn visit_node(
             }
         }
 
+        if node_type == "export_statement"
+            && matches!(config.id, "typescript" | "tsx" | "javascript")
+            && node.child_by_field_name("source").is_some()
+        {
+            if emit_js_ts_re_export_entities(node, file_path, parent_id, source, entities) {
+                continue;
+            }
+        }
+
         // For export statements, look inside for the actual declaration
         if node_type == "export_statement" {
             if let Some(declaration) = node.child_by_field_name("declaration") {
@@ -509,6 +518,77 @@ fn visit_node(
             worklist.push((child, pid_owned.clone(), child_enclosing));
         }
     }
+}
+
+fn emit_js_ts_re_export_entities(
+    node: Node,
+    file_path: &str,
+    parent_id: Option<&str>,
+    source: &[u8],
+    entities: &mut Vec<SemanticEntity>,
+) -> bool {
+    let source_path = node
+        .child_by_field_name("source")
+        .and_then(|n| n.utf8_text(source).ok())
+        .unwrap_or("")
+        .trim_matches(|c: char| c == '\'' || c == '"');
+    if source_path.is_empty() {
+        return false;
+    }
+
+    let mut emitted = false;
+    let mut worklist = vec![node];
+    while let Some(current) = worklist.pop() {
+        let mut cursor = current.walk();
+        for child in current.named_children(&mut cursor) {
+            if child.kind() == "export_specifier" {
+                let original = child
+                    .child_by_field_name("name")
+                    .and_then(|n| n.utf8_text(source).ok())
+                    .map(clean_js_ts_export_name)
+                    .unwrap_or_default();
+                let local = child
+                    .child_by_field_name("alias")
+                    .and_then(|n| n.utf8_text(source).ok())
+                    .map(clean_js_ts_export_name)
+                    .unwrap_or_else(|| original.clone());
+
+                if local.is_empty() {
+                    continue;
+                }
+
+                let content = node_text(node, source).to_string();
+                let mut metadata = HashMap::new();
+                metadata.insert("export.source".to_string(), source_path.to_string());
+                if !original.is_empty() {
+                    metadata.insert("export.original".to_string(), original);
+                }
+
+                entities.push(SemanticEntity {
+                    id: build_entity_id(file_path, "export", &local, parent_id),
+                    file_path: file_path.to_string(),
+                    entity_type: "export".to_string(),
+                    name: local,
+                    parent_id: parent_id.map(String::from),
+                    content_hash: content_hash(&content),
+                    structural_hash: Some(compute_structural_hash(child, source)),
+                    content,
+                    start_line: child.start_position().row + 1,
+                    end_line: child.end_position().row + 1,
+                    metadata: Some(metadata),
+                });
+                emitted = true;
+            } else {
+                worklist.push(child);
+            }
+        }
+    }
+
+    emitted
+}
+
+fn clean_js_ts_export_name(name: &str) -> String {
+    name.trim().strip_prefix("type ").unwrap_or(name.trim()).to_string()
 }
 
 #[derive(Clone)]

--- a/crates/sem-core/src/parser/plugins/code/mod.rs
+++ b/crates/sem-core/src/parser/plugins/code/mod.rs
@@ -527,6 +527,32 @@ export function hello(): string {
     }
 
     #[test]
+    fn test_typescript_re_export_alias_entity_extraction() {
+        let code = r#"
+export { core as publicCore, helper } from './lib';
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "barrel.ts");
+
+        let exports: Vec<_> = entities
+            .iter()
+            .filter(|entity| entity.entity_type == "export")
+            .collect();
+        let names: Vec<&str> = exports.iter().map(|e| e.name.as_str()).collect();
+
+        assert!(
+            names.contains(&"publicCore"),
+            "Should find aliased re-export, got: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"helper"),
+            "Should find direct re-export, got: {:?}",
+            names
+        );
+    }
+
+    #[test]
     fn test_commonjs_typescript_entity_extraction() {
         let code = r#"
 export class Greeter {

--- a/crates/sem-core/src/parser/scope_resolve.rs
+++ b/crates/sem-core/src/parser/scope_resolve.rs
@@ -29,7 +29,10 @@ macro_rules! maybe_par_iter {
     }};
 }
 use crate::parser::graph::{EntityInfo, RefType};
-use crate::parser::import_resolution::{find_import_target, import_source_matches_file};
+use crate::parser::import_resolution::{
+    find_import_file, find_import_target, import_source_matches_file, is_js_ts_file,
+    sort_import_candidate_files, JS_TS_EXTENSIONS,
+};
 use crate::parser::plugins::code::languages::{
     get_language_config, AssignmentStrategy, CallNodeStyle, ClassNameField, InitStrategy,
     ParamNameField, ScopeResolveConfig,
@@ -241,6 +244,8 @@ pub(crate) fn resolve_with_scopes_full(
         }
     }
     let parsed_files: &[(String, String, tree_sitter::Tree)] = &owned_parsed_files;
+    let ts_default_exports =
+        build_ts_default_export_table(parsed_files, &symbol_table, entity_map);
 
     // Pass 1: Scan ALL files for return types and instance attr types first
     // This ensures cross-file return type info is available during resolution
@@ -369,6 +374,7 @@ pub(crate) fn resolve_with_scopes_full(
                 &mut scopes,
                 config,
                 &go_pkg_index,
+                &ts_default_exports,
             );
 
             // Resolve pending call types using the complete return type map
@@ -2404,6 +2410,203 @@ fn inject_return_type_bindings(
     }
 }
 
+fn build_ts_default_export_table(
+    parsed_files: &[(String, String, tree_sitter::Tree)],
+    symbol_table: &HashMap<String, Vec<String>>,
+    entity_map: &HashMap<String, EntityInfo>,
+) -> HashMap<String, String> {
+    let mut default_exports = HashMap::new();
+
+    for (file_path, content, tree) in parsed_files {
+        if !is_js_ts_file(file_path) {
+            continue;
+        }
+
+        for name in extract_ts_default_export_names(tree.root_node(), content.as_bytes()) {
+            let Some(target_ids) = symbol_table.get(&name) else {
+                continue;
+            };
+            let target = target_ids.iter().find(|id| {
+                entity_map.get(*id).map_or(false, |entity| {
+                    entity.file_path == *file_path && entity.parent_id.is_none()
+                })
+            });
+            if let Some(target_id) = target {
+                default_exports.insert(file_path.clone(), target_id.clone());
+            }
+        }
+    }
+
+    default_exports
+}
+
+fn extract_ts_default_export_names(root: tree_sitter::Node, source: &[u8]) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut worklist = vec![root];
+
+    while let Some(node) = worklist.pop() {
+        if node.kind() == "export_statement" {
+            let has_source = node.child_by_field_name("source").is_some();
+            let text = node.utf8_text(source).unwrap_or("");
+            if !has_source {
+                if let Some(declaration) = node.child_by_field_name("declaration") {
+                    if text.contains("default") {
+                        if let Some(name) = ts_default_declaration_name(declaration, source) {
+                            names.push(name);
+                        }
+                    }
+                } else if text.contains("default") && !has_ts_export_specifier(node) {
+                    if let Some(name) = ts_bare_default_export_identifier(node, source) {
+                        names.push(name);
+                    }
+                }
+                collect_ts_default_export_specifiers(node, source, &mut names);
+            }
+        }
+
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            worklist.push(child);
+        }
+    }
+
+    names
+}
+
+fn ts_default_declaration_name(
+    node: tree_sitter::Node,
+    source: &[u8],
+) -> Option<String> {
+    match node.kind() {
+        "function_declaration" | "generator_function_declaration" | "class_declaration"
+        | "lexical_declaration" | "variable_declaration" => ts_declaration_name(node, source),
+        "identifier" => node.utf8_text(source).ok().map(str::to_string),
+        _ => None,
+    }
+}
+
+fn has_ts_export_specifier(node: tree_sitter::Node) -> bool {
+    let mut worklist = vec![node];
+    while let Some(current) = worklist.pop() {
+        let mut cursor = current.walk();
+        for child in current.named_children(&mut cursor) {
+            if child.kind() == "export_specifier" {
+                return true;
+            }
+            worklist.push(child);
+        }
+    }
+    false
+}
+
+fn collect_ts_default_export_specifiers(
+    node: tree_sitter::Node,
+    source: &[u8],
+    names: &mut Vec<String>,
+) {
+    let mut worklist = vec![node];
+    while let Some(current) = worklist.pop() {
+        let mut cursor = current.walk();
+        for child in current.named_children(&mut cursor) {
+            if child.kind() == "export_specifier" {
+                let original = child
+                    .child_by_field_name("name")
+                    .and_then(|n| n.utf8_text(source).ok())
+                    .unwrap_or("");
+                let local = child
+                    .child_by_field_name("alias")
+                    .and_then(|n| n.utf8_text(source).ok())
+                    .unwrap_or(original);
+                if local == "default" && !original.is_empty() {
+                    names.push(original.to_string());
+                }
+            } else {
+                worklist.push(child);
+            }
+        }
+    }
+}
+
+fn ts_declaration_name(node: tree_sitter::Node, source: &[u8]) -> Option<String> {
+    if let Some(name) = node.child_by_field_name("name") {
+        return Some(name.utf8_text(source).ok()?.to_string());
+    }
+
+    if node.kind() == "lexical_declaration" || node.kind() == "variable_declaration" {
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            if child.kind() == "variable_declarator" {
+                if let Some(name) = child.child_by_field_name("name") {
+                    return Some(name.utf8_text(source).ok()?.to_string());
+                }
+            }
+        }
+    }
+
+    let mut cursor = node.walk();
+    let name = node
+        .named_children(&mut cursor)
+        .find(|child| matches!(child.kind(), "identifier" | "type_identifier"))
+        .and_then(|child| child.utf8_text(source).ok())
+        .map(str::to_string);
+    name
+}
+
+fn ts_bare_default_export_identifier(
+    node: tree_sitter::Node,
+    source: &[u8],
+) -> Option<String> {
+    let text = node.utf8_text(source).ok()?.trim();
+    let rest = text.strip_prefix("export")?.trim_start();
+    let rest = rest.strip_prefix("default")?.trim_start();
+    let name_end = js_ts_identifier_end(rest)?;
+    let name = &rest[..name_end];
+    let trailing = rest[name_end..].trim_start();
+    only_js_ts_statement_trivia(trailing).then(|| name.to_string())
+}
+
+fn js_ts_identifier_end(text: &str) -> Option<usize> {
+    let mut chars = text.char_indices();
+    let (_, first) = chars.next()?;
+    if !(first == '_' || first == '$' || first.is_ascii_alphabetic()) {
+        return None;
+    }
+
+    let mut end = first.len_utf8();
+    for (idx, ch) in chars {
+        if ch == '_' || ch == '$' || ch.is_ascii_alphanumeric() {
+            end = idx + ch.len_utf8();
+        } else {
+            break;
+        }
+    }
+    Some(end)
+}
+
+fn only_js_ts_statement_trivia(mut text: &str) -> bool {
+    if let Some(rest) = text.strip_prefix(';') {
+        text = rest;
+    }
+
+    loop {
+        text = text.trim_start();
+        if text.is_empty() {
+            return true;
+        }
+        if text.starts_with("//") {
+            return true;
+        }
+        if let Some(rest) = text.strip_prefix("/*") {
+            let Some(end) = rest.find("*/") else {
+                return false;
+            };
+            text = &rest[end + 2..];
+            continue;
+        }
+        return false;
+    }
+}
+
 /// Extract import statements from the AST.
 fn extract_imports_from_ast(
     root: tree_sitter::Node,
@@ -2415,6 +2618,7 @@ fn extract_imports_from_ast(
     scopes: &mut Vec<Scope>,
     config: &ScopeResolveConfig,
     go_pkg_index: &HashMap<String, Vec<(String, String)>>,
+    ts_default_exports: &HashMap<String, String>,
 ) {
     let mut worklist = vec![root];
     while let Some(node) = worklist.pop() {
@@ -2433,7 +2637,29 @@ fn extract_imports_from_ast(
                 }
                 "import_statement" if !config.self_keywords.contains(&"cls") => {
                     // TS import_statement (not Python - Python uses import_from_statement)
-                    extract_ts_import(child, file_path, source, symbol_table, entity_map, import_table, scopes);
+                    extract_ts_import(
+                        child,
+                        file_path,
+                        source,
+                        symbol_table,
+                        entity_map,
+                        import_table,
+                        scopes,
+                        ts_default_exports,
+                    );
+                    true
+                }
+                "export_statement" if !config.self_keywords.contains(&"cls") => {
+                    extract_ts_re_export(
+                        child,
+                        file_path,
+                        source,
+                        symbol_table,
+                        entity_map,
+                        import_table,
+                        scopes,
+                        ts_default_exports,
+                    );
                     true
                 }
                 "use_declaration" => {
@@ -2462,6 +2688,7 @@ fn extract_ts_import(
     entity_map: &HashMap<String, EntityInfo>,
     import_table: &mut HashMap<(String, String), String>,
     scopes: &mut Vec<Scope>,
+    ts_default_exports: &HashMap<String, String>,
 ) {
     // Extract the source module from the `from '...'` clause
     let source_path = node
@@ -2495,7 +2722,7 @@ fn extract_ts_import(
                                 .unwrap_or(original);
 
                             if !original.is_empty() {
-                                resolve_import_name(original, local, source_path, file_path, &[".ts", ".tsx", ".js", ".jsx"], symbol_table, entity_map, import_table, scopes);
+                                resolve_import_name(original, local, source_path, file_path, JS_TS_EXTENSIONS, symbol_table, entity_map, import_table, scopes);
                             }
                         }
                     }
@@ -2512,15 +2739,95 @@ fn extract_ts_import(
                         .and_then(|n| n.utf8_text(source).ok())
                         .unwrap_or("");
                     if !alias.is_empty() {
-                        register_namespace_import(alias, source_path, file_path, &[".ts", ".tsx", ".js", ".jsx"], symbol_table, entity_map, import_table, scopes);
+                        register_namespace_import(alias, source_path, file_path, JS_TS_EXTENSIONS, symbol_table, entity_map, import_table, scopes);
                     }
                 } else if clause_child.kind() == "identifier" {
                     // Default import: import Foo from './module'
                     let name = clause_child.utf8_text(source).unwrap_or("");
                     if !name.is_empty() {
-                        resolve_import_name(name, name, source_path, file_path, &[".ts", ".tsx", ".js", ".jsx"], symbol_table, entity_map, import_table, scopes);
+                        resolve_default_import(
+                            name,
+                            source_path,
+                            file_path,
+                            JS_TS_EXTENSIONS,
+                            ts_default_exports,
+                            import_table,
+                            scopes,
+                        );
                     }
                 }
+            }
+        }
+    }
+}
+
+fn extract_ts_re_export(
+    node: tree_sitter::Node,
+    file_path: &str,
+    source: &[u8],
+    symbol_table: &HashMap<String, Vec<String>>,
+    entity_map: &HashMap<String, EntityInfo>,
+    import_table: &mut HashMap<(String, String), String>,
+    scopes: &mut Vec<Scope>,
+    ts_default_exports: &HashMap<String, String>,
+) {
+    let source_path = node
+        .child_by_field_name("source")
+        .and_then(|n| n.utf8_text(source).ok())
+        .unwrap_or("")
+        .trim_matches(|c: char| c == '\'' || c == '"');
+
+    if source_path.is_empty() {
+        return;
+    }
+
+    let mut worklist = vec![node];
+    while let Some(current) = worklist.pop() {
+        let mut cursor = current.walk();
+        for child in current.named_children(&mut cursor) {
+            match child.kind() {
+                "export_specifier" => {
+                    let original = child
+                        .child_by_field_name("name")
+                        .and_then(|n| n.utf8_text(source).ok())
+                        .unwrap_or("");
+                    let local = child
+                        .child_by_field_name("alias")
+                        .and_then(|n| n.utf8_text(source).ok())
+                        .unwrap_or(original);
+
+                    if original.is_empty() || local.is_empty() {
+                        continue;
+                    }
+
+                    if original == "default" {
+                        resolve_default_import(
+                            local,
+                            source_path,
+                            file_path,
+                            JS_TS_EXTENSIONS,
+                            ts_default_exports,
+                            import_table,
+                            scopes,
+                        );
+                    } else {
+                        resolve_import_name(
+                            original,
+                            local,
+                            source_path,
+                            file_path,
+                            JS_TS_EXTENSIONS,
+                            symbol_table,
+                            entity_map,
+                            import_table,
+                            scopes,
+                        );
+                    }
+                }
+                "export_clause" | "namespace_export" => {
+                    worklist.push(child);
+                }
+                _ => {}
             }
         }
     }
@@ -2703,6 +3010,32 @@ fn resolve_import_name(
                     .defs
                     .insert(local_name.to_string(), target_id.clone());
             }
+        }
+    }
+}
+
+fn resolve_default_import(
+    local_name: &str,
+    source_path: &str,
+    file_path: &str,
+    extensions: &[&str],
+    default_exports: &HashMap<String, String>,
+    import_table: &mut HashMap<(String, String), String>,
+    scopes: &mut Vec<Scope>,
+) {
+    let mut default_export_files: Vec<&str> = default_exports.keys().map(String::as_str).collect();
+    sort_import_candidate_files(&mut default_export_files, extensions);
+    let target = find_import_file(&default_export_files, source_path, file_path, extensions)
+        .and_then(|target_file| default_exports.get(target_file))
+        .cloned();
+
+    if let Some(target_id) = target {
+        import_table.insert(
+            (file_path.to_string(), local_name.to_string()),
+            target_id.clone(),
+        );
+        if !scopes.is_empty() {
+            scopes[0].defs.insert(local_name.to_string(), target_id);
         }
     }
 }


### PR DESCRIPTION
Fixes #264

## Summary
- Resolve TypeScript/JavaScript relative imports using ordered extension candidates, including `.mts`, `.cts`, `.mjs`, and `.cjs`.
- Resolve default imports to default export declarations and `export { value as default }` specifiers.
- Add entities and graph edges for named re-exports so barrel aliases participate in dependency and impact traversal.

## Test plan
- `cargo test --manifest-path crates/Cargo.toml -p sem-core`
- `cargo build --manifest-path crates/Cargo.toml -p sem-cli`
- Dummy git repo validation under `/tmp/sem-ts-import-validation` covering default imports, default re-export specifiers, ordered extension fallback, aliased/direct barrel re-exports, impact traversal, and exact `.mts/.cts/.mjs/.cjs` imports.