### PR TITLE
Improve graph scaling for deeply nested scopes

### DIFF
--- a/crates/sem-core/src/parser/graph.rs
+++ b/crates/sem-core/src/parser/graph.rs
@@ -20,9 +20,13 @@ use serde::{Deserialize, Serialize};
 macro_rules! maybe_par_iter {
     ($slice:expr) => {{
         #[cfg(feature = "parallel")]
-        { $slice.par_iter() }
+        {
+            $slice.par_iter()
+        }
         #[cfg(not(feature = "parallel"))]
-        { $slice.iter() }
+        {
+            $slice.iter()
+        }
     }};
 }
 
@@ -107,6 +111,274 @@ pub struct EntityInfo {
     pub end_line: usize,
 }
 
+#[derive(Debug)]
+struct LineReferenceIndex {
+    words: Vec<String>,
+    dot_chains: Vec<(String, String)>,
+    call_words: HashSet<String>,
+    import_words: HashSet<String>,
+}
+
+#[derive(Debug)]
+struct FileReferenceIndex {
+    lines: Vec<LineReferenceIndex>,
+}
+
+impl FileReferenceIndex {
+    fn from_content(content: &str) -> Self {
+        let stripped = strip_comments_and_strings(content);
+        let lines = stripped
+            .lines()
+            .map(LineReferenceIndex::from_stripped_line)
+            .collect();
+        Self { lines }
+    }
+
+    fn dot_chains_in_ranges(&self, ranges: &[(usize, usize)]) -> Vec<(&str, &str)> {
+        let mut chains = Vec::new();
+        let mut seen: HashSet<(&str, &str)> = HashSet::new();
+        for &(start_line, end_line) in ranges {
+            for line in self.line_range(start_line, end_line) {
+                for (receiver, member) in &line.dot_chains {
+                    let pair = (receiver.as_str(), member.as_str());
+                    if seen.insert(pair) {
+                        chains.push(pair);
+                    }
+                }
+            }
+        }
+        chains
+    }
+
+    fn refs_with_types_in_ranges(
+        &self,
+        ranges: &[(usize, usize)],
+        own_name: &str,
+    ) -> Vec<(&str, RefType)> {
+        let mut refs = Vec::new();
+        let mut seen: HashMap<&str, (bool, bool)> = HashMap::new();
+        for &(start_line, end_line) in ranges {
+            for line in self.line_range(start_line, end_line) {
+                for word in &line.words {
+                    let word = word.as_str();
+                    if word == own_name {
+                        continue;
+                    }
+                    let first_seen = !seen.contains_key(word);
+                    let flags = seen.entry(word).or_insert((false, false));
+                    flags.0 |= line.call_words.contains(word);
+                    flags.1 |= line.import_words.contains(word);
+                    if first_seen {
+                        refs.push(word);
+                    }
+                }
+            }
+        }
+        refs.into_iter()
+            .map(|word| {
+                let (has_call, has_import) = seen.get(word).copied().unwrap_or_default();
+                let ref_type = if has_call {
+                    RefType::Calls
+                } else if has_import {
+                    RefType::Imports
+                } else {
+                    RefType::TypeRef
+                };
+                (word, ref_type)
+            })
+            .collect()
+    }
+
+    fn line_range(
+        &self,
+        start_line: usize,
+        end_line: usize,
+    ) -> impl Iterator<Item = &LineReferenceIndex> {
+        let start = start_line.saturating_sub(1).min(self.lines.len());
+        let end = end_line.min(self.lines.len()).max(start);
+        self.lines[start..end].iter()
+    }
+}
+
+impl LineReferenceIndex {
+    fn from_stripped_line(line: &str) -> Self {
+        let mut words = Vec::new();
+        let mut seen_words = HashSet::new();
+        let mut call_words = HashSet::new();
+        let mut import_words = HashSet::new();
+        let import_like = {
+            let trimmed = line.trim();
+            trimmed.starts_with("import ")
+                || trimmed.starts_with("use ")
+                || trimmed.starts_with("from ")
+                || trimmed.starts_with("require(")
+        };
+
+        for (word, end_byte) in identifier_tokens(line) {
+            if !is_reference_word(word) {
+                continue;
+            }
+            if seen_words.insert(word) {
+                words.push(word.to_string());
+            }
+            if line.as_bytes().get(end_byte) == Some(&b'(') {
+                call_words.insert(word.to_string());
+            }
+            if import_like {
+                import_words.insert(word.to_string());
+            }
+        }
+
+        let dot_chains = extract_dot_chains(line)
+            .into_iter()
+            .map(|(receiver, member)| (receiver.to_string(), member.to_string()))
+            .collect();
+
+        Self {
+            words,
+            dot_chains,
+            call_words,
+            import_words,
+        }
+    }
+}
+
+fn build_reference_indexes(
+    root: &Path,
+    file_paths: &[String],
+    parsed_files: &[(String, String, tree_sitter::Tree)],
+) -> HashMap<String, FileReferenceIndex> {
+    let parsed_content: HashMap<&str, &str> = parsed_files
+        .iter()
+        .map(|(file_path, content, _)| (file_path.as_str(), content.as_str()))
+        .collect();
+
+    file_paths
+        .iter()
+        .filter_map(|file_path| {
+            let ext = file_path.rfind('.').map(|i| &file_path[i..]).unwrap_or("");
+            crate::parser::plugins::code::languages::get_language_config(ext)?;
+
+            if let Some(content) = parsed_content.get(file_path.as_str()) {
+                return Some((file_path.clone(), FileReferenceIndex::from_content(content)));
+            }
+
+            let content = std::fs::read_to_string(root.join(file_path)).ok()?;
+            Some((
+                file_path.clone(),
+                FileReferenceIndex::from_content(&content),
+            ))
+        })
+        .collect()
+}
+
+fn identifier_tokens(line: &str) -> Vec<(&str, usize)> {
+    let mut tokens = Vec::new();
+    let mut start = None;
+
+    for (idx, ch) in line.char_indices() {
+        if ch.is_alphanumeric() || ch == '_' {
+            if start.is_none() {
+                start = Some(idx);
+            }
+        } else if let Some(token_start) = start.take() {
+            tokens.push((&line[token_start..idx], idx));
+        }
+    }
+
+    if let Some(token_start) = start {
+        tokens.push((&line[token_start..], line.len()));
+    }
+
+    tokens
+}
+
+fn is_reference_word(word: &str) -> bool {
+    if word.is_empty() {
+        return false;
+    }
+    if is_keyword(word) || word.len() < 2 {
+        return false;
+    }
+    if word.starts_with(|c: char| c.is_lowercase()) && word.len() < 3 {
+        return false;
+    }
+    if !word.starts_with(|c: char| c.is_alphabetic() || c == '_') {
+        return false;
+    }
+    if is_common_local_name(word) {
+        return false;
+    }
+    true
+}
+
+fn is_function_like_entity_type(entity_type: &str) -> bool {
+    matches!(
+        entity_type,
+        "function" | "method" | "constructor" | "getter" | "setter"
+    )
+}
+
+fn fallback_reference_end_line(entity: &SemanticEntity, has_scope_resolve: bool) -> usize {
+    if !has_scope_resolve || is_function_like_entity_type(&entity.entity_type) {
+        return entity.end_line;
+    }
+
+    let mut prefix_lines = 0usize;
+    for line in entity.content.lines() {
+        prefix_lines += 1;
+        let trimmed = line.trim_end();
+        if line.contains('{') || trimmed.ends_with(':') || trimmed.ends_with(';') {
+            break;
+        }
+        if prefix_lines >= 16 {
+            break;
+        }
+    }
+
+    (entity.start_line + prefix_lines.saturating_sub(1))
+        .min(entity.end_line)
+        .max(entity.start_line)
+}
+
+fn direct_reference_line_ranges(
+    entity: &SemanticEntity,
+    fallback_end_line: usize,
+    child_line_ranges: &HashMap<String, Vec<(usize, usize)>>,
+) -> Vec<(usize, usize)> {
+    let start_line = entity.start_line;
+    let end_line = fallback_end_line.min(entity.end_line).max(start_line);
+    let mut ranges = Vec::new();
+    let mut next_line = start_line;
+
+    if let Some(children) = child_line_ranges.get(&entity.id) {
+        for &(child_start, child_end) in children {
+            if child_end < next_line {
+                continue;
+            }
+            if child_start > end_line {
+                break;
+            }
+
+            let child_start = child_start.max(start_line);
+            let child_end = child_end.min(end_line);
+            if next_line < child_start {
+                ranges.push((next_line, child_start - 1));
+            }
+            next_line = next_line.max(child_end.saturating_add(1));
+            if next_line > end_line {
+                break;
+            }
+        }
+    }
+
+    if next_line <= end_line {
+        ranges.push((next_line, end_line));
+    }
+
+    ranges
+}
+
 impl EntityGraph {
     /// Reconstruct an EntityGraph from pre-loaded parts (e.g. from a cache).
     pub fn from_parts(entities: HashMap<String, EntityInfo>, edges: Vec<EntityRef>) -> Self {
@@ -142,7 +414,10 @@ impl EntityGraph {
     ) -> (Self, Vec<SemanticEntity>) {
         // Pass 1: Extract all entities in parallel (file I/O + tree-sitter parsing)
         // Also collect (file_path, content, tree) for scope_resolve reuse
-        let per_file: Vec<(Vec<SemanticEntity>, Option<(String, String, tree_sitter::Tree)>)> = maybe_par_iter!(file_paths)
+        let per_file: Vec<(
+            Vec<SemanticEntity>,
+            Option<(String, String, tree_sitter::Tree)>,
+        )> = maybe_par_iter!(file_paths)
             .filter_map(|file_path| {
                 let full_path = root.join(file_path);
                 let content = std::fs::read_to_string(&full_path).ok()?;
@@ -164,9 +439,12 @@ impl EntityGraph {
 
         // Pass A: Build all lookup structures in a single pass over all_entities.
         // This merges what was previously 6 separate O(E) iterations.
-        let mut symbol_table: HashMap<String, Vec<String>> = HashMap::with_capacity(all_entities.len());
-        let mut entity_map: HashMap<String, EntityInfo> = HashMap::with_capacity(all_entities.len());
+        let mut symbol_table: HashMap<String, Vec<String>> =
+            HashMap::with_capacity(all_entities.len());
+        let mut entity_map: HashMap<String, EntityInfo> =
+            HashMap::with_capacity(all_entities.len());
         let mut parent_child_pairs: HashSet<(&str, &str)> = HashSet::new();
+        let mut child_line_ranges: HashMap<String, Vec<(usize, usize)>> = HashMap::new();
         let mut class_child_names: HashSet<(&str, &str)> = HashSet::new();
         let mut class_entity_names: HashSet<&str> = HashSet::new();
         let mut class_entity_files: HashSet<(&str, &str)> = HashSet::new();
@@ -194,18 +472,30 @@ impl EntityGraph {
 
             if let Some(ref pid) = entity.parent_id {
                 parent_child_pairs.insert((pid.as_str(), entity.id.as_str()));
+                child_line_ranges
+                    .entry(pid.clone())
+                    .or_default()
+                    .push((entity.start_line, entity.end_line));
                 class_child_names.insert((pid.as_str(), entity.name.as_str()));
             }
 
-            if matches!(entity.entity_type.as_str(), "class" | "struct" | "interface" | "class_type") {
+            if matches!(
+                entity.entity_type.as_str(),
+                "class" | "struct" | "interface" | "class_type"
+            ) {
                 class_entity_names.insert(entity.name.as_str());
                 class_entity_files.insert((entity.name.as_str(), entity.file_path.as_str()));
             }
 
             id_to_name.insert(entity.id.as_str(), entity.name.as_str());
 
-            scope_entity_ranges.entry(entity.file_path.clone()).or_default()
+            scope_entity_ranges
+                .entry(entity.file_path.clone())
+                .or_default()
                 .push((entity.start_line, entity.end_line, entity.id.clone()));
+        }
+        for ranges in child_line_ranges.values_mut() {
+            ranges.sort_unstable_by_key(|(start, end)| (*start, *end));
         }
 
         // Pass B: Build enclosing_class, class_members, and scope_class_members
@@ -227,16 +517,24 @@ impl EntityGraph {
                 }
                 // scope_class_members for scope resolver (checks entity_type of parent)
                 if let Some(parent) = entity_map.get(pid.as_str()) {
-                    if matches!(parent.entity_type.as_str(), "class" | "struct" | "interface" | "impl") {
-                        scope_class_members.entry(parent.name.clone()).or_default()
+                    if matches!(
+                        parent.entity_type.as_str(),
+                        "class" | "struct" | "interface" | "impl"
+                    ) {
+                        scope_class_members
+                            .entry(parent.name.clone())
+                            .or_default()
                             .push((entity.name.clone(), entity.id.clone()));
                     }
                 }
             }
             // Go receiver-based methods
             if entity.entity_type == "method" && entity.file_path.ends_with(".go") {
-                if let Some(struct_name) = scope_resolve::extract_go_receiver_type(&entity.content) {
-                    scope_class_members.entry(struct_name).or_default()
+                if let Some(struct_name) = scope_resolve::extract_go_receiver_type(&entity.content)
+                {
+                    scope_class_members
+                        .entry(struct_name)
+                        .or_default()
                         .push((entity.name.clone(), entity.id.clone()));
                 }
             }
@@ -244,40 +542,51 @@ impl EntityGraph {
 
         // Build import table: (file_path, imported_name) → target entity ID
         // e.g. ("io_handler.py", "validate") → "core.py::function::validate"
-        let import_table = build_import_table(root, file_paths, &symbol_table, &entity_map, Some(&parsed_files));
+        let import_table = build_import_table(
+            root,
+            file_paths,
+            &symbol_table,
+            &entity_map,
+            Some(&parsed_files),
+        );
         // Build owned Go package index for scope resolver
-        let owned_go_pkg_index: HashMap<String, Vec<(String, String)>> = if file_paths.iter().any(|f| f.ends_with(".go")) {
-            let mut idx: HashMap<String, Vec<(String, String)>> = HashMap::new();
-            for (name, target_ids) in symbol_table.iter() {
-                for target_id in target_ids {
-                    if let Some(entity) = entity_map.get(target_id) {
-                        let file_stem = entity.file_path.rsplit('/').next().unwrap_or(&entity.file_path);
-                        let file_stem = strip_file_ext(file_stem);
-                        idx.entry(file_stem.to_string())
-                            .or_default()
-                            .push((name.clone(), target_id.clone()));
-                        if let Some(parent_start) = entity.file_path.rfind('/') {
-                            let parent_path = &entity.file_path[..parent_start];
-                            if let Some(dir_name_start) = parent_path.rfind('/') {
-                                let dir_name = &parent_path[dir_name_start + 1..];
-                                if dir_name != file_stem {
-                                    idx.entry(dir_name.to_string())
+        let owned_go_pkg_index: HashMap<String, Vec<(String, String)>> =
+            if file_paths.iter().any(|f| f.ends_with(".go")) {
+                let mut idx: HashMap<String, Vec<(String, String)>> = HashMap::new();
+                for (name, target_ids) in symbol_table.iter() {
+                    for target_id in target_ids {
+                        if let Some(entity) = entity_map.get(target_id) {
+                            let file_stem = entity
+                                .file_path
+                                .rsplit('/')
+                                .next()
+                                .unwrap_or(&entity.file_path);
+                            let file_stem = strip_file_ext(file_stem);
+                            idx.entry(file_stem.to_string())
+                                .or_default()
+                                .push((name.clone(), target_id.clone()));
+                            if let Some(parent_start) = entity.file_path.rfind('/') {
+                                let parent_path = &entity.file_path[..parent_start];
+                                if let Some(dir_name_start) = parent_path.rfind('/') {
+                                    let dir_name = &parent_path[dir_name_start + 1..];
+                                    if dir_name != file_stem {
+                                        idx.entry(dir_name.to_string())
+                                            .or_default()
+                                            .push((name.clone(), target_id.clone()));
+                                    }
+                                } else if !parent_path.is_empty() && parent_path != file_stem {
+                                    idx.entry(parent_path.to_string())
                                         .or_default()
                                         .push((name.clone(), target_id.clone()));
                                 }
-                            } else if !parent_path.is_empty() && parent_path != file_stem {
-                                idx.entry(parent_path.to_string())
-                                    .or_default()
-                                    .push((name.clone(), target_id.clone()));
                             }
                         }
                     }
                 }
-            }
-            idx
-        } else {
-            HashMap::new()
-        };
+                idx
+            } else {
+                HashMap::new()
+            };
 
         // Wrap symbol_table in Arc to avoid expensive deep clone (621K entries)
         let symbol_table = Arc::new(symbol_table);
@@ -289,6 +598,8 @@ impl EntityGraph {
             go_pkg_index: owned_go_pkg_index,
         };
 
+        let reference_indexes = build_reference_indexes(root, file_paths, &parsed_files);
+
         // Run scope-aware resolver for supported languages (reuse pre-parsed trees)
         let has_scope_lang = file_paths.iter().any(|f| {
             let ext = f.rfind('.').map(|i| &f[i..]).unwrap_or("");
@@ -297,7 +608,14 @@ impl EntityGraph {
                 .is_some()
         });
         let (scope_edges, scope_consumed_words) = if has_scope_lang {
-            let result = scope_resolve::resolve_with_scopes_full(root, file_paths, &all_entities, &entity_map, Some(parsed_files), Some(pre_built));
+            let result = scope_resolve::resolve_with_scopes_full(
+                root,
+                file_paths,
+                &all_entities,
+                &entity_map,
+                Some(parsed_files),
+                Some(pre_built),
+            );
             let consumed_words = build_scope_consumed_words(&result.resolution_log);
             (result.edges, consumed_words)
         } else {
@@ -313,10 +631,20 @@ impl EntityGraph {
             .flat_map(|entity| {
                 // Skip entities from file types that don't have language configs
                 // (JSON, SQL, YAML, etc. — they extract entities but never produce reference edges)
-                let ext = entity.file_path.rfind('.').map(|i| &entity.file_path[i..]).unwrap_or("");
-                if crate::parser::plugins::code::languages::get_language_config(ext).is_none() {
+                let ext = entity
+                    .file_path
+                    .rfind('.')
+                    .map(|i| &entity.file_path[i..])
+                    .unwrap_or("");
+                let Some(language_config) =
+                    crate::parser::plugins::code::languages::get_language_config(ext)
+                else {
                     return vec![];
-                }
+                };
+                let fallback_end_line =
+                    fallback_reference_end_line(entity, language_config.scope_resolve.is_some());
+                let fallback_ranges =
+                    direct_reference_line_ranges(entity, fallback_end_line, &child_line_ranges);
 
                 let mut entity_edges = Vec::new();
                 let mut consumed_words = scope_consumed_words
@@ -324,11 +652,18 @@ impl EntityGraph {
                     .cloned()
                     .unwrap_or_default();
 
-                // Strip comments/strings once, reuse for both dot-chain and bag-of-words
-                let stripped = strip_comments_and_strings(&entity.content);
+                let reference_index = reference_indexes.get(entity.file_path.as_str());
+                let fallback_stripped = if reference_index.is_none() {
+                    Some(strip_comments_and_strings(&entity.content))
+                } else {
+                    None
+                };
 
                 // Phase 1: Dot-chain resolution
-                let dot_chains = extract_dot_chains(&stripped);
+                let dot_chains = match reference_index {
+                    Some(index) => index.dot_chains_in_ranges(&fallback_ranges),
+                    None => extract_dot_chains(fallback_stripped.as_ref().unwrap()),
+                };
 
                 for (receiver, member) in &dot_chains {
                     let edge_count_before = entity_edges.len();
@@ -372,9 +707,18 @@ impl EntityGraph {
                 }
 
                 // Phase 2: Bag-of-words resolution (skip words consumed by dot-chains)
-                // Reuse the stripped content to avoid stripping twice
-                let refs = extract_references_with_stripped(&entity.content, &entity.name, &stripped);
-                for ref_name in refs {
+                let refs: Vec<(&str, RefType)> = match reference_index {
+                    Some(index) => index.refs_with_types_in_ranges(&fallback_ranges, &entity.name),
+                    None => extract_references_with_stripped(
+                        &entity.content,
+                        &entity.name,
+                        fallback_stripped.as_ref().unwrap(),
+                    )
+                    .into_iter()
+                    .map(|ref_name| (ref_name, infer_ref_type(&entity.content, ref_name)))
+                    .collect(),
+                };
+                for (ref_name, ref_type) in refs {
                     if consumed_words.contains(ref_name) {
                         continue;
                     }
@@ -389,10 +733,11 @@ impl EntityGraph {
                     let import_key = (entity.file_path.clone(), ref_name.to_string());
                     if let Some(import_target_id) = import_table.get(&import_key) {
                         if import_target_id != &entity.id
-                            && !parent_child_pairs.contains(&(entity.id.as_str(), import_target_id.as_str()))
-                            && !parent_child_pairs.contains(&(import_target_id.as_str(), entity.id.as_str()))
+                            && !parent_child_pairs
+                                .contains(&(entity.id.as_str(), import_target_id.as_str()))
+                            && !parent_child_pairs
+                                .contains(&(import_target_id.as_str(), entity.id.as_str()))
                         {
-                            let ref_type = infer_ref_type(&entity.content, &ref_name);
                             entity_edges.push((
                                 entity.id.clone(),
                                 import_target_id.clone(),
@@ -405,28 +750,23 @@ impl EntityGraph {
                     if let Some(target_ids) = symbol_table.get(ref_name) {
                         // Without an import, only resolve to entities in the same file.
                         // Cross-file resolution is handled by the import table above.
-                        let target = target_ids
-                            .iter()
-                            .find(|id| {
-                                *id != &entity.id
-                                    && entity_map
-                                        .get(*id)
-                                        .map_or(false, |e| e.file_path == entity.file_path)
-                            });
+                        let target = target_ids.iter().find(|id| {
+                            *id != &entity.id
+                                && entity_map
+                                    .get(*id)
+                                    .map_or(false, |e| e.file_path == entity.file_path)
+                        });
 
                         if let Some(target_id) = target {
                             // Skip parent-child edges (class -> own method)
-                            if parent_child_pairs.contains(&(entity.id.as_str(), target_id.as_str()))
-                                || parent_child_pairs.contains(&(target_id.as_str(), entity.id.as_str()))
+                            if parent_child_pairs
+                                .contains(&(entity.id.as_str(), target_id.as_str()))
+                                || parent_child_pairs
+                                    .contains(&(target_id.as_str(), entity.id.as_str()))
                             {
                                 continue;
                             }
-                            let ref_type = infer_ref_type(&entity.content, &ref_name);
-                            entity_edges.push((
-                                entity.id.clone(),
-                                target_id.clone(),
-                                ref_type,
-                            ));
+                            entity_edges.push((entity.id.clone(), target_id.clone(), ref_type));
                         }
                     }
                 }
@@ -494,7 +834,10 @@ impl EntityGraph {
         let stale_set: HashSet<&str> = stale_files.iter().map(|s| s.as_str()).collect();
 
         // Parse stale files in parallel to get new entities + trees
-        let per_file: Vec<(Vec<SemanticEntity>, Option<(String, String, tree_sitter::Tree)>)> = maybe_par_iter!(stale_files)
+        let per_file: Vec<(
+            Vec<SemanticEntity>,
+            Option<(String, String, tree_sitter::Tree)>,
+        )> = maybe_par_iter!(stale_files)
             .filter_map(|file_path| {
                 let full_path = root.join(file_path);
                 let content = std::fs::read_to_string(&full_path).ok()?;
@@ -575,12 +918,15 @@ impl EntityGraph {
         for edge in &cached_edges {
             let to_truly_changed = truly_changed_ids.contains(&edge.to_entity)
                 || deleted_ids.contains(edge.to_entity.as_str());
-            if to_truly_changed && !stale_set.contains(
-                all_entities.iter()
-                    .find(|e| e.id == edge.from_entity)
-                    .map(|e| e.file_path.as_str())
-                    .unwrap_or("")
-            ) {
+            if to_truly_changed
+                && !stale_set.contains(
+                    all_entities
+                        .iter()
+                        .find(|e| e.id == edge.from_entity)
+                        .map(|e| e.file_path.as_str())
+                        .unwrap_or(""),
+                )
+            {
                 affected_clean_ids.insert(edge.from_entity.clone());
             }
         }
@@ -591,10 +937,8 @@ impl EntityGraph {
             .filter(|e| stale_set.contains(e.file_path.as_str()))
             .map(|e| e.id.as_str())
             .collect();
-        let current_entity_ids: HashSet<&str> = all_entities
-            .iter()
-            .map(|e| e.id.as_str())
-            .collect();
+        let current_entity_ids: HashSet<&str> =
+            all_entities.iter().map(|e| e.id.as_str()).collect();
 
         // Keep edges where both endpoints are in clean (non-stale) files and from_entity
         // is not affected by target changes. Drop ALL cached edges from stale-file entities
@@ -640,8 +984,10 @@ impl EntityGraph {
         // We still need the full context (symbol table, import table, etc.) from ALL entities.
 
         // Build symbol table from all entities
-        let mut symbol_table: HashMap<String, Vec<String>> = HashMap::with_capacity(all_entities.len());
-        let mut entity_map: HashMap<String, EntityInfo> = HashMap::with_capacity(all_entities.len());
+        let mut symbol_table: HashMap<String, Vec<String>> =
+            HashMap::with_capacity(all_entities.len());
+        let mut entity_map: HashMap<String, EntityInfo> =
+            HashMap::with_capacity(all_entities.len());
 
         for entity in &all_entities {
             symbol_table
@@ -666,25 +1012,51 @@ impl EntityGraph {
         let parent_child_pairs: HashSet<(&str, &str)> = all_entities
             .iter()
             .filter_map(|e| {
-                e.parent_id.as_ref().map(|pid| (pid.as_str(), e.id.as_str()))
+                e.parent_id
+                    .as_ref()
+                    .map(|pid| (pid.as_str(), e.id.as_str()))
             })
             .collect();
+        let mut child_line_ranges: HashMap<String, Vec<(usize, usize)>> = HashMap::new();
+        for entity in &all_entities {
+            if let Some(pid) = &entity.parent_id {
+                child_line_ranges
+                    .entry(pid.clone())
+                    .or_default()
+                    .push((entity.start_line, entity.end_line));
+            }
+        }
+        for ranges in child_line_ranges.values_mut() {
+            ranges.sort_unstable_by_key(|(start, end)| (*start, *end));
+        }
 
         let class_child_names: HashSet<(&str, &str)> = all_entities
             .iter()
             .filter_map(|e| {
-                e.parent_id.as_ref().map(|pid| (pid.as_str(), e.name.as_str()))
+                e.parent_id
+                    .as_ref()
+                    .map(|pid| (pid.as_str(), e.name.as_str()))
             })
             .collect();
 
         let class_entity_names: HashSet<&str> = all_entities
             .iter()
-            .filter(|e| matches!(e.entity_type.as_str(), "class" | "struct" | "interface" | "class_type"))
+            .filter(|e| {
+                matches!(
+                    e.entity_type.as_str(),
+                    "class" | "struct" | "interface" | "class_type"
+                )
+            })
             .map(|e| e.name.as_str())
             .collect();
         let class_entity_files: HashSet<(&str, &str)> = all_entities
             .iter()
-            .filter(|e| matches!(e.entity_type.as_str(), "class" | "struct" | "interface" | "class_type"))
+            .filter(|e| {
+                matches!(
+                    e.entity_type.as_str(),
+                    "class" | "struct" | "interface" | "class_type"
+                )
+            })
             .map(|e| (e.name.as_str(), e.file_path.as_str()))
             .collect();
 
@@ -711,19 +1083,28 @@ impl EntityGraph {
         }
 
         // Build import table from ALL files (imports may reference stale entities)
-        let import_table = build_import_table(root, all_file_paths, &symbol_table, &entity_map, Some(&parsed_files));
+        let import_table = build_import_table(
+            root,
+            all_file_paths,
+            &symbol_table,
+            &entity_map,
+            Some(&parsed_files),
+        );
 
         // Run scope-aware resolver only on files that need resolution
         let resolve_file_paths: Vec<String> = all_file_paths
             .iter()
             .filter(|f| {
                 // Include file if any entity in needs_resolution belongs to it
-                stale_set.contains(f.as_str()) || all_entities.iter().any(|e| {
-                    e.file_path == **f && affected_clean_ids.contains(&e.id)
-                })
+                stale_set.contains(f.as_str())
+                    || all_entities
+                        .iter()
+                        .any(|e| e.file_path == **f && affected_clean_ids.contains(&e.id))
             })
             .cloned()
             .collect();
+
+        let reference_indexes = build_reference_indexes(root, &resolve_file_paths, &parsed_files);
 
         let has_scope_lang = resolve_file_paths.iter().any(|f| {
             let ext = f.rfind('.').map(|i| &f[i..]).unwrap_or("");
@@ -733,13 +1114,25 @@ impl EntityGraph {
         });
         let (scope_edges, scope_consumed_words) = if has_scope_lang {
             // Pass pre-parsed stale-file trees; scope_resolve reads affected clean files from disk
-            let resolve_set: HashSet<&str> = resolve_file_paths.iter().map(|s| s.as_str()).collect();
+            let resolve_set: HashSet<&str> =
+                resolve_file_paths.iter().map(|s| s.as_str()).collect();
             let relevant_parsed: Vec<(String, String, tree_sitter::Tree)> = parsed_files
                 .into_iter()
                 .filter(|(fp, _, _)| resolve_set.contains(fp.as_str()))
                 .collect();
-            let pre = if relevant_parsed.is_empty() { None } else { Some(relevant_parsed) };
-            let result = scope_resolve::resolve_with_scopes_full(root, &resolve_file_paths, &all_entities, &entity_map, pre, None);
+            let pre = if relevant_parsed.is_empty() {
+                None
+            } else {
+                Some(relevant_parsed)
+            };
+            let result = scope_resolve::resolve_with_scopes_full(
+                root,
+                &resolve_file_paths,
+                &all_entities,
+                &entity_map,
+                pre,
+                None,
+            );
             let consumed_words = build_scope_consumed_words(&result.resolution_log);
             (result.edges, consumed_words)
         } else {
@@ -751,10 +1144,20 @@ impl EntityGraph {
             .filter(|e| needs_resolution.contains(e.id.as_str()))
             .flat_map(|entity| {
                 // Skip entities from non-code file types (JSON, SQL, etc.)
-                let ext = entity.file_path.rfind('.').map(|i| &entity.file_path[i..]).unwrap_or("");
-                if crate::parser::plugins::code::languages::get_language_config(ext).is_none() {
+                let ext = entity
+                    .file_path
+                    .rfind('.')
+                    .map(|i| &entity.file_path[i..])
+                    .unwrap_or("");
+                let Some(language_config) =
+                    crate::parser::plugins::code::languages::get_language_config(ext)
+                else {
                     return vec![];
-                }
+                };
+                let fallback_end_line =
+                    fallback_reference_end_line(entity, language_config.scope_resolve.is_some());
+                let fallback_ranges =
+                    direct_reference_line_ranges(entity, fallback_end_line, &child_line_ranges);
 
                 let mut entity_edges = Vec::new();
                 let mut consumed_words = scope_consumed_words
@@ -762,11 +1165,18 @@ impl EntityGraph {
                     .cloned()
                     .unwrap_or_default();
 
-                // Strip comments/strings once, reuse for both dot-chain and bag-of-words
-                let stripped = strip_comments_and_strings(&entity.content);
+                let reference_index = reference_indexes.get(entity.file_path.as_str());
+                let fallback_stripped = if reference_index.is_none() {
+                    Some(strip_comments_and_strings(&entity.content))
+                } else {
+                    None
+                };
 
                 // Phase 1: Dot-chain resolution
-                let dot_chains = extract_dot_chains(&stripped);
+                let dot_chains = match reference_index {
+                    Some(index) => index.dot_chains_in_ranges(&fallback_ranges),
+                    None => extract_dot_chains(fallback_stripped.as_ref().unwrap()),
+                };
 
                 for (receiver, member) in &dot_chains {
                     let edge_count_before = entity_edges.len();
@@ -807,9 +1217,19 @@ impl EntityGraph {
                     }
                 }
 
-                // Phase 2: Bag-of-words resolution (reuse stripped content)
-                let refs = extract_references_with_stripped(&entity.content, &entity.name, &stripped);
-                for ref_name in refs {
+                // Phase 2: Bag-of-words resolution
+                let refs: Vec<(&str, RefType)> = match reference_index {
+                    Some(index) => index.refs_with_types_in_ranges(&fallback_ranges, &entity.name),
+                    None => extract_references_with_stripped(
+                        &entity.content,
+                        &entity.name,
+                        fallback_stripped.as_ref().unwrap(),
+                    )
+                    .into_iter()
+                    .map(|ref_name| (ref_name, infer_ref_type(&entity.content, ref_name)))
+                    .collect(),
+                };
+                for (ref_name, ref_type) in refs {
                     if consumed_words.contains(ref_name) {
                         continue;
                     }
@@ -820,10 +1240,11 @@ impl EntityGraph {
                     let import_key = (entity.file_path.clone(), ref_name.to_string());
                     if let Some(import_target_id) = import_table.get(&import_key) {
                         if import_target_id != &entity.id
-                            && !parent_child_pairs.contains(&(entity.id.as_str(), import_target_id.as_str()))
-                            && !parent_child_pairs.contains(&(import_target_id.as_str(), entity.id.as_str()))
+                            && !parent_child_pairs
+                                .contains(&(entity.id.as_str(), import_target_id.as_str()))
+                            && !parent_child_pairs
+                                .contains(&(import_target_id.as_str(), entity.id.as_str()))
                         {
-                            let ref_type = infer_ref_type(&entity.content, &ref_name);
                             entity_edges.push((
                                 entity.id.clone(),
                                 import_target_id.clone(),
@@ -834,27 +1255,22 @@ impl EntityGraph {
                     }
 
                     if let Some(target_ids) = symbol_table.get(ref_name) {
-                        let target = target_ids
-                            .iter()
-                            .find(|id| {
-                                *id != &entity.id
-                                    && entity_map
-                                        .get(*id)
-                                        .map_or(false, |e| e.file_path == entity.file_path)
-                            });
+                        let target = target_ids.iter().find(|id| {
+                            *id != &entity.id
+                                && entity_map
+                                    .get(*id)
+                                    .map_or(false, |e| e.file_path == entity.file_path)
+                        });
 
                         if let Some(target_id) = target {
-                            if parent_child_pairs.contains(&(entity.id.as_str(), target_id.as_str()))
-                                || parent_child_pairs.contains(&(target_id.as_str(), entity.id.as_str()))
+                            if parent_child_pairs
+                                .contains(&(entity.id.as_str(), target_id.as_str()))
+                                || parent_child_pairs
+                                    .contains(&(target_id.as_str(), entity.id.as_str()))
                             {
                                 continue;
                             }
-                            let ref_type = infer_ref_type(&entity.content, &ref_name);
-                            entity_edges.push((
-                                entity.id.clone(),
-                                target_id.clone(),
-                                ref_type,
-                            ));
+                            entity_edges.push((entity.id.clone(), target_id.clone(), ref_type));
                         }
                     }
                 }
@@ -929,11 +1345,7 @@ impl EntityGraph {
     pub fn get_dependents(&self, entity_id: &str) -> Vec<&EntityInfo> {
         self.dependents
             .get(entity_id)
-            .map(|ids| {
-                ids.iter()
-                    .filter_map(|id| self.entities.get(id))
-                    .collect()
-            })
+            .map(|ids| ids.iter().filter_map(|id| self.entities.get(id)).collect())
             .unwrap_or_default()
     }
 
@@ -941,11 +1353,7 @@ impl EntityGraph {
     pub fn get_dependencies(&self, entity_id: &str) -> Vec<&EntityInfo> {
         self.dependencies
             .get(entity_id)
-            .map(|ids| {
-                ids.iter()
-                    .filter_map(|id| self.entities.get(id))
-                    .collect()
-            })
+            .map(|ids| ids.iter().filter_map(|id| self.entities.get(id)).collect())
             .unwrap_or_default()
     }
 
@@ -957,9 +1365,14 @@ impl EntityGraph {
 
     /// Depth-limited impact analysis. Returns transitive dependents with their BFS depth.
     /// `max_depth == 0` means unlimited. Default depth of 2 covers direct + one transitive level.
-    pub fn impact_analysis_bounded(&self, entity_id: &str, max_depth: usize) -> Vec<(&EntityInfo, usize)> {
+    pub fn impact_analysis_bounded(
+        &self,
+        entity_id: &str,
+        max_depth: usize,
+    ) -> Vec<(&EntityInfo, usize)> {
         let mut visited: HashSet<&str> = HashSet::new();
-        let mut queue: std::collections::VecDeque<(&str, usize)> = std::collections::VecDeque::new();
+        let mut queue: std::collections::VecDeque<(&str, usize)> =
+            std::collections::VecDeque::new();
         let mut result = Vec::new();
 
         let start_key = match self.entities.get_key_value(entity_id) {
@@ -1065,7 +1478,10 @@ impl EntityGraph {
 
     /// Filter entities to those that look like tests.
     /// Uses name heuristics, file path patterns, and content patterns.
-    pub fn filter_test_entities(&self, entities: &[crate::model::entity::SemanticEntity]) -> HashSet<String> {
+    pub fn filter_test_entities(
+        &self,
+        entities: &[crate::model::entity::SemanticEntity],
+    ) -> HashSet<String> {
         let mut test_ids = HashSet::new();
         for entity in entities {
             if is_test_entity(entity) {
@@ -1176,10 +1592,8 @@ impl EntityGraph {
 
         // Also re-resolve references for entities in OTHER files that might
         // reference entities in changed files (their targets may have changed)
-        let changed_entity_names: HashSet<String> = new_entities
-            .iter()
-            .map(|e| e.name.clone())
-            .collect();
+        let changed_entity_names: HashSet<String> =
+            new_entities.iter().map(|e| e.name.clone()).collect();
 
         // Find entities in unchanged files that reference any changed entity name
         let entities_to_recheck: Vec<String> = self
@@ -1187,15 +1601,13 @@ impl EntityGraph {
             .values()
             .filter(|e| !affected_files.contains(&e.file_path))
             .filter(|e| {
-                self.dependencies
-                    .get(&e.id)
-                    .map_or(false, |deps| {
-                        deps.iter().any(|dep_id| {
-                            self.entities
-                                .get(dep_id)
-                                .map_or(false, |dep| changed_entity_names.contains(&dep.name))
-                        })
+                self.dependencies.get(&e.id).map_or(false, |deps| {
+                    deps.iter().any(|dep_id| {
+                        self.entities
+                            .get(dep_id)
+                            .map_or(false, |dep| changed_entity_names.contains(&dep.name))
                     })
+                })
             })
             .map(|e| e.id.clone())
             .collect();
@@ -1244,8 +1656,9 @@ impl EntityGraph {
         }
 
         // Remove edges involving these entities
-        self.edges
-            .retain(|e| !id_set.contains(e.from_entity.as_str()) && !id_set.contains(e.to_entity.as_str()));
+        self.edges.retain(|e| {
+            !id_set.contains(e.from_entity.as_str()) && !id_set.contains(e.to_entity.as_str())
+        });
 
         // Clean up dependency/dependent indexes
         for id in &ids_to_remove {
@@ -1331,7 +1744,11 @@ fn is_test_entity(entity: &crate::model::entity::SemanticEntity) -> bool {
     let content = &entity.content;
 
     // Name patterns
-    if name.starts_with("test_") || name.starts_with("Test") || name.ends_with("_test") || name.ends_with("Test") {
+    if name.starts_with("test_")
+        || name.starts_with("Test")
+        || name.ends_with("_test")
+        || name.ends_with("Test")
+    {
         return true;
     }
     if name.starts_with("it_") || name.starts_with("describe_") || name.starts_with("spec_") {
@@ -1375,7 +1792,10 @@ fn build_import_table(
     // Build a content lookup from pre-parsed files to avoid re-reading from disk
     let content_map: HashMap<&str, &str> = pre_parsed_content
         .map(|files| {
-            files.iter().map(|(fp, content, _)| (fp.as_str(), content.as_str())).collect()
+            files
+                .iter()
+                .map(|(fp, content, _)| (fp.as_str(), content.as_str()))
+                .collect()
         })
         .unwrap_or_default();
 
@@ -1699,6 +2119,12 @@ fn strip_file_ext(s: &str) -> &str {
 
 /// Strip comments and string literals from content to avoid false references.
 /// Returns a new string with comments/docstrings replaced by spaces.
+fn blank_span_preserving_newlines(result: &mut [u8], bytes: &[u8], start: usize, end: usize) {
+    for idx in start..end.min(bytes.len()) {
+        result[idx] = if bytes[idx] == b'\n' { b'\n' } else { b' ' };
+    }
+}
+
 fn strip_comments_and_strings(content: &str) -> String {
     let bytes = content.as_bytes();
     let len = bytes.len();
@@ -1708,64 +2134,117 @@ fn strip_comments_and_strings(content: &str) -> String {
     while i < len {
         // Triple-quoted strings (Python docstrings)
         if i + 2 < len && bytes[i] == b'"' && bytes[i + 1] == b'"' && bytes[i + 2] == b'"' {
+            let span_start = i;
             i += 3;
-            while i + 2 < len {
-                if bytes[i] == b'"' && bytes[i + 1] == b'"' && bytes[i + 2] == b'"' {
+            while i < len {
+                if i + 2 < len
+                    && bytes[i] == b'"'
+                    && bytes[i + 1] == b'"'
+                    && bytes[i + 2] == b'"'
+                {
                     i += 3;
                     break;
                 }
+                if bytes[i] == b'\n' {
+                    result[i] = b'\n';
+                }
                 i += 1;
             }
+            blank_span_preserving_newlines(&mut result, bytes, span_start, i);
             continue;
         }
         if i + 2 < len && bytes[i] == b'\'' && bytes[i + 1] == b'\'' && bytes[i + 2] == b'\'' {
+            let span_start = i;
             i += 3;
-            while i + 2 < len {
-                if bytes[i] == b'\'' && bytes[i + 1] == b'\'' && bytes[i + 2] == b'\'' {
+            while i < len {
+                if i + 2 < len
+                    && bytes[i] == b'\''
+                    && bytes[i + 1] == b'\''
+                    && bytes[i + 2] == b'\''
+                {
                     i += 3;
                     break;
                 }
+                if bytes[i] == b'\n' {
+                    result[i] = b'\n';
+                }
                 i += 1;
             }
+            blank_span_preserving_newlines(&mut result, bytes, span_start, i);
             continue;
         }
         // Double-quoted strings
         if bytes[i] == b'"' {
+            let span_start = i;
             i += 1;
             while i < len {
-                if bytes[i] == b'\\' { i += 2; continue; }
-                if bytes[i] == b'"' { i += 1; break; }
+                if bytes[i] == b'\\' {
+                    i = (i + 2).min(len);
+                    continue;
+                }
+                if bytes[i] == b'"' {
+                    i += 1;
+                    break;
+                }
+                if bytes[i] == b'\n' {
+                    result[i] = b'\n';
+                }
                 i += 1;
             }
+            blank_span_preserving_newlines(&mut result, bytes, span_start, i);
             continue;
         }
         // Single-quoted strings
         if bytes[i] == b'\'' {
+            let span_start = i;
             i += 1;
             while i < len {
-                if bytes[i] == b'\\' { i += 2; continue; }
-                if bytes[i] == b'\'' { i += 1; break; }
+                if bytes[i] == b'\\' {
+                    i = (i + 2).min(len);
+                    continue;
+                }
+                if bytes[i] == b'\'' {
+                    i += 1;
+                    break;
+                }
+                if bytes[i] == b'\n' {
+                    result[i] = b'\n';
+                }
                 i += 1;
             }
+            blank_span_preserving_newlines(&mut result, bytes, span_start, i);
             continue;
         }
         // Python/Ruby single-line comments
         if bytes[i] == b'#' {
-            while i < len && bytes[i] != b'\n' { i += 1; }
+            let span_start = i;
+            while i < len && bytes[i] != b'\n' {
+                i += 1;
+            }
+            blank_span_preserving_newlines(&mut result, bytes, span_start, i);
             continue;
         }
         // C-style single-line comments
         if i + 1 < len && bytes[i] == b'/' && bytes[i + 1] == b'/' {
-            while i < len && bytes[i] != b'\n' { i += 1; }
+            let span_start = i;
+            while i < len && bytes[i] != b'\n' {
+                i += 1;
+            }
+            blank_span_preserving_newlines(&mut result, bytes, span_start, i);
             continue;
         }
         // C-style block comments
         if i + 1 < len && bytes[i] == b'/' && bytes[i + 1] == b'*' {
+            let span_start = i;
             i += 2;
-            while i + 1 < len {
-                if bytes[i] == b'*' && bytes[i + 1] == b'/' { i += 2; break; }
+            while i < len {
+                if i + 1 < len && bytes[i] == b'*' && bytes[i + 1] == b'/' {
+                    i += 2;
+                    break;
+                }
                 i += 1;
             }
+            blank_span_preserving_newlines(&mut result, bytes, span_start, i);
             continue;
         }
         // Regular code: copy through
@@ -1773,15 +2252,14 @@ fn strip_comments_and_strings(content: &str) -> String {
         i += 1;
     }
 
-    String::from_utf8_lossy(&result).into_owned()
+    String::from_utf8(result).expect("stripped source preserves UTF-8 boundaries")
 }
 
 /// Extract dot-chains (receiver.member) from content for precise resolution.
 /// Returns unique (receiver, member) pairs found in the content.
 fn extract_dot_chains<'a>(content: &'a str) -> Vec<(&'a str, &'a str)> {
-    static DOT_CHAIN_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"\b([A-Za-z_]\w*)\.([A-Za-z_]\w*)").unwrap()
-    });
+    static DOT_CHAIN_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"\b([A-Za-z_]\w*)\.([A-Za-z_]\w*)").unwrap());
 
     let mut chains = Vec::new();
     let mut seen: HashSet<(&str, &str)> = HashSet::new();
@@ -1806,7 +2284,11 @@ fn extract_references_from_content<'a>(content: &'a str, own_name: &str) -> Vec<
 /// Extract references using a pre-stripped version of the content.
 /// Use this when you already have the stripped content (e.g. from dot-chain extraction)
 /// to avoid stripping comments/strings twice.
-fn extract_references_with_stripped<'a>(content: &'a str, own_name: &str, stripped: &str) -> Vec<&'a str> {
+fn extract_references_with_stripped<'a>(
+    content: &'a str,
+    own_name: &str,
+    stripped: &str,
+) -> Vec<&'a str> {
     let stripped_words: HashSet<&str> = stripped
         .split(|c: char| !c.is_alphanumeric() && c != '_')
         .filter(|w| !w.is_empty())
@@ -1847,19 +2329,16 @@ fn extract_references_with_stripped<'a>(content: &'a str, own_name: &str, stripp
 
 static COMMON_LOCAL_NAMES: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
     [
-        "result", "results", "data", "config", "value", "values",
-        "item", "items", "input", "output", "args", "opts",
-        "name", "path", "file", "line", "count", "index",
-        "temp", "prev", "next", "curr", "current", "node",
-        "left", "right", "root", "head", "tail", "body",
-        "text", "content", "source", "target", "entry",
-        "error", "errors", "message", "response", "request",
-        "context", "state", "props", "event", "handler",
-        "callback", "options", "params", "query", "list",
-        "base", "info", "meta", "kind", "mode", "flag",
-        "size", "length", "width", "height", "start", "stop",
-        "begin", "done", "found", "status", "code",
-    ].into_iter().collect()
+        "result", "results", "data", "config", "value", "values", "item", "items", "input",
+        "output", "args", "opts", "name", "path", "file", "line", "count", "index", "temp", "prev",
+        "next", "curr", "current", "node", "left", "right", "root", "head", "tail", "body", "text",
+        "content", "source", "target", "entry", "error", "errors", "message", "response",
+        "request", "context", "state", "props", "event", "handler", "callback", "options",
+        "params", "query", "list", "base", "info", "meta", "kind", "mode", "flag", "size",
+        "length", "width", "height", "start", "stop", "begin", "done", "found", "status", "code",
+    ]
+    .into_iter()
+    .collect()
 });
 
 /// Names that are overwhelmingly local variables, not entity references.
@@ -1899,8 +2378,10 @@ fn infer_ref_type(content: &str, ref_name: &str) -> RefType {
     // Check if it's in an import/use statement (line-level, not substring)
     for line in content.lines() {
         let trimmed = line.trim();
-        if (trimmed.starts_with("import ") || trimmed.starts_with("use ")
-            || trimmed.starts_with("from ") || trimmed.starts_with("require("))
+        if (trimmed.starts_with("import ")
+            || trimmed.starts_with("use ")
+            || trimmed.starts_with("from ")
+            || trimmed.starts_with("require("))
             && trimmed.contains(ref_name)
         {
             return RefType::Imports;
@@ -1914,52 +2395,220 @@ fn infer_ref_type(content: &str, ref_name: &str) -> RefType {
 static KEYWORDS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
     [
         // Common across languages
-        "if", "else", "for", "while", "do", "switch", "case", "break",
-        "continue", "return", "try", "catch", "finally", "throw",
-        "new", "delete", "typeof", "instanceof", "in", "of",
-        "true", "false", "null", "undefined", "void", "this",
-        "super", "class", "extends", "implements", "interface",
-        "enum", "const", "let", "var", "function", "async",
-        "await", "yield", "import", "export", "default", "from",
-        "as", "static", "public", "private", "protected",
-        "abstract", "final", "override",
+        "if",
+        "else",
+        "for",
+        "while",
+        "do",
+        "switch",
+        "case",
+        "break",
+        "continue",
+        "return",
+        "try",
+        "catch",
+        "finally",
+        "throw",
+        "new",
+        "delete",
+        "typeof",
+        "instanceof",
+        "in",
+        "of",
+        "true",
+        "false",
+        "null",
+        "undefined",
+        "void",
+        "this",
+        "super",
+        "class",
+        "extends",
+        "implements",
+        "interface",
+        "enum",
+        "const",
+        "let",
+        "var",
+        "function",
+        "async",
+        "await",
+        "yield",
+        "import",
+        "export",
+        "default",
+        "from",
+        "as",
+        "static",
+        "public",
+        "private",
+        "protected",
+        "abstract",
+        "final",
+        "override",
         // Rust
-        "fn", "pub", "mod", "use", "struct", "impl", "trait",
-        "where", "type", "self", "Self", "mut", "ref", "match",
-        "loop", "move", "unsafe", "extern", "crate", "dyn",
+        "fn",
+        "pub",
+        "mod",
+        "use",
+        "struct",
+        "impl",
+        "trait",
+        "where",
+        "type",
+        "self",
+        "Self",
+        "mut",
+        "ref",
+        "match",
+        "loop",
+        "move",
+        "unsafe",
+        "extern",
+        "crate",
+        "dyn",
         // Python
-        "def", "elif", "except", "raise", "with",
-        "pass", "lambda", "nonlocal", "global", "assert",
-        "True", "False", "and", "or", "not", "is",
+        "def",
+        "elif",
+        "except",
+        "raise",
+        "with",
+        "pass",
+        "lambda",
+        "nonlocal",
+        "global",
+        "assert",
+        "True",
+        "False",
+        "and",
+        "or",
+        "not",
+        "is",
         // Go
-        "func", "package", "range", "select", "chan", "go",
-        "defer", "map", "make", "append", "len", "cap",
+        "func",
+        "package",
+        "range",
+        "select",
+        "chan",
+        "go",
+        "defer",
+        "map",
+        "make",
+        "append",
+        "len",
+        "cap",
         // C/C++
-        "auto", "register", "volatile", "sizeof", "typedef",
-        "template", "typename", "namespace", "virtual", "inline",
-        "constexpr", "nullptr", "noexcept", "explicit", "friend",
-        "operator", "using", "cout", "endl", "cerr", "cin",
-        "printf", "scanf", "malloc", "free", "NULL", "include",
-        "ifdef", "ifndef", "endif", "define", "pragma",
+        "auto",
+        "register",
+        "volatile",
+        "sizeof",
+        "typedef",
+        "template",
+        "typename",
+        "namespace",
+        "virtual",
+        "inline",
+        "constexpr",
+        "nullptr",
+        "noexcept",
+        "explicit",
+        "friend",
+        "operator",
+        "using",
+        "cout",
+        "endl",
+        "cerr",
+        "cin",
+        "printf",
+        "scanf",
+        "malloc",
+        "free",
+        "NULL",
+        "include",
+        "ifdef",
+        "ifndef",
+        "endif",
+        "define",
+        "pragma",
         // Ruby
-        "end", "then", "elsif", "unless", "until",
-        "begin", "rescue", "ensure", "when", "require",
-        "attr_accessor", "attr_reader", "attr_writer",
-        "puts", "nil", "module", "defined",
+        "end",
+        "then",
+        "elsif",
+        "unless",
+        "until",
+        "begin",
+        "rescue",
+        "ensure",
+        "when",
+        "require",
+        "attr_accessor",
+        "attr_reader",
+        "attr_writer",
+        "puts",
+        "nil",
+        "module",
+        "defined",
         // C#
-        "internal", "sealed", "readonly",
-        "partial", "delegate", "event", "params", "out",
-        "object", "decimal", "sbyte", "ushort", "uint",
-        "ulong", "nint", "nuint", "dynamic",
-        "get", "set", "value", "init", "record",
+        "internal",
+        "sealed",
+        "readonly",
+        "partial",
+        "delegate",
+        "event",
+        "params",
+        "out",
+        "object",
+        "decimal",
+        "sbyte",
+        "ushort",
+        "uint",
+        "ulong",
+        "nint",
+        "nuint",
+        "dynamic",
+        "get",
+        "set",
+        "value",
+        "init",
+        "record",
         // Types (primitives)
-        "string", "number", "boolean", "int", "float", "double",
-        "bool", "char", "byte", "i8", "i16", "i32", "i64",
-        "u8", "u16", "u32", "u64", "f32", "f64", "usize",
-        "isize", "str", "String", "Vec", "Option", "Result",
-        "Box", "Arc", "Rc", "HashMap", "HashSet", "Some",
-        "Ok", "Err",
-    ].into_iter().collect()
+        "string",
+        "number",
+        "boolean",
+        "int",
+        "float",
+        "double",
+        "bool",
+        "char",
+        "byte",
+        "i8",
+        "i16",
+        "i32",
+        "i64",
+        "u8",
+        "u16",
+        "u32",
+        "u64",
+        "f32",
+        "f64",
+        "usize",
+        "isize",
+        "str",
+        "String",
+        "Vec",
+        "Option",
+        "Result",
+        "Box",
+        "Arc",
+        "Rc",
+        "HashMap",
+        "HashSet",
+        "Some",
+        "Ok",
+        "Err",
+    ]
+    .into_iter()
+    .collect()
 });
 
 fn is_keyword(word: &str) -> bool {
@@ -1986,6 +2635,190 @@ mod tests {
         }
         let mut f = std::fs::File::create(path).unwrap();
         f.write_all(content.as_bytes()).unwrap();
+    }
+
+    fn deep_typescript(depth: usize) -> String {
+        let mut content = String::from("class L0 {\n");
+        for i in 1..depth {
+            content.push_str(&"  ".repeat(i));
+            content.push_str(&format!("L{i} = class {{\n"));
+        }
+        content.push_str(&"  ".repeat(depth));
+        content.push_str("method() { return 1; }\n");
+        for i in (1..depth).rev() {
+            content.push_str(&"  ".repeat(i));
+            content.push_str("};\n");
+        }
+        content.push_str("}\n");
+        content
+    }
+
+    #[test]
+    fn test_file_reference_index_matches_reference_helpers() {
+        let content = "\
+import { Foo } from './foo';
+class Runner {
+    run() { return this.validate(Foo); }
+    validate(input) { return input; }
+}
+";
+        let index = FileReferenceIndex::from_content(content);
+        let refs = index.refs_with_types_in_ranges(&[(1, 5)], "run");
+        assert!(refs.iter().any(|(word, _)| *word == "Foo"));
+        assert!(refs.iter().any(|(word, _)| *word == "Runner"));
+        assert!(!refs.iter().any(|(word, _)| *word == "input"));
+
+        let dot_chains = index.dot_chains_in_ranges(&[(1, 5)]);
+        assert!(dot_chains.contains(&("this", "validate")));
+        assert!(refs
+            .iter()
+            .any(|(word, ref_type)| *word == "Foo" && *ref_type == RefType::Imports));
+        assert!(refs
+            .iter()
+            .any(|(word, ref_type)| *word == "validate" && *ref_type == RefType::Calls));
+    }
+
+    #[test]
+    fn test_direct_reference_ranges_skip_nested_child_entities() {
+        let parent = SemanticEntity {
+            id: "parent".to_string(),
+            file_path: "sample.ts".to_string(),
+            entity_type: "function".to_string(),
+            name: "outer".to_string(),
+            parent_id: None,
+            content: String::new(),
+            content_hash: String::new(),
+            structural_hash: None,
+            start_line: 1,
+            end_line: 7,
+            metadata: None,
+        };
+        let mut child_line_ranges = HashMap::new();
+        child_line_ranges.insert("parent".to_string(), vec![(3, 5)]);
+
+        let ranges = direct_reference_line_ranges(&parent, parent.end_line, &child_line_ranges);
+        assert_eq!(ranges, vec![(1, 2), (6, 7)]);
+
+        let content = "\
+function outer() {
+  setup();
+  function inner() {
+    nested();
+  }
+  finish();
+}
+";
+        let index = FileReferenceIndex::from_content(content);
+        let refs = index.refs_with_types_in_ranges(&ranges, "outer");
+
+        assert!(refs.iter().any(|(word, _)| *word == "setup"));
+        assert!(refs.iter().any(|(word, _)| *word == "finish"));
+        assert!(!refs.iter().any(|(word, _)| *word == "nested"));
+    }
+
+    #[test]
+    fn test_deep_nested_typescript_graph_builds() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        let depth = 160;
+        write_file(root, "deep.ts", &deep_typescript(depth));
+
+        let (graph, entities) = EntityGraph::build(root, &["deep.ts".into()], &registry);
+
+        assert!(graph.entities.contains_key("deep.ts::class::L0"));
+        assert!(entities.iter().any(|e| e.name == "method"));
+        assert_eq!(entities.len(), depth + 1);
+    }
+
+    #[test]
+    fn test_ts_class_extends_type_ref_survives_scope_fallback_bound() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "types.ts",
+            "\
+class Base {}
+class Child extends Base {
+    run() { return 1; }
+}
+",
+        );
+
+        let (graph, _) = EntityGraph::build(root, &["types.ts".into()], &registry);
+
+        assert!(
+            graph.edges.iter().any(|edge| {
+                edge.from_entity.contains("Child")
+                    && graph
+                        .entities
+                        .get(&edge.to_entity)
+                        .map_or(false, |e| e.name == "Base")
+            }),
+            "Child should keep a type-ref edge to Base. Edges: {:?}",
+            graph.edges
+        );
+    }
+
+    #[test]
+    fn test_multiline_block_comment_preserves_reference_line_index() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "calls.c",
+            "\
+/*
+ multiline
+ comment
+*/
+int helper() { return 1; }
+int caller() { return helper(); }
+",
+        );
+
+        let (graph, _) = EntityGraph::build(root, &["calls.c".into()], &registry);
+
+        let caller_id = graph
+            .entities
+            .keys()
+            .find(|id| id.contains("caller"))
+            .expect("caller entity should exist");
+        let deps = graph.get_dependencies(caller_id);
+        assert!(
+            deps.iter().any(|dep| dep.name == "helper"),
+            "caller should depend on helper after a multiline block comment. Deps: {:?}",
+            deps.iter().map(|d| &d.name).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_strip_comments_and_strings_preserves_newlines_and_utf8() {
+        let content = "\
+const value = \"é\\
+still string\";
+const done = call();
+/* unterminated block
+comment with Helper
+";
+
+        let stripped = strip_comments_and_strings(content);
+        let newline_count = |text: &str| text.bytes().filter(|byte| *byte == b'\n').count();
+
+        assert_eq!(newline_count(&stripped), newline_count(content));
+        assert!(stripped.contains("const done = call();"));
+        assert!(!stripped.contains("still string"));
+        assert!(!stripped.contains("Helper"));
+
+        let trailing_escape = strip_comments_and_strings("const value = \"unterminated\\");
+        assert_eq!(newline_count(&trailing_escape), 0);
+
+        let triple = strip_comments_and_strings("'''doc\nwith Helper");
+        assert_eq!(newline_count(&triple), 1);
+        assert!(!triple.contains("Helper"));
     }
 
     #[test]
@@ -2066,7 +2899,11 @@ mod tests {
         let root = dir.path();
 
         write_file(root, "a.ts", "export function foo() { return bar(); }\n");
-        write_file(root, "b.ts", "export function bar() { return 1; }\nexport function baz() { return 2; }\n");
+        write_file(
+            root,
+            "b.ts",
+            "export function bar() { return 1; }\nexport function baz() { return 2; }\n",
+        );
 
         let (mut graph, _) = EntityGraph::build(root, &["a.ts".into(), "b.ts".into()], &registry);
         assert_eq!(graph.entities.len(), 3);
@@ -2089,8 +2926,16 @@ mod tests {
         // foo should now depend on baz, not bar
         let foo_deps = graph.get_dependencies("a.ts::function::foo");
         let dep_names: Vec<&str> = foo_deps.iter().map(|d| d.name.as_str()).collect();
-        assert!(dep_names.contains(&"baz"), "foo should depend on baz after modification. Deps: {:?}", dep_names);
-        assert!(!dep_names.contains(&"bar"), "foo should no longer depend on bar. Deps: {:?}", dep_names);
+        assert!(
+            dep_names.contains(&"baz"),
+            "foo should depend on baz after modification. Deps: {:?}",
+            dep_names
+        );
+        assert!(
+            !dep_names.contains(&"bar"),
+            "foo should no longer depend on bar. Deps: {:?}",
+            dep_names
+        );
     }
 
     #[test]
@@ -2190,7 +3035,9 @@ mod tests {
 
         assert_eq!(run.parent_id.as_deref(), Some(service.id.as_str()));
         assert!(graph.entities.contains_key("models.go::type::Service::Run"));
-        assert!(!graph.entities.contains_key("methods.go::type::Service::Run"));
+        assert!(!graph
+            .entities
+            .contains_key("methods.go::type::Service::Run"));
     }
 
     #[test]
@@ -2231,12 +3078,12 @@ mod tests {
     #[test]
     fn test_infer_ref_type_multibyte_utf8() {
         // Ensure no panic when content contains multi-byte UTF-8 characters
+        assert_eq!(infer_ref_type("let café = foo(x)", "foo"), RefType::Calls,);
         assert_eq!(
-            infer_ref_type("let café = foo(x)", "foo"),
-            RefType::Calls,
-        );
-        assert_eq!(
-            infer_ref_type("class HandicapfrPublicationFieldsEnum:\n    É = 1\n    bar()", "bar"),
+            infer_ref_type(
+                "class HandicapfrPublicationFieldsEnum:\n    É = 1\n    bar()",
+                "bar"
+            ),
             RefType::Calls,
         );
         // No match should not panic either
@@ -2251,19 +3098,25 @@ mod tests {
         let (dir, registry) = create_test_repo();
         let root = dir.path();
 
-        write_file(root, "service.py", "\
+        write_file(
+            root,
+            "service.py",
+            "\
 class MyService:
     def process(self):
         return self.validate()
 
     def validate(self):
         return True
-");
+",
+        );
 
         let (graph, _) = EntityGraph::build(root, &["service.py".into()], &registry);
 
         // process should have an edge to validate via self.validate()
-        let process_id = graph.entities.keys()
+        let process_id = graph
+            .entities
+            .keys()
             .find(|id| id.contains("process"))
             .expect("process entity should exist");
         let deps = graph.get_dependencies(process_id);
@@ -2279,7 +3132,10 @@ class MyService:
         let (dir, registry) = create_test_repo();
         let root = dir.path();
 
-        write_file(root, "service.ts", "\
+        write_file(
+            root,
+            "service.ts",
+            "\
 class UserService {
     process() {
         return this.validate();
@@ -2288,11 +3144,14 @@ class UserService {
         return true;
     }
 }
-");
+",
+        );
 
         let (graph, _) = EntityGraph::build(root, &["service.ts".into()], &registry);
 
-        let process_id = graph.entities.keys()
+        let process_id = graph
+            .entities
+            .keys()
             .find(|id| id.contains("process"))
             .expect("process entity should exist");
         let deps = graph.get_dependencies(process_id);
@@ -2308,16 +3167,22 @@ class UserService {
         let (dir, registry) = create_test_repo();
         let root = dir.path();
 
-        write_file(root, "utils.ts", "\
+        write_file(
+            root,
+            "utils.ts",
+            "\
 class MathUtils {
     static compute() { return 1; }
 }
 function caller() { return MathUtils.compute(); }
-");
+",
+        );
 
         let (graph, _) = EntityGraph::build(root, &["utils.ts".into()], &registry);
 
-        let caller_id = graph.entities.keys()
+        let caller_id = graph
+            .entities
+            .keys()
             .find(|id| id.contains("caller"))
             .expect("caller entity should exist");
         let deps = graph.get_dependencies(caller_id);
@@ -2333,21 +3198,28 @@ function caller() { return MathUtils.compute(); }
         let (dir, registry) = create_test_repo();
         let root = dir.path();
 
-        write_file(root, "helper.ts", "\
+        write_file(
+            root,
+            "helper.ts",
+            "\
 export function helper() { return 1; }
-");
-        write_file(root, "main.ts", "\
+",
+        );
+        write_file(
+            root,
+            "main.ts",
+            "\
 import { helper } from './helper';
 export function main() { return helper(); }
-");
-
-        let (graph, _) = EntityGraph::build(
-            root,
-            &["helper.ts".into(), "main.ts".into()],
-            &registry,
+",
         );
 
-        let main_id = graph.entities.keys()
+        let (graph, _) =
+            EntityGraph::build(root, &["helper.ts".into(), "main.ts".into()], &registry);
+
+        let main_id = graph
+            .entities
+            .keys()
             .find(|id| id.contains("main"))
             .expect("main entity should exist");
         let deps = graph.get_dependencies(main_id);
@@ -2363,36 +3235,61 @@ export function main() { return helper(); }
         let (dir, registry) = create_test_repo();
         let root = dir.path();
 
-        write_file(root, "src/a/util.ts", "\
+        write_file(
+            root,
+            "src/a/util.ts",
+            "\
 export function helper() { return 1; }
-");
-        write_file(root, "src/b/util.ts", "\
+",
+        );
+        write_file(
+            root,
+            "src/b/util.ts",
+            "\
 export function helper() { return 2; }
-");
-        write_file(root, "src/main.ts", "\
+",
+        );
+        write_file(
+            root,
+            "src/main.ts",
+            "\
 import { helper } from './b/util';
 export function caller() { return helper(); }
-");
+",
+        );
 
         let (graph, _) = EntityGraph::build(
             root,
-            &["src/a/util.ts".into(), "src/b/util.ts".into(), "src/main.ts".into()],
+            &[
+                "src/a/util.ts".into(),
+                "src/b/util.ts".into(),
+                "src/main.ts".into(),
+            ],
             &registry,
         );
 
-        let caller_id = graph.entities.keys()
+        let caller_id = graph
+            .entities
+            .keys()
             .find(|id| id.contains("caller"))
             .expect("caller entity should exist");
         let deps = graph.get_dependencies(caller_id);
         assert!(
-            deps.iter().any(|d| d.name == "helper" && d.file_path == "src/b/util.ts"),
+            deps.iter()
+                .any(|d| d.name == "helper" && d.file_path == "src/b/util.ts"),
             "caller should resolve helper to src/b/util.ts. Deps: {:?}",
-            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+            deps.iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
         );
         assert!(
-            !deps.iter().any(|d| d.name == "helper" && d.file_path == "src/a/util.ts"),
+            !deps
+                .iter()
+                .any(|d| d.name == "helper" && d.file_path == "src/a/util.ts"),
             "caller should not resolve helper to src/a/util.ts. Deps: {:?}",
-            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+            deps.iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
         );
     }
 
@@ -2401,36 +3298,61 @@ export function caller() { return helper(); }
         let (dir, registry) = create_test_repo();
         let root = dir.path();
 
-        write_file(root, "src/util.js", "\
+        write_file(
+            root,
+            "src/util.js",
+            "\
 export function helper() { return 1; }
-");
-        write_file(root, "src/util.ts", "\
+",
+        );
+        write_file(
+            root,
+            "src/util.ts",
+            "\
 export function helper() { return 2; }
-");
-        write_file(root, "src/main.ts", "\
+",
+        );
+        write_file(
+            root,
+            "src/main.ts",
+            "\
 import { helper } from './util.ts';
 export function caller() { return helper(); }
-");
+",
+        );
 
         let (graph, _) = EntityGraph::build(
             root,
-            &["src/util.js".into(), "src/util.ts".into(), "src/main.ts".into()],
+            &[
+                "src/util.js".into(),
+                "src/util.ts".into(),
+                "src/main.ts".into(),
+            ],
             &registry,
         );
 
-        let caller_id = graph.entities.keys()
+        let caller_id = graph
+            .entities
+            .keys()
             .find(|id| id.contains("caller"))
             .expect("caller entity should exist");
         let deps = graph.get_dependencies(caller_id);
         assert!(
-            deps.iter().any(|d| d.name == "helper" && d.file_path == "src/util.ts"),
+            deps.iter()
+                .any(|d| d.name == "helper" && d.file_path == "src/util.ts"),
             "caller should resolve helper to explicit src/util.ts. Deps: {:?}",
-            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+            deps.iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
         );
         assert!(
-            !deps.iter().any(|d| d.name == "helper" && d.file_path == "src/util.js"),
+            !deps
+                .iter()
+                .any(|d| d.name == "helper" && d.file_path == "src/util.js"),
             "caller should not resolve explicit ./util.ts to src/util.js. Deps: {:?}",
-            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+            deps.iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
         );
     }
 
@@ -2439,40 +3361,65 @@ export function caller() { return helper(); }
         let (dir, registry) = create_test_repo();
         let root = dir.path();
 
-        write_file(root, "src/a/util.py", "\
+        write_file(
+            root,
+            "src/a/util.py",
+            "\
 def helper():
     return 1
-");
-        write_file(root, "src/b/util.py", "\
+",
+        );
+        write_file(
+            root,
+            "src/b/util.py",
+            "\
 def helper():
     return 2
-");
-        write_file(root, "src/main.py", "\
+",
+        );
+        write_file(
+            root,
+            "src/main.py",
+            "\
 from .b.util import helper
 
 def caller():
     return helper()
-");
+",
+        );
 
         let (graph, _) = EntityGraph::build(
             root,
-            &["src/a/util.py".into(), "src/b/util.py".into(), "src/main.py".into()],
+            &[
+                "src/a/util.py".into(),
+                "src/b/util.py".into(),
+                "src/main.py".into(),
+            ],
             &registry,
         );
 
-        let caller_id = graph.entities.keys()
+        let caller_id = graph
+            .entities
+            .keys()
             .find(|id| id.contains("caller"))
             .expect("caller entity should exist");
         let deps = graph.get_dependencies(caller_id);
         assert!(
-            deps.iter().any(|d| d.name == "helper" && d.file_path == "src/b/util.py"),
+            deps.iter()
+                .any(|d| d.name == "helper" && d.file_path == "src/b/util.py"),
             "caller should resolve helper to src/b/util.py. Deps: {:?}",
-            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+            deps.iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
         );
         assert!(
-            !deps.iter().any(|d| d.name == "helper" && d.file_path == "src/a/util.py"),
+            !deps
+                .iter()
+                .any(|d| d.name == "helper" && d.file_path == "src/a/util.py"),
             "caller should not resolve helper to src/a/util.py. Deps: {:?}",
-            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+            deps.iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
         );
     }
 
@@ -2481,40 +3428,65 @@ def caller():
         let (dir, registry) = create_test_repo();
         let root = dir.path();
 
-        write_file(root, "src/a/util.py", "\
+        write_file(
+            root,
+            "src/a/util.py",
+            "\
 def helper():
     return 1
-");
-        write_file(root, "src/b/util.py", "\
+",
+        );
+        write_file(
+            root,
+            "src/b/util.py",
+            "\
 def helper():
     return 2
-");
-        write_file(root, "src/main.py", "\
+",
+        );
+        write_file(
+            root,
+            "src/main.py",
+            "\
 from src.b.util import helper
 
 def caller():
     return helper()
-");
+",
+        );
 
         let (graph, _) = EntityGraph::build(
             root,
-            &["src/a/util.py".into(), "src/b/util.py".into(), "src/main.py".into()],
+            &[
+                "src/a/util.py".into(),
+                "src/b/util.py".into(),
+                "src/main.py".into(),
+            ],
             &registry,
         );
 
-        let caller_id = graph.entities.keys()
+        let caller_id = graph
+            .entities
+            .keys()
             .find(|id| id.contains("caller"))
             .expect("caller entity should exist");
         let deps = graph.get_dependencies(caller_id);
         assert!(
-            deps.iter().any(|d| d.name == "helper" && d.file_path == "src/b/util.py"),
+            deps.iter()
+                .any(|d| d.name == "helper" && d.file_path == "src/b/util.py"),
             "caller should resolve helper to src/b/util.py. Deps: {:?}",
-            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+            deps.iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
         );
         assert!(
-            !deps.iter().any(|d| d.name == "helper" && d.file_path == "src/a/util.py"),
+            !deps
+                .iter()
+                .any(|d| d.name == "helper" && d.file_path == "src/a/util.py"),
             "caller should not resolve helper to src/a/util.py. Deps: {:?}",
-            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+            deps.iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
         );
     }
 
@@ -2523,39 +3495,57 @@ def caller():
         let (dir, registry) = create_test_repo();
         let root = dir.path();
 
-        write_file(root, "lib.ts", "\
+        write_file(
+            root,
+            "lib.ts",
+            "\
 export function foo() { return 1; }
-");
-        write_file(root, "main.ts", "\
+",
+        );
+        write_file(
+            root,
+            "main.ts",
+            "\
 import { foo } from './lib';
 export function caller(other) { return other.foo(); }
 export function actual() { return foo(); }
-");
-
-        let (graph, _) = EntityGraph::build(
-            root,
-            &["lib.ts".into(), "main.ts".into()],
-            &registry,
+",
         );
 
-        let caller_id = graph.entities.keys()
+        let (graph, _) = EntityGraph::build(root, &["lib.ts".into(), "main.ts".into()], &registry);
+
+        let caller_id = graph
+            .entities
+            .keys()
             .find(|id| id.contains("caller"))
             .expect("caller entity should exist");
         let caller_deps = graph.get_dependencies(caller_id);
         assert!(
-            !caller_deps.iter().any(|d| d.name == "foo" && d.file_path == "lib.ts"),
+            !caller_deps
+                .iter()
+                .any(|d| d.name == "foo" && d.file_path == "lib.ts"),
             "other.foo() should not resolve through a bare named import. Deps: {:?}",
-            caller_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+            caller_deps
+                .iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
         );
 
-        let actual_id = graph.entities.keys()
+        let actual_id = graph
+            .entities
+            .keys()
             .find(|id| id.contains("actual"))
             .expect("actual entity should exist");
         let actual_deps = graph.get_dependencies(actual_id);
         assert!(
-            actual_deps.iter().any(|d| d.name == "foo" && d.file_path == "lib.ts"),
+            actual_deps
+                .iter()
+                .any(|d| d.name == "foo" && d.file_path == "lib.ts"),
             "foo() should still resolve through the named import. Deps: {:?}",
-            actual_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+            actual_deps
+                .iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
         );
     }
 
@@ -2564,37 +3554,50 @@ export function actual() { return foo(); }
         let (dir, registry) = create_test_repo();
         let root = dir.path();
 
-        write_file(root, "lib.ts", "\
+        write_file(
+            root,
+            "lib.ts",
+            "\
 export const answer = 1;
 export function foo() { return 1; }
-");
-        write_file(root, "main.ts", "\
+",
+        );
+        write_file(
+            root,
+            "main.ts",
+            "\
 import { answer, foo } from './lib';
 export function caller(other) {
     other.foo();
     return answer;
 }
-");
-
-        let (graph, _) = EntityGraph::build(
-            root,
-            &["lib.ts".into(), "main.ts".into()],
-            &registry,
+",
         );
 
-        let caller_id = graph.entities.keys()
+        let (graph, _) = EntityGraph::build(root, &["lib.ts".into(), "main.ts".into()], &registry);
+
+        let caller_id = graph
+            .entities
+            .keys()
             .find(|id| id.contains("caller"))
             .expect("caller entity should exist");
         let deps = graph.get_dependencies(caller_id);
         assert!(
-            deps.iter().any(|d| d.name == "answer" && d.file_path == "lib.ts"),
+            deps.iter()
+                .any(|d| d.name == "answer" && d.file_path == "lib.ts"),
             "unresolved other.foo() should not block bare answer import fallback. Deps: {:?}",
-            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+            deps.iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
         );
         assert!(
-            !deps.iter().any(|d| d.name == "foo" && d.file_path == "lib.ts"),
+            !deps
+                .iter()
+                .any(|d| d.name == "foo" && d.file_path == "lib.ts"),
             "other.foo() should not resolve through the named import. Deps: {:?}",
-            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+            deps.iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
         );
     }
 
@@ -2603,17 +3606,29 @@ export function caller(other) {
         let (dir, registry) = create_test_repo();
         let root = dir.path();
 
-        write_file(root, "lib.ts", "\
+        write_file(
+            root,
+            "lib.ts",
+            "\
 export function foo() { return 1; }
-");
-        write_file(root, "other.ts", "\
+",
+        );
+        write_file(
+            root,
+            "other.ts",
+            "\
 export function foo() { return 2; }
-");
-        write_file(root, "main.ts", "\
+",
+        );
+        write_file(
+            root,
+            "main.ts",
+            "\
 import * as lib from './lib';
 export function caller(other) { return other.foo(); }
 export function actual() { return lib.foo(); }
-");
+",
+        );
 
         let (graph, _) = EntityGraph::build(
             root,
@@ -2621,29 +3636,46 @@ export function actual() { return lib.foo(); }
             &registry,
         );
 
-        let caller_id = graph.entities.keys()
+        let caller_id = graph
+            .entities
+            .keys()
             .find(|id| id.contains("caller"))
             .expect("caller entity should exist");
         let caller_deps = graph.get_dependencies(caller_id);
         assert!(
             !caller_deps.iter().any(|d| d.name == "foo"),
             "other.foo() should not resolve via namespace import lib. Deps: {:?}",
-            caller_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+            caller_deps
+                .iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
         );
 
-        let actual_id = graph.entities.keys()
+        let actual_id = graph
+            .entities
+            .keys()
             .find(|id| id.contains("actual"))
             .expect("actual entity should exist");
         let actual_deps = graph.get_dependencies(actual_id);
         assert!(
-            actual_deps.iter().any(|d| d.name == "foo" && d.file_path == "lib.ts"),
+            actual_deps
+                .iter()
+                .any(|d| d.name == "foo" && d.file_path == "lib.ts"),
             "lib.foo() should resolve to lib.ts. Deps: {:?}",
-            actual_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+            actual_deps
+                .iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
         );
         assert!(
-            !actual_deps.iter().any(|d| d.name == "foo" && d.file_path == "other.ts"),
+            !actual_deps
+                .iter()
+                .any(|d| d.name == "foo" && d.file_path == "other.ts"),
             "lib.foo() should not resolve to other.ts. Deps: {:?}",
-            actual_deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+            actual_deps
+                .iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
         );
     }
 
@@ -2652,35 +3684,49 @@ export function actual() { return lib.foo(); }
         let (dir, registry) = create_test_repo();
         let root = dir.path();
 
-        write_file(root, "lib.ts", "\
+        write_file(
+            root,
+            "lib.ts",
+            "\
 export class Service {
     static run() { return 1; }
 }
-");
-        write_file(root, "main.ts", "\
+",
+        );
+        write_file(
+            root,
+            "main.ts",
+            "\
 import { Service } from './lib';
 export function caller(Service) { return Service.run(); }
-");
-
-        let (graph, _) = EntityGraph::build(
-            root,
-            &["lib.ts".into(), "main.ts".into()],
-            &registry,
+",
         );
 
-        let caller_id = graph.entities.keys()
+        let (graph, _) = EntityGraph::build(root, &["lib.ts".into(), "main.ts".into()], &registry);
+
+        let caller_id = graph
+            .entities
+            .keys()
             .find(|id| id.contains("caller"))
             .expect("caller entity should exist");
         let deps = graph.get_dependencies(caller_id);
         assert!(
-            !deps.iter().any(|d| d.name == "run" && d.file_path == "lib.ts"),
+            !deps
+                .iter()
+                .any(|d| d.name == "run" && d.file_path == "lib.ts"),
             "local parameter Service should shadow imported class receiver. Deps: {:?}",
-            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+            deps.iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
         );
         assert!(
-            !deps.iter().any(|d| d.name == "Service" && d.file_path == "lib.ts"),
+            !deps
+                .iter()
+                .any(|d| d.name == "Service" && d.file_path == "lib.ts"),
             "local parameter Service should shadow imported class name. Deps: {:?}",
-            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+            deps.iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
         );
     }
 
@@ -2689,28 +3735,38 @@ export function caller(Service) { return Service.run(); }
         let (dir, registry) = create_test_repo();
         let root = dir.path();
 
-        write_file(root, "lib.ts", "\
+        write_file(
+            root,
+            "lib.ts",
+            "\
 export function foo() { return 1; }
-");
-        write_file(root, "main.ts", "\
+",
+        );
+        write_file(
+            root,
+            "main.ts",
+            "\
 import * as lib from './lib';
 export function caller(lib) { return lib.foo(); }
-");
-
-        let (graph, _) = EntityGraph::build(
-            root,
-            &["lib.ts".into(), "main.ts".into()],
-            &registry,
+",
         );
 
-        let caller_id = graph.entities.keys()
+        let (graph, _) = EntityGraph::build(root, &["lib.ts".into(), "main.ts".into()], &registry);
+
+        let caller_id = graph
+            .entities
+            .keys()
             .find(|id| id.contains("caller"))
             .expect("caller entity should exist");
         let deps = graph.get_dependencies(caller_id);
         assert!(
-            !deps.iter().any(|d| d.name == "foo" && d.file_path == "lib.ts"),
+            !deps
+                .iter()
+                .any(|d| d.name == "foo" && d.file_path == "lib.ts"),
             "local parameter lib should shadow namespace import receiver. Deps: {:?}",
-            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+            deps.iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
         );
     }
 
@@ -2719,28 +3775,38 @@ export function caller(lib) { return lib.foo(); }
         let (dir, registry) = create_test_repo();
         let root = dir.path();
 
-        write_file(root, "lib.ts", "\
+        write_file(
+            root,
+            "lib.ts",
+            "\
 export function foo() { return 1; }
-");
-        write_file(root, "main.ts", "\
+",
+        );
+        write_file(
+            root,
+            "main.ts",
+            "\
 import { foo } from './lib';
 export function caller(foo) { return foo(); }
-");
-
-        let (graph, _) = EntityGraph::build(
-            root,
-            &["lib.ts".into(), "main.ts".into()],
-            &registry,
+",
         );
 
-        let caller_id = graph.entities.keys()
+        let (graph, _) = EntityGraph::build(root, &["lib.ts".into(), "main.ts".into()], &registry);
+
+        let caller_id = graph
+            .entities
+            .keys()
             .find(|id| id.contains("caller"))
             .expect("caller entity should exist");
         let deps = graph.get_dependencies(caller_id);
         assert!(
-            !deps.iter().any(|d| d.name == "foo" && d.file_path == "lib.ts"),
+            !deps
+                .iter()
+                .any(|d| d.name == "foo" && d.file_path == "lib.ts"),
             "local parameter foo should shadow named import. Deps: {:?}",
-            deps.iter().map(|d| (&d.name, &d.file_path)).collect::<Vec<_>>()
+            deps.iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
         );
     }
 
@@ -2751,27 +3817,33 @@ export function caller(foo) { return foo(); }
 
         // Two classes with same method name "process".
         // self.process() in ClassA should NOT create edge to ClassB::process.
-        write_file(root, "a.py", "\
+        write_file(
+            root,
+            "a.py",
+            "\
 class ClassA:
     def run(self):
         return self.process()
 
     def process(self):
         return 1
-");
-        write_file(root, "b.py", "\
+",
+        );
+        write_file(
+            root,
+            "b.py",
+            "\
 class ClassB:
     def process(self):
         return 2
-");
-
-        let (graph, _) = EntityGraph::build(
-            root,
-            &["a.py".into(), "b.py".into()],
-            &registry,
+",
         );
 
-        let run_id = graph.entities.keys()
+        let (graph, _) = EntityGraph::build(root, &["a.py".into(), "b.py".into()], &registry);
+
+        let run_id = graph
+            .entities
+            .keys()
             .find(|id| id.contains("run"))
             .expect("run entity should exist");
         let deps = graph.get_dependencies(run_id);
@@ -2795,17 +3867,23 @@ class ClassB:
         // someVar.unknownMethod() - "someVar" is not a class,
         // so the chain is unresolved and words fall through to bag-of-words.
         // "helper" should still resolve via bag-of-words.
-        write_file(root, "app.ts", "\
+        write_file(
+            root,
+            "app.ts",
+            "\
 export function helper() { return 1; }
 export function caller() {
     const val = helper();
     return val;
 }
-");
+",
+        );
 
         let (graph, _) = EntityGraph::build(root, &["app.ts".into()], &registry);
 
-        let caller_id = graph.entities.keys()
+        let caller_id = graph
+            .entities
+            .keys()
             .find(|id| id.contains("caller"))
             .expect("caller entity should exist");
         let deps = graph.get_dependencies(caller_id);
@@ -2815,5 +3893,4 @@ export function caller() {
             deps.iter().map(|d| &d.name).collect::<Vec<_>>()
         );
     }
-
 }

--- a/crates/sem-core/src/parser/scope_resolve.rs
+++ b/crates/sem-core/src/parser/scope_resolve.rs
@@ -23,9 +23,13 @@ use crate::model::entity::SemanticEntity;
 macro_rules! maybe_par_iter {
     ($slice:expr) => {{
         #[cfg(feature = "parallel")]
-        { $slice.par_iter() }
+        {
+            $slice.par_iter()
+        }
         #[cfg(not(feature = "parallel"))]
-        { $slice.iter() }
+        {
+            $slice.iter()
+        }
     }};
 }
 use crate::parser::graph::{EntityInfo, RefType};
@@ -101,6 +105,52 @@ pub(crate) struct PreBuiltLookups {
     pub(crate) go_pkg_index: HashMap<String, Vec<(String, String)>>,
 }
 
+struct FileEntityLookup<'a> {
+    by_name: HashMap<&'a str, Vec<&'a SemanticEntity>>,
+}
+
+impl<'a> FileEntityLookup<'a> {
+    fn new(file_entities: &[&'a SemanticEntity]) -> Self {
+        let mut by_name: HashMap<&'a str, Vec<&'a SemanticEntity>> = HashMap::new();
+        for entity in file_entities {
+            by_name
+                .entry(entity.name.as_str())
+                .or_default()
+                .push(*entity);
+        }
+        Self { by_name }
+    }
+
+    fn find_at_line<F>(
+        &self,
+        name: &str,
+        line: usize,
+        type_matches: F,
+    ) -> Option<&'a SemanticEntity>
+    where
+        F: Fn(&SemanticEntity) -> bool,
+    {
+        if name.is_empty() {
+            return None;
+        }
+        self.by_name.get(name)?.iter().find_map(|entity| {
+            if entity.start_line <= line && line <= entity.end_line && type_matches(entity) {
+                Some(*entity)
+            } else {
+                None
+            }
+        })
+    }
+}
+
+#[derive(Default)]
+struct ScopeLookupCache {
+    defs: HashMap<(usize, String), Option<String>>,
+    local_bindings: HashMap<(usize, String), bool>,
+    types: HashMap<(usize, String), Option<String>>,
+    enclosing_classes: HashMap<usize, Option<String>>,
+}
+
 /// Public API — preserves the original 5-parameter signature for semver compatibility.
 pub fn resolve_with_scopes(
     root: &Path,
@@ -126,7 +176,12 @@ pub(crate) fn resolve_with_scopes_full(
 
     // Use pre-built lookups if provided, otherwise build from scratch
     let (symbol_table, class_members, entity_ranges, go_pkg_index) = if let Some(pb) = pre_built {
-        (pb.symbol_table, pb.class_members, pb.entity_ranges, pb.go_pkg_index)
+        (
+            pb.symbol_table,
+            pb.class_members,
+            pb.entity_ranges,
+            pb.go_pkg_index,
+        )
     } else {
         let mut symbol_table: HashMap<String, Vec<String>> = HashMap::new();
         let mut class_members: HashMap<String, Vec<(String, String)>> = HashMap::new();
@@ -142,9 +197,14 @@ pub(crate) fn resolve_with_scopes_full(
                 if let Some(parent) = entity_map.get(pid) {
                     if matches!(
                         parent.entity_type.as_str(),
-                        "class" | "struct" | "interface" | "impl"
-                            | "enum" | "protocol_declaration"
-                            | "object_declaration" | "companion_object"
+                        "class"
+                            | "struct"
+                            | "interface"
+                            | "impl"
+                            | "enum"
+                            | "protocol_declaration"
+                            | "object_declaration"
+                            | "companion_object"
                     ) {
                         class_members
                             .entry(parent.name.clone())
@@ -172,7 +232,12 @@ pub(crate) fn resolve_with_scopes_full(
         // Build Go package index for O(1) import lookup
         let go_pkg_index = build_go_pkg_index(&symbol_table, entity_map);
 
-        (Arc::new(symbol_table), class_members, entity_ranges, go_pkg_index)
+        (
+            Arc::new(symbol_table),
+            class_members,
+            entity_ranges,
+            go_pkg_index,
+        )
     };
 
     // Build file-path indexed entity lookup: file_path -> Vec<&SemanticEntity>
@@ -256,13 +321,17 @@ pub(crate) fn resolve_with_scopes_full(
             let ext = file_path.rfind('.').map(|i| &file_path[i..]).unwrap_or("");
             let config = get_language_config(ext).and_then(|c| c.scope_resolve)?;
 
-            let file_entities = entities_by_file.get(file_path.as_str()).map(|v| v.as_slice()).unwrap_or(&[]);
+            let file_entities = entities_by_file
+                .get(file_path.as_str())
+                .map(|v| v.as_slice())
+                .unwrap_or(&[]);
+            let file_lookup = FileEntityLookup::new(file_entities);
 
             let mut local_return_type_map: HashMap<String, String> = HashMap::new();
             scan_return_types(
                 tree.root_node(),
                 file_path,
-                file_entities,
+                &file_lookup,
                 source,
                 &mut local_return_type_map,
                 config,
@@ -283,7 +352,12 @@ pub(crate) fn resolve_with_scopes_full(
                 config,
             );
 
-            Some((local_return_type_map, local_instance_attr_types, local_init_params, local_attr_to_param))
+            Some((
+                local_return_type_map,
+                local_instance_attr_types,
+                local_init_params,
+                local_attr_to_param,
+            ))
         })
         .collect();
 
@@ -308,158 +382,169 @@ pub(crate) fn resolve_with_scopes_full(
     );
 
     // Pass 2: Build scopes, imports, and resolve references per file (parallel)
-    let per_file_results: Vec<(Vec<(String, String, RefType)>, Vec<ResolutionEntry>)> = maybe_par_iter!(parsed_files)
-        .filter_map(|(file_path, content, tree)| {
-            let source = content.as_bytes();
-            let ext = file_path.rfind('.').map(|i| &file_path[i..]).unwrap_or("");
-            let config = get_language_config(ext).and_then(|c| c.scope_resolve)?;
+    let per_file_results: Vec<(Vec<(String, String, RefType)>, Vec<ResolutionEntry>)> =
+        maybe_par_iter!(parsed_files)
+            .filter_map(|(file_path, content, tree)| {
+                let source = content.as_bytes();
+                let ext = file_path.rfind('.').map(|i| &file_path[i..]).unwrap_or("");
+                let config = get_language_config(ext).and_then(|c| c.scope_resolve)?;
 
-            let mut scopes: Vec<Scope> = vec![Scope {
-                parent: None,
-                defs: HashMap::new(),
-                bindings: HashSet::new(),
-                types: HashMap::new(),
-                pending_call_types: HashMap::new(),
-                owner_id: None,
-                kind: "module",
-            }];
+                let mut scopes: Vec<Scope> = vec![Scope {
+                    parent: None,
+                    defs: HashMap::new(),
+                    bindings: HashSet::new(),
+                    types: HashMap::new(),
+                    pending_call_types: HashMap::new(),
+                    owner_id: None,
+                    kind: "module",
+                }];
 
-            let mut entity_scope_map: HashMap<String, usize> = HashMap::new();
-            let mut entity_inner_scope: HashMap<String, usize> = HashMap::new();
+                let mut entity_scope_map: HashMap<String, usize> = HashMap::new();
+                let mut entity_inner_scope: HashMap<String, usize> = HashMap::new();
 
-            if let Some(ranges) = entity_ranges.get(file_path.as_str()) {
-                for (_start, _end, eid) in ranges {
-                    if let Some(info) = entity_map.get(eid) {
-                        if info.parent_id.is_none() {
-                            scopes[0].defs.insert(info.name.clone(), eid.clone());
-                            entity_scope_map.insert(eid.clone(), 0);
+                if let Some(ranges) = entity_ranges.get(file_path.as_str()) {
+                    for (_start, _end, eid) in ranges {
+                        if let Some(info) = entity_map.get(eid) {
+                            if info.parent_id.is_none() {
+                                scopes[0].defs.insert(info.name.clone(), eid.clone());
+                                entity_scope_map.insert(eid.clone(), 0);
+                            }
                         }
                     }
                 }
-            }
 
-            let file_entities: Vec<&SemanticEntity> = entities_by_file
-                .get(file_path.as_str())
-                .map(|v| v.as_slice())
-                .unwrap_or(&[])
-                .to_vec();
+                let file_entities: Vec<&SemanticEntity> = entities_by_file
+                    .get(file_path.as_str())
+                    .map(|v| v.as_slice())
+                    .unwrap_or(&[])
+                    .to_vec();
+                let file_lookup = FileEntityLookup::new(&file_entities);
 
-            build_scopes_from_ast(
-                tree.root_node(),
-                0,
-                &mut scopes,
-                &mut entity_scope_map,
-                &mut entity_inner_scope,
-                &file_entities,
-                &children_by_parent,
-                entity_map,
-                file_path,
-                source,
-                config,
-            );
+                build_scopes_from_ast(
+                    tree.root_node(),
+                    0,
+                    &mut scopes,
+                    &mut entity_scope_map,
+                    &mut entity_inner_scope,
+                    &file_lookup,
+                    &children_by_parent,
+                    entity_map,
+                    file_path,
+                    source,
+                    config,
+                );
 
-            let mut local_import_table: HashMap<(String, String), String> = HashMap::new();
-            extract_imports_from_ast(
-                tree.root_node(),
-                file_path,
-                source,
-                &symbol_table,
-                entity_map,
-                &mut local_import_table,
-                &mut scopes,
-                config,
-                &go_pkg_index,
-            );
+                let mut local_import_table: HashMap<(String, String), String> = HashMap::new();
+                extract_imports_from_ast(
+                    tree.root_node(),
+                    file_path,
+                    source,
+                    &symbol_table,
+                    entity_map,
+                    &mut local_import_table,
+                    &mut scopes,
+                    config,
+                    &go_pkg_index,
+                );
 
-            // Resolve pending call types using the complete return type map
-            inject_return_type_bindings(
-                &entity_inner_scope,
-                &mut scopes,
-                &return_type_map,
-                &local_import_table,
-                file_path,
-                entity_map,
-            );
+                // Resolve pending call types using the complete return type map
+                inject_return_type_bindings(
+                    &entity_inner_scope,
+                    &mut scopes,
+                    &return_type_map,
+                    &local_import_table,
+                    file_path,
+                    entity_map,
+                );
 
-            let mut file_edges: Vec<(String, String, RefType)> = Vec::new();
-            let mut file_log: Vec<ResolutionEntry> = Vec::new();
+                let mut file_edges: Vec<(String, String, RefType)> = Vec::new();
+                let mut file_log: Vec<ResolutionEntry> = Vec::new();
 
-            // Walk the AST once for the entire file, collecting all refs with row positions
-            let all_file_refs = collect_all_file_refs(tree.root_node(), source, config);
+                // Walk the AST once for the entire file, collecting all refs with row positions
+                let all_file_refs = collect_all_file_refs(tree.root_node(), source, config);
+                let refs_by_row = build_refs_by_row(&all_file_refs);
+                let mut lookup_cache = ScopeLookupCache::default();
 
-            for entity in &file_entities {
-                let scope_idx = entity_inner_scope
-                    .get(&entity.id)
-                    .or_else(|| entity_scope_map.get(&entity.id))
-                    .copied()
-                    .unwrap_or(0);
+                for entity in &file_entities {
+                    let scope_idx = entity_inner_scope
+                        .get(&entity.id)
+                        .or_else(|| entity_scope_map.get(&entity.id))
+                        .copied()
+                        .unwrap_or(0);
 
-                let start_row = entity.start_line.saturating_sub(1); // 1-indexed to 0-indexed
-                let end_row = entity.end_line; // exclusive
+                    let start_row = entity.start_line.saturating_sub(1).min(refs_by_row.len());
+                let end_row = entity.end_line.min(refs_by_row.len()).max(start_row);
 
-                // Filter pre-collected refs to this entity's line range
-                for ast_ref in all_file_refs.iter().filter(|r| r.row >= start_row && r.row < end_row) {
-                    // Skip self-name refs (was previously done during collection)
-                    let is_self_ref = match &ast_ref.kind {
-                        AstRefKind::Call(name) => name == &entity.name,
-                        AstRefKind::MethodCall { .. } => false,
-                    };
-                    if is_self_ref {
-                        continue;
-                    }
+                    // Filter pre-collected refs to this entity's line range
+                    for row_refs in &refs_by_row[start_row..end_row] {
+                        for &ref_idx in row_refs {
+                            let ast_ref = &all_file_refs[ref_idx];
+                            // Skip self-name refs (was previously done during collection)
+                            let is_self_ref = match &ast_ref.kind {
+                                AstRefKind::Call(name) => name == &entity.name,
+                                AstRefKind::MethodCall { .. } => false,
+                            };
+                            if is_self_ref {
+                                continue;
+                            }
 
-                    // Languages without per-symbol imports (e.g. Swift, Kotlin)
-                    // allow cross-file resolution for lowercase function names.
-                    let allow_cross_file = config.import_extractor.is_none();
-                    let resolution = resolve_ref(
-                        ast_ref,
-                        scope_idx,
-                        &scopes,
-                        &symbol_table,
-                        &class_members,
-                        &local_import_table,
-                        &instance_attr_types,
-                        entity_map,
-                        file_path,
-                        &entity.id,
-                        allow_cross_file,
-                    );
+                            // Languages without per-symbol imports (e.g. Swift, Kotlin)
+                            // allow cross-file resolution for lowercase function names.
+                            let allow_cross_file = config.import_extractor.is_none();
+                            let resolution = resolve_ref(
+                                ast_ref,
+                                scope_idx,
+                                &scopes,
+                                &symbol_table,
+                                &class_members,
+                                &local_import_table,
+                                &instance_attr_types,
+                                entity_map,
+                                file_path,
+                                &entity.id,
+                                allow_cross_file,
+                                &mut lookup_cache,
+                            );
 
-                    if let Some((target_id, ref_type, method)) = resolution {
-                        if target_id != entity.id {
-                            let is_parent_child = entity
-                                .parent_id
-                                .as_ref()
-                                .map_or(false, |pid| pid == &target_id || entity_map.get(&target_id).map_or(false, |t| t.parent_id.as_ref() == Some(&entity.id)));
+                            if let Some((target_id, ref_type, method)) = resolution {
+                                if target_id != entity.id {
+                                    let is_parent_child =
+                                        entity.parent_id.as_ref().map_or(false, |pid| {
+                                            pid == &target_id
+                                                || entity_map.get(&target_id).map_or(false, |t| {
+                                                    t.parent_id.as_ref() == Some(&entity.id)
+                                                })
+                                        });
 
-                            if !is_parent_child {
-                                file_edges.push((
-                                    entity.id.clone(),
-                                    target_id.clone(),
-                                    ref_type,
-                                ));
+                                    if !is_parent_child {
+                                        file_edges.push((
+                                            entity.id.clone(),
+                                            target_id.clone(),
+                                            ref_type,
+                                        ));
+                                        file_log.push(ResolutionEntry {
+                                            from_entity: entity.id.clone(),
+                                            reference: ref_description(ast_ref),
+                                            resolved_to: Some(target_id),
+                                            method,
+                                        });
+                                    }
+                                }
+                            } else {
                                 file_log.push(ResolutionEntry {
                                     from_entity: entity.id.clone(),
                                     reference: ref_description(ast_ref),
-                                    resolved_to: Some(target_id),
-                                    method,
+                                    resolved_to: None,
+                                    method: "unresolved",
                                 });
                             }
                         }
-                    } else {
-                        file_log.push(ResolutionEntry {
-                            from_entity: entity.id.clone(),
-                            reference: ref_description(ast_ref),
-                            resolved_to: None,
-                            method: "unresolved",
-                        });
                     }
                 }
-            }
 
-            Some((file_edges, file_log))
-        })
-        .collect();
+                Some((file_edges, file_log))
+            })
+            .collect();
 
     for (file_edges, file_log) in per_file_results {
         all_edges.extend(file_edges);
@@ -467,7 +552,8 @@ pub(crate) fn resolve_with_scopes_full(
     }
 
     // Deduplicate edges
-    let mut seen: std::collections::HashSet<(String, String)> = std::collections::HashSet::with_capacity(all_edges.len());
+    let mut seen: std::collections::HashSet<(String, String)> =
+        std::collections::HashSet::with_capacity(all_edges.len());
     let deduped_edges: Vec<(String, String, RefType)> = {
         let mut result = Vec::with_capacity(all_edges.len());
         for edge in all_edges {
@@ -502,7 +588,7 @@ fn build_scopes_from_ast(
     scopes: &mut Vec<Scope>,
     entity_scope_map: &mut HashMap<String, usize>,
     entity_inner_scope: &mut HashMap<String, usize>,
-    file_entities: &[&SemanticEntity],
+    file_lookup: &FileEntityLookup<'_>,
     children_by_parent: &HashMap<&str, Vec<&SemanticEntity>>,
     entity_map: &HashMap<String, EntityInfo>,
     _file_path: &str,
@@ -528,11 +614,10 @@ fn build_scopes_from_ast(
                     .unwrap_or("")
             } else {
                 match &config.class_name_field {
-                    ClassNameField::Simple(field) => {
-                        node.child_by_field_name(field)
-                            .and_then(|n| n.utf8_text(source).ok())
-                            .unwrap_or("")
-                    }
+                    ClassNameField::Simple(field) => node
+                        .child_by_field_name(field)
+                        .and_then(|n| n.utf8_text(source).ok())
+                        .unwrap_or(""),
                     ClassNameField::TypeSpec { spec_kind, field } => {
                         let mut name = "";
                         let mut cursor = node.walk();
@@ -547,23 +632,26 @@ fn build_scopes_from_ast(
                         }
                         name
                     }
-                    ClassNameField::ImplType(field) => {
-                        node.child_by_field_name(field)
-                            .and_then(|n| n.utf8_text(source).ok())
-                            .unwrap_or("")
-                    }
+                    ClassNameField::ImplType(field) => node
+                        .child_by_field_name(field)
+                        .and_then(|n| n.utf8_text(source).ok())
+                        .unwrap_or(""),
                 }
             };
 
-            let class_entity = file_entities.iter().find(|e| {
-                e.name == class_name
-                    && matches!(
-                        e.entity_type.as_str(),
-                        "class" | "struct" | "interface"
-                            | "enum" | "protocol_declaration"
-                            | "object_declaration" | "companion_object"
-                    )
-            }).copied();
+            let line = node.start_position().row + 1;
+            let class_entity = file_lookup.find_at_line(class_name, line, |entity| {
+                matches!(
+                    entity.entity_type.as_str(),
+                    "class"
+                        | "struct"
+                        | "interface"
+                        | "enum"
+                        | "protocol_declaration"
+                        | "object_declaration"
+                        | "companion_object"
+                )
+            });
 
             if let Some(ce) = class_entity {
                 let existing_scope = entity_inner_scope.get(&ce.id).copied();
@@ -640,18 +728,15 @@ fn build_scopes_from_ast(
             });
 
             // Register any entities that are children of this module
-            let mod_entity = file_entities.iter().find(|e| {
-                e.name == mod_name
-                    && e.entity_type == "module"
-                    && {
-                        let line = node.start_position().row + 1;
-                        e.start_line <= line && line <= e.end_line
-                    }
-            }).copied();
+            let line = node.start_position().row + 1;
+            let mod_entity =
+                file_lookup.find_at_line(mod_name, line, |entity| entity.entity_type == "module");
 
             if let Some(me) = mod_entity {
                 scopes[mod_scope_idx].owner_id = Some(me.id.clone());
-                entity_scope_map.entry(me.id.clone()).or_insert(current_scope);
+                entity_scope_map
+                    .entry(me.id.clone())
+                    .or_insert(current_scope);
                 entity_inner_scope.insert(me.id.clone(), mod_scope_idx);
 
                 // Register child entities in the module scope
@@ -677,18 +762,24 @@ fn build_scopes_from_ast(
         let is_function_like = config.function_scope_nodes.contains(&kind);
 
         if is_function_like {
-            let func_name = node.child_by_field_name("name")
+            let func_name = node
+                .child_by_field_name("name")
                 .and_then(|n| n.utf8_text(source).ok())
                 .unwrap_or("");
 
             let parent_scope = if config.external_method && kind == "method_declaration" {
-                let receiver_type = node.utf8_text(source).ok()
+                let receiver_type = node
+                    .utf8_text(source)
+                    .ok()
                     .and_then(|t| extract_go_receiver_type(t));
                 if let Some(ref struct_name) = receiver_type {
                     let found = scopes.iter().enumerate().find(|(_, s)| {
-                        s.kind == "class" && s.owner_id.as_ref().map_or(false, |oid| {
-                            entity_map.get(oid).map_or(false, |e| e.name == *struct_name)
-                        })
+                        s.kind == "class"
+                            && s.owner_id.as_ref().map_or(false, |oid| {
+                                entity_map
+                                    .get(oid)
+                                    .map_or(false, |e| e.name == *struct_name)
+                            })
                     });
                     found.map(|(idx, _)| idx).unwrap_or(current_scope)
                 } else {
@@ -709,19 +800,22 @@ fn build_scopes_from_ast(
                 kind: "function",
             });
 
-            let func_entity = file_entities.iter().find(|e| {
-                e.name == func_name && {
-                    let line = node.start_position().row + 1;
-                    e.start_line <= line && line <= e.end_line
-                }
-            }).copied();
+            let line = node.start_position().row + 1;
+            let func_entity = file_lookup.find_at_line(func_name, line, |_| true);
 
             if let Some(fe) = func_entity {
                 scopes[func_scope_idx].owner_id = Some(fe.id.clone());
-                entity_scope_map.entry(fe.id.clone()).or_insert(parent_scope);
+                entity_scope_map
+                    .entry(fe.id.clone())
+                    .or_insert(parent_scope);
                 entity_inner_scope.insert(fe.id.clone(), func_scope_idx);
-                if config.external_method && kind == "method_declaration" && parent_scope != current_scope {
-                    scopes[parent_scope].defs.insert(fe.name.clone(), fe.id.clone());
+                if config.external_method
+                    && kind == "method_declaration"
+                    && parent_scope != current_scope
+                {
+                    scopes[parent_scope]
+                        .defs
+                        .insert(fe.name.clone(), fe.id.clone());
                 }
             }
 
@@ -847,7 +941,10 @@ fn scan_function_params(
     for child in iter_node.named_children(&mut cursor) {
         // When using direct children, only process param-like nodes
         if use_direct {
-            let is_param = config.param_rules.iter().any(|r| child.kind() == r.node_kind);
+            let is_param = config
+                .param_rules
+                .iter()
+                .any(|r| child.kind() == r.node_kind);
             if !is_param {
                 continue;
             }
@@ -858,40 +955,37 @@ fn scan_function_params(
             }
 
             let param_name = match &rule.name_field {
-                ParamNameField::Simple(field) => {
-                    child.child_by_field_name(field)
-                        .and_then(|n| n.utf8_text(source).ok())
-                        .unwrap_or("")
-                }
-                ParamNameField::WithFallback(field) => {
-                    child.child_by_field_name(field)
-                        .or_else(|| child.named_child(0).filter(|n| n.kind() == "identifier"))
-                        .and_then(|n| n.utf8_text(source).ok())
-                        .unwrap_or("")
-                }
-                ParamNameField::RustPattern => {
-                    child.child_by_field_name("pattern")
-                        .and_then(|n| {
-                            if n.kind() == "identifier" {
-                                n.utf8_text(source).ok()
-                            } else if n.kind() == "mut_pattern" {
-                                n.named_child(0).and_then(|c| c.utf8_text(source).ok())
-                            } else if n.kind() == "reference_pattern" {
-                                n.named_child(0).and_then(|c| {
-                                    if c.kind() == "identifier" {
-                                        c.utf8_text(source).ok()
-                                    } else if c.kind() == "mut_pattern" {
-                                        c.named_child(0).and_then(|cc| cc.utf8_text(source).ok())
-                                    } else {
-                                        None
-                                    }
-                                })
-                            } else {
-                                None
-                            }
-                        })
-                        .unwrap_or("")
-                }
+                ParamNameField::Simple(field) => child
+                    .child_by_field_name(field)
+                    .and_then(|n| n.utf8_text(source).ok())
+                    .unwrap_or(""),
+                ParamNameField::WithFallback(field) => child
+                    .child_by_field_name(field)
+                    .or_else(|| child.named_child(0).filter(|n| n.kind() == "identifier"))
+                    .and_then(|n| n.utf8_text(source).ok())
+                    .unwrap_or(""),
+                ParamNameField::RustPattern => child
+                    .child_by_field_name("pattern")
+                    .and_then(|n| {
+                        if n.kind() == "identifier" {
+                            n.utf8_text(source).ok()
+                        } else if n.kind() == "mut_pattern" {
+                            n.named_child(0).and_then(|c| c.utf8_text(source).ok())
+                        } else if n.kind() == "reference_pattern" {
+                            n.named_child(0).and_then(|c| {
+                                if c.kind() == "identifier" {
+                                    c.utf8_text(source).ok()
+                                } else if c.kind() == "mut_pattern" {
+                                    c.named_child(0).and_then(|cc| cc.utf8_text(source).ok())
+                                } else {
+                                    None
+                                }
+                            })
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or(""),
             };
 
             if param_name.is_empty() || rule.skip_names.contains(&param_name) {
@@ -905,7 +999,10 @@ fn scan_function_params(
             if type_node.is_none() {
                 let mut tc = child.walk();
                 for ch in child.named_children(&mut tc) {
-                    if matches!(ch.kind(), "user_type" | "type_annotation" | "type_identifier") {
+                    if matches!(
+                        ch.kind(),
+                        "user_type" | "type_annotation" | "type_identifier"
+                    ) {
                         type_node = Some(ch);
                         break;
                     }
@@ -937,7 +1034,10 @@ fn scan_single_assignment(
     } else {
         let mut cursor = node.walk();
         let children: Vec<_> = node.named_children(&mut cursor).collect();
-        match children.into_iter().find(|c| c.kind() == "assignment" || c.kind() == "assignment_expression") {
+        match children
+            .into_iter()
+            .find(|c| c.kind() == "assignment" || c.kind() == "assignment_expression")
+        {
             Some(a) => a,
             None => return,
         }
@@ -991,9 +1091,7 @@ fn scan_ts_var_declaration(
                 if !type_text.is_empty()
                     && type_text.chars().next().map_or(false, |c| c.is_uppercase())
                 {
-                    scopes[scope_idx]
-                        .types
-                        .insert(var_name.clone(), type_text);
+                    scopes[scope_idx].types.insert(var_name.clone(), type_text);
                     continue;
                 }
             }
@@ -1079,14 +1177,17 @@ fn scan_ts_var_declaration(
                         if !type_text.is_empty()
                             && type_text.chars().next().map_or(false, |c| c.is_uppercase())
                         {
-                            scopes[scope_idx].types.insert(var_name_kt.clone(), type_text);
+                            scopes[scope_idx]
+                                .types
+                                .insert(var_name_kt.clone(), type_text);
                             return;
                         }
                     }
                     // Find the value (sibling call_expression or other expression)
                     let mut c2 = node.walk();
                     for sibling in node.named_children(&mut c2) {
-                        if sibling.kind() == "call_expression" || sibling.kind() == "new_expression" {
+                        if sibling.kind() == "call_expression" || sibling.kind() == "new_expression"
+                        {
                             record_type_from_rhs(sibling, &var_name_kt, scope_idx, scopes, source);
                             break;
                         }
@@ -1128,12 +1229,8 @@ fn scan_rust_let_declaration(
     // Check for explicit type annotation: `let x: Connection = ...`
     if let Some(type_node) = node.child_by_field_name("type") {
         let type_text = extract_base_type(type_node, source);
-        if !type_text.is_empty()
-            && type_text.chars().next().map_or(false, |c| c.is_uppercase())
-        {
-            scopes[scope_idx]
-                .types
-                .insert(var_name, type_text);
+        if !type_text.is_empty() && type_text.chars().next().map_or(false, |c| c.is_uppercase()) {
+            scopes[scope_idx].types.insert(var_name, type_text);
             return;
         }
     }
@@ -1231,9 +1328,7 @@ fn scan_go_var_declaration(
                 if !type_text.is_empty()
                     && type_text.chars().next().map_or(false, |c| c.is_uppercase())
                 {
-                    scopes[scope_idx]
-                        .types
-                        .insert(var_name, type_text);
+                    scopes[scope_idx].types.insert(var_name, type_text);
                     continue;
                 }
             }
@@ -1267,7 +1362,10 @@ fn record_type_from_rhs(
                 .child_by_field_name("function")
                 .or_else(|| rhs.named_child(0));
             if let Some(func) = func_node {
-                if func.kind() == "identifier" || func.kind() == "simple_identifier" || func.kind() == "type_identifier" {
+                if func.kind() == "identifier"
+                    || func.kind() == "simple_identifier"
+                    || func.kind() == "type_identifier"
+                {
                     let name = func.utf8_text(source).unwrap_or("");
                     if name.chars().next().map_or(false, |c| c.is_uppercase()) {
                         scopes[scope_idx]
@@ -1312,7 +1410,9 @@ fn record_type_from_rhs(
                                 .types
                                 .insert(var_name.to_string(), type_name.to_string());
                         }
-                    } else if field.starts_with("Get") || field.chars().next().map_or(false, |c| c.is_uppercase()) {
+                    } else if field.starts_with("Get")
+                        || field.chars().next().map_or(false, |c| c.is_uppercase())
+                    {
                         // Other Go package functions: record for return type resolution
                         scopes[scope_idx]
                             .pending_call_types
@@ -1399,7 +1499,11 @@ fn build_go_pkg_index(
                 if !entity.file_path.ends_with(".go") {
                     continue;
                 }
-                let file_stem = entity.file_path.rsplit('/').next().unwrap_or(&entity.file_path);
+                let file_stem = entity
+                    .file_path
+                    .rsplit('/')
+                    .next()
+                    .unwrap_or(&entity.file_path);
                 let file_stem = file_stem.strip_suffix(".go").unwrap_or(file_stem);
                 idx.entry(file_stem.to_string())
                     .or_default()
@@ -1429,7 +1533,7 @@ fn build_go_pkg_index(
 fn scan_return_types(
     root: tree_sitter::Node,
     _file_path: &str,
-    file_entities: &[&SemanticEntity],
+    file_lookup: &FileEntityLookup<'_>,
     source: &[u8],
     return_type_map: &mut HashMap<String, String>,
     config: &ScopeResolveConfig,
@@ -1446,19 +1550,17 @@ fn scan_return_types(
                 .and_then(|n| n.utf8_text(source).ok())
                 .unwrap_or("");
 
-            let func_entity = file_entities.iter().find(|e| {
-                e.name == func_name && {
-                    let line = node.start_position().row + 1;
-                    e.start_line <= line && line <= e.end_line
-                }
-            }).copied();
+            let line = node.start_position().row + 1;
+            let func_entity = file_lookup.find_at_line(func_name, line, |_| true);
 
             if let Some(fe) = func_entity {
                 // Try explicit return type annotation first
                 let ret_type = config.return_type_field.and_then(|field| {
                     node.child_by_field_name(field)
                         .map(|n| extract_base_type(n, source))
-                        .filter(|t| !t.is_empty() && t.chars().next().map_or(false, |c| c.is_uppercase()))
+                        .filter(|t| {
+                            !t.is_empty() && t.chars().next().map_or(false, |c| c.is_uppercase())
+                        })
                 });
 
                 if let Some(rt) = ret_type {
@@ -1548,7 +1650,12 @@ fn scan_init_self_attrs(
         let kind = node.kind();
 
         match &config.init_strategy {
-            InitStrategy::ConstructorBody { class_nodes, init_node_kind, self_keyword: _, .. } => {
+            InitStrategy::ConstructorBody {
+                class_nodes,
+                init_node_kind,
+                self_keyword: _,
+                ..
+            } => {
                 if class_nodes.contains(&kind) {
                     let class_name = node
                         .child_by_field_name("name")
@@ -1565,7 +1672,15 @@ fn scan_init_self_attrs(
                             "anonymous_initializer" => "kotlin",
                             _ => "typescript",
                         };
-                        scan_class_for_init(node, &class_name, source, instance_attr_types, init_params_map, attr_to_param_map, lang);
+                        scan_class_for_init(
+                            node,
+                            &class_name,
+                            source,
+                            instance_attr_types,
+                            init_params_map,
+                            attr_to_param_map,
+                            lang,
+                        );
                     }
                 }
             }
@@ -1580,7 +1695,12 @@ fn scan_init_self_attrs(
                             .to_string();
 
                         if !struct_name.is_empty() {
-                            scan_rust_struct_fields(node, &struct_name, source, instance_attr_types);
+                            scan_rust_struct_fields(
+                                node,
+                                &struct_name,
+                                source,
+                                instance_attr_types,
+                            );
                         }
                     }
                     // Go: extract field types from type declarations
@@ -1624,7 +1744,10 @@ fn scan_rust_struct_fields(
 
                     if !field_name.is_empty()
                         && !field_type.is_empty()
-                        && field_type.chars().next().map_or(false, |c| c.is_uppercase())
+                        && field_type
+                            .chars()
+                            .next()
+                            .map_or(false, |c| c.is_uppercase())
                     {
                         instance_attr_types.insert(
                             (struct_name.to_string(), field_name.to_string()),
@@ -1677,7 +1800,10 @@ fn scan_go_struct_fields(
 
                                     if !field_name.is_empty()
                                         && !field_type.is_empty()
-                                        && field_type.chars().next().map_or(false, |c| c.is_uppercase())
+                                        && field_type
+                                            .chars()
+                                            .next()
+                                            .map_or(false, |c| c.is_uppercase())
                                     {
                                         instance_attr_types.insert(
                                             (struct_name.clone(), field_name.to_string()),
@@ -1724,7 +1850,14 @@ fn scan_class_for_init(
                     let params = extract_init_params(child, source);
                     let ordered_params = extract_init_param_names_ordered(child, source);
                     init_params_map.insert(class_name.to_string(), ordered_params);
-                    scan_init_body(child, class_name, &params, source, instance_attr_types, attr_to_param_map);
+                    scan_init_body(
+                        child,
+                        class_name,
+                        &params,
+                        source,
+                        instance_attr_types,
+                        attr_to_param_map,
+                    );
                 }
             }
 
@@ -1736,22 +1869,46 @@ fn scan_class_for_init(
                     .unwrap_or("");
                 if name == "constructor" {
                     // Scan for this.attr = param patterns
-                    scan_ts_constructor_body(child, class_name, source, instance_attr_types, init_params_map, attr_to_param_map);
+                    scan_ts_constructor_body(
+                        child,
+                        class_name,
+                        source,
+                        instance_attr_types,
+                        init_params_map,
+                        attr_to_param_map,
+                    );
                 }
             }
 
             // Swift init_declaration
             if ck == "init_declaration" && lang == "swift" {
-                scan_swift_init_body(child, class_name, source, instance_attr_types, init_params_map, attr_to_param_map);
+                scan_swift_init_body(
+                    child,
+                    class_name,
+                    source,
+                    instance_attr_types,
+                    init_params_map,
+                    attr_to_param_map,
+                );
             }
 
             // Kotlin anonymous_initializer (init { ... } block)
             if ck == "anonymous_initializer" && lang == "kotlin" {
-                scan_kotlin_init_body(child, class_name, source, instance_attr_types, attr_to_param_map);
+                scan_kotlin_init_body(
+                    child,
+                    class_name,
+                    source,
+                    instance_attr_types,
+                    attr_to_param_map,
+                );
             }
 
             // TS: typed class field declarations `private conn: Connection`
-            if (ck == "public_field_definition" || ck == "property_declaration" || ck == "field_definition") && lang == "typescript" {
+            if (ck == "public_field_definition"
+                || ck == "property_declaration"
+                || ck == "field_definition")
+                && lang == "typescript"
+            {
                 let field_name = child
                     .child_by_field_name("name")
                     .and_then(|n| n.utf8_text(source).ok())
@@ -1762,10 +1919,8 @@ fn scan_class_for_init(
                         && !type_text.is_empty()
                         && type_text.chars().next().map_or(false, |c| c.is_uppercase())
                     {
-                        instance_attr_types.insert(
-                            (class_name.to_string(), field_name.to_string()),
-                            type_text,
-                        );
+                        instance_attr_types
+                            .insert((class_name.to_string(), field_name.to_string()), type_text);
                     }
                 }
             }
@@ -1780,9 +1935,14 @@ fn scan_class_for_init(
                 scan_kotlin_property_declaration(child, class_name, source, instance_attr_types);
             }
 
-            if ck == "block" || ck == "class_body" || ck == "statement_block"
-                || ck == "struct_body" || ck == "function_body" || ck == "code_block"
-                || ck == "statements" || ck == "enum_class_body"
+            if ck == "block"
+                || ck == "class_body"
+                || ck == "statement_block"
+                || ck == "struct_body"
+                || ck == "function_body"
+                || ck == "code_block"
+                || ck == "statements"
+                || ck == "enum_class_body"
             {
                 worklist.push(child);
             }
@@ -1811,17 +1971,27 @@ fn scan_swift_init_body(
             let ck = child.kind();
             // Look for assignment: self.X = Y via directly_assigned_expression or assignment
             if ck == "directly_assigned_expression" || ck == "assignment" {
-                if let Some(left) = child.child_by_field_name("left").or_else(|| child.named_child(0)) {
+                if let Some(left) = child
+                    .child_by_field_name("left")
+                    .or_else(|| child.named_child(0))
+                {
                     if left.kind() == "navigation_expression" {
-                        let obj = left.child_by_field_name("target")
+                        let obj = left
+                            .child_by_field_name("target")
                             .and_then(|n| n.utf8_text(source).ok())
                             .unwrap_or("");
-                        let prop = left.child_by_field_name("suffix")
+                        let prop = left
+                            .child_by_field_name("suffix")
                             .and_then(|n| n.utf8_text(source).ok())
                             .unwrap_or("");
                         if obj == "self" && !prop.is_empty() {
-                            if let Some(right) = child.child_by_field_name("right").or_else(|| child.named_child(1)) {
-                                if right.kind() == "simple_identifier" || right.kind() == "identifier" {
+                            if let Some(right) = child
+                                .child_by_field_name("right")
+                                .or_else(|| child.named_child(1))
+                            {
+                                if right.kind() == "simple_identifier"
+                                    || right.kind() == "identifier"
+                                {
                                     let rhs_name = right.utf8_text(source).unwrap_or("");
                                     if params.contains_key(rhs_name) {
                                         attr_to_param_map.insert(
@@ -1841,8 +2011,11 @@ fn scan_swift_init_body(
                     }
                 }
             }
-            if ck == "function_body" || ck == "code_block" || ck == "statements"
-                || ck == "expression_statement" || ck == "block"
+            if ck == "function_body"
+                || ck == "code_block"
+                || ck == "statements"
+                || ck == "expression_statement"
+                || ck == "block"
             {
                 worklist.push(child);
             }
@@ -1860,7 +2033,10 @@ fn scan_swift_property_declaration(
     // Swift property_declaration has a "name" (via pattern binding) and type annotation
     let mut cursor = node.walk();
     for child in node.named_children(&mut cursor) {
-        if child.kind() == "pattern" || child.kind() == "simple_identifier" || child.kind() == "identifier" {
+        if child.kind() == "pattern"
+            || child.kind() == "simple_identifier"
+            || child.kind() == "identifier"
+        {
             let field_name = child.utf8_text(source).unwrap_or("");
             if let Some(type_ann) = node.child_by_field_name("type") {
                 let type_text = extract_base_type(type_ann, source);
@@ -1868,10 +2044,8 @@ fn scan_swift_property_declaration(
                     && !type_text.is_empty()
                     && type_text.chars().next().map_or(false, |c| c.is_uppercase())
                 {
-                    instance_attr_types.insert(
-                        (class_name.to_string(), field_name.to_string()),
-                        type_text,
-                    );
+                    instance_attr_types
+                        .insert((class_name.to_string(), field_name.to_string()), type_text);
                 }
             }
         }
@@ -1896,12 +2070,12 @@ fn scan_kotlin_property_declaration(
 
     if !field_name.is_empty()
         && !field_type.is_empty()
-        && field_type.chars().next().map_or(false, |c| c.is_uppercase())
+        && field_type
+            .chars()
+            .next()
+            .map_or(false, |c| c.is_uppercase())
     {
-        instance_attr_types.insert(
-            (class_name.to_string(), field_name.to_string()),
-            field_type,
-        );
+        instance_attr_types.insert((class_name.to_string(), field_name.to_string()), field_type);
     }
 }
 
@@ -1921,8 +2095,10 @@ fn scan_kotlin_primary_constructor(
                 if param.kind() == "class_parameter" {
                     // Check if this has val/var modifier (makes it a property)
                     let text = param.utf8_text(source).unwrap_or("");
-                    let has_val_var = text.starts_with("val ") || text.starts_with("var ")
-                        || text.contains("val ") || text.contains("var ");
+                    let has_val_var = text.starts_with("val ")
+                        || text.starts_with("var ")
+                        || text.contains("val ")
+                        || text.contains("var ");
                     if has_val_var {
                         let param_name = param
                             .child_by_field_name("name")
@@ -1934,7 +2110,10 @@ fn scan_kotlin_primary_constructor(
                             .unwrap_or_default();
                         if !param_name.is_empty()
                             && !param_type.is_empty()
-                            && param_type.chars().next().map_or(false, |c| c.is_uppercase())
+                            && param_type
+                                .chars()
+                                .next()
+                                .map_or(false, |c| c.is_uppercase())
                         {
                             instance_attr_types.insert(
                                 (class_name.to_string(), param_name.to_string()),
@@ -1962,17 +2141,27 @@ fn scan_kotlin_init_body(
         for child in wnode.named_children(&mut cursor) {
             let ck = child.kind();
             if ck == "assignment" || ck == "directly_assigned_expression" {
-                if let Some(left) = child.child_by_field_name("left").or_else(|| child.named_child(0)) {
+                if let Some(left) = child
+                    .child_by_field_name("left")
+                    .or_else(|| child.named_child(0))
+                {
                     if left.kind() == "navigation_expression" {
-                        let obj = left.child_by_field_name("expression")
+                        let obj = left
+                            .child_by_field_name("expression")
                             .and_then(|n| n.utf8_text(source).ok())
                             .unwrap_or("");
-                        let prop = left.child_by_field_name("navigation_suffix")
+                        let prop = left
+                            .child_by_field_name("navigation_suffix")
                             .and_then(|n| n.utf8_text(source).ok())
                             .unwrap_or("");
                         if obj == "this" && !prop.is_empty() {
-                            if let Some(right) = child.child_by_field_name("right").or_else(|| child.named_child(1)) {
-                                if right.kind() == "simple_identifier" || right.kind() == "identifier" {
+                            if let Some(right) = child
+                                .child_by_field_name("right")
+                                .or_else(|| child.named_child(1))
+                            {
+                                if right.kind() == "simple_identifier"
+                                    || right.kind() == "identifier"
+                                {
                                     let rhs_name = right.utf8_text(source).unwrap_or("");
                                     attr_to_param_map.insert(
                                         (class_name.to_string(), prop.to_string()),
@@ -1981,7 +2170,8 @@ fn scan_kotlin_init_body(
                                 }
                                 // If RHS is a constructor call, record type directly
                                 if right.kind() == "call_expression" {
-                                    let callee = right.child_by_field_name("function")
+                                    let callee = right
+                                        .child_by_field_name("function")
                                         .and_then(|n| n.utf8_text(source).ok())
                                         .unwrap_or("");
                                     if !callee.is_empty()
@@ -2020,7 +2210,14 @@ fn scan_ts_constructor_body(
     init_params_map.insert(class_name.to_string(), ordered_params);
 
     // Scan body for this.X = param
-    scan_init_body_this(node, class_name, &params, source, instance_attr_types, attr_to_param_map);
+    scan_init_body_this(
+        node,
+        class_name,
+        &params,
+        source,
+        instance_attr_types,
+        attr_to_param_map,
+    );
 }
 
 /// Scan constructor body for `this.attr = param` patterns (TS variant)
@@ -2044,10 +2241,12 @@ fn scan_init_body_this(
                     if inner.kind() == "assignment_expression" {
                         if let Some(left) = inner.child_by_field_name("left") {
                             if left.kind() == "member_expression" {
-                                let obj = left.child_by_field_name("object")
+                                let obj = left
+                                    .child_by_field_name("object")
                                     .and_then(|n| n.utf8_text(source).ok())
                                     .unwrap_or("");
-                                let prop = left.child_by_field_name("property")
+                                let prop = left
+                                    .child_by_field_name("property")
                                     .and_then(|n| n.utf8_text(source).ok())
                                     .unwrap_or("");
                                 if obj == "this" && !prop.is_empty() {
@@ -2059,7 +2258,8 @@ fn scan_init_body_this(
                                                     (class_name.to_string(), prop.to_string()),
                                                     rhs_name.to_string(),
                                                 );
-                                                if let Some(Some(type_hint)) = params.get(rhs_name) {
+                                                if let Some(Some(type_hint)) = params.get(rhs_name)
+                                                {
                                                     instance_attr_types.insert(
                                                         (class_name.to_string(), prop.to_string()),
                                                         type_hint.clone(),
@@ -2068,7 +2268,9 @@ fn scan_init_body_this(
                                             }
                                         }
                                         if right.kind() == "new_expression" {
-                                            if let Some(ctor) = right.child_by_field_name("constructor") {
+                                            if let Some(ctor) =
+                                                right.child_by_field_name("constructor")
+                                            {
                                                 let name = ctor.utf8_text(source).unwrap_or("");
                                                 if !name.is_empty() {
                                                     instance_attr_types.insert(
@@ -2100,8 +2302,10 @@ fn extract_init_param_names_ordered(func_node: tree_sitter::Node, source: &[u8])
         for child in params_node.named_children(&mut cursor) {
             let param_name = if child.kind() == "identifier" {
                 child.utf8_text(source).unwrap_or("").to_string()
-            } else if child.kind() == "typed_parameter" || child.kind() == "typed_default_parameter" {
-                child.child_by_field_name("name")
+            } else if child.kind() == "typed_parameter" || child.kind() == "typed_default_parameter"
+            {
+                child
+                    .child_by_field_name("name")
                     .or_else(|| child.named_child(0))
                     .and_then(|n| n.utf8_text(source).ok())
                     .unwrap_or("")
@@ -2117,15 +2321,20 @@ fn extract_init_param_names_ordered(func_node: tree_sitter::Node, source: &[u8])
     names
 }
 
-fn extract_init_params(func_node: tree_sitter::Node, source: &[u8]) -> HashMap<String, Option<String>> {
+fn extract_init_params(
+    func_node: tree_sitter::Node,
+    source: &[u8],
+) -> HashMap<String, Option<String>> {
     let mut params = HashMap::new();
     if let Some(params_node) = func_node.child_by_field_name("parameters") {
         let mut cursor = params_node.walk();
         for child in params_node.named_children(&mut cursor) {
             let param_name = if child.kind() == "identifier" {
                 child.utf8_text(source).unwrap_or("").to_string()
-            } else if child.kind() == "typed_parameter" || child.kind() == "typed_default_parameter" {
-                child.child_by_field_name("name")
+            } else if child.kind() == "typed_parameter" || child.kind() == "typed_default_parameter"
+            {
+                child
+                    .child_by_field_name("name")
                     .or_else(|| child.named_child(0))
                     .and_then(|n| n.utf8_text(source).ok())
                     .unwrap_or("")
@@ -2135,7 +2344,8 @@ fn extract_init_params(func_node: tree_sitter::Node, source: &[u8]) -> HashMap<S
             };
             if param_name != "self" && param_name != "cls" {
                 // Check for type annotation
-                let type_hint = child.child_by_field_name("type")
+                let type_hint = child
+                    .child_by_field_name("type")
                     .and_then(|n| n.utf8_text(source).ok())
                     .map(|s| s.to_string());
                 params.insert(param_name, type_hint);
@@ -2171,10 +2381,12 @@ fn scan_init_body(
 
                 if let Some(left) = assign.child_by_field_name("left") {
                     if left.kind() == "attribute" {
-                        let obj = left.child_by_field_name("object")
+                        let obj = left
+                            .child_by_field_name("object")
                             .and_then(|n| n.utf8_text(source).ok())
                             .unwrap_or("");
-                        let attr = left.child_by_field_name("attribute")
+                        let attr = left
+                            .child_by_field_name("attribute")
                             .and_then(|n| n.utf8_text(source).ok())
                             .unwrap_or("");
 
@@ -2201,7 +2413,11 @@ fn scan_init_body(
                                     if let Some(func) = right.child_by_field_name("function") {
                                         if func.kind() == "identifier" {
                                             let fname = func.utf8_text(source).unwrap_or("");
-                                            if fname.chars().next().map_or(false, |c| c.is_uppercase()) {
+                                            if fname
+                                                .chars()
+                                                .next()
+                                                .map_or(false, |c| c.is_uppercase())
+                                            {
                                                 instance_attr_types.insert(
                                                     (class_name.to_string(), attr.to_string()),
                                                     fname.to_string(),
@@ -2285,7 +2501,11 @@ fn scan_constructor_calls(
                 if func.kind() == "identifier" {
                     let class_name = func.utf8_text(source).unwrap_or("");
                     // Only process uppercase names (constructor calls)
-                    if class_name.chars().next().map_or(false, |c| c.is_uppercase()) {
+                    if class_name
+                        .chars()
+                        .next()
+                        .map_or(false, |c| c.is_uppercase())
+                    {
                         if let Some(param_names) = init_params.get(class_name) {
                             // Extract argument types
                             if let Some(args_node) = node.child_by_field_name("arguments") {
@@ -2423,25 +2643,69 @@ fn extract_imports_from_ast(
             let ck = child.kind();
             let handled = match ck {
                 "import_from_statement" => {
-                    extract_python_import(child, file_path, source, symbol_table, entity_map, import_table, scopes);
+                    extract_python_import(
+                        child,
+                        file_path,
+                        source,
+                        symbol_table,
+                        entity_map,
+                        import_table,
+                        scopes,
+                    );
                     true
                 }
-                "import_statement" if config.self_keywords.contains(&"self") && config.self_keywords.contains(&"cls") => {
+                "import_statement"
+                    if config.self_keywords.contains(&"self")
+                        && config.self_keywords.contains(&"cls") =>
+                {
                     // Python: `import mod` or `import mod as m`
-                    extract_python_module_import(child, file_path, source, symbol_table, entity_map, import_table, scopes);
+                    extract_python_module_import(
+                        child,
+                        file_path,
+                        source,
+                        symbol_table,
+                        entity_map,
+                        import_table,
+                        scopes,
+                    );
                     true
                 }
                 "import_statement" if !config.self_keywords.contains(&"cls") => {
                     // TS import_statement (not Python - Python uses import_from_statement)
-                    extract_ts_import(child, file_path, source, symbol_table, entity_map, import_table, scopes);
+                    extract_ts_import(
+                        child,
+                        file_path,
+                        source,
+                        symbol_table,
+                        entity_map,
+                        import_table,
+                        scopes,
+                    );
                     true
                 }
                 "use_declaration" => {
-                    extract_rust_use(child, file_path, source, symbol_table, entity_map, import_table, scopes);
+                    extract_rust_use(
+                        child,
+                        file_path,
+                        source,
+                        symbol_table,
+                        entity_map,
+                        import_table,
+                        scopes,
+                    );
                     true
                 }
                 "import_declaration" => {
-                    extract_go_import(child, file_path, source, symbol_table, entity_map, import_table, scopes, go_pkg_index);
+                    extract_go_import(
+                        child,
+                        file_path,
+                        source,
+                        symbol_table,
+                        entity_map,
+                        import_table,
+                        scopes,
+                        go_pkg_index,
+                    );
                     true
                 }
                 _ => false,
@@ -2495,7 +2759,17 @@ fn extract_ts_import(
                                 .unwrap_or(original);
 
                             if !original.is_empty() {
-                                resolve_import_name(original, local, source_path, file_path, &[".ts", ".tsx", ".js", ".jsx"], symbol_table, entity_map, import_table, scopes);
+                                resolve_import_name(
+                                    original,
+                                    local,
+                                    source_path,
+                                    file_path,
+                                    &[".ts", ".tsx", ".js", ".jsx"],
+                                    symbol_table,
+                                    entity_map,
+                                    import_table,
+                                    scopes,
+                                );
                             }
                         }
                     }
@@ -2506,19 +2780,39 @@ fn extract_ts_import(
                     let alias = clause_child
                         .child_by_field_name("alias")
                         .or_else(|| {
-                            clause_child.named_children(&mut ns_cursor)
+                            clause_child
+                                .named_children(&mut ns_cursor)
                                 .find(|c| c.kind() == "identifier")
                         })
                         .and_then(|n| n.utf8_text(source).ok())
                         .unwrap_or("");
                     if !alias.is_empty() {
-                        register_namespace_import(alias, source_path, file_path, &[".ts", ".tsx", ".js", ".jsx"], symbol_table, entity_map, import_table, scopes);
+                        register_namespace_import(
+                            alias,
+                            source_path,
+                            file_path,
+                            &[".ts", ".tsx", ".js", ".jsx"],
+                            symbol_table,
+                            entity_map,
+                            import_table,
+                            scopes,
+                        );
                     }
                 } else if clause_child.kind() == "identifier" {
                     // Default import: import Foo from './module'
                     let name = clause_child.utf8_text(source).unwrap_or("");
                     if !name.is_empty() {
-                        resolve_import_name(name, name, source_path, file_path, &[".ts", ".tsx", ".js", ".jsx"], symbol_table, entity_map, import_table, scopes);
+                        resolve_import_name(
+                            name,
+                            name,
+                            source_path,
+                            file_path,
+                            &[".ts", ".tsx", ".js", ".jsx"],
+                            symbol_table,
+                            entity_map,
+                            import_table,
+                            scopes,
+                        );
                     }
                 }
             }
@@ -2569,7 +2863,17 @@ fn extract_rust_use(
                 (name_part, name_part)
             };
             if !original.is_empty() {
-                resolve_import_name(original, local, source_module, file_path, &[".rs"], symbol_table, entity_map, import_table, scopes);
+                resolve_import_name(
+                    original,
+                    local,
+                    source_module,
+                    file_path,
+                    &[".rs"],
+                    symbol_table,
+                    entity_map,
+                    import_table,
+                    scopes,
+                );
             }
         }
     } else {
@@ -2590,7 +2894,17 @@ fn extract_rust_use(
             parts[0]
         };
         if !original.is_empty() && !source_module.is_empty() {
-            resolve_import_name(original, local, source_module, file_path, &[".rs"], symbol_table, entity_map, import_table, scopes);
+            resolve_import_name(
+                original,
+                local,
+                source_module,
+                file_path,
+                &[".rs"],
+                symbol_table,
+                entity_map,
+                import_table,
+                scopes,
+            );
         }
     }
 }
@@ -2609,12 +2923,34 @@ fn extract_go_import(
     let mut cursor = node.walk();
     for child in node.named_children(&mut cursor) {
         if child.kind() == "import_spec" || child.kind() == "import_spec_list" {
-            extract_go_import_specs(child, file_path, source, symbol_table, entity_map, import_table, scopes, go_pkg_index);
-        } else if child.kind() == "interpreted_string_literal" || child.kind() == "raw_string_literal" {
-            let path = child.utf8_text(source).unwrap_or("")
-                .trim_matches('"').trim_matches('`');
+            extract_go_import_specs(
+                child,
+                file_path,
+                source,
+                symbol_table,
+                entity_map,
+                import_table,
+                scopes,
+                go_pkg_index,
+            );
+        } else if child.kind() == "interpreted_string_literal"
+            || child.kind() == "raw_string_literal"
+        {
+            let path = child
+                .utf8_text(source)
+                .unwrap_or("")
+                .trim_matches('"')
+                .trim_matches('`');
             let pkg_name = path.rsplit('/').next().unwrap_or(path);
-            register_go_package_imports(pkg_name, file_path, symbol_table, entity_map, import_table, scopes, go_pkg_index);
+            register_go_package_imports(
+                pkg_name,
+                file_path,
+                symbol_table,
+                entity_map,
+                import_table,
+                scopes,
+                go_pkg_index,
+            );
         }
     }
 }
@@ -2634,13 +2970,25 @@ fn extract_go_import_specs(
         let mut cursor = node.walk();
         for child in node.named_children(&mut cursor) {
             if child.kind() == "import_spec" {
-                let path_node = child.child_by_field_name("path")
+                let path_node = child
+                    .child_by_field_name("path")
                     .or_else(|| child.named_child(0));
                 if let Some(pn) = path_node {
-                    let path = pn.utf8_text(source).unwrap_or("")
-                        .trim_matches('"').trim_matches('`');
+                    let path = pn
+                        .utf8_text(source)
+                        .unwrap_or("")
+                        .trim_matches('"')
+                        .trim_matches('`');
                     let pkg_name = path.rsplit('/').next().unwrap_or(path);
-                    register_go_package_imports(pkg_name, file_path, symbol_table, entity_map, import_table, scopes, go_pkg_index);
+                    register_go_package_imports(
+                        pkg_name,
+                        file_path,
+                        symbol_table,
+                        entity_map,
+                        import_table,
+                        scopes,
+                        go_pkg_index,
+                    );
                 }
             } else {
                 worklist.push(child);
@@ -2661,10 +3009,7 @@ fn register_go_package_imports(
     // Use pre-built package index for O(1) lookup instead of O(symbol_table) scan
     if let Some(entries) = go_pkg_index.get(pkg_name) {
         for (name, target_id) in entries {
-            import_table.insert(
-                (file_path.to_string(), name.clone()),
-                target_id.clone(),
-            );
+            import_table.insert((file_path.to_string(), name.clone()), target_id.clone());
             if !scopes.is_empty() {
                 scopes[0].defs.insert(name.clone(), target_id.clone());
             }
@@ -2685,13 +3030,7 @@ fn resolve_import_name(
     scopes: &mut Vec<Scope>,
 ) {
     if let Some(target_ids) = symbol_table.get(original_name) {
-        let target = find_import_target(
-            target_ids,
-            source_path,
-            file_path,
-            extensions,
-            entity_map,
-        );
+        let target = find_import_target(target_ids, source_path, file_path, extensions, entity_map);
 
         if let Some(target_id) = target {
             import_table.insert(
@@ -2725,7 +3064,8 @@ fn register_namespace_import(
         for target_id in target_ids {
             if let Some(info) = entity_map.get(target_id) {
                 if import_source_matches_file(file_path, source_path, extensions, &info.file_path)
-                    && info.parent_id.is_none() {
+                    && info.parent_id.is_none()
+                {
                     let qualified_name = format!("{alias}.{name}");
                     import_table.insert(
                         (file_path.to_string(), qualified_name.clone()),
@@ -2777,7 +3117,17 @@ fn extract_python_import(
                 continue;
             }
 
-            resolve_import_name(original, local, module_name, file_path, &[".py"], symbol_table, entity_map, import_table, scopes);
+            resolve_import_name(
+                original,
+                local,
+                module_name,
+                file_path,
+                &[".py"],
+                symbol_table,
+                entity_map,
+                import_table,
+                scopes,
+            );
         }
     }
 }
@@ -2860,8 +3210,12 @@ fn collect_all_file_refs(
                         extract_call_ref(func, "", "", source, &mut refs, config, node_row);
                     }
                 }
-                CallNodeStyle::DirectMethod { object_field, method_field } => {
-                    let method_name = node.child_by_field_name(method_field)
+                CallNodeStyle::DirectMethod {
+                    object_field,
+                    method_field,
+                } => {
+                    let method_name = node
+                        .child_by_field_name(method_field)
                         .and_then(|n| n.utf8_text(source).ok())
                         .unwrap_or("");
                     if !method_name.is_empty() && !is_builtin(method_name, config) {
@@ -2869,7 +3223,10 @@ fn collect_all_file_refs(
                             let receiver = obj_node.utf8_text(source).unwrap_or("").to_string();
                             let receiver = receiver.trim_end_matches('.').to_string();
                             refs.push(AstRef {
-                                kind: AstRefKind::MethodCall { receiver, method: method_name.to_string() },
+                                kind: AstRefKind::MethodCall {
+                                    receiver,
+                                    method: method_name.to_string(),
+                                },
                                 row: node_row,
                             });
                         } else {
@@ -2953,6 +3310,15 @@ fn collect_all_file_refs(
     refs
 }
 
+fn build_refs_by_row(refs: &[AstRef]) -> Vec<Vec<usize>> {
+    let max_row = refs.iter().map(|r| r.row).max().unwrap_or(0);
+    let mut refs_by_row = vec![Vec::new(); max_row + 1];
+    for (idx, ast_ref) in refs.iter().enumerate() {
+        refs_by_row[ast_ref.row].push(idx);
+    }
+    refs_by_row
+}
+
 /// Extract a call reference from a function/callee node (shared across languages)
 fn extract_call_ref(
     func: tree_sitter::Node,
@@ -2965,7 +3331,10 @@ fn extract_call_ref(
 ) {
     let func_kind = func.kind();
 
-    if func_kind == "identifier" || func_kind == "simple_identifier" || func_kind == "type_identifier" {
+    if func_kind == "identifier"
+        || func_kind == "simple_identifier"
+        || func_kind == "type_identifier"
+    {
         let name = func.utf8_text(source).unwrap_or("");
         if !name.is_empty() && name != entity_name && !is_builtin(name, config) {
             refs.push(AstRef {
@@ -2991,8 +3360,7 @@ fn extract_call_ref(
         if parts.len() >= 2 {
             // Handle super:: and self:: prefixed paths by emitting a call
             // to the final name so scope chain resolution can find it.
-            let is_path_prefix =
-                parts[0] == "super" || parts[0] == "self" || parts[0] == "crate";
+            let is_path_prefix = parts[0] == "super" || parts[0] == "self" || parts[0] == "crate";
             let method_name = parts[parts.len() - 1];
             if is_path_prefix {
                 if !method_name.is_empty() && !is_builtin(method_name, config) {
@@ -3055,11 +3423,13 @@ fn extract_member_call_ref(
     // Fallback: positional children (Kotlin navigation_expression has no field names)
     let child_count = node.named_child_count();
     if child_count >= 2 {
-        let obj = node.named_child(0)
+        let obj = node
+            .named_child(0)
             .and_then(|n| n.utf8_text(source).ok())
             .unwrap_or("");
         let last_idx = (child_count - 1) as u32;
-        let attr = node.named_child(last_idx)
+        let attr = node
+            .named_child(last_idx)
             .and_then(|n| n.utf8_text(source).ok())
             .unwrap_or("");
         if !obj.is_empty() && !attr.is_empty() {
@@ -3091,15 +3461,16 @@ fn resolve_ref(
     file_path: &str,
     from_entity_id: &str,
     allow_cross_file_calls: bool,
+    lookup_cache: &mut ScopeLookupCache,
 ) -> Option<(String, RefType, &'static str)> {
     match &ast_ref.kind {
         AstRefKind::Call(name) => {
-            if is_local_binding_in_scopes(scope_idx, scopes, name) {
+            if is_local_binding_in_scopes_cached(scope_idx, scopes, name, lookup_cache) {
                 return None;
             }
 
             // 1. Walk scope chain for the name
-            if let Some(eid) = lookup_scope_chain(scope_idx, scopes, name) {
+            if let Some(eid) = lookup_scope_chain_cached(scope_idx, scopes, name, lookup_cache) {
                 if eid != from_entity_id {
                     return Some((eid, RefType::Calls, "scope_chain"));
                 }
@@ -3114,7 +3485,11 @@ fn resolve_ref(
             // 3. Global symbol table fallback (constructor calls or cross-file functions)
             if let Some(target_ids) = symbol_table.get(name.as_str()) {
                 let is_constructor = name.chars().next().map_or(false, |c| c.is_uppercase());
-                let ref_type = if is_constructor { RefType::TypeRef } else { RefType::Calls };
+                let ref_type = if is_constructor {
+                    RefType::TypeRef
+                } else {
+                    RefType::Calls
+                };
                 // Prefer same-file, then any
                 let target = target_ids
                     .iter()
@@ -3141,7 +3516,10 @@ fn resolve_ref(
             None
         }
 
-        AstRefKind::MethodCall { receiver: raw_receiver, method } => {
+        AstRefKind::MethodCall {
+            receiver: raw_receiver,
+            method,
+        } => {
             // Strip prefix operators like ! (Swift: `!dog.validate()`)
             let receiver = raw_receiver.trim_start_matches('!').trim_start_matches('~');
             if receiver == "self" || receiver == "this" {
@@ -3166,8 +3544,9 @@ fn resolve_ref(
             // receiver is "self.X" where X is an instance attribute
             if receiver.starts_with("self.") || receiver.starts_with("this.") {
                 let attr_name = &receiver[5..]; // strip "self." or "this."
-                // Find the enclosing class name
-                let class_name = find_enclosing_class(scope_idx, scopes, entity_map);
+                                                // Find the enclosing class name
+                let class_name =
+                    find_enclosing_class_cached(scope_idx, scopes, entity_map, lookup_cache);
                 if let Some(cn) = class_name {
                     // Look up instance attribute type
                     if let Some(attr_type) = instance_attr_types.get(&(cn, attr_name.to_string())) {
@@ -3181,12 +3560,19 @@ fn resolve_ref(
             }
 
             // Handle chained var.field.method() pattern (e.g. Go receiver: t.Conn.Execute())
-            if receiver.contains('.') && !receiver.starts_with("self.") && !receiver.starts_with("this.") {
+            if receiver.contains('.')
+                && !receiver.starts_with("self.")
+                && !receiver.starts_with("this.")
+            {
                 if let Some(dot_pos) = receiver.find('.') {
                     let var_part = &receiver[..dot_pos];
                     let field_part = &receiver[dot_pos + 1..];
-                    if let Some(var_type) = lookup_type_in_scopes(scope_idx, scopes, var_part) {
-                        if let Some(attr_type) = instance_attr_types.get(&(var_type, field_part.to_string())) {
+                    if let Some(var_type) =
+                        lookup_type_in_scopes_cached(scope_idx, scopes, var_part, lookup_cache)
+                    {
+                        if let Some(attr_type) =
+                            instance_attr_types.get(&(var_type, field_part.to_string()))
+                        {
                             if let Some(members) = class_members.get(attr_type.as_str()) {
                                 if let Some((_, mid)) = members.iter().find(|(n, _)| n == method) {
                                     return Some((mid.clone(), RefType::Calls, "type_tracking"));
@@ -3198,7 +3584,8 @@ fn resolve_ref(
             }
 
             // receiver.method() -> look up receiver type, then resolve method
-            let receiver_type = lookup_type_in_scopes(scope_idx, scopes, receiver);
+            let receiver_type =
+                lookup_type_in_scopes_cached(scope_idx, scopes, receiver, lookup_cache);
 
             if let Some(class_name) = receiver_type {
                 if let Some(members) = class_members.get(class_name.as_str()) {
@@ -3210,8 +3597,10 @@ fn resolve_ref(
 
             // ClassName.method() static call, only when ClassName is visible and
             // not shadowed by a local binding.
-            if !is_local_binding_in_scopes(scope_idx, scopes, receiver) {
-                if let Some(class_id) = lookup_scope_chain(scope_idx, scopes, receiver) {
+            if !is_local_binding_in_scopes_cached(scope_idx, scopes, receiver, lookup_cache) {
+                if let Some(class_id) =
+                    lookup_scope_chain_cached(scope_idx, scopes, receiver, lookup_cache)
+                {
                     if let Some(info) = entity_map.get(&class_id) {
                         if matches!(info.entity_type.as_str(), "class" | "struct" | "interface")
                             && info.name == receiver
@@ -3227,20 +3616,14 @@ fn resolve_ref(
             }
 
             // Fallback: check import table for the receiver
-            if !is_local_binding_in_scopes(scope_idx, scopes, receiver) {
+            if !is_local_binding_in_scopes_cached(scope_idx, scopes, receiver, lookup_cache) {
                 let key = (file_path.to_string(), receiver.to_string());
                 if let Some(target_id) = import_table.get(&key) {
                     if let Some(info) = entity_map.get(target_id) {
                         if matches!(info.entity_type.as_str(), "class" | "struct") {
                             if let Some(members) = class_members.get(&info.name) {
-                                if let Some((_, mid)) =
-                                    members.iter().find(|(n, _)| n == method)
-                                {
-                                    return Some((
-                                        mid.clone(),
-                                        RefType::Calls,
-                                        "type_tracking",
-                                    ));
+                                if let Some((_, mid)) = members.iter().find(|(n, _)| n == method) {
+                                    return Some((mid.clone(), RefType::Calls, "type_tracking"));
                                 }
                             }
                         }
@@ -3288,12 +3671,22 @@ fn find_enclosing_class(
     }
 }
 
-/// Walk up the scope chain looking for a definition.
-fn lookup_scope_chain(
+fn find_enclosing_class_cached(
     start_scope: usize,
     scopes: &[Scope],
-    name: &str,
+    entity_map: &HashMap<String, EntityInfo>,
+    cache: &mut ScopeLookupCache,
 ) -> Option<String> {
+    if let Some(cached) = cache.enclosing_classes.get(&start_scope) {
+        return cached.clone();
+    }
+    let value = find_enclosing_class(start_scope, scopes, entity_map);
+    cache.enclosing_classes.insert(start_scope, value.clone());
+    value
+}
+
+/// Walk up the scope chain looking for a definition.
+fn lookup_scope_chain(start_scope: usize, scopes: &[Scope], name: &str) -> Option<String> {
     let mut idx = start_scope;
     loop {
         if let Some(eid) = scopes[idx].defs.get(name) {
@@ -3306,12 +3699,23 @@ fn lookup_scope_chain(
     }
 }
 
-/// Walk up the scope chain looking for a local binding that shadows a definition.
-fn is_local_binding_in_scopes(
+fn lookup_scope_chain_cached(
     start_scope: usize,
     scopes: &[Scope],
     name: &str,
-) -> bool {
+    cache: &mut ScopeLookupCache,
+) -> Option<String> {
+    let key = (start_scope, name.to_string());
+    if let Some(cached) = cache.defs.get(&key) {
+        return cached.clone();
+    }
+    let value = lookup_scope_chain(start_scope, scopes, name);
+    cache.defs.insert(key, value.clone());
+    value
+}
+
+/// Walk up the scope chain looking for a local binding that shadows a definition.
+fn is_local_binding_in_scopes(start_scope: usize, scopes: &[Scope], name: &str) -> bool {
     let mut idx = start_scope;
     loop {
         if scopes[idx].bindings.contains(name) {
@@ -3324,12 +3728,23 @@ fn is_local_binding_in_scopes(
     }
 }
 
-/// Walk up the scope chain looking for a type binding.
-fn lookup_type_in_scopes(
+fn is_local_binding_in_scopes_cached(
     start_scope: usize,
     scopes: &[Scope],
-    var_name: &str,
-) -> Option<String> {
+    name: &str,
+    cache: &mut ScopeLookupCache,
+) -> bool {
+    let key = (start_scope, name.to_string());
+    if let Some(cached) = cache.local_bindings.get(&key) {
+        return *cached;
+    }
+    let value = is_local_binding_in_scopes(start_scope, scopes, name);
+    cache.local_bindings.insert(key, value);
+    value
+}
+
+/// Walk up the scope chain looking for a type binding.
+fn lookup_type_in_scopes(start_scope: usize, scopes: &[Scope], var_name: &str) -> Option<String> {
     let mut idx = start_scope;
     loop {
         if let Some(type_name) = scopes[idx].types.get(var_name) {
@@ -3342,9 +3757,27 @@ fn lookup_type_in_scopes(
     }
 }
 
+fn lookup_type_in_scopes_cached(
+    start_scope: usize,
+    scopes: &[Scope],
+    var_name: &str,
+    cache: &mut ScopeLookupCache,
+) -> Option<String> {
+    let key = (start_scope, var_name.to_string());
+    if let Some(cached) = cache.types.get(&key) {
+        return cached.clone();
+    }
+    let value = lookup_type_in_scopes(start_scope, scopes, var_name);
+    cache.types.insert(key, value.clone());
+    value
+}
+
 fn is_builtin(name: &str, config: &ScopeResolveConfig) -> bool {
     // Common builtins across languages
-    if matches!(name, "None" | "True" | "False" | "null" | "undefined" | "nil") {
+    if matches!(
+        name,
+        "None" | "True" | "False" | "null" | "undefined" | "nil"
+    ) {
         return true;
     }
     config.builtins.contains(&name)


### PR DESCRIPTION
Fixes #252

## Summary
- Add file-level reference indexes so fallback graph resolution scans stripped source once per file instead of once per nested entity body.
- Bucket scope-aware AST refs by row and cache scope-chain lookups during resolution.
- Exclude nested child entity ranges from fallback scans to avoid repeated ancestor processing on deeply nested TypeScript.
- Preserve line positions through multiline comments/strings and add regression coverage for scope fallback refs.

## Test Plan
- cargo check -p sem-core
- cargo test -p sem-core parser::graph::tests -- --nocapture
- cargo test -p sem-core --test graph_accuracy -- --nocapture
- cargo test -p sem-core scope_resolve_typescript -- --nocapture
- cargo test -p sem-core scope_resolve_integrated_graph -- --nocapture
- cargo build --release -p sem-cli
- Dummy git repos under /tmp/sem-issue-252-validation: sem graph deep.ts at depths 100/200/400/800 completed in 0.667s / 0.072s / 0.223s / 0.803s
- On the 800-depth dummy repo: sem impact root --file deep.ts --json completed in 0.108s; sem context root --file deep.ts --budget 1000 --json completed in 0.097s

## Notes
- Existing warnings in sem-core/tests/scope_resolve_bench.rs remain unrelated to this change.