### PR TITLE
Consolidate graph and scope resolution

### DIFF
--- a/crates/sem-core/src/parser/differ.rs
+++ b/crates/sem-core/src/parser/differ.rs
@@ -243,6 +243,7 @@ fn suppress_redundant_parents(
         "module",
         "class",
         "interface",
+        "protocol",
         "mixin",
         "extension",
         "namespace",
@@ -787,6 +788,74 @@ mod tests {
                 .iter()
                 .any(|c| c.entity_name == "UserService" && c.change_type == ChangeType::Modified),
             "class should be suppressed when only the method body changed, got: {names:?}"
+        );
+    }
+
+    #[test]
+    fn test_protocol_parent_suppressed_when_only_associatedtype_renamed() {
+        let before = "protocol Repository {\n    associatedtype Item\n}\n";
+        let after = "protocol Repository {\n    associatedtype Canvas\n}\n";
+
+        let registry = create_default_registry();
+        let result = compute_semantic_diff(
+            &[modified_file("Repository.swift", before, after)],
+            &registry,
+            None,
+            None,
+        );
+
+        let names: Vec<&str> = result
+            .changes
+            .iter()
+            .map(|c| c.entity_name.as_str())
+            .collect();
+        assert!(
+            result
+                .changes
+                .iter()
+                .any(|c| c.entity_type == "associatedtype"),
+            "expected associatedtype change, got: {names:?}"
+        );
+        assert!(
+            !result
+                .changes
+                .iter()
+                .any(|c| c.entity_name == "Repository" && c.change_type == ChangeType::Modified),
+            "protocol should be suppressed when only the associatedtype changed, got: {names:?}"
+        );
+    }
+
+    #[test]
+    fn test_protocol_parent_not_suppressed_when_own_declaration_changes() {
+        let before = "protocol Repository {\n    associatedtype Item\n}\n";
+        let after = "protocol Repository: Sendable {\n    associatedtype Canvas\n}\n";
+
+        let registry = create_default_registry();
+        let result = compute_semantic_diff(
+            &[modified_file("Repository.swift", before, after)],
+            &registry,
+            None,
+            None,
+        );
+
+        let names: Vec<&str> = result
+            .changes
+            .iter()
+            .map(|c| c.entity_name.as_str())
+            .collect();
+        assert!(
+            result
+                .changes
+                .iter()
+                .any(|c| c.entity_type == "associatedtype"),
+            "expected associatedtype change, got: {names:?}"
+        );
+        assert!(
+            result
+                .changes
+                .iter()
+                .any(|c| c.entity_name == "Repository" && c.change_type == ChangeType::Modified),
+            "protocol should remain Modified when its own declaration changed, got: {names:?}"
         );
     }
 

--- a/crates/sem-core/src/parser/graph.rs
+++ b/crates/sem-core/src/parser/graph.rs
@@ -52,6 +52,9 @@ fn build_scope_consumed_words(
 
 fn add_scope_reference_words(words: &mut HashSet<String>, reference: &str) {
     let reference = reference.strip_suffix("()").unwrap_or(reference);
+    let reference = reference
+        .split_once('(')
+        .map_or(reference, |(name, _)| name);
     if let Some((receiver, member)) = reference.rsplit_once('.') {
         if !receiver.is_empty() {
             words.insert(receiver.to_string());
@@ -59,9 +62,236 @@ fn add_scope_reference_words(words: &mut HashSet<String>, reference: &str) {
         if !member.is_empty() {
             words.insert(member.to_string());
         }
+    } else if reference.contains("::") {
+        for part in reference.split("::").filter(|part| !part.is_empty()) {
+            words.insert(part.to_string());
+        }
     } else if !reference.is_empty() {
         words.insert(reference.to_string());
     }
+}
+
+#[derive(Clone, Copy)]
+struct ChildRange<'a> {
+    file_path: &'a str,
+    start_line: usize,
+    end_line: usize,
+    start_byte: Option<usize>,
+    end_byte: Option<usize>,
+}
+
+fn build_child_ranges_by_parent<'a>(
+    entities: &'a [SemanticEntity],
+) -> HashMap<&'a str, Vec<ChildRange<'a>>> {
+    let entity_by_id: HashMap<&str, &SemanticEntity> = entities
+        .iter()
+        .map(|entity| (entity.id.as_str(), entity))
+        .collect();
+    let mut line_starts_by_parent: HashMap<&'a str, Vec<usize>> = HashMap::new();
+    let mut child_ranges_by_parent: HashMap<&'a str, Vec<ChildRange<'a>>> = HashMap::new();
+
+    for child in entities {
+        let Some(parent_id) = child.parent_id.as_deref() else {
+            continue;
+        };
+        let (start_byte, end_byte) = entity_by_id
+            .get(parent_id)
+            .and_then(|parent| {
+                let parent_line_starts = line_starts_by_parent
+                    .entry(parent_id)
+                    .or_insert_with(|| line_start_offsets(&parent.content));
+                child_content_span_in_parent(parent, child, parent_line_starts)
+            })
+            .map_or((None, None), |(start, end)| (Some(start), Some(end)));
+
+        child_ranges_by_parent
+            .entry(parent_id)
+            .or_default()
+            .push(ChildRange {
+                file_path: child.file_path.as_str(),
+                start_line: child.start_line,
+                end_line: child.end_line,
+                start_byte,
+                end_byte,
+            });
+    }
+
+    for child_ranges in child_ranges_by_parent.values_mut() {
+        child_ranges.sort_unstable_by(|left, right| {
+            match (left.start_byte, right.start_byte) {
+                (Some(left_start), Some(right_start)) => left_start.cmp(&right_start),
+                (Some(_), None) => std::cmp::Ordering::Less,
+                (None, Some(_)) => std::cmp::Ordering::Greater,
+                (None, None) => std::cmp::Ordering::Equal,
+            }
+            .then_with(|| left.end_byte.cmp(&right.end_byte))
+            .then_with(|| left.file_path.cmp(right.file_path))
+            .then_with(|| left.start_line.cmp(&right.start_line))
+            .then_with(|| left.end_line.cmp(&right.end_line))
+        });
+    }
+
+    child_ranges_by_parent
+}
+
+fn child_content_span_in_parent(
+    parent: &SemanticEntity,
+    child: &SemanticEntity,
+    parent_line_starts: &[usize],
+) -> Option<(usize, usize)> {
+    if parent.file_path != child.file_path || child.content.is_empty() {
+        return None;
+    }
+
+    let expected_local_line = child.start_line.checked_sub(parent.start_line)? + 1;
+    if let Some(span) = child_content_span_at_expected_line(
+        &parent.content,
+        &child.content,
+        expected_local_line,
+        parent_line_starts,
+    ) {
+        return Some(span);
+    }
+
+    for (offset, _) in parent.content.match_indices(&child.content) {
+        let local_line = line_for_byte(&parent.content, offset);
+        if local_line == expected_local_line {
+            return Some((offset, offset + child.content.len()));
+        }
+    }
+
+    None
+}
+
+fn child_content_span_at_expected_line(
+    parent_content: &str,
+    child_content: &str,
+    expected_local_line: usize,
+    parent_line_starts: &[usize],
+) -> Option<(usize, usize)> {
+    let line_start = *parent_line_starts.get(expected_local_line.checked_sub(1)?)?;
+    if let Some(span) = content_span_at(parent_content, child_content, line_start) {
+        return Some(span);
+    }
+
+    let line_end = parent_line_starts
+        .get(expected_local_line)
+        .copied()
+        .map(|next_line_start| next_line_start.saturating_sub(1))
+        .unwrap_or(parent_content.len());
+    let line = parent_content.get(line_start..line_end)?;
+
+    let trimmed_line_start = line_start + line.len().saturating_sub(line.trim_start().len());
+    if trimmed_line_start != line_start {
+        if let Some(span) = content_span_at(parent_content, child_content, trimmed_line_start) {
+            return Some(span);
+        }
+    }
+
+    let first_child_line = child_content
+        .split_once('\n')
+        .map_or(child_content, |(line, _)| line);
+    if first_child_line.is_empty() {
+        return None;
+    }
+
+    for (candidate_offset, _) in line.match_indices(first_child_line) {
+        if let Some(span) =
+            content_span_at(parent_content, child_content, line_start + candidate_offset)
+        {
+            return Some(span);
+        }
+    }
+
+    None
+}
+
+fn content_span_at(content: &str, needle: &str, start: usize) -> Option<(usize, usize)> {
+    let end = start.checked_add(needle.len())?;
+    (content.get(start..end) == Some(needle)).then_some((start, end))
+}
+
+fn entity_owns_content_span(
+    entity_id: &str,
+    file_path: &str,
+    source_line: usize,
+    local_start_byte: Option<usize>,
+    local_end_byte: Option<usize>,
+    child_ranges_by_parent: &HashMap<&str, Vec<ChildRange<'_>>>,
+) -> bool {
+    let Some(child_ranges) = child_ranges_by_parent.get(entity_id) else {
+        return true;
+    };
+
+    let child_has_source_line = |child: &ChildRange<'_>| {
+        child.file_path == file_path
+            && source_line >= child.start_line
+            && source_line <= child.end_line
+    };
+
+    let first_without_byte = child_ranges.partition_point(|child| child.start_byte.is_some());
+    if let (Some(start), Some(end)) = (local_start_byte, local_end_byte) {
+        let byte_ranges = &child_ranges[..first_without_byte];
+        let possible_end = byte_ranges.partition_point(|child| {
+            child
+                .start_byte
+                .is_some_and(|child_start| child_start < end)
+        });
+        for child in byte_ranges[..possible_end].iter().rev() {
+            let (Some(child_start), Some(child_end)) = (child.start_byte, child.end_byte) else {
+                continue;
+            };
+            if child_end <= start {
+                break;
+            }
+            if start < child_end && end > child_start && child_has_source_line(child) {
+                return false;
+            }
+        }
+    } else if child_ranges.iter().any(child_has_source_line) {
+        return false;
+    }
+
+    !child_ranges[first_without_byte..]
+        .iter()
+        .any(child_has_source_line)
+}
+
+fn source_line_for_entity_content(entity: &SemanticEntity, local_line: usize) -> usize {
+    entity.start_line + local_line.saturating_sub(1)
+}
+
+fn entity_requires_content_span_filter(
+    entity: &SemanticEntity,
+    child_ranges_by_parent: &HashMap<&str, Vec<ChildRange<'_>>>,
+) -> bool {
+    entity.start_line == entity.end_line
+        || child_ranges_by_parent
+            .get(entity.id.as_str())
+            .map_or(false, |children| {
+                children.iter().any(|child| {
+                    child.start_line == child.end_line
+                        || child.start_line == entity.start_line
+                        || child.end_line == entity.end_line
+                })
+            })
+}
+
+fn line_for_byte(content: &str, byte: usize) -> usize {
+    1 + content[..byte]
+        .bytes()
+        .filter(|current| *current == b'\n')
+        .count()
+}
+
+fn line_start_offsets(content: &str) -> Vec<usize> {
+    let mut starts = vec![0];
+    for (idx, byte) in content.bytes().enumerate() {
+        if byte == b'\n' {
+            starts.push(idx + 1);
+        }
+    }
+    starts
 }
 
 /// A reference from one entity to another.
@@ -116,6 +346,273 @@ pub struct EntityInfo {
     pub parent_id: Option<String>,
     pub start_line: usize,
     pub end_line: usize,
+}
+
+#[derive(Debug)]
+struct LineReferenceIndex {
+    words: Vec<String>,
+    dot_chains: Vec<(String, String)>,
+    call_words: HashSet<String>,
+    import_words: HashSet<String>,
+}
+
+#[derive(Debug)]
+struct FileReferenceIndex {
+    lines: Vec<LineReferenceIndex>,
+}
+
+impl FileReferenceIndex {
+    fn from_content(content: &str) -> Self {
+        let stripped = strip_comments_and_strings(content);
+        let lines = stripped
+            .lines()
+            .map(LineReferenceIndex::from_stripped_line)
+            .collect();
+        Self { lines }
+    }
+
+    fn dot_chains_in_ranges(&self, ranges: &[(usize, usize)]) -> Vec<(&str, &str)> {
+        let mut chains = Vec::new();
+        let mut seen: HashSet<(&str, &str)> = HashSet::new();
+        for &(start_line, end_line) in ranges {
+            for line in self.line_range(start_line, end_line) {
+                for (receiver, member) in &line.dot_chains {
+                    let pair = (receiver.as_str(), member.as_str());
+                    if seen.insert(pair) {
+                        chains.push(pair);
+                    }
+                }
+            }
+        }
+        chains
+    }
+
+    fn refs_with_types_in_ranges(
+        &self,
+        ranges: &[(usize, usize)],
+        own_name: &str,
+    ) -> Vec<(&str, RefType)> {
+        let mut refs = Vec::new();
+        let mut seen: HashMap<&str, (bool, bool)> = HashMap::new();
+        for &(start_line, end_line) in ranges {
+            for line in self.line_range(start_line, end_line) {
+                for word in &line.words {
+                    let word = word.as_str();
+                    if word == own_name {
+                        continue;
+                    }
+                    let first_seen = !seen.contains_key(word);
+                    let flags = seen.entry(word).or_insert((false, false));
+                    flags.0 |= line.call_words.contains(word);
+                    flags.1 |= line.import_words.contains(word);
+                    if first_seen {
+                        refs.push(word);
+                    }
+                }
+            }
+        }
+        refs.into_iter()
+            .map(|word| {
+                let (has_call, has_import) = seen.get(word).copied().unwrap_or_default();
+                let ref_type = if has_call {
+                    RefType::Calls
+                } else if has_import {
+                    RefType::Imports
+                } else {
+                    RefType::TypeRef
+                    };
+                (word, ref_type)
+            })
+            .collect()
+    }
+
+    fn line_range(
+        &self,
+        start_line: usize,
+        end_line: usize,
+    ) -> impl Iterator<Item = &LineReferenceIndex> {
+        let start = start_line.saturating_sub(1).min(self.lines.len());
+        let end = end_line.min(self.lines.len()).max(start);
+        self.lines[start..end].iter()
+    }
+}
+
+impl LineReferenceIndex {
+    fn from_stripped_line(line: &str) -> Self {
+        let mut words = Vec::new();
+        let mut seen_words = HashSet::new();
+        let mut call_words = HashSet::new();
+        let mut import_words = HashSet::new();
+        let import_like = {
+            let trimmed = line.trim();
+            trimmed.starts_with("import ")
+                || trimmed.starts_with("use ")
+                || trimmed.starts_with("from ")
+                || trimmed.starts_with("require(")
+        };
+
+        for (word, end_byte) in identifier_tokens(line) {
+            if !is_reference_word(word) {
+                continue;
+            }
+            if seen_words.insert(word) {
+                words.push(word.to_string());
+            }
+            if line.as_bytes().get(end_byte) == Some(&b'(') {
+                call_words.insert(word.to_string());
+            }
+            if import_like {
+                import_words.insert(word.to_string());
+            }
+        }
+
+        let dot_chains = extract_dot_chains(line)
+            .into_iter()
+            .map(|(receiver, member)| (receiver.to_string(), member.to_string()))
+            .collect();
+
+        Self {
+            words,
+            dot_chains,
+            call_words,
+            import_words,
+        }
+    }
+}
+
+fn build_reference_indexes(
+    root: &Path,
+    file_paths: &[String],
+    parsed_files: &[(String, String, tree_sitter::Tree)],
+) -> HashMap<String, FileReferenceIndex> {
+    let parsed_content: HashMap<&str, &str> = parsed_files
+        .iter()
+        .map(|(file_path, content, _)| (file_path.as_str(), content.as_str()))
+        .collect();
+
+    maybe_par_iter!(file_paths)
+        .filter_map(|file_path| {
+            let ext = file_path.rfind('.').map(|i| &file_path[i..]).unwrap_or("");
+            crate::parser::plugins::code::languages::get_language_config(ext)?;
+
+            if let Some(content) = parsed_content.get(file_path.as_str()) {
+                return Some((file_path.clone(), FileReferenceIndex::from_content(content)));
+            }
+
+            let content = std::fs::read_to_string(root.join(file_path)).ok()?;
+            Some((
+                file_path.clone(),
+                FileReferenceIndex::from_content(&content),
+            ))
+        })
+        .collect()
+}
+
+fn identifier_tokens(line: &str) -> impl Iterator<Item = (&str, usize)> {
+    let mut start = None;
+    let mut chars = line.char_indices();
+
+    std::iter::from_fn(move || {
+        for (idx, ch) in chars.by_ref() {
+            if ch.is_alphanumeric() || ch == '_' {
+                if start.is_none() {
+                    start = Some(idx);
+                }
+            } else if let Some(token_start) = start.take() {
+                return Some((&line[token_start..idx], idx));
+            }
+        }
+
+        start
+            .take()
+            .map(|token_start| (&line[token_start..], line.len()))
+    })
+}
+
+fn is_reference_word(word: &str) -> bool {
+    if word.is_empty() {
+        return false;
+    }
+    if is_keyword(word) || word.len() < 2 {
+        return false;
+    }
+    if word.starts_with(|c: char| c.is_lowercase()) && word.len() < 3 {
+        return false;
+    }
+    if !word.starts_with(|c: char| c.is_alphabetic() || c == '_') {
+        return false;
+    }
+    if is_common_local_name(word) {
+        return false;
+    }
+    true
+}
+
+fn is_function_like_entity_type(entity_type: &str) -> bool {
+    matches!(
+        entity_type,
+        "function" | "method" | "constructor" | "getter" | "setter"
+    )
+}
+
+fn fallback_reference_end_line(entity: &SemanticEntity, has_scope_resolve: bool) -> usize {
+    if !has_scope_resolve || is_function_like_entity_type(&entity.entity_type) {
+        return entity.end_line;
+    }
+
+    let mut prefix_lines = 0usize;
+    for line in entity.content.lines() {
+        prefix_lines += 1;
+        let trimmed = line.trim_end();
+        if line.contains('{') || trimmed.ends_with(':') || trimmed.ends_with(';') {
+            break;
+        }
+        if prefix_lines >= 16 {
+            break;
+        }
+    }
+
+    (entity.start_line + prefix_lines.saturating_sub(1))
+        .min(entity.end_line)
+        .max(entity.start_line)
+}
+
+fn direct_reference_line_ranges(
+    entity: &SemanticEntity,
+    fallback_end_line: usize,
+    child_line_ranges: &HashMap<String, Vec<(usize, usize)>>,
+) -> Vec<(usize, usize)> {
+    let start_line = entity.start_line;
+    let end_line = fallback_end_line.min(entity.end_line).max(start_line);
+    let mut ranges = Vec::new();
+    let mut next_line = start_line;
+
+    if let Some(children) = child_line_ranges.get(&entity.id) {
+        for &(child_start, child_end) in children {
+            if child_end < next_line {
+                continue;
+            }
+            if child_start > end_line {
+                break;
+            }
+
+            let child_start = child_start.max(start_line);
+            let child_end = child_end.min(end_line);
+            if next_line < child_start {
+                ranges.push((next_line, child_start - 1));
+            }
+            next_line = next_line.max(child_end.saturating_add(1));
+            if next_line > end_line {
+                break;
+            }
+        }
+    }
+
+    if next_line <= end_line {
+        ranges.push((next_line, end_line));
+    }
+
+    ranges
 }
 
 impl EntityGraph {
@@ -183,7 +680,9 @@ impl EntityGraph {
         let mut entity_map: HashMap<String, EntityInfo> =
             HashMap::with_capacity(all_entities.len());
         let mut parent_child_pairs: HashSet<(&str, &str)> = HashSet::new();
+        let mut child_line_ranges: HashMap<String, Vec<(usize, usize)>> = HashMap::new();
         let mut class_child_names: HashSet<(&str, &str)> = HashSet::new();
+        let child_ranges_by_parent = build_child_ranges_by_parent(&all_entities);
         let mut class_entity_names: HashSet<&str> = HashSet::new();
         let mut class_entity_files: HashSet<(&str, &str)> = HashSet::new();
         let mut id_to_name: HashMap<&str, &str> = HashMap::with_capacity(all_entities.len());
@@ -210,13 +709,14 @@ impl EntityGraph {
 
             if let Some(ref pid) = entity.parent_id {
                 parent_child_pairs.insert((pid.as_str(), entity.id.as_str()));
+                child_line_ranges
+                    .entry(pid.clone())
+                    .or_default()
+                    .push((entity.start_line, entity.end_line));
                 class_child_names.insert((pid.as_str(), entity.name.as_str()));
             }
 
-            if matches!(
-                entity.entity_type.as_str(),
-                "class" | "struct" | "interface" | "class_type"
-            ) {
+            if is_nominal_member_container(entity.entity_type.as_str()) {
                 class_entity_names.insert(entity.name.as_str());
                 class_entity_files.insert((entity.name.as_str(), entity.file_path.as_str()));
             }
@@ -227,6 +727,9 @@ impl EntityGraph {
                 .entry(entity.file_path.clone())
                 .or_default()
                 .push((entity.start_line, entity.end_line, entity.id.clone()));
+        }
+        for ranges in child_line_ranges.values_mut() {
+            ranges.sort_unstable_by_key(|(start, end)| (*start, *end));
         }
 
         // Pass B: Build enclosing_class, class_members, and scope_class_members
@@ -248,12 +751,9 @@ impl EntityGraph {
                 }
                 // scope_class_members for scope resolver (checks entity_type of parent)
                 if let Some(parent) = entity_map.get(pid.as_str()) {
-                    if matches!(
-                        parent.entity_type.as_str(),
-                        "class" | "struct" | "interface" | "impl"
-                    ) {
+                    if let Some(owner_name) = scope_resolve::class_member_owner_name(parent) {
                         scope_class_members
-                            .entry(parent.name.clone())
+                            .entry(owner_name.to_string())
                             .or_default()
                             .push((entity.name.clone(), entity.id.clone()));
                     }
@@ -329,6 +829,8 @@ impl EntityGraph {
             go_pkg_index: owned_go_pkg_index,
         };
 
+        let reference_indexes = build_reference_indexes(root, file_paths, &parsed_files);
+
         // Run scope-aware resolver for supported languages (reuse pre-parsed trees)
         let has_scope_lang = file_paths.iter().any(|f| {
             let ext = f.rfind('.').map(|i| &f[i..]).unwrap_or("");
@@ -350,7 +852,6 @@ impl EntityGraph {
         } else {
             (vec![], HashMap::new())
         };
-
         // Pass 2: Extract references in parallel, then resolve against symbol table
         // Phase 1: Dot-chain resolution (precise self.X, this.X, ClassName.X)
         // Phase 2: Bag-of-words resolution (existing logic, skipping consumed words)
@@ -365,9 +866,15 @@ impl EntityGraph {
                     .rfind('.')
                     .map(|i| &entity.file_path[i..])
                     .unwrap_or("");
-                if crate::parser::plugins::code::languages::get_language_config(ext).is_none() {
+                let Some(language_config) =
+                    crate::parser::plugins::code::languages::get_language_config(ext)
+                else {
                     return vec![];
-                }
+                    };
+                let fallback_end_line =
+                    fallback_reference_end_line(entity, language_config.scope_resolve.is_some());
+                let fallback_ranges =
+                    direct_reference_line_ranges(entity, fallback_end_line, &child_line_ranges);
 
                 let mut entity_edges = Vec::new();
                 let mut consumed_words = scope_consumed_words
@@ -375,13 +882,63 @@ impl EntityGraph {
                     .cloned()
                     .unwrap_or_default();
 
-                // Strip comments/strings once, reuse for both dot-chain and bag-of-words
-                let stripped = strip_comments_and_strings(&entity.content);
+                let reference_index =
+                    if entity_requires_content_span_filter(entity, &child_ranges_by_parent) {
+                        None
+                    } else {
+                        reference_indexes.get(entity.file_path.as_str())
+                    };
+                let fallback_stripped = if reference_index.is_none() {
+                    Some(strip_comments_and_strings(&entity.content))
+                } else {
+                    None
+                };
+                let local_bindings =
+                    local_binding_names_filtered(&entity.content, ext, |local_line, start, end| {
+                        entity_owns_content_span(
+                            entity.id.as_str(),
+                            entity.file_path.as_str(),
+                            source_line_for_entity_content(entity, local_line),
+                            Some(start),
+                            Some(end),
+                            &child_ranges_by_parent,
+                        )
+                    });
 
                 // Phase 1: Dot-chain resolution
-                let dot_chains = extract_dot_chains(&stripped);
+                let dot_chains: Vec<(&str, &str, Option<(usize, usize, usize)>)> =
+                    match reference_index {
+                        Some(index) => index
+                            .dot_chains_in_ranges(&fallback_ranges)
+                            .into_iter()
+                            .map(|(receiver, member)| (receiver, member, None))
+                            .collect(),
+                        None => {
+                            extract_dot_chains_with_positions(fallback_stripped.as_ref().unwrap())
+                                .into_iter()
+                                .map(|(receiver, member, line, start, end)| {
+                                    (receiver, member, Some((line, start, end)))
+                                })
+                                .collect()
+                        }
+                };
 
-                for (receiver, member) in &dot_chains {
+                for (receiver, member, position) in &dot_chains {
+                    if consumed_words.contains(*member) {
+                        continue;
+                    }
+                    if let Some((local_line, local_start_byte, local_end_byte)) = *position {
+                        if !entity_owns_content_span(
+                            entity.id.as_str(),
+                            entity.file_path.as_str(),
+                            source_line_for_entity_content(entity, local_line),
+                            Some(local_start_byte),
+                            Some(local_end_byte),
+                            &child_ranges_by_parent,
+                        ) {
+                            continue;
+                        }
+                    }
                     let edge_count_before = entity_edges.len();
                     if *receiver == "self" || *receiver == "this" {
                         // self.B / this.B: resolve to sibling method in enclosing class
@@ -423,11 +980,35 @@ impl EntityGraph {
                 }
 
                 // Phase 2: Bag-of-words resolution (skip words consumed by dot-chains)
-                // Reuse the stripped content to avoid stripping twice
-                let refs =
-                    extract_references_with_stripped(&entity.content, &entity.name, &stripped);
-                for ref_name in refs {
+                let refs: Vec<(&str, RefType)> = match reference_index {
+                    Some(index) => index.refs_with_types_in_ranges(&fallback_ranges, &entity.name),
+                    None => {
+                        let stripped = fallback_stripped.as_ref().unwrap();
+                        extract_references_with_stripped_filtered(
+                            &entity.content,
+                            &entity.name,
+                            stripped,
+                            |local_line, local_start_byte, local_end_byte| {
+                                entity_owns_content_span(
+                                    entity.id.as_str(),
+                                    entity.file_path.as_str(),
+                                    source_line_for_entity_content(entity, local_line),
+                                    Some(local_start_byte),
+                                    Some(local_end_byte),
+                                    &child_ranges_by_parent,
+                                )
+                            },
+                        )
+                        .into_iter()
+                        .map(|ref_name| (ref_name, infer_ref_type(&entity.content, ref_name)))
+                        .collect()
+                    }
+                };
+                for (ref_name, ref_type) in refs {
                     if consumed_words.contains(ref_name) {
+                        continue;
+                    }
+                    if local_bindings.contains(ref_name) {
                         continue;
                     }
 
@@ -446,7 +1027,6 @@ impl EntityGraph {
                             && !parent_child_pairs
                                 .contains(&(import_target_id.as_str(), entity.id.as_str()))
                         {
-                            let ref_type = infer_ref_type(&entity.content, &ref_name);
                             entity_edges.push((
                                 entity.id.clone(),
                                 import_target_id.clone(),
@@ -475,7 +1055,6 @@ impl EntityGraph {
                             {
                                 continue;
                             }
-                            let ref_type = infer_ref_type(&entity.content, &ref_name);
                             entity_edges.push((entity.id.clone(), target_id.clone(), ref_type));
                         }
                     }
@@ -936,6 +1515,18 @@ impl EntityGraph {
                     .map(|pid| (pid.as_str(), e.id.as_str()))
             })
             .collect();
+        let mut child_line_ranges: HashMap<String, Vec<(usize, usize)>> = HashMap::new();
+        for entity in &all_entities {
+            if let Some(pid) = &entity.parent_id {
+                child_line_ranges
+                    .entry(pid.clone())
+                    .or_default()
+                    .push((entity.start_line, entity.end_line));
+            }
+        }
+        for ranges in child_line_ranges.values_mut() {
+            ranges.sort_unstable_by_key(|(start, end)| (*start, *end));
+        }
 
         let class_child_names: HashSet<(&str, &str)> = all_entities
             .iter()
@@ -946,24 +1537,16 @@ impl EntityGraph {
             })
             .collect();
 
+        let child_ranges_by_parent = build_child_ranges_by_parent(&all_entities);
+
         let class_entity_names: HashSet<&str> = all_entities
             .iter()
-            .filter(|e| {
-                matches!(
-                    e.entity_type.as_str(),
-                    "class" | "struct" | "interface" | "class_type"
-                )
-            })
+            .filter(|e| is_nominal_member_container(e.entity_type.as_str()))
             .map(|e| e.name.as_str())
             .collect();
         let class_entity_files: HashSet<(&str, &str)> = all_entities
             .iter()
-            .filter(|e| {
-                matches!(
-                    e.entity_type.as_str(),
-                    "class" | "struct" | "interface" | "class_type"
-                )
-            })
+            .filter(|e| is_nominal_member_container(e.entity_type.as_str()))
             .map(|e| (e.name.as_str(), e.file_path.as_str()))
             .collect();
 
@@ -998,6 +1581,8 @@ impl EntityGraph {
             .cloned()
             .collect();
 
+        let reference_indexes = build_reference_indexes(root, &resolve_file_paths, &parsed_files);
+
         let has_scope_lang = resolve_file_paths.iter().any(|f| {
             let ext = f.rfind('.').map(|i| &f[i..]).unwrap_or("");
             crate::parser::plugins::code::languages::get_language_config(ext)
@@ -1030,7 +1615,6 @@ impl EntityGraph {
         } else {
             (vec![], HashMap::new())
         };
-
         // Resolve references only for entities in needs_resolution
         let resolved_refs: Vec<(String, String, RefType)> = maybe_par_iter!(all_entities)
             .filter(|e| needs_resolution.contains(e.id.as_str()))
@@ -1041,9 +1625,15 @@ impl EntityGraph {
                     .rfind('.')
                     .map(|i| &entity.file_path[i..])
                     .unwrap_or("");
-                if crate::parser::plugins::code::languages::get_language_config(ext).is_none() {
+                let Some(language_config) =
+                    crate::parser::plugins::code::languages::get_language_config(ext)
+                else {
                     return vec![];
-                }
+                };
+                let fallback_end_line =
+                    fallback_reference_end_line(entity, language_config.scope_resolve.is_some());
+                let fallback_ranges =
+                    direct_reference_line_ranges(entity, fallback_end_line, &child_line_ranges);
 
                 let mut entity_edges = Vec::new();
                 let mut consumed_words = scope_consumed_words
@@ -1051,13 +1641,63 @@ impl EntityGraph {
                     .cloned()
                     .unwrap_or_default();
 
-                // Strip comments/strings once, reuse for both dot-chain and bag-of-words
-                let stripped = strip_comments_and_strings(&entity.content);
+                let reference_index =
+                    if entity_requires_content_span_filter(entity, &child_ranges_by_parent) {
+                        None
+                    } else {
+                        reference_indexes.get(entity.file_path.as_str())
+                    };
+                let fallback_stripped = if reference_index.is_none() {
+                    Some(strip_comments_and_strings(&entity.content))
+                } else {
+                    None
+                };
+                let local_bindings =
+                    local_binding_names_filtered(&entity.content, ext, |local_line, start, end| {
+                        entity_owns_content_span(
+                            entity.id.as_str(),
+                            entity.file_path.as_str(),
+                            source_line_for_entity_content(entity, local_line),
+                            Some(start),
+                            Some(end),
+                            &child_ranges_by_parent,
+                        )
+                    });
 
                 // Phase 1: Dot-chain resolution
-                let dot_chains = extract_dot_chains(&stripped);
+                let dot_chains: Vec<(&str, &str, Option<(usize, usize, usize)>)> =
+                    match reference_index {
+                        Some(index) => index
+                            .dot_chains_in_ranges(&fallback_ranges)
+                            .into_iter()
+                            .map(|(receiver, member)| (receiver, member, None))
+                            .collect(),
+                        None => {
+                            extract_dot_chains_with_positions(fallback_stripped.as_ref().unwrap())
+                                .into_iter()
+                                .map(|(receiver, member, line, start, end)| {
+                                    (receiver, member, Some((line, start, end)))
+                                })
+                                .collect()
+                        }
+                };
 
-                for (receiver, member) in &dot_chains {
+                for (receiver, member, position) in &dot_chains {
+                    if consumed_words.contains(*member) {
+                        continue;
+                    }
+                    if let Some((local_line, local_start_byte, local_end_byte)) = *position {
+                        if !entity_owns_content_span(
+                            entity.id.as_str(),
+                            entity.file_path.as_str(),
+                            source_line_for_entity_content(entity, local_line),
+                            Some(local_start_byte),
+                            Some(local_end_byte),
+                            &child_ranges_by_parent,
+                        ) {
+                            continue;
+                        }
+                    }
                     let edge_count_before = entity_edges.len();
                     if *receiver == "self" || *receiver == "this" {
                         if let Some(class_name) = enclosing_class.get(entity.id.as_str()) {
@@ -1096,11 +1736,36 @@ impl EntityGraph {
                     }
                 }
 
-                // Phase 2: Bag-of-words resolution (reuse stripped content)
-                let refs =
-                    extract_references_with_stripped(&entity.content, &entity.name, &stripped);
-                for ref_name in refs {
+                // Phase 2: Bag-of-words resolution
+                let refs: Vec<(&str, RefType)> = match reference_index {
+                    Some(index) => index.refs_with_types_in_ranges(&fallback_ranges, &entity.name),
+                    None => {
+                        let stripped = fallback_stripped.as_ref().unwrap();
+                        extract_references_with_stripped_filtered(
+                            &entity.content,
+                            &entity.name,
+                            stripped,
+                            |local_line, local_start_byte, local_end_byte| {
+                                entity_owns_content_span(
+                                    entity.id.as_str(),
+                                    entity.file_path.as_str(),
+                                    source_line_for_entity_content(entity, local_line),
+                                    Some(local_start_byte),
+                                    Some(local_end_byte),
+                                    &child_ranges_by_parent,
+                                )
+                            },
+                        )
+                        .into_iter()
+                        .map(|ref_name| (ref_name, infer_ref_type(&entity.content, ref_name)))
+                        .collect()
+                    }
+                };
+                for (ref_name, ref_type) in refs {
                     if consumed_words.contains(ref_name) {
+                        continue;
+                    }
+                    if local_bindings.contains(ref_name) {
                         continue;
                     }
                     if class_child_names.contains(&(entity.id.as_str(), ref_name)) {
@@ -1115,7 +1780,6 @@ impl EntityGraph {
                             && !parent_child_pairs
                                 .contains(&(import_target_id.as_str(), entity.id.as_str()))
                         {
-                            let ref_type = infer_ref_type(&entity.content, &ref_name);
                             entity_edges.push((
                                 entity.id.clone(),
                                 import_target_id.clone(),
@@ -1141,7 +1805,6 @@ impl EntityGraph {
                             {
                                 continue;
                             }
-                            let ref_type = infer_ref_type(&entity.content, &ref_name);
                             entity_edges.push((entity.id.clone(), target_id.clone(), ref_type));
                         }
                     }
@@ -1462,10 +2125,11 @@ impl EntityGraph {
 
         // Rebuild the global symbol table from all current entities
         let symbol_table = self.build_symbol_table();
+        let child_ranges_by_parent = build_child_ranges_by_parent(&new_entities);
 
         // Re-resolve references for new entities
         for entity in &new_entities {
-            self.resolve_entity_references(entity, &symbol_table);
+            self.resolve_entity_references(entity, &symbol_table, &child_ranges_by_parent);
         }
 
         // Also re-resolve references for entities in OTHER files that might
@@ -1578,8 +2242,24 @@ impl EntityGraph {
         &mut self,
         entity: &SemanticEntity,
         symbol_table: &HashMap<String, Vec<String>>,
+        child_ranges_by_parent: &HashMap<&str, Vec<ChildRange<'_>>>,
     ) {
-        let refs = extract_references_from_content(&entity.content, &entity.name);
+        let stripped = strip_comments_and_strings(&entity.content);
+        let refs = extract_references_with_stripped_filtered(
+            &entity.content,
+            &entity.name,
+            &stripped,
+            |local_line, local_start_byte, local_end_byte| {
+                entity_owns_content_span(
+                    entity.id.as_str(),
+                    entity.file_path.as_str(),
+                    source_line_for_entity_content(entity, local_line),
+                    Some(local_start_byte),
+                    Some(local_end_byte),
+                    child_ranges_by_parent,
+                )
+            },
+        );
 
         for ref_name in refs {
             if let Some(target_ids) = symbol_table.get(ref_name) {
@@ -1613,6 +2293,28 @@ impl EntityGraph {
             }
         }
     }
+}
+
+fn is_nominal_member_container(entity_type: &str) -> bool {
+    matches!(
+        entity_type,
+        "class" | "struct" | "interface" | "class_type" | "enum" | "protocol"
+    )
+}
+
+#[cfg(test)]
+fn is_scope_member_container(entity_type: &str) -> bool {
+    matches!(
+        entity_type,
+        "class"
+            | "struct"
+            | "interface"
+            | "impl"
+            | "enum"
+            | "protocol"
+            | "object_declaration"
+            | "companion_object"
+    )
 }
 
 /// Check if an entity looks like a test based on name, file path, and content patterns.
@@ -1997,6 +2699,12 @@ fn strip_file_ext(s: &str) -> &str {
 
 /// Strip comments and string literals from content to avoid false references.
 /// Returns a new string with comments/docstrings replaced by spaces.
+fn blank_span_preserving_newlines(result: &mut [u8], bytes: &[u8], start: usize, end: usize) {
+    for idx in start..end.min(bytes.len()) {
+        result[idx] = if bytes[idx] == b'\n' { b'\n' } else { b' ' };
+    }
+}
+
 fn strip_comments_and_strings(content: &str) -> String {
     let bytes = content.as_bytes();
     let len = bytes.len();
@@ -2006,83 +2714,113 @@ fn strip_comments_and_strings(content: &str) -> String {
     while i < len {
         // Triple-quoted strings (Python docstrings)
         if i + 2 < len && bytes[i] == b'"' && bytes[i + 1] == b'"' && bytes[i + 2] == b'"' {
+            let span_start = i;
             i += 3;
-            while i + 2 < len {
-                if bytes[i] == b'"' && bytes[i + 1] == b'"' && bytes[i + 2] == b'"' {
+            while i < len {
+                if i + 2 < len && bytes[i] == b'"' && bytes[i + 1] == b'"' && bytes[i + 2] == b'"' {
                     i += 3;
                     break;
                 }
+                if bytes[i] == b'\n' {
+                    result[i] = b'\n';
+                }
                 i += 1;
             }
+            blank_span_preserving_newlines(&mut result, bytes, span_start, i);
             continue;
         }
         if i + 2 < len && bytes[i] == b'\'' && bytes[i + 1] == b'\'' && bytes[i + 2] == b'\'' {
+            let span_start = i;
             i += 3;
-            while i + 2 < len {
-                if bytes[i] == b'\'' && bytes[i + 1] == b'\'' && bytes[i + 2] == b'\'' {
+            while i < len {
+                if i + 2 < len
+                    && bytes[i] == b'\''
+                    && bytes[i + 1] == b'\''
+                    && bytes[i + 2] == b'\''
+                {
                     i += 3;
                     break;
                 }
+                if bytes[i] == b'\n' {
+                    result[i] = b'\n';
+                }
                 i += 1;
             }
+            blank_span_preserving_newlines(&mut result, bytes, span_start, i);
             continue;
         }
         // Double-quoted strings
         if bytes[i] == b'"' {
+            let span_start = i;
             i += 1;
             while i < len {
                 if bytes[i] == b'\\' {
-                    i += 2;
+                    i = (i + 2).min(len);
                     continue;
                 }
                 if bytes[i] == b'"' {
                     i += 1;
                     break;
                 }
+                if bytes[i] == b'\n' {
+                    result[i] = b'\n';
+                }
                 i += 1;
             }
+            blank_span_preserving_newlines(&mut result, bytes, span_start, i);
             continue;
         }
         // Single-quoted strings
         if bytes[i] == b'\'' {
+            let span_start = i;
             i += 1;
             while i < len {
                 if bytes[i] == b'\\' {
-                    i += 2;
+                    i = (i + 2).min(len);
                     continue;
                 }
                 if bytes[i] == b'\'' {
                     i += 1;
                     break;
                 }
+                if bytes[i] == b'\n' {
+                    result[i] = b'\n';
+                }
                 i += 1;
             }
+            blank_span_preserving_newlines(&mut result, bytes, span_start, i);
             continue;
         }
         // Python/Ruby single-line comments
         if bytes[i] == b'#' {
+            let span_start = i;
             while i < len && bytes[i] != b'\n' {
                 i += 1;
             }
+            blank_span_preserving_newlines(&mut result, bytes, span_start, i);
             continue;
         }
         // C-style single-line comments
         if i + 1 < len && bytes[i] == b'/' && bytes[i + 1] == b'/' {
+            let span_start = i;
             while i < len && bytes[i] != b'\n' {
                 i += 1;
             }
+            blank_span_preserving_newlines(&mut result, bytes, span_start, i);
             continue;
         }
         // C-style block comments
         if i + 1 < len && bytes[i] == b'/' && bytes[i + 1] == b'*' {
+            let span_start = i;
             i += 2;
-            while i + 1 < len {
-                if bytes[i] == b'*' && bytes[i + 1] == b'/' {
+            while i < len {
+                if i + 1 < len && bytes[i] == b'*' && bytes[i + 1] == b'/' {
                     i += 2;
                     break;
                 }
                 i += 1;
             }
+            blank_span_preserving_newlines(&mut result, bytes, span_start, i);
             continue;
         }
         // Regular code: copy through
@@ -2090,25 +2828,170 @@ fn strip_comments_and_strings(content: &str) -> String {
         i += 1;
     }
 
-    String::from_utf8_lossy(&result).into_owned()
+    String::from_utf8(result).expect("stripped source preserves UTF-8 boundaries")
 }
 
 /// Extract dot-chains (receiver.member) from content for precise resolution.
 /// Returns unique (receiver, member) pairs found in the content.
 fn extract_dot_chains<'a>(content: &'a str) -> Vec<(&'a str, &'a str)> {
+    extract_dot_chains_with_positions(content)
+        .into_iter()
+        .map(|(receiver, member, _, _, _)| (receiver, member))
+        .collect()
+}
+
+/// Returns unique receiver/member pairs with one-based content lines and byte offsets.
+fn extract_dot_chains_with_positions<'a>(
+    content: &'a str,
+) -> Vec<(&'a str, &'a str, usize, usize, usize)> {
     static DOT_CHAIN_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"\b([A-Za-z_]\w*)\.([A-Za-z_]\w*)").unwrap());
 
     let mut chains = Vec::new();
-    let mut seen: HashSet<(&str, &str)> = HashSet::new();
+    let mut seen: HashSet<(&str, &str, usize, usize)> = HashSet::new();
     for cap in DOT_CHAIN_RE.captures_iter(content) {
+        let matched = cap.get(0).unwrap();
+        let line = line_for_byte(content, matched.start());
         let receiver = cap.get(1).unwrap().as_str();
         let member = cap.get(2).unwrap().as_str();
-        if seen.insert((receiver, member)) {
-            chains.push((receiver, member));
+        if seen.insert((receiver, member, line, matched.start())) {
+            chains.push((receiver, member, line, matched.start(), matched.end()));
         }
     }
     chains
+}
+
+fn local_binding_names_filtered<F>(
+    content: &str,
+    ext: &str,
+    mut include_token: F,
+) -> HashSet<String>
+where
+    F: FnMut(usize, usize, usize) -> bool,
+{
+    let mut names = HashSet::new();
+    if !matches!(ext, ".js" | ".jsx" | ".ts" | ".tsx" | ".py" | ".swift") {
+        return names;
+    }
+
+    let mut line_no = 1;
+    let mut line_start = 0;
+    for chunk in content.split_inclusive('\n') {
+        let line = chunk.strip_suffix('\n').unwrap_or(chunk);
+        match ext {
+            ".js" | ".jsx" | ".ts" | ".tsx" | ".swift" => {
+                collect_local_binding_captures(
+                    line,
+                    line_no,
+                    line_start,
+                    &JS_TS_SWIFT_LOCAL_DECL_RE,
+                    &mut include_token,
+                    &mut names,
+                );
+            }
+            ".py" => {
+                collect_python_local_bindings(
+                    line,
+                    line_no,
+                    line_start,
+                    &mut include_token,
+                    &mut names,
+                );
+            }
+            _ => {}
+        }
+        line_start += chunk.len();
+        line_no += 1;
+    }
+
+    names
+}
+
+static JS_TS_SWIFT_LOCAL_DECL_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\b(?:const|let|var)\s+([A-Za-z_]\w*)").unwrap());
+
+static PY_LOCAL_ASSIGN_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\s*([A-Za-z_]\w*)\s*(?::[^=]+)?([+\-*/%&|^]?=)").unwrap());
+
+static PY_FOR_BINDING_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\s*for\s+([A-Za-z_]\w*)\s+in\b").unwrap());
+
+fn collect_local_binding_captures<F>(
+    line: &str,
+    line_no: usize,
+    line_start: usize,
+    regex: &Regex,
+    include_token: &mut F,
+    names: &mut HashSet<String>,
+) where
+    F: FnMut(usize, usize, usize) -> bool,
+{
+    for cap in regex.captures_iter(line) {
+        if let Some(name_match) = cap.get(1) {
+            maybe_add_local_binding_name(
+                name_match.as_str(),
+                line_no,
+                line_start,
+                name_match,
+                include_token,
+                names,
+            );
+        }
+    }
+}
+
+fn collect_python_local_bindings<F>(
+    line: &str,
+    line_no: usize,
+    line_start: usize,
+    include_token: &mut F,
+    names: &mut HashSet<String>,
+) where
+    F: FnMut(usize, usize, usize) -> bool,
+{
+    if let Some(cap) = PY_LOCAL_ASSIGN_RE.captures(line) {
+        if let (Some(name_match), Some(op_match)) = (cap.get(1), cap.get(2)) {
+            if line.as_bytes().get(op_match.end()) != Some(&b'=') {
+                maybe_add_local_binding_name(
+                    name_match.as_str(),
+                    line_no,
+                    line_start,
+                    name_match,
+                    include_token,
+                    names,
+                );
+            }
+        }
+    }
+
+    collect_local_binding_captures(
+        line,
+        line_no,
+        line_start,
+        &PY_FOR_BINDING_RE,
+        include_token,
+        names,
+    );
+}
+
+fn maybe_add_local_binding_name<F>(
+    name: &str,
+    line_no: usize,
+    line_start: usize,
+    name_match: regex::Match<'_>,
+    include_token: &mut F,
+    names: &mut HashSet<String>,
+) where
+    F: FnMut(usize, usize, usize) -> bool,
+{
+    if !is_reference_word(name) {
+        return;
+    }
+    let start = line_start + name_match.start();
+    let end = line_start + name_match.end();
+    if include_token(line_no, start, end) {
+        names.insert(name.to_string());
+    }
 }
 
 /// Extract identifier references from entity content using simple token analysis.
@@ -2296,42 +3179,108 @@ fn extract_references_with_stripped<'a>(
     own_name: &str,
     stripped: &str,
 ) -> Vec<&'a str> {
-    let stripped_words: HashSet<&str> = stripped
-        .split(|c: char| !c.is_alphanumeric() && c != '_')
-        .filter(|w| !w.is_empty())
-        .collect();
+    extract_references_with_stripped_filtered(content, own_name, stripped, |_, _, _| true)
+}
 
+fn extract_references_with_stripped_filtered<'a, F>(
+    content: &'a str,
+    own_name: &str,
+    stripped: &str,
+    mut include_token: F,
+) -> Vec<&'a str>
+where
+    F: FnMut(usize, usize, usize) -> bool,
+{
     let mut refs = Vec::new();
     let mut seen: HashSet<&str> = HashSet::new();
+    let mut token_start: Option<usize> = None;
+    let mut line = 1;
 
-    for word in content.split(|c: char| !c.is_alphanumeric() && c != '_') {
-        if word.is_empty() || word == own_name {
+    for (idx, ch) in content.char_indices() {
+        if ch.is_alphanumeric() || ch == '_' {
+            if token_start.is_none() {
+                token_start = Some(idx);
+            }
             continue;
         }
-        if is_keyword(word) || word.len() < 2 {
-            continue;
+
+        if let Some(start) = token_start.take() {
+            maybe_push_reference_token(
+                content,
+                stripped,
+                start,
+                idx,
+                line,
+                own_name,
+                &mut seen,
+                &mut refs,
+                &mut include_token,
+            );
         }
-        // Skip very short lowercase identifiers (likely local vars: i, x, a, ok, id, etc.)
-        if word.starts_with(|c: char| c.is_lowercase()) && word.len() < 3 {
-            continue;
-        }
-        if !word.starts_with(|c: char| c.is_alphabetic() || c == '_') {
-            continue;
-        }
-        // Skip common local variable names that create false graph edges
-        if is_common_local_name(word) {
-            continue;
-        }
-        // Skip words that only appear in comments/strings
-        if !stripped_words.contains(word) {
-            continue;
-        }
-        if seen.insert(word) {
-            refs.push(word);
+
+        if ch == '\n' {
+            line += 1;
         }
     }
 
+    if let Some(start) = token_start {
+        maybe_push_reference_token(
+            content,
+            stripped,
+            start,
+            content.len(),
+            line,
+            own_name,
+            &mut seen,
+            &mut refs,
+            &mut include_token,
+        );
+    }
+
     refs
+}
+
+fn maybe_push_reference_token<'a, F>(
+    content: &'a str,
+    stripped: &str,
+    start: usize,
+    end: usize,
+    line: usize,
+    own_name: &str,
+    seen: &mut HashSet<&'a str>,
+    refs: &mut Vec<&'a str>,
+    include_token: &mut F,
+) where
+    F: FnMut(usize, usize, usize) -> bool,
+{
+    let word = &content[start..end];
+    if word.is_empty() || word == own_name {
+        return;
+    }
+    if is_keyword(word) || word.len() < 2 {
+        return;
+    }
+    // Skip very short lowercase identifiers (likely local vars: i, x, a, ok, id, etc.)
+    if word.starts_with(|c: char| c.is_lowercase()) && word.len() < 3 {
+        return;
+    }
+    if !word.starts_with(|c: char| c.is_alphabetic() || c == '_') {
+        return;
+    }
+    // Skip common local variable names that create false graph edges
+    if is_common_local_name(word) {
+        return;
+    }
+    // Skip words that only appear in comments/strings
+    if stripped.get(start..end) != Some(word) {
+        return;
+    }
+    if !include_token(line, start, end) {
+        return;
+    }
+    if seen.insert(word) {
+        refs.push(word);
+    }
 }
 
 static COMMON_LOCAL_NAMES: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
@@ -2642,6 +3591,190 @@ mod tests {
         }
         let mut f = std::fs::File::create(path).unwrap();
         f.write_all(content.as_bytes()).unwrap();
+    }
+
+    fn deep_typescript(depth: usize) -> String {
+        let mut content = String::from("class L0 {\n");
+        for i in 1..depth {
+            content.push_str(&"  ".repeat(i));
+            content.push_str(&format!("L{i} = class {{\n"));
+        }
+        content.push_str(&"  ".repeat(depth));
+        content.push_str("method() { return 1; }\n");
+        for i in (1..depth).rev() {
+            content.push_str(&"  ".repeat(i));
+            content.push_str("};\n");
+        }
+        content.push_str("}\n");
+        content
+    }
+
+    #[test]
+    fn test_file_reference_index_matches_reference_helpers() {
+        let content = "\
+import { Foo } from './foo';
+class Runner {
+    run() { return this.validate(Foo); }
+    validate(input) { return input; }
+}
+";
+        let index = FileReferenceIndex::from_content(content);
+        let refs = index.refs_with_types_in_ranges(&[(1, 5)], "run");
+        assert!(refs.iter().any(|(word, _)| *word == "Foo"));
+        assert!(refs.iter().any(|(word, _)| *word == "Runner"));
+        assert!(!refs.iter().any(|(word, _)| *word == "input"));
+
+        let dot_chains = index.dot_chains_in_ranges(&[(1, 5)]);
+        assert!(dot_chains.contains(&("this", "validate")));
+        assert!(refs
+            .iter()
+            .any(|(word, ref_type)| *word == "Foo" && *ref_type == RefType::Imports));
+        assert!(refs
+            .iter()
+            .any(|(word, ref_type)| *word == "validate" && *ref_type == RefType::Calls));
+    }
+
+    #[test]
+    fn test_direct_reference_ranges_skip_nested_child_entities() {
+        let parent = SemanticEntity {
+            id: "parent".to_string(),
+            file_path: "sample.ts".to_string(),
+            entity_type: "function".to_string(),
+            name: "outer".to_string(),
+            parent_id: None,
+            content: String::new(),
+            content_hash: String::new(),
+            structural_hash: None,
+            start_line: 1,
+            end_line: 7,
+            metadata: None,
+        };
+        let mut child_line_ranges = HashMap::new();
+        child_line_ranges.insert("parent".to_string(), vec![(3, 5)]);
+
+        let ranges = direct_reference_line_ranges(&parent, parent.end_line, &child_line_ranges);
+        assert_eq!(ranges, vec![(1, 2), (6, 7)]);
+
+        let content = "\
+function outer() {
+  setup();
+  function inner() {
+    nested();
+  }
+  finish();
+}
+";
+        let index = FileReferenceIndex::from_content(content);
+        let refs = index.refs_with_types_in_ranges(&ranges, "outer");
+
+        assert!(refs.iter().any(|(word, _)| *word == "setup"));
+        assert!(refs.iter().any(|(word, _)| *word == "finish"));
+        assert!(!refs.iter().any(|(word, _)| *word == "nested"));
+    }
+
+    #[test]
+    fn test_deep_nested_typescript_graph_builds() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        let depth = 160;
+        write_file(root, "deep.ts", &deep_typescript(depth));
+
+        let (graph, entities) = EntityGraph::build(root, &["deep.ts".into()], &registry);
+
+        assert!(graph.entities.contains_key("deep.ts::class::L0"));
+        assert!(entities.iter().any(|e| e.name == "method"));
+        assert_eq!(entities.len(), depth + 1);
+    }
+
+    #[test]
+    fn test_ts_class_extends_type_ref_survives_scope_fallback_bound() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "types.ts",
+            "\
+class Base {}
+class Child extends Base {
+    run() { return 1; }
+}
+",
+        );
+
+        let (graph, _) = EntityGraph::build(root, &["types.ts".into()], &registry);
+
+        assert!(
+            graph.edges.iter().any(|edge| {
+                edge.from_entity.contains("Child")
+                    && graph
+                        .entities
+                        .get(&edge.to_entity)
+                        .map_or(false, |e| e.name == "Base")
+            }),
+            "Child should keep a type-ref edge to Base. Edges: {:?}",
+            graph.edges
+        );
+    }
+
+    #[test]
+    fn test_multiline_block_comment_preserves_reference_line_index() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "calls.c",
+            "\
+/*
+ multiline
+ comment
+*/
+int helper() { return 1; }
+int caller() { return helper(); }
+",
+        );
+
+        let (graph, _) = EntityGraph::build(root, &["calls.c".into()], &registry);
+
+        let caller_id = graph
+            .entities
+            .keys()
+            .find(|id| id.contains("caller"))
+            .expect("caller entity should exist");
+        let deps = graph.get_dependencies(caller_id);
+        assert!(
+            deps.iter().any(|dep| dep.name == "helper"),
+            "caller should depend on helper after a multiline block comment. Deps: {:?}",
+            deps.iter().map(|d| &d.name).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_strip_comments_and_strings_preserves_newlines_and_utf8() {
+        let content = "\
+const value = \"é\\
+still string\";
+const done = call();
+/* unterminated block
+comment with Helper
+";
+
+        let stripped = strip_comments_and_strings(content);
+        let newline_count = |text: &str| text.bytes().filter(|byte| *byte == b'\n').count();
+
+        assert_eq!(newline_count(&stripped), newline_count(content));
+        assert!(stripped.contains("const done = call();"));
+        assert!(!stripped.contains("still string"));
+        assert!(!stripped.contains("Helper"));
+
+        let trailing_escape = strip_comments_and_strings("const value = \"unterminated\\");
+        assert_eq!(newline_count(&trailing_escape), 0);
+
+        let triple = strip_comments_and_strings("'''doc\nwith Helper");
+        assert_eq!(newline_count(&triple), 1);
+        assert!(!triple.contains("Helper"));
     }
 
     #[test]
@@ -3124,6 +4257,78 @@ mod tests {
     }
 
     #[test]
+    fn test_incremental_swift_overload_uses_clean_callee_signatures() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "Callee.swift",
+            r#"func load(id: Int) -> String { return "id" }
+
+func load(name: String) -> String { return "name" }
+"#,
+        );
+        write_file(
+            root,
+            "Caller.swift",
+            r#"func call() -> String { return load(id: 1) }
+"#,
+        );
+
+        let file_paths = vec!["Caller.swift".to_string(), "Callee.swift".to_string()];
+        let (initial_graph, initial_entities) = EntityGraph::build(root, &file_paths, &registry);
+
+        write_file(
+            root,
+            "Caller.swift",
+            r#"func call() -> String { return load(name: "x") }
+"#,
+        );
+
+        let stale_file_cached_entities: Vec<SemanticEntity> = initial_entities
+            .iter()
+            .filter(|entity| entity.file_path == "Caller.swift")
+            .cloned()
+            .collect();
+        let cached_entities: Vec<SemanticEntity> = initial_entities
+            .into_iter()
+            .filter(|entity| entity.file_path != "Caller.swift")
+            .collect();
+
+        let (graph, _) = EntityGraph::build_incremental(
+            root,
+            &["Caller.swift".to_string()],
+            &file_paths,
+            cached_entities,
+            initial_graph.edges,
+            stale_file_cached_entities,
+            &registry,
+        );
+
+        let has_edge = |from: &str, to: &str| {
+            graph.edges.iter().any(|edge| {
+                edge.from_entity == from && edge.to_entity == to && edge.ref_type == RefType::Calls
+            })
+        };
+
+        assert!(
+            has_edge(
+                "Caller.swift::function::call",
+                "Callee.swift::function::load@L3"
+            ),
+            "incremental caller should resolve load(name:) using clean callee signatures"
+        );
+        assert!(
+            !has_edge(
+                "Caller.swift::function::call",
+                "Callee.swift::function::load@L1"
+            ),
+            "incremental caller should not fall back to load(id:)"
+        );
+    }
+
+    #[test]
     fn test_incremental_with_content() {
         let (dir, registry) = create_test_repo();
         let root = dir.path();
@@ -3226,6 +4431,178 @@ mod tests {
         assert!(metadata.repaired_clean_entity_ids);
     }
 
+    #[cfg(feature = "lang-go")]
+    #[test]
+    fn test_go_receiver_child_range_does_not_hide_parent_file_edges() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "models.go",
+            "package demo\n\
+             type Dependency struct{}\n\
+             type Service struct { Dependency }\n",
+        );
+        write_file(
+            root,
+            "methods.go",
+            "package demo\n\n\
+             func (s *Service) Run() {}\n",
+        );
+
+        let (graph, _) =
+            EntityGraph::build(root, &["models.go".into(), "methods.go".into()], &registry);
+
+        assert!(
+            graph.edges.iter().any(|edge| {
+                edge.from_entity == "models.go::type::Service"
+                    && edge.to_entity == "models.go::type::Dependency"
+            }),
+            "Service should keep its Dependency edge. Edges: {:?}",
+            graph.edges
+        );
+    }
+
+    #[cfg(feature = "lang-swift")]
+    #[test]
+    fn test_swift_extension_member_resolves_through_receiver_type() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "Example.swift",
+            r#"
+struct Widget {
+    let name: String
+}
+
+extension Widget {
+    func render() -> String { return name }
+}
+
+func draw(widget: Widget) {
+    print(widget.render())
+}
+"#,
+        );
+
+        let (graph, _) = EntityGraph::build(root, &["Example.swift".into()], &registry);
+        let draw = graph
+            .entities
+            .values()
+            .find(|entity| entity.name == "draw")
+            .expect("draw function should be in the graph");
+        let extension = graph
+            .entities
+            .values()
+            .find(|entity| entity.entity_type == "extension")
+            .expect("extension should be in the graph");
+        assert_eq!(extension.name, "Widget");
+        let render = graph
+            .entities
+            .values()
+            .find(|entity| entity.name == "render")
+            .expect("extension method should be in the graph");
+        assert_eq!(render.parent_id.as_deref(), Some(extension.id.as_str()));
+
+        assert!(
+            graph.edges.iter().any(|edge| {
+                edge.from_entity == draw.id
+                    && edge.to_entity == render.id
+                    && edge.ref_type == RefType::Calls
+            }),
+            "draw should call Widget.render. Edges: {:?}",
+            graph.edges
+        );
+
+        let render_dependents = graph.get_dependents(&render.id);
+        assert!(
+            render_dependents.iter().any(|entity| entity.id == draw.id),
+            "render should be impacted by draw. Dependents: {:?}",
+            render_dependents
+                .iter()
+                .map(|entity| &entity.name)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[cfg(feature = "lang-swift")]
+    #[test]
+    fn test_swift_extension_member_resolves_without_prebuilt_lookup() {
+        let (_dir, registry) = create_test_repo();
+        let source = r#"
+struct Widget {
+    let name: String
+}
+
+extension Widget {
+    func render() -> String { return name }
+}
+
+func draw(widget: Widget) {
+    print(widget.render())
+}
+"#;
+
+        let all_entities = registry.extract_entities("Example.swift", source);
+        let extension = all_entities
+            .iter()
+            .find(|entity| entity.entity_type == "extension")
+            .expect("extension should be extracted");
+        assert_eq!(extension.name, "Widget");
+        let render = all_entities
+            .iter()
+            .find(|entity| entity.name == "render")
+            .expect("extension method should be extracted");
+        assert_eq!(render.parent_id.as_deref(), Some(extension.id.as_str()));
+        let entity_map: HashMap<String, EntityInfo> = all_entities
+            .iter()
+            .map(|entity| {
+                (
+                    entity.id.clone(),
+                    EntityInfo {
+                        id: entity.id.clone(),
+                        name: entity.name.clone(),
+                        entity_type: entity.entity_type.clone(),
+                        file_path: entity.file_path.clone(),
+                        parent_id: entity.parent_id.clone(),
+                        start_line: entity.start_line,
+                        end_line: entity.end_line,
+                    },
+                )
+            })
+            .collect();
+
+        let result = scope_resolve::resolve_with_scopes(
+            Path::new("."),
+            &["Example.swift".into()],
+            &all_entities,
+            &entity_map,
+            Some(vec![(
+                "Example.swift".into(),
+                source.into(),
+                registry
+                    .extract_entities_with_tree("Example.swift", source)
+                    .and_then(|(_, tree)| tree)
+                    .expect("Swift parser should produce a tree"),
+            )]),
+        );
+        let draw = all_entities
+            .iter()
+            .find(|entity| entity.name == "draw")
+            .expect("draw function should be extracted");
+
+        assert!(
+            result.edges.iter().any(|(from, to, ref_type)| {
+                from == &draw.id && to == &render.id && *ref_type == RefType::Calls
+            }),
+            "fallback scope resolver should resolve draw to Widget.render. Edges: {:?}",
+            result.edges
+        );
+    }
+
     #[test]
     fn test_extract_references() {
         let content = "function processData(input) {\n  const result = validateInput(input);\n  return transform(result);\n}";
@@ -3233,6 +4610,164 @@ mod tests {
         assert!(refs.contains(&"validateInput"));
         assert!(refs.contains(&"transform"));
         assert!(!refs.contains(&"processData")); // self excluded
+    }
+
+    #[test]
+    fn test_container_does_not_inherit_child_call_edges() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "app.ts",
+            "export function helper() { return 1; }\n\
+             export class Service {\n\
+               method() { return helper(); }\n\
+             }\n\
+             export class InlineService { method() { return helper(); } }\n",
+        );
+
+        let (graph, _) = EntityGraph::build(root, &["app.ts".into()], &registry);
+        let helper_id = "app.ts::function::helper";
+
+        for (class_id, method_id) in [
+            ("app.ts::class::Service", "app.ts::class::Service::method"),
+            (
+                "app.ts::class::InlineService",
+                "app.ts::class::InlineService::method",
+            ),
+        ] {
+            assert!(
+                graph.edges.iter().any(|edge| {
+                    edge.from_entity == method_id
+                        && edge.to_entity == helper_id
+                        && edge.ref_type == RefType::Calls
+                }),
+                "{method_id} should call helper. Edges: {:?}",
+                graph.edges
+            );
+            assert!(
+                !graph
+                    .edges
+                    .iter()
+                    .any(|edge| edge.from_entity == class_id && edge.to_entity == helper_id),
+                "{class_id} should not call helper. Edges: {:?}",
+                graph.edges
+            );
+        }
+    }
+
+    #[test]
+    fn test_incremental_container_does_not_inherit_child_call_edges() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "app.ts",
+            "export function helper() { return 1; }\n\
+             export class Service {\n\
+               method() { return helper(); }\n\
+             }\n",
+        );
+        let (initial_graph, initial_entities) =
+            EntityGraph::build(root, &["app.ts".into()], &registry);
+
+        write_file(
+            root,
+            "app.ts",
+            "export function helper() { return 2; }\n\
+             export function extra() { return 3; }\n\
+             export class Service {\n\
+               method() { return helper(); }\n\
+             }\n",
+        );
+
+        let (graph, _) = EntityGraph::build_incremental(
+            root,
+            &["app.ts".into()],
+            &["app.ts".into()],
+            vec![],
+            initial_graph.edges,
+            initial_entities,
+            &registry,
+        );
+
+        let class_id = "app.ts::class::Service";
+        let method_id = "app.ts::class::Service::method";
+        let helper_id = "app.ts::function::helper";
+        assert!(
+            graph.edges.iter().any(|edge| {
+                edge.from_entity == method_id
+                    && edge.to_entity == helper_id
+                    && edge.ref_type == RefType::Calls
+            }),
+            "{method_id} should call helper. Edges: {:?}",
+            graph.edges
+        );
+        assert!(
+            !graph
+                .edges
+                .iter()
+                .any(|edge| edge.from_entity == class_id && edge.to_entity == helper_id),
+            "{class_id} should not call helper. Edges: {:?}",
+            graph.edges
+        );
+    }
+
+    #[test]
+    fn test_same_line_container_and_child_refs_use_byte_spans() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "app.ts",
+            "export function helper() { return 1; }\n\
+             export function other() { return 2; }\n\
+             export class Service { static { helper(); } method() { return other(); } }\n",
+        );
+
+        let (graph, _) = EntityGraph::build(root, &["app.ts".into()], &registry);
+        let class_id = "app.ts::class::Service";
+        let method_id = "app.ts::class::Service::method";
+        let helper_id = "app.ts::function::helper";
+        let other_id = "app.ts::function::other";
+
+        assert!(
+            graph.edges.iter().any(|edge| {
+                edge.from_entity == class_id
+                    && edge.to_entity == helper_id
+                    && edge.ref_type == RefType::Calls
+            }),
+            "{class_id} should own the static-block helper call. Edges: {:?}",
+            graph.edges
+        );
+        assert!(
+            graph.edges.iter().any(|edge| {
+                edge.from_entity == method_id
+                    && edge.to_entity == other_id
+                    && edge.ref_type == RefType::Calls
+            }),
+            "{method_id} should own the method-body other call. Edges: {:?}",
+            graph.edges
+        );
+        assert!(
+            !graph
+                .edges
+                .iter()
+                .any(|edge| edge.from_entity == method_id && edge.to_entity == helper_id),
+            "{method_id} should not inherit the static-block helper call. Edges: {:?}",
+            graph.edges
+        );
+        assert!(
+            !graph
+                .edges
+                .iter()
+                .any(|edge| edge.from_entity == class_id && edge.to_entity == other_id),
+            "{class_id} should not inherit the method-body other call. Edges: {:?}",
+            graph.edges
+        );
     }
 
     #[test]
@@ -3348,6 +4883,307 @@ class UserService {
         );
     }
 
+    #[cfg(feature = "lang-swift")]
+    #[test]
+    fn test_swift_bare_instance_property_receiver_resolution() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "Example.swift",
+            "\
+class Connection {
+    func execute(query: String) {}
+    func commit() {}
+}
+
+class Transaction {
+    let conn: Connection
+    init(conn: Connection) { self.conn = conn }
+
+    func execute(query: String) {
+        conn.execute(query: query)
+    }
+
+    func commit() {
+        conn.commit()
+    }
+}
+",
+        );
+
+        let (graph, _) = EntityGraph::build(root, &["Example.swift".into()], &registry);
+
+        let transaction_execute_id = graph
+            .entities
+            .iter()
+            .find(|(id, info)| info.name == "execute" && id.contains("Transaction"))
+            .map(|(id, _)| id.clone())
+            .expect("Transaction.execute entity should exist");
+        let execute_deps = graph.get_dependencies(&transaction_execute_id);
+        assert!(
+            execute_deps.iter().any(|d| {
+                d.name == "execute"
+                    && d.parent_id
+                        .as_deref()
+                        .map_or(false, |parent| parent.contains("Connection"))
+            }),
+            "Transaction.execute should depend on Connection.execute. Deps: {:?}",
+            execute_deps
+                .iter()
+                .map(|d| (&d.name, &d.parent_id))
+                .collect::<Vec<_>>()
+        );
+
+        let transaction_commit_id = graph
+            .entities
+            .iter()
+            .find(|(id, info)| info.name == "commit" && id.contains("Transaction"))
+            .map(|(id, _)| id.clone())
+            .expect("Transaction.commit entity should exist");
+        let commit_deps = graph.get_dependencies(&transaction_commit_id);
+        assert!(
+            commit_deps.iter().any(|d| {
+                d.name == "commit"
+                    && d.parent_id
+                        .as_deref()
+                        .map_or(false, |parent| parent.contains("Connection"))
+            }),
+            "Transaction.commit should depend on Connection.commit. Deps: {:?}",
+            commit_deps
+                .iter()
+                .map(|d| (&d.name, &d.parent_id))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[cfg(feature = "lang-swift")]
+    #[test]
+    fn test_swift_static_method_does_not_resolve_instance_property_receiver() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "Example.swift",
+            "\
+class Connection {
+    func execute(query: String) {}
+}
+
+class Transaction {
+    let conn: Connection
+
+    static func run() {
+        conn.execute(query: \"SELECT 1\")
+    }
+}
+",
+        );
+
+        let (graph, _) = EntityGraph::build(root, &["Example.swift".into()], &registry);
+
+        let run_id = graph
+            .entities
+            .keys()
+            .find(|id| id.contains("Transaction") && id.contains("run"))
+            .expect("Transaction.run entity should exist");
+        let deps = graph.get_dependencies(run_id);
+        assert!(
+            !deps.iter().any(|d| {
+                d.name == "execute"
+                    && d.parent_id
+                        .as_deref()
+                        .map_or(false, |parent| parent.contains("Connection"))
+            }),
+            "static Transaction.run should not depend on Connection.execute via instance property. Deps: {:?}",
+            deps.iter()
+                .map(|d| (&d.name, &d.parent_id))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[cfg(feature = "lang-swift")]
+    #[test]
+    fn test_swift_multi_binding_property_receivers_resolve() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "Example.swift",
+            "\
+class PrimaryConnection {
+    func execute(query: String) {}
+}
+
+class BackupConnection {
+    func flush() {}
+}
+
+class Transaction {
+    let conn: PrimaryConnection, backup: BackupConnection
+
+    func run(query: String) {
+        conn.execute(query: query)
+        backup.flush()
+    }
+}
+",
+        );
+
+        let (graph, _) = EntityGraph::build(root, &["Example.swift".into()], &registry);
+
+        let run_id = graph
+            .entities
+            .keys()
+            .find(|id| id.contains("Transaction") && id.contains("run"))
+            .expect("Transaction.run entity should exist");
+        let deps = graph.get_dependencies(run_id);
+        assert!(
+            deps.iter().any(|d| {
+                d.name == "execute"
+                    && d.parent_id
+                        .as_deref()
+                        .map_or(false, |parent| parent.contains("PrimaryConnection"))
+            }),
+            "conn.execute should resolve to PrimaryConnection.execute. Deps: {:?}",
+            deps.iter()
+                .map(|d| (&d.name, &d.parent_id))
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            deps.iter().any(|d| {
+                d.name == "flush"
+                    && d.parent_id
+                        .as_deref()
+                        .map_or(false, |parent| parent.contains("BackupConnection"))
+            }),
+            "backup.flush should resolve to BackupConnection.flush. Deps: {:?}",
+            deps.iter()
+                .map(|d| (&d.name, &d.parent_id))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[cfg(feature = "lang-swift")]
+    #[test]
+    fn test_swift_nested_local_binding_shadows_instance_property_receiver() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "Example.swift",
+            "\
+class Connection {
+    func execute(query: String) {}
+}
+
+class MockConnection {
+    func execute(query: String) {}
+}
+
+class Transaction {
+    let conn: Connection
+    init(conn: Connection) { self.conn = conn }
+
+    func execute(query: String, useMock: Bool) {
+        if useMock {
+            let conn = MockConnection()
+            conn.execute(query: query)
+        }
+    }
+}
+",
+        );
+
+        let (graph, _) = EntityGraph::build(root, &["Example.swift".into()], &registry);
+
+        let transaction_execute_id = graph
+            .entities
+            .iter()
+            .find(|(id, info)| info.name == "execute" && id.contains("Transaction"))
+            .map(|(id, _)| id.clone())
+            .expect("Transaction.execute entity should exist");
+        let deps = graph.get_dependencies(&transaction_execute_id);
+        assert!(
+            deps.iter().any(|d| {
+                d.name == "execute"
+                    && d.parent_id
+                        .as_deref()
+                        .map_or(false, |parent| parent.contains("MockConnection"))
+            }),
+            "nested local conn should resolve to MockConnection.execute. Deps: {:?}",
+            deps.iter()
+                .map(|d| (&d.name, &d.parent_id))
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            !deps.iter().any(|d| {
+                d.name == "execute"
+                    && d.parent_id.as_deref().map_or(false, |parent| {
+                        parent.contains("Connection") && !parent.contains("MockConnection")
+                    })
+            }),
+            "nested local conn should shadow Transaction.conn. Deps: {:?}",
+            deps.iter()
+                .map(|d| (&d.name, &d.parent_id))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_typescript_bare_identifier_does_not_resolve_instance_property() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "service.ts",
+            "\
+class Connection {
+    execute() {
+        return true;
+    }
+}
+
+class Transaction {
+    conn: Connection;
+    constructor(conn: Connection) {
+        this.conn = conn;
+    }
+
+    run() {
+        return conn.execute();
+    }
+}
+",
+        );
+
+        let (graph, _) = EntityGraph::build(root, &["service.ts".into()], &registry);
+
+        let run_id = graph
+            .entities
+            .keys()
+            .find(|id| id.contains("Transaction") && id.contains("run"))
+            .expect("Transaction.run entity should exist");
+        let deps = graph.get_dependencies(run_id);
+        assert!(
+            !deps.iter().any(|d| {
+                d.name == "execute"
+                    && d.parent_id
+                        .as_deref()
+                        .map_or(false, |parent| parent.contains("Connection"))
+            }),
+            "bare conn.execute() should not resolve through a TypeScript instance property. Deps: {:?}",
+            deps.iter()
+                .map(|d| (&d.name, &d.parent_id))
+                .collect::<Vec<_>>()
+        );
+    }
+
     #[test]
     fn test_dot_chain_class_static() {
         let (dir, registry) = create_test_repo();
@@ -3377,6 +5213,12 @@ function caller() { return MathUtils.compute(); }
             "caller should depend on compute via MathUtils.compute(). Deps: {:?}",
             deps.iter().map(|d| &d.name).collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn test_protocols_are_member_containers() {
+        assert!(is_nominal_member_container("protocol"));
+        assert!(is_scope_member_container("protocol"));
     }
 
     #[test]
@@ -3990,6 +5832,236 @@ export function caller(foo) { return foo(); }
                 .iter()
                 .any(|d| d.name == "foo" && d.file_path == "lib.ts"),
             "local parameter foo should shadow named import. Deps: {:?}",
+            deps.iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_nested_local_binding_does_not_hide_parent_reference() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "lib.ts",
+            "\
+export const answer = 42;
+",
+        );
+        write_file(
+            root,
+            "main.ts",
+            "\
+import { answer } from './lib';
+export function outer() {
+    const value = answer;
+    function inner() {
+        const answer = 0;
+        return answer;
+    }
+    return value;
+}
+",
+        );
+
+        let (graph, _) = EntityGraph::build(root, &["lib.ts".into(), "main.ts".into()], &registry);
+
+        let outer_id = graph
+            .entities
+            .iter()
+            .find(|(_, entity)| entity.name == "outer")
+            .map(|(id, _)| id)
+            .expect("outer entity should exist");
+        let outer_deps = graph.get_dependencies(outer_id);
+        assert!(
+            outer_deps
+                .iter()
+                .any(|d| d.name == "answer" && d.file_path == "lib.ts"),
+            "parent bare reference to imported answer should remain resolved. Deps: {:?}",
+            outer_deps
+                .iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
+        );
+
+        let inner_id = graph
+            .entities
+            .iter()
+            .find(|(_, entity)| entity.name == "inner")
+            .map(|(id, _)| id)
+            .expect("inner entity should exist");
+        let inner_deps = graph.get_dependencies(inner_id);
+        assert!(
+            !inner_deps
+                .iter()
+                .any(|d| d.name == "answer" && d.file_path == "lib.ts"),
+            "nested local binding answer should not resolve to imported answer. Deps: {:?}",
+            inner_deps
+                .iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_python_local_binding_shadows_same_file_function() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "b.py",
+            "\
+def total(items):
+    return sum(items)
+
+def report():
+    total = 0
+    for i in range(10):
+        total = total + i
+    return total
+",
+        );
+
+        let (graph, _) = EntityGraph::build(root, &["b.py".into()], &registry);
+
+        let report_id = graph
+            .entities
+            .iter()
+            .find(|(_, entity)| entity.name == "report")
+            .map(|(id, _)| id)
+            .expect("report entity should exist");
+        let deps = graph.get_dependencies(report_id);
+        assert!(
+            !deps.iter().any(|d| d.name == "total"),
+            "local variable total should not resolve to same-file function total. Deps: {:?}",
+            deps.iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_rust_impl_container_does_not_inherit_child_build_call() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "graph.rs",
+            "\
+pub struct EntityGraph;
+
+impl EntityGraph {
+    pub fn build(a: i32, b: i32, c: i32) -> i32 {
+        a + b + c
+    }
+}
+",
+        );
+        write_file(
+            root,
+            "server.rs",
+            "\
+use crate::graph::EntityGraph;
+
+struct SemServer;
+
+impl SemServer {
+    fn find_supported_files() {
+        let mut builder = ignore::WalkBuilder::new(\".\");
+        let walker = builder.build();
+    }
+
+    fn get_or_build_graph() {
+        let _ = EntityGraph::build(1, 2, 3);
+    }
+}
+
+impl SemServer {
+    fn metadata(&self) -> i32 {
+        1
+    }
+}
+",
+        );
+
+        let (graph, _) =
+            EntityGraph::build(root, &["graph.rs".into(), "server.rs".into()], &registry);
+
+        let sem_server_impls: Vec<_> = graph
+            .entities
+            .iter()
+            .filter(|(_, entity)| entity.entity_type == "impl" && entity.name == "SemServer")
+            .collect();
+        assert!(
+            sem_server_impls.len() >= 2,
+            "test fixture should produce duplicate SemServer impl entities"
+        );
+        for (impl_id, _) in sem_server_impls {
+            let impl_deps = graph.get_dependencies(impl_id);
+            assert!(
+                !impl_deps
+                    .iter()
+                    .any(|d| d.name == "build" && d.file_path == "graph.rs"),
+                "impl container should not inherit child build calls. Deps: {:?}",
+                impl_deps
+                    .iter()
+                    .map(|d| (&d.name, &d.file_path))
+                    .collect::<Vec<_>>()
+            );
+        }
+
+        let method_id = graph
+            .entities
+            .iter()
+            .find(|(_, entity)| entity.name == "get_or_build_graph")
+            .map(|(id, _)| id)
+            .expect("get_or_build_graph entity should exist");
+        let method_deps = graph.get_dependencies(method_id);
+        assert!(
+            method_deps
+                .iter()
+                .any(|d| d.name == "build" && d.file_path == "graph.rs"),
+            "direct EntityGraph::build call should remain resolved. Deps: {:?}",
+            method_deps
+                .iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_rust_lowercase_scoped_path_does_not_fallback_to_local_function() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "main.rs",
+            "\
+fn baz() {}
+
+fn caller() {
+    foo::bar::baz();
+}
+",
+        );
+
+        let (graph, _) = EntityGraph::build(root, &["main.rs".into()], &registry);
+
+        let caller_id = graph
+            .entities
+            .iter()
+            .find(|(_, entity)| entity.name == "caller")
+            .map(|(id, _)| id)
+            .expect("caller entity should exist");
+        let deps = graph.get_dependencies(caller_id);
+        assert!(
+            !deps.iter().any(|d| d.name == "baz"),
+            "lowercase scoped path should not fall back to local baz function. Deps: {:?}",
             deps.iter()
                 .map(|d| (&d.name, &d.file_path))
                 .collect::<Vec<_>>()

--- a/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
+++ b/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
@@ -898,7 +898,7 @@ fn swift_declaration_keyword_type(keyword: &str) -> Option<&'static str> {
         "class" => Some("class"),
         "enum" => Some("enum"),
         "extension" => Some("extension"),
-        "protocol" => Some("protocol_declaration"),
+        "protocol" => Some("protocol"),
         "struct" => Some("struct"),
         _ => None,
     }
@@ -1105,12 +1105,25 @@ fn compute_structural_hash(node: Node, source: &[u8]) -> String {
 /// Find the byte range of the name node, mirroring extract_name() logic.
 /// Returns (start_byte, end_byte) of the name token to exclude from hashing.
 fn find_name_byte_range(node: Node, _source: &[u8]) -> Option<(usize, usize)> {
+    let node_type = node.kind();
+
+    if node_type == "operator_declaration" {
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            if child.kind() == "custom_operator" || child.kind() == "simple_identifier" {
+                return Some((child.start_byte(), child.end_byte()));
+            }
+        }
+    }
+
+    if node_type == "subscript_declaration" || node_type == "deinit_declaration" {
+        return None;
+    }
+
     // Try 'name' field first (works for most languages)
     if let Some(name_node) = node.child_by_field_name("name") {
         return Some((name_node.start_byte(), name_node.end_byte()));
     }
-
-    let node_type = node.kind();
 
     // Variable/lexical declarations: name is inside variable_declarator
     if node_type == "lexical_declaration" || node_type == "variable_declaration" {
@@ -1325,14 +1338,31 @@ fn find_declarator_name_range(mut node: Node) -> Option<(usize, usize)> {
 }
 
 fn extract_name(node: Node, source: &[u8]) -> Option<String> {
+    let node_type = node.kind();
+
+    if node_type == "subscript_declaration" {
+        return Some("subscript".to_string());
+    }
+
+    if node_type == "deinit_declaration" {
+        return Some("deinit".to_string());
+    }
+
+    if node_type == "operator_declaration" {
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            if child.kind() == "custom_operator" || child.kind() == "simple_identifier" {
+                return Some(node_text(child, source).to_string());
+            }
+        }
+    }
+
     // Try 'name' field first (works for most languages)
     if let Some(name_node) = node.child_by_field_name("name") {
         return Some(node_text(name_node, source).to_string());
     }
 
     // For variable/lexical declarations, try to get the declarator name
-    let node_type = node.kind();
-
     // For Rust impl blocks, construct unique name from trait + type
     // e.g. "impl Display for Foo" -> "Display for Foo", "impl Foo" -> "Foo"
     if node_type == "impl_item" {
@@ -1707,7 +1737,13 @@ fn map_node_type(tree_sitter_type: &str) -> &str {
         | "method_signature" | "operator_signature" => "method",
         "class_declaration" | "class_definition" | "class_specifier" => "class",
         "interface_declaration" => "interface",
-        "type_alias_declaration" | "type_declaration" | "type_item" | "type_definition" | "type_alias" => "type",
+        "protocol_declaration" => "protocol",
+        "init_declaration" => "init",
+        "deinit_declaration" => "deinit",
+        "subscript_declaration" => "subscript",
+        "type_alias_declaration" | "typealias_declaration" | "type_declaration" | "type_item" | "type_definition" | "type_alias" => "type",
+        "associatedtype_declaration" => "associatedtype",
+        "operator_declaration" => "operator",
         "enum_declaration" | "enum_item" | "enum_specifier" | "enum_definition" => "enum",
         "mixin_declaration" => "mixin",
         "extension_declaration" | "extension_type_declaration" => "extension",

--- a/crates/sem-core/src/parser/plugins/code/languages.rs
+++ b/crates/sem-core/src/parser/plugins/code/languages.rs
@@ -89,7 +89,10 @@ pub enum CallNodeStyle {
     FunctionField(&'static str),
     /// The call node directly has object (optional) + method name fields.
     /// Java: method_invocation(object, name). Ruby: call(receiver, method).
-    DirectMethod { object_field: &'static str, method_field: &'static str },
+    DirectMethod {
+        object_field: &'static str,
+        method_field: &'static str,
+    },
     /// The callee is the first named child of the call node (no field name).
     /// Swift: call_expression(simple_identifier|navigation_expression, call_suffix)
     /// Kotlin: call_expression(identifier|navigation_expression, value_arguments)
@@ -101,7 +104,10 @@ pub enum ClassNameField {
     /// Simple field lookup: `node.child_by_field_name(field)`
     Simple(&'static str),
     /// Go-style: look for a child of type `spec_kind`, then get field `field` from it
-    TypeSpec { spec_kind: &'static str, field: &'static str },
+    TypeSpec {
+        spec_kind: &'static str,
+        field: &'static str,
+    },
     /// Rust impl: get name from `node.child_by_field_name(field)` (the "type" field)
     ImplType(&'static str),
 }
@@ -424,7 +430,12 @@ static TYPESCRIPT_CONFIG: LanguageConfig = LanguageConfig {
         "method_signature",
         "property_signature",
     ],
-    container_node_types: &["class_body", "interface_body", "enum_body", "statement_block"],
+    container_node_types: &[
+        "class_body",
+        "interface_body",
+        "enum_body",
+        "statement_block",
+    ],
     call_entity_identifiers: &[],
     suppressed_nested_entities: JS_TS_SUPPRESSED_NESTED,
     scope_boundary_types: JS_TS_SCOPE_BOUNDARIES,
@@ -451,7 +462,12 @@ static TSX_CONFIG: LanguageConfig = LanguageConfig {
         "method_signature",
         "property_signature",
     ],
-    container_node_types: &["class_body", "interface_body", "enum_body", "statement_block"],
+    container_node_types: &[
+        "class_body",
+        "interface_body",
+        "enum_body",
+        "statement_block",
+    ],
     call_entity_identifiers: &[],
     suppressed_nested_entities: JS_TS_SUPPRESSED_NESTED,
     scope_boundary_types: JS_TS_SCOPE_BOUNDARIES,
@@ -555,7 +571,13 @@ static JAVA_CONFIG: LanguageConfig = LanguageConfig {
         "constructor_declaration",
         "annotation_type_declaration",
     ],
-    container_node_types: &["class_body", "interface_body", "enum_body", "record_body", "block"],
+    container_node_types: &[
+        "class_body",
+        "interface_body",
+        "enum_body",
+        "record_body",
+        "block",
+    ],
     call_entity_identifiers: &[],
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
@@ -597,7 +619,11 @@ static CPP_CONFIG: LanguageConfig = LanguageConfig {
         "declaration",
         "type_definition",
     ],
-    container_node_types: &["field_declaration_list", "declaration_list", "compound_statement"],
+    container_node_types: &[
+        "field_declaration_list",
+        "declaration_list",
+        "compound_statement",
+    ],
     call_entity_identifiers: &[],
     suppressed_nested_entities: CPP_SUPPRESSED_NESTED,
     scope_boundary_types: CPP_SCOPE_BOUNDARIES,
@@ -609,12 +635,7 @@ static CPP_CONFIG: LanguageConfig = LanguageConfig {
 static RUBY_CONFIG: LanguageConfig = LanguageConfig {
     id: "ruby",
     extensions: &[".rb"],
-    entity_node_types: &[
-        "method",
-        "singleton_method",
-        "class",
-        "module",
-    ],
+    entity_node_types: &["method", "singleton_method", "class", "module"],
     container_node_types: &["body_statement"],
     call_entity_identifiers: &[],
     suppressed_nested_entities: &[],
@@ -661,7 +682,11 @@ static PHP_CONFIG: LanguageConfig = LanguageConfig {
         "enum_declaration",
         "namespace_definition",
     ],
-    container_node_types: &["declaration_list", "enum_declaration_list", "compound_statement"],
+    container_node_types: &[
+        "declaration_list",
+        "enum_declaration_list",
+        "compound_statement",
+    ],
     call_entity_identifiers: &[],
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
@@ -707,7 +732,13 @@ static SWIFT_CONFIG: LanguageConfig = LanguageConfig {
         "operator_declaration",
         "associatedtype_declaration",
     ],
-    container_node_types: &["class_body", "protocol_body", "enum_class_body", "struct_body", "function_body"],
+    container_node_types: &[
+        "class_body",
+        "protocol_body",
+        "enum_class_body",
+        "struct_body",
+        "function_body",
+    ],
     call_entity_identifiers: &[],
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
@@ -722,9 +753,18 @@ static ELIXIR_CONFIG: LanguageConfig = LanguageConfig {
     entity_node_types: &[],
     container_node_types: &["do_block"],
     call_entity_identifiers: &[
-        "defmodule", "def", "defp", "defmacro", "defmacrop",
-        "defguard", "defguardp", "defprotocol", "defimpl",
-        "defstruct", "defexception", "defdelegate",
+        "defmodule",
+        "def",
+        "defp",
+        "defmacro",
+        "defmacrop",
+        "defguard",
+        "defguardp",
+        "defprotocol",
+        "defimpl",
+        "defstruct",
+        "defexception",
+        "defdelegate",
     ],
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
@@ -785,7 +825,10 @@ static KOTLIN_CONFIG: LanguageConfig = LanguageConfig {
 #[cfg(feature = "lang-xml")]
 static XML_CONFIG: LanguageConfig = LanguageConfig {
     id: "xml",
-    extensions: &[".xml", ".plist", ".svg", ".xhtml", ".csproj", ".fsproj", ".vbproj", ".props", ".targets", ".nuspec", ".resx", ".xaml", ".axml"],
+    extensions: &[
+        ".xml", ".plist", ".svg", ".xhtml", ".csproj", ".fsproj", ".vbproj", ".props", ".targets",
+        ".nuspec", ".resx", ".xaml", ".axml",
+    ],
     entity_node_types: &["element"],
     container_node_types: &["content"],
     call_entity_identifiers: &[],
@@ -818,15 +861,12 @@ static DART_CONFIG: LanguageConfig = LanguageConfig {
     get_language: get_dart,
     scope_resolve: Some(&DART_SCOPE_CONFIG),
 };
-  
+
 #[cfg(feature = "lang-perl")]
 static PERL_CONFIG: LanguageConfig = LanguageConfig {
     id: "perl",
     extensions: &[".pl", ".pm", ".t"],
-    entity_node_types: &[
-        "subroutine_declaration_statement",
-        "package_statement",
-    ],
+    entity_node_types: &["subroutine_declaration_statement", "package_statement"],
     container_node_types: &["block"],
     call_entity_identifiers: &[],
     suppressed_nested_entities: &[],
@@ -915,12 +955,10 @@ static ZIG_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["block"],
     call_entity_identifiers: &[],
-    suppressed_nested_entities: &[
-        SuppressedNestedEntity {
-            parent_entity_node_type: "function_declaration",
-            child_entity_node_type: "variable_declaration",
-        },
-    ],
+    suppressed_nested_entities: &[SuppressedNestedEntity {
+        parent_entity_node_type: "function_declaration",
+        child_entity_node_type: "variable_declaration",
+    }],
     scope_boundary_types: &[],
     get_language: get_zig,
     scope_resolve: Some(&ZIG_SCOPE_CONFIG),
@@ -948,14 +986,30 @@ static PYTHON_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     class_name_field: ClassNameField::Simple("name"),
 
     assignment_rules: &[
-        AssignmentRule { node_kind: "assignment", strategy: AssignmentStrategy::LeftRight },
-        AssignmentRule { node_kind: "expression_statement", strategy: AssignmentStrategy::LeftRight },
+        AssignmentRule {
+            node_kind: "assignment",
+            strategy: AssignmentStrategy::LeftRight,
+        },
+        AssignmentRule {
+            node_kind: "expression_statement",
+            strategy: AssignmentStrategy::LeftRight,
+        },
     ],
     assignment_recurse_into: &["block"],
 
     param_rules: &[
-        ParamRule { node_kind: "typed_parameter", name_field: ParamNameField::WithFallback("name"), type_field: "type", skip_names: &["self", "cls"] },
-        ParamRule { node_kind: "typed_default_parameter", name_field: ParamNameField::WithFallback("name"), type_field: "type", skip_names: &["self", "cls"] },
+        ParamRule {
+            node_kind: "typed_parameter",
+            name_field: ParamNameField::WithFallback("name"),
+            type_field: "type",
+            skip_names: &["self", "cls"],
+        },
+        ParamRule {
+            node_kind: "typed_default_parameter",
+            name_field: ParamNameField::WithFallback("name"),
+            type_field: "type",
+            skip_names: &["self", "cls"],
+        },
     ],
 
     return_type_field: None,
@@ -965,7 +1019,11 @@ static PYTHON_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     new_expr_nodes: &[],
     new_expr_type_field: "constructor",
     composite_literal_nodes: &[],
-    member_access: &[MemberAccess { node_kind: "attribute", object_field: "object", property_field: "attribute" }],
+    member_access: &[MemberAccess {
+        node_kind: "attribute",
+        object_field: "object",
+        property_field: "attribute",
+    }],
     scoped_call_nodes: &[],
 
     self_keywords: &["self", "cls"],
@@ -984,34 +1042,92 @@ static PYTHON_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     external_method: false,
 
     builtins: &[
-        "print", "len", "range", "str", "int", "float", "bool",
-        "list", "dict", "set", "tuple", "type", "super",
-        "isinstance", "issubclass", "getattr", "setattr",
-        "hasattr", "delattr", "open", "input", "map",
-        "filter", "zip", "enumerate", "sorted", "reversed",
-        "min", "max", "sum", "any", "all", "abs",
-        "round", "format", "repr", "id", "hash",
-        "ValueError", "TypeError", "KeyError", "RuntimeError",
-        "Exception", "StopIteration",
+        "print",
+        "len",
+        "range",
+        "str",
+        "int",
+        "float",
+        "bool",
+        "list",
+        "dict",
+        "set",
+        "tuple",
+        "type",
+        "super",
+        "isinstance",
+        "issubclass",
+        "getattr",
+        "setattr",
+        "hasattr",
+        "delattr",
+        "open",
+        "input",
+        "map",
+        "filter",
+        "zip",
+        "enumerate",
+        "sorted",
+        "reversed",
+        "min",
+        "max",
+        "sum",
+        "any",
+        "all",
+        "abs",
+        "round",
+        "format",
+        "repr",
+        "id",
+        "hash",
+        "ValueError",
+        "TypeError",
+        "KeyError",
+        "RuntimeError",
+        "Exception",
+        "StopIteration",
     ],
 };
 
 static TS_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     class_scope_nodes: &["class_declaration", "abstract_class_declaration"],
     impl_scope_nodes: &[],
-    function_scope_nodes: &["function_declaration", "method_definition", "arrow_function"],
+    function_scope_nodes: &[
+        "function_declaration",
+        "method_definition",
+        "arrow_function",
+    ],
     class_name_field: ClassNameField::Simple("name"),
 
     assignment_rules: &[
-        AssignmentRule { node_kind: "lexical_declaration", strategy: AssignmentStrategy::Declarators },
-        AssignmentRule { node_kind: "variable_declaration", strategy: AssignmentStrategy::Declarators },
-        AssignmentRule { node_kind: "expression_statement", strategy: AssignmentStrategy::LeftRight },
+        AssignmentRule {
+            node_kind: "lexical_declaration",
+            strategy: AssignmentStrategy::Declarators,
+        },
+        AssignmentRule {
+            node_kind: "variable_declaration",
+            strategy: AssignmentStrategy::Declarators,
+        },
+        AssignmentRule {
+            node_kind: "expression_statement",
+            strategy: AssignmentStrategy::LeftRight,
+        },
     ],
     assignment_recurse_into: &["statement_block"],
 
     param_rules: &[
-        ParamRule { node_kind: "required_parameter", name_field: ParamNameField::WithFallback("pattern"), type_field: "type", skip_names: &["this"] },
-        ParamRule { node_kind: "optional_parameter", name_field: ParamNameField::WithFallback("pattern"), type_field: "type", skip_names: &["this"] },
+        ParamRule {
+            node_kind: "required_parameter",
+            name_field: ParamNameField::WithFallback("pattern"),
+            type_field: "type",
+            skip_names: &["this"],
+        },
+        ParamRule {
+            node_kind: "optional_parameter",
+            name_field: ParamNameField::WithFallback("pattern"),
+            type_field: "type",
+            skip_names: &["this"],
+        },
     ],
 
     return_type_field: Some("return_type"),
@@ -1021,7 +1137,11 @@ static TS_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     new_expr_nodes: &["new_expression"],
     new_expr_type_field: "constructor",
     composite_literal_nodes: &[],
-    member_access: &[MemberAccess { node_kind: "member_expression", object_field: "object", property_field: "property" }],
+    member_access: &[MemberAccess {
+        node_kind: "member_expression",
+        object_field: "object",
+        property_field: "property",
+    }],
     scoped_call_nodes: &[],
 
     self_keywords: &["this"],
@@ -1040,23 +1160,78 @@ static TS_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     external_method: false,
 
     builtins: &[
-        "console", "parseInt", "parseFloat", "isNaN", "isFinite",
-        "setTimeout", "setInterval", "clearTimeout", "clearInterval",
-        "Promise", "Array", "Object", "Map", "Set", "WeakMap", "WeakSet",
-        "JSON", "Math", "Date", "RegExp", "Error", "TypeError",
-        "RangeError", "Symbol", "Proxy", "Reflect",
-        "String", "Number", "Boolean", "BigInt",
-        "require", "module", "exports", "process",
-        "Buffer", "global", "window", "document",
-        "fetch", "Response", "Request", "Headers", "URL",
-        "undefined", "encodeURIComponent", "decodeURIComponent",
-        "encodeURI", "decodeURI", "AbortController", "TextEncoder",
-        "TextDecoder", "Uint8Array", "Int8Array", "Float32Array",
-        "ArrayBuffer", "DataView", "ReadableStream", "WritableStream",
-        "Blob", "File", "FormData", "URLSearchParams",
-        "Event", "EventTarget", "CustomEvent",
-        "queueMicrotask", "structuredClone", "atob", "btoa",
-        "crypto", "performance", "navigator",
+        "console",
+        "parseInt",
+        "parseFloat",
+        "isNaN",
+        "isFinite",
+        "setTimeout",
+        "setInterval",
+        "clearTimeout",
+        "clearInterval",
+        "Promise",
+        "Array",
+        "Object",
+        "Map",
+        "Set",
+        "WeakMap",
+        "WeakSet",
+        "JSON",
+        "Math",
+        "Date",
+        "RegExp",
+        "Error",
+        "TypeError",
+        "RangeError",
+        "Symbol",
+        "Proxy",
+        "Reflect",
+        "String",
+        "Number",
+        "Boolean",
+        "BigInt",
+        "require",
+        "module",
+        "exports",
+        "process",
+        "Buffer",
+        "global",
+        "window",
+        "document",
+        "fetch",
+        "Response",
+        "Request",
+        "Headers",
+        "URL",
+        "undefined",
+        "encodeURIComponent",
+        "decodeURIComponent",
+        "encodeURI",
+        "decodeURI",
+        "AbortController",
+        "TextEncoder",
+        "TextDecoder",
+        "Uint8Array",
+        "Int8Array",
+        "Float32Array",
+        "ArrayBuffer",
+        "DataView",
+        "ReadableStream",
+        "WritableStream",
+        "Blob",
+        "File",
+        "FormData",
+        "URLSearchParams",
+        "Event",
+        "EventTarget",
+        "CustomEvent",
+        "queueMicrotask",
+        "structuredClone",
+        "atob",
+        "btoa",
+        "crypto",
+        "performance",
+        "navigator",
     ],
 };
 
@@ -1066,14 +1241,18 @@ static RUST_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     function_scope_nodes: &["function_item"],
     class_name_field: ClassNameField::Simple("name"),
 
-    assignment_rules: &[
-        AssignmentRule { node_kind: "let_declaration", strategy: AssignmentStrategy::PatternBased },
-    ],
+    assignment_rules: &[AssignmentRule {
+        node_kind: "let_declaration",
+        strategy: AssignmentStrategy::PatternBased,
+    }],
     assignment_recurse_into: &["block", "expression_statement"],
 
-    param_rules: &[
-        ParamRule { node_kind: "parameter", name_field: ParamNameField::RustPattern, type_field: "type", skip_names: &["self"] },
-    ],
+    param_rules: &[ParamRule {
+        node_kind: "parameter",
+        name_field: ParamNameField::RustPattern,
+        type_field: "type",
+        skip_names: &["self"],
+    }],
 
     return_type_field: Some("return_type"),
 
@@ -1082,7 +1261,11 @@ static RUST_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     new_expr_nodes: &[],
     new_expr_type_field: "constructor",
     composite_literal_nodes: &[],
-    member_access: &[MemberAccess { node_kind: "field_expression", object_field: "value", property_field: "field" }],
+    member_access: &[MemberAccess {
+        node_kind: "field_expression",
+        object_field: "value",
+        property_field: "field",
+    }],
     scoped_call_nodes: &["scoped_identifier"],
 
     self_keywords: &["self"],
@@ -1095,18 +1278,59 @@ static RUST_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     external_method: false,
 
     builtins: &[
-        "println", "eprintln", "print", "eprint", "dbg",
-        "format", "write", "writeln",
-        "vec", "panic", "todo", "unimplemented", "unreachable",
-        "assert", "assert_eq", "assert_ne", "debug_assert",
-        "Some", "None", "Ok", "Err",
-        "Box", "Vec", "String", "HashMap", "HashSet",
-        "Arc", "Rc", "Mutex", "RwLock", "Cell", "RefCell",
-        "Option", "Result", "Iterator", "IntoIterator",
-        "Clone", "Copy", "Debug", "Display", "Default",
-        "From", "Into", "TryFrom", "TryInto",
-        "Send", "Sync", "Sized", "Unpin",
-        "cfg", "derive", "include", "env",
+        "println",
+        "eprintln",
+        "print",
+        "eprint",
+        "dbg",
+        "format",
+        "write",
+        "writeln",
+        "vec",
+        "panic",
+        "todo",
+        "unimplemented",
+        "unreachable",
+        "assert",
+        "assert_eq",
+        "assert_ne",
+        "debug_assert",
+        "Some",
+        "None",
+        "Ok",
+        "Err",
+        "Box",
+        "Vec",
+        "String",
+        "HashMap",
+        "HashSet",
+        "Arc",
+        "Rc",
+        "Mutex",
+        "RwLock",
+        "Cell",
+        "RefCell",
+        "Option",
+        "Result",
+        "Iterator",
+        "IntoIterator",
+        "Clone",
+        "Copy",
+        "Debug",
+        "Display",
+        "Default",
+        "From",
+        "Into",
+        "TryFrom",
+        "TryInto",
+        "Send",
+        "Sync",
+        "Sized",
+        "Unpin",
+        "cfg",
+        "derive",
+        "include",
+        "env",
     ],
 };
 
@@ -1114,17 +1338,29 @@ static GO_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     class_scope_nodes: &["type_declaration"],
     impl_scope_nodes: &[],
     function_scope_nodes: &["function_declaration", "method_declaration"],
-    class_name_field: ClassNameField::TypeSpec { spec_kind: "type_spec", field: "name" },
+    class_name_field: ClassNameField::TypeSpec {
+        spec_kind: "type_spec",
+        field: "name",
+    },
 
     assignment_rules: &[
-        AssignmentRule { node_kind: "short_var_declaration", strategy: AssignmentStrategy::ShortVar },
-        AssignmentRule { node_kind: "var_declaration", strategy: AssignmentStrategy::VarSpec },
+        AssignmentRule {
+            node_kind: "short_var_declaration",
+            strategy: AssignmentStrategy::ShortVar,
+        },
+        AssignmentRule {
+            node_kind: "var_declaration",
+            strategy: AssignmentStrategy::VarSpec,
+        },
     ],
     assignment_recurse_into: &["block"],
 
-    param_rules: &[
-        ParamRule { node_kind: "parameter_declaration", name_field: ParamNameField::Simple("name"), type_field: "type", skip_names: &[] },
-    ],
+    param_rules: &[ParamRule {
+        node_kind: "parameter_declaration",
+        name_field: ParamNameField::Simple("name"),
+        type_field: "type",
+        skip_names: &[],
+    }],
 
     return_type_field: Some("result"),
 
@@ -1133,7 +1369,11 @@ static GO_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     new_expr_nodes: &[],
     new_expr_type_field: "constructor",
     composite_literal_nodes: &["composite_literal"],
-    member_access: &[MemberAccess { node_kind: "selector_expression", object_field: "operand", property_field: "field" }],
+    member_access: &[MemberAccess {
+        node_kind: "selector_expression",
+        object_field: "operand",
+        property_field: "field",
+    }],
     scoped_call_nodes: &[],
 
     self_keywords: &[],
@@ -1146,43 +1386,99 @@ static GO_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     external_method: true,
 
     builtins: &[
-        "fmt", "log", "os", "io", "strings", "strconv", "bytes",
-        "make", "len", "cap", "append", "copy", "delete", "close",
-        "panic", "recover", "new", "print", "println",
-        "error", "string", "int", "int8", "int16", "int32", "int64",
-        "uint", "uint8", "uint16", "uint32", "uint64",
-        "float32", "float64", "complex64", "complex128",
-        "bool", "byte", "rune", "uintptr",
-        "Println", "Printf", "Sprintf", "Fprintf", "Errorf",
+        "fmt",
+        "log",
+        "os",
+        "io",
+        "strings",
+        "strconv",
+        "bytes",
+        "make",
+        "len",
+        "cap",
+        "append",
+        "copy",
+        "delete",
+        "close",
+        "panic",
+        "recover",
+        "new",
+        "print",
+        "println",
+        "error",
+        "string",
+        "int",
+        "int8",
+        "int16",
+        "int32",
+        "int64",
+        "uint",
+        "uint8",
+        "uint16",
+        "uint32",
+        "uint64",
+        "float32",
+        "float64",
+        "complex64",
+        "complex128",
+        "bool",
+        "byte",
+        "rune",
+        "uintptr",
+        "Println",
+        "Printf",
+        "Sprintf",
+        "Fprintf",
+        "Errorf",
     ],
 };
 
 // ─── Tier 1 Scope Resolve Configs ─────────────────────────────────────────────
 
 static JAVA_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
-    class_scope_nodes: &["class_declaration", "interface_declaration", "enum_declaration"],
+    class_scope_nodes: &[
+        "class_declaration",
+        "interface_declaration",
+        "enum_declaration",
+    ],
     impl_scope_nodes: &[],
     function_scope_nodes: &["method_declaration", "constructor_declaration"],
     class_name_field: ClassNameField::Simple("name"),
 
     assignment_rules: &[
-        AssignmentRule { node_kind: "local_variable_declaration", strategy: AssignmentStrategy::Declarators },
-        AssignmentRule { node_kind: "expression_statement", strategy: AssignmentStrategy::LeftRight },
+        AssignmentRule {
+            node_kind: "local_variable_declaration",
+            strategy: AssignmentStrategy::Declarators,
+        },
+        AssignmentRule {
+            node_kind: "expression_statement",
+            strategy: AssignmentStrategy::LeftRight,
+        },
     ],
     assignment_recurse_into: &["block"],
 
-    param_rules: &[
-        ParamRule { node_kind: "formal_parameter", name_field: ParamNameField::Simple("name"), type_field: "type", skip_names: &[] },
-    ],
+    param_rules: &[ParamRule {
+        node_kind: "formal_parameter",
+        name_field: ParamNameField::Simple("name"),
+        type_field: "type",
+        skip_names: &[],
+    }],
 
     return_type_field: Some("type"),
 
     call_nodes: &["method_invocation"],
-    call_style: CallNodeStyle::DirectMethod { object_field: "object", method_field: "name" },
+    call_style: CallNodeStyle::DirectMethod {
+        object_field: "object",
+        method_field: "name",
+    },
     new_expr_nodes: &["object_creation_expression"],
     new_expr_type_field: "type",
     composite_literal_nodes: &[],
-    member_access: &[MemberAccess { node_kind: "method_invocation", object_field: "object", property_field: "name" }],
+    member_access: &[MemberAccess {
+        node_kind: "method_invocation",
+        object_field: "object",
+        property_field: "name",
+    }],
     scoped_call_nodes: &[],
 
     self_keywords: &["this"],
@@ -1192,29 +1488,64 @@ static JAVA_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     external_method: false,
 
     builtins: &[
-        "System", "String", "Integer", "Long", "Double", "Float", "Boolean",
-        "Object", "Class", "Math", "Collections", "Arrays", "List", "Map", "Set",
-        "ArrayList", "HashMap", "HashSet", "Optional", "Stream",
-        "Exception", "RuntimeException", "NullPointerException",
-        "println", "printf", "format",
+        "System",
+        "String",
+        "Integer",
+        "Long",
+        "Double",
+        "Float",
+        "Boolean",
+        "Object",
+        "Class",
+        "Math",
+        "Collections",
+        "Arrays",
+        "List",
+        "Map",
+        "Set",
+        "ArrayList",
+        "HashMap",
+        "HashSet",
+        "Optional",
+        "Stream",
+        "Exception",
+        "RuntimeException",
+        "NullPointerException",
+        "println",
+        "printf",
+        "format",
     ],
 };
 
 static CSHARP_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
-    class_scope_nodes: &["class_declaration", "interface_declaration", "struct_declaration", "enum_declaration"],
+    class_scope_nodes: &[
+        "class_declaration",
+        "interface_declaration",
+        "struct_declaration",
+        "enum_declaration",
+    ],
     impl_scope_nodes: &[],
     function_scope_nodes: &["method_declaration", "constructor_declaration"],
     class_name_field: ClassNameField::Simple("name"),
 
     assignment_rules: &[
-        AssignmentRule { node_kind: "local_declaration_statement", strategy: AssignmentStrategy::Declarators },
-        AssignmentRule { node_kind: "expression_statement", strategy: AssignmentStrategy::LeftRight },
+        AssignmentRule {
+            node_kind: "local_declaration_statement",
+            strategy: AssignmentStrategy::Declarators,
+        },
+        AssignmentRule {
+            node_kind: "expression_statement",
+            strategy: AssignmentStrategy::LeftRight,
+        },
     ],
     assignment_recurse_into: &["block"],
 
-    param_rules: &[
-        ParamRule { node_kind: "parameter", name_field: ParamNameField::Simple("name"), type_field: "type", skip_names: &[] },
-    ],
+    param_rules: &[ParamRule {
+        node_kind: "parameter",
+        name_field: ParamNameField::Simple("name"),
+        type_field: "type",
+        skip_names: &[],
+    }],
 
     return_type_field: Some("type"),
 
@@ -1223,7 +1554,11 @@ static CSHARP_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     new_expr_nodes: &["object_creation_expression"],
     new_expr_type_field: "type",
     composite_literal_nodes: &[],
-    member_access: &[MemberAccess { node_kind: "member_access_expression", object_field: "expression", property_field: "name" }],
+    member_access: &[MemberAccess {
+        node_kind: "member_access_expression",
+        object_field: "expression",
+        property_field: "name",
+    }],
     scoped_call_nodes: &[],
 
     self_keywords: &["this"],
@@ -1233,10 +1568,25 @@ static CSHARP_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     external_method: false,
 
     builtins: &[
-        "Console", "String", "Int32", "Int64", "Double", "Boolean",
-        "Object", "Math", "List", "Dictionary", "HashSet",
-        "Task", "Async", "Exception", "ArgumentException",
-        "WriteLine", "ReadLine", "ToString", "Equals",
+        "Console",
+        "String",
+        "Int32",
+        "Int64",
+        "Double",
+        "Boolean",
+        "Object",
+        "Math",
+        "List",
+        "Dictionary",
+        "HashSet",
+        "Task",
+        "Async",
+        "Exception",
+        "ArgumentException",
+        "WriteLine",
+        "ReadLine",
+        "ToString",
+        "Equals",
     ],
 };
 
@@ -1247,14 +1597,23 @@ static CPP_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     class_name_field: ClassNameField::Simple("name"),
 
     assignment_rules: &[
-        AssignmentRule { node_kind: "declaration", strategy: AssignmentStrategy::Declarators },
-        AssignmentRule { node_kind: "expression_statement", strategy: AssignmentStrategy::LeftRight },
+        AssignmentRule {
+            node_kind: "declaration",
+            strategy: AssignmentStrategy::Declarators,
+        },
+        AssignmentRule {
+            node_kind: "expression_statement",
+            strategy: AssignmentStrategy::LeftRight,
+        },
     ],
     assignment_recurse_into: &["compound_statement"],
 
-    param_rules: &[
-        ParamRule { node_kind: "parameter_declaration", name_field: ParamNameField::Simple("declarator"), type_field: "type", skip_names: &[] },
-    ],
+    param_rules: &[ParamRule {
+        node_kind: "parameter_declaration",
+        name_field: ParamNameField::Simple("declarator"),
+        type_field: "type",
+        skip_names: &[],
+    }],
 
     return_type_field: Some("type"),
 
@@ -1263,9 +1622,11 @@ static CPP_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     new_expr_nodes: &["new_expression"],
     new_expr_type_field: "type",
     composite_literal_nodes: &[],
-    member_access: &[
-        MemberAccess { node_kind: "field_expression", object_field: "argument", property_field: "field" },
-    ],
+    member_access: &[MemberAccess {
+        node_kind: "field_expression",
+        object_field: "argument",
+        property_field: "field",
+    }],
     scoped_call_nodes: &["qualified_identifier"],
 
     self_keywords: &["this"],
@@ -1277,10 +1638,31 @@ static CPP_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     external_method: false,
 
     builtins: &[
-        "std", "cout", "cin", "endl", "printf", "scanf", "malloc", "free",
-        "string", "vector", "map", "set", "pair", "make_pair",
-        "shared_ptr", "unique_ptr", "make_shared", "make_unique",
-        "nullptr", "size_t", "int", "char", "double", "float", "bool",
+        "std",
+        "cout",
+        "cin",
+        "endl",
+        "printf",
+        "scanf",
+        "malloc",
+        "free",
+        "string",
+        "vector",
+        "map",
+        "set",
+        "pair",
+        "make_pair",
+        "shared_ptr",
+        "unique_ptr",
+        "make_shared",
+        "make_unique",
+        "nullptr",
+        "size_t",
+        "int",
+        "char",
+        "double",
+        "float",
+        "bool",
     ],
 };
 
@@ -1290,9 +1672,10 @@ static RUBY_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     function_scope_nodes: &["method", "singleton_method"],
     class_name_field: ClassNameField::Simple("name"),
 
-    assignment_rules: &[
-        AssignmentRule { node_kind: "assignment", strategy: AssignmentStrategy::LeftRight },
-    ],
+    assignment_rules: &[AssignmentRule {
+        node_kind: "assignment",
+        strategy: AssignmentStrategy::LeftRight,
+    }],
     assignment_recurse_into: &["body_statement"],
 
     param_rules: &[],
@@ -1300,11 +1683,18 @@ static RUBY_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     return_type_field: None,
 
     call_nodes: &["call"],
-    call_style: CallNodeStyle::DirectMethod { object_field: "receiver", method_field: "method" },
+    call_style: CallNodeStyle::DirectMethod {
+        object_field: "receiver",
+        method_field: "method",
+    },
     new_expr_nodes: &[],
     new_expr_type_field: "constructor",
     composite_literal_nodes: &[],
-    member_access: &[MemberAccess { node_kind: "call", object_field: "receiver", property_field: "method" }],
+    member_access: &[MemberAccess {
+        node_kind: "call",
+        object_field: "receiver",
+        property_field: "method",
+    }],
     scoped_call_nodes: &["scope_resolution"],
 
     self_keywords: &["self"],
@@ -1314,28 +1704,54 @@ static RUBY_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     external_method: false,
 
     builtins: &[
-        "puts", "print", "p", "require", "require_relative", "include", "extend",
-        "attr_accessor", "attr_reader", "attr_writer",
-        "raise", "rescue", "yield", "block_given?",
-        "Array", "Hash", "String", "Integer", "Float", "Symbol",
-        "nil", "true", "false",
+        "puts",
+        "print",
+        "p",
+        "require",
+        "require_relative",
+        "include",
+        "extend",
+        "attr_accessor",
+        "attr_reader",
+        "attr_writer",
+        "raise",
+        "rescue",
+        "yield",
+        "block_given?",
+        "Array",
+        "Hash",
+        "String",
+        "Integer",
+        "Float",
+        "Symbol",
+        "nil",
+        "true",
+        "false",
     ],
 };
 
 static KOTLIN_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
-    class_scope_nodes: &["class_declaration", "object_declaration", "companion_object"],
+    class_scope_nodes: &[
+        "class_declaration",
+        "object_declaration",
+        "companion_object",
+    ],
     impl_scope_nodes: &[],
     function_scope_nodes: &["function_declaration", "secondary_constructor"],
     class_name_field: ClassNameField::Simple("name"),
 
-    assignment_rules: &[
-        AssignmentRule { node_kind: "property_declaration", strategy: AssignmentStrategy::Declarators },
-    ],
+    assignment_rules: &[AssignmentRule {
+        node_kind: "property_declaration",
+        strategy: AssignmentStrategy::Declarators,
+    }],
     assignment_recurse_into: &["statements", "block", "function_body"],
 
-    param_rules: &[
-        ParamRule { node_kind: "parameter", name_field: ParamNameField::Simple("name"), type_field: "type", skip_names: &[] },
-    ],
+    param_rules: &[ParamRule {
+        node_kind: "parameter",
+        name_field: ParamNameField::Simple("name"),
+        type_field: "type",
+        skip_names: &[],
+    }],
 
     return_type_field: Some("type"),
 
@@ -1344,7 +1760,11 @@ static KOTLIN_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     new_expr_nodes: &[],
     new_expr_type_field: "constructor",
     composite_literal_nodes: &[],
-    member_access: &[MemberAccess { node_kind: "navigation_expression", object_field: "expression", property_field: "navigation_suffix" }],
+    member_access: &[MemberAccess {
+        node_kind: "navigation_expression",
+        object_field: "expression",
+        property_field: "navigation_suffix",
+    }],
     scoped_call_nodes: &[],
 
     self_keywords: &["this"],
@@ -1362,37 +1782,90 @@ static KOTLIN_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     external_method: false,
 
     builtins: &[
-        "println", "print", "listOf", "mapOf", "setOf", "arrayOf",
-        "mutableListOf", "mutableMapOf", "mutableSetOf",
-        "String", "Int", "Long", "Double", "Float", "Boolean",
-        "Any", "Unit", "Nothing", "Pair", "Triple",
-        "require", "check", "error", "TODO",
-        "emptyList", "emptyMap", "emptySet",
-        "lazy", "run", "let", "also", "apply", "with", "takeIf", "takeUnless",
-        "Throwable", "Exception", "RuntimeException", "IllegalArgumentException",
-        "IllegalStateException", "UnsupportedOperationException",
-        "Regex", "Sequence", "Iterable", "Iterator",
-        "coroutineScope", "launch", "async", "withContext", "runBlocking",
-        "Flow", "StateFlow", "SharedFlow",
-        "Dispatchers", "Job", "SupervisorJob", "CoroutineScope",
-        "suspend", "Channel",
+        "println",
+        "print",
+        "listOf",
+        "mapOf",
+        "setOf",
+        "arrayOf",
+        "mutableListOf",
+        "mutableMapOf",
+        "mutableSetOf",
+        "String",
+        "Int",
+        "Long",
+        "Double",
+        "Float",
+        "Boolean",
+        "Any",
+        "Unit",
+        "Nothing",
+        "Pair",
+        "Triple",
+        "require",
+        "check",
+        "error",
+        "TODO",
+        "emptyList",
+        "emptyMap",
+        "emptySet",
+        "lazy",
+        "run",
+        "let",
+        "also",
+        "apply",
+        "with",
+        "takeIf",
+        "takeUnless",
+        "Throwable",
+        "Exception",
+        "RuntimeException",
+        "IllegalArgumentException",
+        "IllegalStateException",
+        "UnsupportedOperationException",
+        "Regex",
+        "Sequence",
+        "Iterable",
+        "Iterator",
+        "coroutineScope",
+        "launch",
+        "async",
+        "withContext",
+        "runBlocking",
+        "Flow",
+        "StateFlow",
+        "SharedFlow",
+        "Dispatchers",
+        "Job",
+        "SupervisorJob",
+        "CoroutineScope",
+        "suspend",
+        "Channel",
     ],
 };
 
 static PHP_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
-    class_scope_nodes: &["class_declaration", "interface_declaration", "trait_declaration"],
+    class_scope_nodes: &[
+        "class_declaration",
+        "interface_declaration",
+        "trait_declaration",
+    ],
     impl_scope_nodes: &[],
     function_scope_nodes: &["function_definition", "method_declaration"],
     class_name_field: ClassNameField::Simple("name"),
 
-    assignment_rules: &[
-        AssignmentRule { node_kind: "expression_statement", strategy: AssignmentStrategy::LeftRight },
-    ],
+    assignment_rules: &[AssignmentRule {
+        node_kind: "expression_statement",
+        strategy: AssignmentStrategy::LeftRight,
+    }],
     assignment_recurse_into: &["compound_statement"],
 
-    param_rules: &[
-        ParamRule { node_kind: "simple_parameter", name_field: ParamNameField::Simple("name"), type_field: "type", skip_names: &[] },
-    ],
+    param_rules: &[ParamRule {
+        node_kind: "simple_parameter",
+        name_field: ParamNameField::Simple("name"),
+        type_field: "type",
+        skip_names: &[],
+    }],
 
     return_type_field: Some("return_type"),
 
@@ -1401,7 +1874,11 @@ static PHP_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     new_expr_nodes: &["object_creation_expression"],
     new_expr_type_field: "type",
     composite_literal_nodes: &[],
-    member_access: &[MemberAccess { node_kind: "member_call_expression", object_field: "object", property_field: "name" }],
+    member_access: &[MemberAccess {
+        node_kind: "member_call_expression",
+        object_field: "object",
+        property_field: "name",
+    }],
     scoped_call_nodes: &["scoped_call_expression"],
 
     self_keywords: &["$this"],
@@ -1411,27 +1888,61 @@ static PHP_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     external_method: false,
 
     builtins: &[
-        "echo", "print", "var_dump", "print_r", "isset", "unset", "empty",
-        "array", "count", "strlen", "substr", "strpos",
-        "is_null", "is_array", "is_string", "is_int",
-        "Exception", "RuntimeException", "InvalidArgumentException",
+        "echo",
+        "print",
+        "var_dump",
+        "print_r",
+        "isset",
+        "unset",
+        "empty",
+        "array",
+        "count",
+        "strlen",
+        "substr",
+        "strpos",
+        "is_null",
+        "is_array",
+        "is_string",
+        "is_int",
+        "Exception",
+        "RuntimeException",
+        "InvalidArgumentException",
     ],
 };
 
 static SWIFT_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
-    class_scope_nodes: &["class_declaration", "protocol_declaration", "struct_declaration", "enum_declaration"],
+    class_scope_nodes: &[
+        "class_declaration",
+        "protocol_declaration",
+        "struct_declaration",
+        "enum_declaration",
+    ],
     impl_scope_nodes: &["extension_declaration"],
     function_scope_nodes: &["function_declaration", "init_declaration"],
     class_name_field: ClassNameField::Simple("name"),
 
-    assignment_rules: &[
-        AssignmentRule { node_kind: "property_declaration", strategy: AssignmentStrategy::Declarators },
+    assignment_rules: &[AssignmentRule {
+        node_kind: "property_declaration",
+        strategy: AssignmentStrategy::Declarators,
+    }],
+    assignment_recurse_into: &[
+        "function_body",
+        "code_block",
+        "statements",
+        "if_statement",
+        "guard_statement",
+        "for_statement",
+        "while_statement",
+        "repeat_while_statement",
+        "switch_statement",
     ],
-    assignment_recurse_into: &["function_body", "code_block", "statements"],
 
-    param_rules: &[
-        ParamRule { node_kind: "parameter", name_field: ParamNameField::Simple("name"), type_field: "type", skip_names: &[] },
-    ],
+    param_rules: &[ParamRule {
+        node_kind: "parameter",
+        name_field: ParamNameField::Simple("name"),
+        type_field: "type",
+        skip_names: &[],
+    }],
 
     return_type_field: Some("return_type"),
 
@@ -1440,7 +1951,11 @@ static SWIFT_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     new_expr_nodes: &[],
     new_expr_type_field: "constructor",
     composite_literal_nodes: &[],
-    member_access: &[MemberAccess { node_kind: "navigation_expression", object_field: "target", property_field: "suffix" }],
+    member_access: &[MemberAccess {
+        node_kind: "navigation_expression",
+        object_field: "target",
+        property_field: "suffix",
+    }],
     scoped_call_nodes: &[],
 
     self_keywords: &["self"],
@@ -1458,17 +1973,54 @@ static SWIFT_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     external_method: false,
 
     builtins: &[
-        "print", "debugPrint", "fatalError", "precondition", "assert",
-        "String", "Int", "Double", "Float", "Bool", "Array", "Dictionary", "Set",
-        "Optional", "Result", "Error", "NSError",
-        "nil", "Any", "AnyObject", "Void", "Never",
-        "Data", "URL", "URLRequest", "URLSession",
-        "Codable", "Hashable", "Equatable", "Comparable", "Identifiable",
-        "Task", "MainActor", "Sendable",
-        "min", "max", "abs", "zip", "stride", "type",
-        "DispatchQueue", "NotificationCenter", "UserDefaults",
-        "NSObject", "Bundle", "FileManager",
-        "true", "false",
+        "print",
+        "debugPrint",
+        "fatalError",
+        "precondition",
+        "assert",
+        "String",
+        "Int",
+        "Double",
+        "Float",
+        "Bool",
+        "Array",
+        "Dictionary",
+        "Set",
+        "Optional",
+        "Result",
+        "Error",
+        "NSError",
+        "nil",
+        "Any",
+        "AnyObject",
+        "Void",
+        "Never",
+        "Data",
+        "URL",
+        "URLRequest",
+        "URLSession",
+        "Codable",
+        "Hashable",
+        "Equatable",
+        "Comparable",
+        "Identifiable",
+        "Task",
+        "MainActor",
+        "Sendable",
+        "min",
+        "max",
+        "abs",
+        "zip",
+        "stride",
+        "type",
+        "DispatchQueue",
+        "NotificationCenter",
+        "UserDefaults",
+        "NSObject",
+        "Bundle",
+        "FileManager",
+        "true",
+        "false",
     ],
 };
 
@@ -1478,14 +2030,18 @@ static SCALA_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     function_scope_nodes: &["function_definition", "function_declaration"],
     class_name_field: ClassNameField::Simple("name"),
 
-    assignment_rules: &[
-        AssignmentRule { node_kind: "val_definition", strategy: AssignmentStrategy::Declarators },
-    ],
+    assignment_rules: &[AssignmentRule {
+        node_kind: "val_definition",
+        strategy: AssignmentStrategy::Declarators,
+    }],
     assignment_recurse_into: &["template_body"],
 
-    param_rules: &[
-        ParamRule { node_kind: "parameter", name_field: ParamNameField::Simple("name"), type_field: "type", skip_names: &[] },
-    ],
+    param_rules: &[ParamRule {
+        node_kind: "parameter",
+        name_field: ParamNameField::Simple("name"),
+        type_field: "type",
+        skip_names: &[],
+    }],
 
     return_type_field: Some("return_type"),
 
@@ -1494,7 +2050,11 @@ static SCALA_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     new_expr_nodes: &[],
     new_expr_type_field: "constructor",
     composite_literal_nodes: &[],
-    member_access: &[MemberAccess { node_kind: "field_expression", object_field: "value", property_field: "field" }],
+    member_access: &[MemberAccess {
+        node_kind: "field_expression",
+        object_field: "value",
+        property_field: "field",
+    }],
     scoped_call_nodes: &[],
 
     self_keywords: &["this"],
@@ -1504,10 +2064,9 @@ static SCALA_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     external_method: false,
 
     builtins: &[
-        "println", "print", "require", "assert",
-        "String", "Int", "Long", "Double", "Float", "Boolean",
-        "List", "Map", "Set", "Seq", "Vector", "Option", "Some", "None",
-        "Future", "Try", "Either", "Left", "Right",
+        "println", "print", "require", "assert", "String", "Int", "Long", "Double", "Float",
+        "Boolean", "List", "Map", "Set", "Seq", "Vector", "Option", "Some", "None", "Future",
+        "Try", "Either", "Left", "Right",
     ],
 };
 
@@ -1522,9 +2081,12 @@ static DART_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     assignment_rules: &[],
     assignment_recurse_into: &[],
 
-    param_rules: &[
-        ParamRule { node_kind: "formal_parameter", name_field: ParamNameField::Simple("name"), type_field: "type", skip_names: &[] },
-    ],
+    param_rules: &[ParamRule {
+        node_kind: "formal_parameter",
+        name_field: ParamNameField::Simple("name"),
+        type_field: "type",
+        skip_names: &[],
+    }],
 
     return_type_field: None,
 
@@ -1543,8 +2105,17 @@ static DART_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     external_method: false,
 
     builtins: &[
-        "print", "debugPrint", "String", "int", "double", "bool",
-        "List", "Map", "Set", "Future", "Stream",
+        "print",
+        "debugPrint",
+        "String",
+        "int",
+        "double",
+        "bool",
+        "List",
+        "Map",
+        "Set",
+        "Future",
+        "Stream",
     ],
 };
 
@@ -1566,7 +2137,11 @@ static ZIG_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     new_expr_nodes: &[],
     new_expr_type_field: "constructor",
     composite_literal_nodes: &[],
-    member_access: &[MemberAccess { node_kind: "field_expression", object_field: "object", property_field: "field" }],
+    member_access: &[MemberAccess {
+        node_kind: "field_expression",
+        object_field: "object",
+        property_field: "field",
+    }],
     scoped_call_nodes: &[],
 
     self_keywords: &[],
@@ -1576,8 +2151,14 @@ static ZIG_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     external_method: false,
 
     builtins: &[
-        "std", "print", "debug", "assert", "expect",
-        "allocator", "mem", "testing",
+        "std",
+        "print",
+        "debug",
+        "assert",
+        "expect",
+        "allocator",
+        "mem",
+        "testing",
     ],
 };
 
@@ -1609,9 +2190,8 @@ static BASH_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     external_method: false,
 
     builtins: &[
-        "echo", "printf", "cd", "ls", "cat", "grep", "sed", "awk",
-        "if", "then", "else", "fi", "for", "while", "do", "done",
-        "exit", "return", "export", "source", "eval",
+        "echo", "printf", "cd", "ls", "cat", "grep", "sed", "awk", "if", "then", "else", "fi",
+        "for", "while", "do", "done", "exit", "return", "export", "source", "eval",
     ],
 };
 
@@ -1687,7 +2267,10 @@ pub fn get_all_code_extensions() -> &'static [&'static str] {
     // Derived from ALL_CONFIGS to avoid duplication drift.
     // When you add an extension to a LanguageConfig, it's automatically included here.
     static EXTENSIONS: std::sync::LazyLock<Vec<&'static str>> = std::sync::LazyLock::new(|| {
-        ALL_CONFIGS.iter().flat_map(|c| c.extensions.iter().copied()).collect()
+        ALL_CONFIGS
+            .iter()
+            .flat_map(|c| c.extensions.iter().copied())
+            .collect()
     });
     &EXTENSIONS
 }

--- a/crates/sem-core/src/parser/plugins/code/mod.rs
+++ b/crates/sem-core/src/parser/plugins/code/mod.rs
@@ -351,11 +351,19 @@ int main() {
         let code = r#"
 import Foundation
 
+typealias Handler = (Int) -> Void
+
+prefix operator ~~~
+
 class UserService {
     var name: String
 
     init(name: String) {
         self.name = name
+    }
+
+    deinit {
+        print("freed")
     }
 
     func getUsers() -> [User] {
@@ -366,6 +374,10 @@ class UserService {
 struct Point {
     var x: Double
     var y: Double
+
+    subscript(index: Int) -> Double {
+        return x + y + Double(index)
+    }
 }
 
 enum Status {
@@ -375,9 +387,9 @@ enum Status {
 }
 
 protocol Repository {
-    associatedtype Item
-    func findById(id: String) -> Item?
-    func findAll() -> [Item]
+    associatedtype Canvas
+    func findById(id: String) -> Canvas?
+    func findAll() -> [Canvas]
 }
 
 func helper(x: Int) -> Int {
@@ -393,13 +405,63 @@ func helper(x: Int) -> Int {
         assert!(names.contains(&"Point"), "Should find struct Point, got: {:?}", names);
         assert!(names.contains(&"Status"), "Should find enum Status, got: {:?}", names);
         assert!(names.contains(&"Repository"), "Should find protocol Repository, got: {:?}", names);
+        assert!(names.contains(&"Canvas"), "Should find associatedtype Canvas, got: {:?}", names);
+        assert!(names.contains(&"Handler"), "Should find typealias Handler, got: {:?}", names);
+        assert!(names.contains(&"~~~"), "Should find custom operator ~~~, got: {:?}", names);
+        assert!(names.contains(&"init"), "Should find initializer init, got: {:?}", names);
+        assert!(names.contains(&"deinit"), "Should find deinitializer deinit, got: {:?}", names);
+        assert!(names.contains(&"subscript"), "Should find subscript, got: {:?}", names);
         assert!(names.contains(&"helper"), "Should find function helper, got: {:?}", names);
+
+        let handler = entities.iter().find(|e| e.name == "Handler").unwrap();
+        assert_eq!(handler.entity_type, "type");
+        assert!(handler.parent_id.is_none());
+
+        let operator = entities.iter().find(|e| e.name == "~~~").unwrap();
+        assert_eq!(operator.entity_type, "operator");
+        assert!(operator.parent_id.is_none());
+
+        let user_service = entities.iter().find(|e| e.name == "UserService").unwrap();
+        assert_eq!(user_service.entity_type, "class");
+
+        let initializer = entities.iter().find(|e| e.name == "init").unwrap();
+        assert_eq!(initializer.entity_type, "init");
+        assert_eq!(initializer.parent_id.as_deref(), Some(user_service.id.as_str()));
+        assert_eq!(initializer.id, "UserService.swift::class::UserService::init");
+
+        let deinitializer = entities.iter().find(|e| e.name == "deinit").unwrap();
+        assert_eq!(deinitializer.entity_type, "deinit");
+        assert_eq!(deinitializer.parent_id.as_deref(), Some(user_service.id.as_str()));
+        assert_eq!(
+            deinitializer.id,
+            "UserService.swift::class::UserService::deinit"
+        );
 
         let point = entities.iter().find(|e| e.name == "Point").unwrap();
         assert_eq!(point.entity_type, "struct");
 
+        let subscript = entities.iter().find(|e| e.name == "subscript").unwrap();
+        assert_eq!(subscript.entity_type, "subscript");
+        assert_eq!(subscript.parent_id.as_deref(), Some(point.id.as_str()));
+        assert_eq!(
+            subscript.id,
+            "UserService.swift::struct::Point::subscript"
+        );
+
         let status = entities.iter().find(|e| e.name == "Status").unwrap();
         assert_eq!(status.entity_type, "enum");
+
+        let repository = entities.iter().find(|e| e.name == "Repository").unwrap();
+        assert_eq!(repository.entity_type, "protocol");
+        assert_eq!(repository.id, "UserService.swift::protocol::Repository");
+
+        let canvas = entities.iter().find(|e| e.name == "Canvas").unwrap();
+        assert_eq!(canvas.entity_type, "associatedtype");
+        assert_eq!(canvas.parent_id.as_deref(), Some(repository.id.as_str()));
+        assert_eq!(
+            canvas.id,
+            "UserService.swift::protocol::Repository::Canvas"
+        );
     }
 
     #[test]
@@ -847,6 +909,69 @@ impl Greeting for Cat {
             entities_a[0].content_hash, entities_b[0].content_hash,
             "Content hash should differ since raw content includes the name"
         );
+    }
+
+    #[test]
+    fn test_swift_renamed_operator_same_structural_hash() {
+        let plugin = CodeParserPlugin;
+        let entities_a = plugin.extract_entities("prefix operator ~~~\n", "a.swift");
+        let entities_b = plugin.extract_entities("prefix operator !!!\n", "b.swift");
+
+        assert_eq!(entities_a.len(), 1, "Should find one entity in a");
+        assert_eq!(entities_b.len(), 1, "Should find one entity in b");
+        assert_eq!(entities_a[0].name, "~~~");
+        assert_eq!(entities_b[0].name, "!!!");
+        assert_eq!(entities_a[0].entity_type, "operator");
+        assert_eq!(entities_b[0].entity_type, "operator");
+        assert_eq!(
+            entities_a[0].structural_hash, entities_b[0].structural_hash,
+            "Renamed operator with otherwise identical declaration should have same structural_hash"
+        );
+        assert_ne!(
+            entities_a[0].content_hash, entities_b[0].content_hash,
+            "Content hash should differ since raw content includes the operator token"
+        );
+    }
+
+    #[test]
+    fn test_swift_synthesized_names_disambiguate_overloads() {
+        let plugin = CodeParserPlugin;
+        let code = r#"
+struct Matrix {
+    subscript(row: Int) -> Double {
+        return Double(row)
+    }
+
+    subscript(row: Int, column: Int) -> Double {
+        return Double(row + column)
+    }
+}
+
+class Builder {
+    init(value: Int) {}
+    init(text: String) {}
+}
+"#;
+
+        let entities = plugin.extract_entities(code, "Overloads.swift");
+
+        let subscript_ids: Vec<&str> = entities
+            .iter()
+            .filter(|e| e.entity_type == "subscript")
+            .map(|e| e.id.as_str())
+            .collect();
+        assert_eq!(subscript_ids.len(), 2);
+        assert_ne!(subscript_ids[0], subscript_ids[1]);
+        assert!(subscript_ids.iter().all(|id| id.contains("@L")));
+
+        let init_ids: Vec<&str> = entities
+            .iter()
+            .filter(|e| e.entity_type == "init")
+            .map(|e| e.id.as_str())
+            .collect();
+        assert_eq!(init_ids.len(), 2);
+        assert_ne!(init_ids[0], init_ids[1]);
+        assert!(init_ids.iter().all(|id| id.contains("@L")));
     }
 
     #[test]

--- a/crates/sem-core/src/parser/scope_resolve.rs
+++ b/crates/sem-core/src/parser/scope_resolve.rs
@@ -23,9 +23,13 @@ use crate::model::entity::SemanticEntity;
 macro_rules! maybe_par_iter {
     ($slice:expr) => {{
         #[cfg(feature = "parallel")]
-        { $slice.par_iter() }
+        {
+            $slice.par_iter()
+        }
         #[cfg(not(feature = "parallel"))]
-        { $slice.iter() }
+        {
+            $slice.iter()
+        }
     }};
 }
 use crate::parser::graph::{EntityInfo, RefType};
@@ -42,6 +46,8 @@ pub struct Scope {
     defs: HashMap<String, String>,
     /// Local bindings that shadow outer names but are not graph entities.
     bindings: HashSet<String>,
+    /// Binding declaration rows keyed by name.
+    binding_rows: HashMap<String, Vec<usize>>,
     /// Variable type bindings: var_name -> class_name (from `x = Foo()`)
     types: HashMap<String, String>,
     /// Unresolved call assignments: var_name -> function_name (from `x = func()`)
@@ -59,13 +65,181 @@ struct AstRef {
     kind: AstRefKind,
     /// Row (0-indexed) where this reference appears in the source
     row: usize,
+    /// Byte range for the referenced syntax node in the file.
+    start_byte: usize,
+    end_byte: usize,
 }
 
 enum AstRefKind {
     /// Bare name call: `foo()`
-    Call(String),
+    Call {
+        name: String,
+        argument_labels: Option<Vec<Option<String>>>,
+    },
+    /// Qualified path call: `module::function()`
+    ScopedCall { path: String, name: String },
     /// Attribute call: `x.method()`
-    MethodCall { receiver: String, method: String },
+    MethodCall {
+        receiver: String,
+        method: String,
+        argument_labels: Option<Vec<Option<String>>>,
+    },
+}
+
+struct SwiftCallSignature {
+    argument_labels: Vec<Option<String>>,
+}
+
+enum SwiftOverloadSelection {
+    Matched(String),
+    NoMatch,
+    NotApplicable,
+}
+
+#[derive(Clone, Copy)]
+struct SourceSpan {
+    start_byte: usize,
+    end_byte: usize,
+}
+
+fn entity_creates_reference_scope(entity_type: &str) -> bool {
+    matches!(
+        entity_type,
+        "function"
+            | "method"
+            | "constructor"
+            | "init"
+            | "init_declaration"
+            | "class"
+            | "struct"
+            | "interface"
+            | "impl"
+            | "enum"
+            | "protocol"
+            | "protocol_declaration"
+            | "object_declaration"
+            | "companion_object"
+            | "extension"
+            | "module"
+            | "namespace"
+    )
+}
+
+fn entity_owns_ref(
+    entity: &SemanticEntity,
+    ast_ref: &AstRef,
+    children_by_parent: &HashMap<&str, Vec<&SemanticEntity>>,
+    entity_spans: &HashMap<&str, SourceSpan>,
+) -> bool {
+    let source_line = ast_ref.row + 1;
+    if let Some(entity_span) = entity_spans.get(entity.id.as_str()) {
+        if ast_ref.end_byte <= entity_span.start_byte || ast_ref.start_byte >= entity_span.end_byte
+        {
+            return false;
+        }
+    }
+
+    children_by_parent
+        .get(entity.id.as_str())
+        .map_or(true, |children| {
+            children.iter().all(|child| {
+                if !entity_creates_reference_scope(&child.entity_type) {
+                    return true;
+                }
+                if child.file_path != entity.file_path
+                    || source_line < child.start_line
+                    || source_line > child.end_line
+                {
+                    return true;
+                }
+
+                if let Some(child_span) = entity_spans.get(child.id.as_str()) {
+                    ast_ref.end_byte <= child_span.start_byte
+                        || ast_ref.start_byte >= child_span.end_byte
+                } else {
+                    false
+                }
+            })
+        })
+}
+
+fn find_entity_source_spans<'a>(
+    entities: &[&'a SemanticEntity],
+    source: &str,
+) -> HashMap<&'a str, SourceSpan> {
+    let mut spans = HashMap::new();
+    let line_starts = source_line_starts(source);
+    for entity in entities {
+        if entity.content.is_empty() {
+            continue;
+        }
+
+        if let Some(span) = find_entity_source_span(entity, source, &line_starts) {
+            spans.insert(entity.id.as_str(), span);
+        }
+    }
+    spans
+}
+
+fn source_line_starts(source: &str) -> Vec<usize> {
+    let mut starts = vec![0];
+    for (idx, byte) in source.bytes().enumerate() {
+        if byte == b'\n' && idx + 1 < source.len() {
+            starts.push(idx + 1);
+        }
+    }
+    starts
+}
+
+fn find_entity_source_span(
+    entity: &SemanticEntity,
+    source: &str,
+    line_starts: &[usize],
+) -> Option<SourceSpan> {
+    let line_index = entity.start_line.checked_sub(1)?;
+    let line_start = *line_starts.get(line_index)?;
+
+    if let Some(span) = source_span_at(source, &entity.content, line_start) {
+        return Some(span);
+    }
+
+    let line_end = line_starts
+        .get(line_index + 1)
+        .copied()
+        .unwrap_or(source.len());
+    let line = source.get(line_start..line_end)?;
+    let trimmed_line_start = line_start + line.len().saturating_sub(line.trim_start().len());
+    if trimmed_line_start != line_start {
+        if let Some(span) = source_span_at(source, &entity.content, trimmed_line_start) {
+            return Some(span);
+        }
+    }
+
+    let first_content_line = entity.content.lines().next().unwrap_or("").trim_start();
+    if first_content_line.is_empty() {
+        return None;
+    }
+
+    for (candidate_offset, _) in line.match_indices(first_content_line) {
+        if let Some(span) =
+            source_span_at(source, &entity.content, line_start + candidate_offset)
+        {
+            return Some(span);
+        }
+    }
+
+    None
+}
+
+fn source_span_at(source: &str, content: &str, start_byte: usize) -> Option<SourceSpan> {
+    if source.get(start_byte..)?.starts_with(content) {
+        Some(SourceSpan {
+            start_byte,
+            end_byte: start_byte + content.len(),
+        })
+    } else {
+        None
+    }
 }
 
 /// Result of scope-aware resolution
@@ -101,6 +275,69 @@ pub(crate) struct PreBuiltLookups {
     pub(crate) go_pkg_index: HashMap<String, Vec<(String, String)>>,
 }
 
+struct FileEntityLookup<'a> {
+    by_name: HashMap<&'a str, Vec<&'a SemanticEntity>>,
+}
+
+impl<'a> FileEntityLookup<'a> {
+    fn new(file_entities: &[&'a SemanticEntity]) -> Self {
+        let mut by_name: HashMap<&'a str, Vec<&'a SemanticEntity>> = HashMap::new();
+        for entity in file_entities {
+            by_name
+                .entry(entity.name.as_str())
+                .or_default()
+                .push(*entity);
+        }
+        Self { by_name }
+    }
+
+    fn find_at_line<F>(
+        &self,
+        name: &str,
+        line: usize,
+        type_matches: F,
+    ) -> Option<&'a SemanticEntity>
+    where
+        F: Fn(&SemanticEntity) -> bool,
+    {
+        if name.is_empty() {
+            return None;
+        }
+        self.by_name.get(name)?.iter().find_map(|entity| {
+            if entity.start_line <= line && line <= entity.end_line && type_matches(entity) {
+                Some(*entity)
+            } else {
+                None
+            }
+        })
+    }
+}
+
+#[derive(Default)]
+struct ScopeLookupCache {
+    defs: HashMap<usize, HashMap<String, Option<String>>>,
+    local_bindings: HashMap<usize, HashMap<String, bool>>,
+    types: HashMap<usize, HashMap<String, Option<String>>>,
+    enclosing_classes: HashMap<usize, Option<String>>,
+}
+
+pub(crate) fn class_member_owner_name(parent: &EntityInfo) -> Option<&str> {
+    matches!(
+        parent.entity_type.as_str(),
+        "class"
+            | "struct"
+            | "interface"
+            | "impl"
+            | "enum"
+            | "protocol"
+            | "protocol_declaration"
+            | "object_declaration"
+            | "companion_object"
+            | "extension"
+    )
+    .then_some(parent.name.as_str())
+}
+
 /// Public API — preserves the original 5-parameter signature for semver compatibility.
 pub fn resolve_with_scopes(
     root: &Path,
@@ -126,7 +363,12 @@ pub(crate) fn resolve_with_scopes_full(
 
     // Use pre-built lookups if provided, otherwise build from scratch
     let (symbol_table, class_members, entity_ranges, go_pkg_index) = if let Some(pb) = pre_built {
-        (pb.symbol_table, pb.class_members, pb.entity_ranges, pb.go_pkg_index)
+        (
+            pb.symbol_table,
+            pb.class_members,
+            pb.entity_ranges,
+            pb.go_pkg_index,
+        )
     } else {
         let mut symbol_table: HashMap<String, Vec<String>> = HashMap::new();
         let mut class_members: HashMap<String, Vec<(String, String)>> = HashMap::new();
@@ -140,14 +382,9 @@ pub(crate) fn resolve_with_scopes_full(
 
             if let Some(ref pid) = entity.parent_id {
                 if let Some(parent) = entity_map.get(pid) {
-                    if matches!(
-                        parent.entity_type.as_str(),
-                        "class" | "struct" | "interface" | "impl"
-                            | "enum" | "protocol_declaration"
-                            | "object_declaration" | "companion_object"
-                    ) {
+                    if let Some(owner_name) = class_member_owner_name(parent) {
                         class_members
-                            .entry(parent.name.clone())
+                            .entry(owner_name.to_string())
                             .or_default()
                             .push((entity.name.clone(), entity.id.clone()));
                     }
@@ -172,7 +409,12 @@ pub(crate) fn resolve_with_scopes_full(
         // Build Go package index for O(1) import lookup
         let go_pkg_index = build_go_pkg_index(&symbol_table, entity_map);
 
-        (Arc::new(symbol_table), class_members, entity_ranges, go_pkg_index)
+        (
+            Arc::new(symbol_table),
+            class_members,
+            entity_ranges,
+            go_pkg_index,
+        )
     };
 
     // Build file-path indexed entity lookup: file_path -> Vec<&SemanticEntity>
@@ -256,13 +498,17 @@ pub(crate) fn resolve_with_scopes_full(
             let ext = file_path.rfind('.').map(|i| &file_path[i..]).unwrap_or("");
             let config = get_language_config(ext).and_then(|c| c.scope_resolve)?;
 
-            let file_entities = entities_by_file.get(file_path.as_str()).map(|v| v.as_slice()).unwrap_or(&[]);
+            let file_entities = entities_by_file
+                .get(file_path.as_str())
+                .map(|v| v.as_slice())
+                .unwrap_or(&[]);
+            let file_lookup = FileEntityLookup::new(file_entities);
 
             let mut local_return_type_map: HashMap<String, String> = HashMap::new();
             scan_return_types(
                 tree.root_node(),
                 file_path,
-                file_entities,
+                &file_lookup,
                 source,
                 &mut local_return_type_map,
                 config,
@@ -283,7 +529,12 @@ pub(crate) fn resolve_with_scopes_full(
                 config,
             );
 
-            Some((local_return_type_map, local_instance_attr_types, local_init_params, local_attr_to_param))
+            Some((
+                local_return_type_map,
+                local_instance_attr_types,
+                local_init_params,
+                local_attr_to_param,
+            ))
         })
         .collect();
 
@@ -307,159 +558,205 @@ pub(crate) fn resolve_with_scopes_full(
         &mut instance_attr_types,
     );
 
+    let swift_call_signatures =
+        build_swift_call_signatures(parsed_files, all_entities, &entity_ranges, entity_map);
+
     // Pass 2: Build scopes, imports, and resolve references per file (parallel)
-    let per_file_results: Vec<(Vec<(String, String, RefType)>, Vec<ResolutionEntry>)> = maybe_par_iter!(parsed_files)
-        .filter_map(|(file_path, content, tree)| {
-            let source = content.as_bytes();
-            let ext = file_path.rfind('.').map(|i| &file_path[i..]).unwrap_or("");
-            let config = get_language_config(ext).and_then(|c| c.scope_resolve)?;
+    let per_file_results: Vec<(Vec<(String, String, RefType)>, Vec<ResolutionEntry>)> =
+        maybe_par_iter!(parsed_files)
+            .filter_map(|(file_path, content, tree)| {
+                let source = content.as_bytes();
+                let ext = file_path.rfind('.').map(|i| &file_path[i..]).unwrap_or("");
+                let config = get_language_config(ext).and_then(|c| c.scope_resolve)?;
 
-            let mut scopes: Vec<Scope> = vec![Scope {
-                parent: None,
-                defs: HashMap::new(),
-                bindings: HashSet::new(),
-                types: HashMap::new(),
-                pending_call_types: HashMap::new(),
-                owner_id: None,
-                kind: "module",
-            }];
+                let mut scopes: Vec<Scope> = vec![Scope {
+                    parent: None,
+                    defs: HashMap::new(),
+                    bindings: HashSet::new(),
+                    binding_rows: HashMap::new(),
+                    types: HashMap::new(),
+                    pending_call_types: HashMap::new(),
+                    owner_id: None,
+                    kind: "module",
+                }];
 
-            let mut entity_scope_map: HashMap<String, usize> = HashMap::new();
-            let mut entity_inner_scope: HashMap<String, usize> = HashMap::new();
+                let mut entity_scope_map: HashMap<String, usize> = HashMap::new();
+                let mut entity_inner_scope: HashMap<String, usize> = HashMap::new();
 
-            if let Some(ranges) = entity_ranges.get(file_path.as_str()) {
-                for (_start, _end, eid) in ranges {
-                    if let Some(info) = entity_map.get(eid) {
-                        if info.parent_id.is_none() {
-                            scopes[0].defs.insert(info.name.clone(), eid.clone());
-                            entity_scope_map.insert(eid.clone(), 0);
+                if let Some(ranges) = entity_ranges.get(file_path.as_str()) {
+                    for (_start, _end, eid) in ranges {
+                        if let Some(info) = entity_map.get(eid) {
+                            if info.parent_id.is_none() {
+                                scopes[0].defs.insert(info.name.clone(), eid.clone());
+                                entity_scope_map.insert(eid.clone(), 0);
+                            }
                         }
                     }
                 }
-            }
 
-            let file_entities: Vec<&SemanticEntity> = entities_by_file
-                .get(file_path.as_str())
-                .map(|v| v.as_slice())
-                .unwrap_or(&[])
-                .to_vec();
+                let file_entities: Vec<&SemanticEntity> = entities_by_file
+                    .get(file_path.as_str())
+                    .map(|v| v.as_slice())
+                    .unwrap_or(&[])
+                    .to_vec();
+                let file_lookup = FileEntityLookup::new(&file_entities);
+                let entity_spans = find_entity_source_spans(&file_entities, content);
 
-            build_scopes_from_ast(
-                tree.root_node(),
-                0,
-                &mut scopes,
-                &mut entity_scope_map,
-                &mut entity_inner_scope,
-                &file_entities,
-                &children_by_parent,
-                entity_map,
-                file_path,
-                source,
-                config,
-            );
+                build_scopes_from_ast(
+                    tree.root_node(),
+                    0,
+                    &mut scopes,
+                    &mut entity_scope_map,
+                    &mut entity_inner_scope,
+                    &file_lookup,
+                    &children_by_parent,
+                    entity_map,
+                    file_path,
+                    source,
+                    config,
+                );
 
-            let mut local_import_table: HashMap<(String, String), String> = HashMap::new();
-            extract_imports_from_ast(
-                tree.root_node(),
-                file_path,
-                source,
-                &symbol_table,
-                entity_map,
-                &mut local_import_table,
-                &mut scopes,
-                config,
-                &go_pkg_index,
-            );
+                let mut local_import_table: HashMap<(String, String), String> = HashMap::new();
+                extract_imports_from_ast(
+                    tree.root_node(),
+                    file_path,
+                    source,
+                    &symbol_table,
+                    entity_map,
+                    &mut local_import_table,
+                    &mut scopes,
+                    config,
+                    &go_pkg_index,
+                );
 
-            // Resolve pending call types using the complete return type map
-            inject_return_type_bindings(
-                &entity_inner_scope,
-                &mut scopes,
-                &return_type_map,
-                &local_import_table,
-                file_path,
-                entity_map,
-            );
+                // Resolve pending call types using the complete return type map
+                inject_return_type_bindings(
+                    &entity_inner_scope,
+                    &mut scopes,
+                    &return_type_map,
+                    &local_import_table,
+                    file_path,
+                    entity_map,
+                );
 
-            let mut file_edges: Vec<(String, String, RefType)> = Vec::new();
-            let mut file_log: Vec<ResolutionEntry> = Vec::new();
+                let mut file_edges: Vec<(String, String, RefType)> = Vec::new();
+                let mut file_log: Vec<ResolutionEntry> = Vec::new();
 
-            // Walk the AST once for the entire file, collecting all refs with row positions
-            let all_file_refs = collect_all_file_refs(tree.root_node(), source, config);
+                // Walk the AST once for the entire file, collecting all refs with row positions
+                let all_file_refs = collect_all_file_refs(tree.root_node(), source, config);
+                let refs_by_row = build_refs_by_row(&all_file_refs);
+                let descendant_ranges_by_entity =
+                    build_descendant_ranges_by_entity(&file_entities, entity_map);
+                let mut lookup_cache = ScopeLookupCache::default();
 
-            for entity in &file_entities {
-                let scope_idx = entity_inner_scope
-                    .get(&entity.id)
-                    .or_else(|| entity_scope_map.get(&entity.id))
-                    .copied()
-                    .unwrap_or(0);
+                for entity in &file_entities {
+                    let scope_idx = entity_inner_scope
+                        .get(&entity.id)
+                        .or_else(|| entity_scope_map.get(&entity.id))
+                        .copied()
+                        .unwrap_or(0);
 
-                let start_row = entity.start_line.saturating_sub(1); // 1-indexed to 0-indexed
-                let end_row = entity.end_line; // exclusive
-
-                // Filter pre-collected refs to this entity's line range
-                for ast_ref in all_file_refs.iter().filter(|r| r.row >= start_row && r.row < end_row) {
-                    // Skip self-name refs (was previously done during collection)
-                    let is_self_ref = match &ast_ref.kind {
-                        AstRefKind::Call(name) => name == &entity.name,
-                        AstRefKind::MethodCall { .. } => false,
-                    };
-                    if is_self_ref {
-                        continue;
-                    }
-
-                    // Languages without per-symbol imports (e.g. Swift, Kotlin)
-                    // allow cross-file resolution for lowercase function names.
-                    let allow_cross_file = config.import_extractor.is_none();
-                    let resolution = resolve_ref(
-                        ast_ref,
-                        scope_idx,
-                        &scopes,
-                        &symbol_table,
-                        &class_members,
-                        &local_import_table,
-                        &instance_attr_types,
-                        entity_map,
-                        file_path,
+                    let start_row = entity.start_line.saturating_sub(1).min(refs_by_row.len());
+                    let end_row = entity.end_line.min(refs_by_row.len()).max(start_row);
+                    log_scope_bindings(
+                        &mut file_log,
                         &entity.id,
-                        allow_cross_file,
+                        &scopes[scope_idx],
+                        start_row,
+                        end_row,
+                        &descendant_ranges_by_entity,
                     );
+                    let allow_implicit_instance_member_receiver =
+                        allows_implicit_instance_member_receiver(
+                            file_path,
+                            &entity.entity_type,
+                            &entity.content,
+                        );
 
-                    if let Some((target_id, ref_type, method)) = resolution {
-                        if target_id != entity.id {
-                            let is_parent_child = entity
-                                .parent_id
-                                .as_ref()
-                                .map_or(false, |pid| pid == &target_id || entity_map.get(&target_id).map_or(false, |t| t.parent_id.as_ref() == Some(&entity.id)));
+                    // Filter pre-collected refs to this entity's line range
+                    for row_refs in &refs_by_row[start_row..end_row] {
+                        for &ref_idx in row_refs {
+                            let ast_ref = &all_file_refs[ref_idx];
+                            if !entity_owns_ref(entity, ast_ref, &children_by_parent, &entity_spans)
+                            {
+                                continue;
+                            }
+                            if row_belongs_to_descendant(
+                                &descendant_ranges_by_entity,
+                                &entity.id,
+                                ast_ref.row,
+                            ) {
+                                continue;
+                            }
+                            // Skip self-name refs (was previously done during collection)
+                            let is_self_ref = match &ast_ref.kind {
+                                AstRefKind::Call { name, .. } => name == &entity.name,
+                                AstRefKind::ScopedCall { .. } => false,
+                                AstRefKind::MethodCall { .. } => false,
+                            };
+                            if is_self_ref {
+                                continue;
+                            }
 
-                            if !is_parent_child {
-                                file_edges.push((
-                                    entity.id.clone(),
-                                    target_id.clone(),
-                                    ref_type,
-                                ));
+                            // Languages without per-symbol imports (e.g. Swift, Kotlin)
+                            // allow cross-file resolution for lowercase function names.
+                            let allow_cross_file = config.import_extractor.is_none();
+                            let resolution = resolve_ref(
+                                ast_ref,
+                                scope_idx,
+                                &scopes,
+                                &symbol_table,
+                                &class_members,
+                                &local_import_table,
+                                &instance_attr_types,
+                                entity_map,
+                                &swift_call_signatures,
+                                file_path,
+                                &entity.id,
+                                allow_cross_file,
+                                allow_implicit_instance_member_receiver,
+                                &mut lookup_cache,
+                            );
+
+                            if let Some((target_id, ref_type, method)) = resolution {
+                                if target_id != entity.id {
+                                    let is_parent_child =
+                                        entity.parent_id.as_ref().map_or(false, |pid| {
+                                            pid == &target_id
+                                                || entity_map.get(&target_id).map_or(false, |t| {
+                                                    t.parent_id.as_ref() == Some(&entity.id)
+                                                })
+                                        });
+
+                                    if !is_parent_child {
+                                        file_edges.push((
+                                            entity.id.clone(),
+                                            target_id.clone(),
+                                            ref_type,
+                                        ));
+                                        file_log.push(ResolutionEntry {
+                                            from_entity: entity.id.clone(),
+                                            reference: ref_description(ast_ref),
+                                            resolved_to: Some(target_id),
+                                            method,
+                                        });
+                                    }
+                                }
+                            } else {
                                 file_log.push(ResolutionEntry {
                                     from_entity: entity.id.clone(),
                                     reference: ref_description(ast_ref),
-                                    resolved_to: Some(target_id),
-                                    method,
+                                    resolved_to: None,
+                                    method: "unresolved",
                                 });
                             }
                         }
-                    } else {
-                        file_log.push(ResolutionEntry {
-                            from_entity: entity.id.clone(),
-                            reference: ref_description(ast_ref),
-                            resolved_to: None,
-                            method: "unresolved",
-                        });
                     }
                 }
-            }
 
-            Some((file_edges, file_log))
-        })
-        .collect();
+                Some((file_edges, file_log))
+            })
+            .collect();
 
     for (file_edges, file_log) in per_file_results {
         all_edges.extend(file_edges);
@@ -467,7 +764,8 @@ pub(crate) fn resolve_with_scopes_full(
     }
 
     // Deduplicate edges
-    let mut seen: std::collections::HashSet<(String, String)> = std::collections::HashSet::with_capacity(all_edges.len());
+    let mut seen: std::collections::HashSet<(String, String)> =
+        std::collections::HashSet::with_capacity(all_edges.len());
     let deduped_edges: Vec<(String, String, RefType)> = {
         let mut result = Vec::with_capacity(all_edges.len());
         for edge in all_edges {
@@ -487,9 +785,154 @@ pub(crate) fn resolve_with_scopes_full(
 
 fn ref_description(ast_ref: &AstRef) -> String {
     match &ast_ref.kind {
-        AstRefKind::Call(name) => format!("{}()", name),
-        AstRefKind::MethodCall { receiver, method } => format!("{}.{}()", receiver, method),
+        AstRefKind::Call {
+            name,
+            argument_labels,
+        } => format!(
+            "{}({})",
+            name,
+            format_argument_labels(argument_labels.as_deref())
+        ),
+        AstRefKind::ScopedCall { path, name } => format!("{}::{}()", path, name),
+        AstRefKind::MethodCall {
+            receiver,
+            method,
+            argument_labels,
+        } => format!(
+            "{}.{}({})",
+            receiver,
+            method,
+            format_argument_labels(argument_labels.as_deref())
+        ),
     }
+}
+
+fn format_argument_labels(argument_labels: Option<&[Option<String>]>) -> String {
+    argument_labels
+        .map(|labels| {
+            labels
+                .iter()
+                .map(|label| {
+                    label
+                        .as_deref()
+                        .map_or("_:".to_string(), |label| format!("{label}:"))
+                })
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .unwrap_or_default()
+}
+
+fn log_scope_bindings(
+    file_log: &mut Vec<ResolutionEntry>,
+    from_entity: &str,
+    scope: &Scope,
+    start_row: usize,
+    end_row: usize,
+    descendant_ranges_by_entity: &HashMap<String, Vec<(usize, usize)>>,
+) {
+    let mut bindings: Vec<&String> = scope.bindings.iter().collect();
+    bindings.sort();
+    for binding in bindings {
+        let belongs_to_entity = scope.binding_rows.get(binding).map_or(false, |rows| {
+            rows.iter().any(|row| {
+                *row >= start_row
+                    && *row < end_row
+                    && !row_belongs_to_descendant(descendant_ranges_by_entity, from_entity, *row)
+            })
+        });
+        if !belongs_to_entity {
+            continue;
+        }
+        file_log.push(ResolutionEntry {
+            from_entity: from_entity.to_string(),
+            reference: binding.clone(),
+            resolved_to: None,
+            method: "local_binding",
+        });
+    }
+}
+
+fn build_descendant_ranges_by_entity(
+    file_entities: &[&SemanticEntity],
+    entity_map: &HashMap<String, EntityInfo>,
+) -> HashMap<String, Vec<(usize, usize)>> {
+    let mut ranges_by_entity: HashMap<String, Vec<(usize, usize)>> = HashMap::new();
+    let mut sorted_entities = file_entities.to_vec();
+    sorted_entities.sort_by(|left, right| {
+        left.start_line
+            .cmp(&right.start_line)
+            .then_with(|| right.end_line.cmp(&left.end_line))
+            .then_with(|| left.id.cmp(&right.id))
+    });
+
+    let mut ancestor_stack: Vec<&SemanticEntity> = Vec::new();
+    for entity in sorted_entities {
+        while ancestor_stack
+            .last()
+            .map_or(false, |candidate| !is_strict_enclosing_range(candidate, entity))
+        {
+            ancestor_stack.pop();
+        }
+
+        if !entity_creates_reference_scope(&entity.entity_type) {
+            ancestor_stack.push(entity);
+            continue;
+        }
+
+        let child_range = (entity.start_line.saturating_sub(1), entity.end_line);
+        let mut current = entity.parent_id.as_deref();
+        let mut visited = HashSet::new();
+        while let Some(parent_id) = current {
+            if !visited.insert(parent_id.to_string()) {
+                break;
+            }
+            ranges_by_entity
+                .entry(parent_id.to_string())
+                .or_default()
+                .push(child_range);
+            current = entity_map
+                .get(parent_id)
+                .and_then(|parent| parent.parent_id.as_deref());
+        }
+
+        for ancestor in &ancestor_stack {
+            ranges_by_entity
+                .entry(ancestor.id.clone())
+                .or_default()
+                .push(child_range);
+        }
+
+        ancestor_stack.push(entity);
+    }
+    for ranges in ranges_by_entity.values_mut() {
+        ranges.sort_unstable();
+        ranges.dedup();
+    }
+    ranges_by_entity
+}
+
+fn is_strict_enclosing_range(candidate: &SemanticEntity, child: &SemanticEntity) -> bool {
+    candidate.file_path == child.file_path
+        && candidate.start_line <= child.start_line
+        && child.end_line <= candidate.end_line
+        && (candidate.start_line < child.start_line || child.end_line < candidate.end_line)
+}
+
+fn row_belongs_to_descendant(
+    descendant_ranges_by_entity: &HashMap<String, Vec<(usize, usize)>>,
+    entity_id: &str,
+    row: usize,
+) -> bool {
+    descendant_ranges_by_entity
+        .get(entity_id)
+        .map_or(false, |ranges| {
+            let eligible = ranges.partition_point(|(start, _)| *start <= row);
+            ranges[..eligible]
+                .iter()
+                .rev()
+                .any(|(start, end)| row >= *start && row < *end)
+        })
 }
 
 /// Build scope tree by walking the AST.
@@ -502,7 +945,7 @@ fn build_scopes_from_ast(
     scopes: &mut Vec<Scope>,
     entity_scope_map: &mut HashMap<String, usize>,
     entity_inner_scope: &mut HashMap<String, usize>,
-    file_entities: &[&SemanticEntity],
+    file_lookup: &FileEntityLookup<'_>,
     children_by_parent: &HashMap<&str, Vec<&SemanticEntity>>,
     entity_map: &HashMap<String, EntityInfo>,
     _file_path: &str,
@@ -528,11 +971,10 @@ fn build_scopes_from_ast(
                     .unwrap_or("")
             } else {
                 match &config.class_name_field {
-                    ClassNameField::Simple(field) => {
-                        node.child_by_field_name(field)
-                            .and_then(|n| n.utf8_text(source).ok())
-                            .unwrap_or("")
-                    }
+                    ClassNameField::Simple(field) => node
+                        .child_by_field_name(field)
+                        .and_then(|n| n.utf8_text(source).ok())
+                        .unwrap_or(""),
                     ClassNameField::TypeSpec { spec_kind, field } => {
                         let mut name = "";
                         let mut cursor = node.walk();
@@ -547,23 +989,27 @@ fn build_scopes_from_ast(
                         }
                         name
                     }
-                    ClassNameField::ImplType(field) => {
-                        node.child_by_field_name(field)
-                            .and_then(|n| n.utf8_text(source).ok())
-                            .unwrap_or("")
-                    }
+                    ClassNameField::ImplType(field) => node
+                        .child_by_field_name(field)
+                        .and_then(|n| n.utf8_text(source).ok())
+                        .unwrap_or(""),
                 }
             };
 
-            let class_entity = file_entities.iter().find(|e| {
-                e.name == class_name
-                    && matches!(
-                        e.entity_type.as_str(),
-                        "class" | "struct" | "interface"
-                            | "enum" | "protocol_declaration"
-                            | "object_declaration" | "companion_object"
-                    )
-            }).copied();
+            let line = node.start_position().row + 1;
+            let class_entity = file_lookup.find_at_line(class_name, line, |entity| {
+                matches!(
+                    entity.entity_type.as_str(),
+                    "class"
+                        | "struct"
+                        | "interface"
+                        | "enum"
+                        | "protocol"
+                        | "protocol_declaration"
+                        | "object_declaration"
+                        | "companion_object"
+                )
+            });
 
             if let Some(ce) = class_entity {
                 let existing_scope = entity_inner_scope.get(&ce.id).copied();
@@ -576,6 +1022,7 @@ fn build_scopes_from_ast(
                         parent: Some(current_scope),
                         defs: HashMap::new(),
                         bindings: HashSet::new(),
+                        binding_rows: HashMap::new(),
                         types: HashMap::new(),
                         pending_call_types: HashMap::new(),
                         owner_id: Some(ce.id.clone()),
@@ -607,6 +1054,7 @@ fn build_scopes_from_ast(
                     parent: Some(current_scope),
                     defs: HashMap::new(),
                     bindings: HashSet::new(),
+                    binding_rows: HashMap::new(),
                     types: HashMap::new(),
                     pending_call_types: HashMap::new(),
                     owner_id: None,
@@ -633,6 +1081,7 @@ fn build_scopes_from_ast(
                 parent: Some(current_scope),
                 defs: HashMap::new(),
                 bindings: HashSet::new(),
+                binding_rows: HashMap::new(),
                 types: HashMap::new(),
                 pending_call_types: HashMap::new(),
                 owner_id: None,
@@ -640,18 +1089,15 @@ fn build_scopes_from_ast(
             });
 
             // Register any entities that are children of this module
-            let mod_entity = file_entities.iter().find(|e| {
-                e.name == mod_name
-                    && e.entity_type == "module"
-                    && {
-                        let line = node.start_position().row + 1;
-                        e.start_line <= line && line <= e.end_line
-                    }
-            }).copied();
+            let line = node.start_position().row + 1;
+            let mod_entity =
+                file_lookup.find_at_line(mod_name, line, |entity| entity.entity_type == "module");
 
             if let Some(me) = mod_entity {
                 scopes[mod_scope_idx].owner_id = Some(me.id.clone());
-                entity_scope_map.entry(me.id.clone()).or_insert(current_scope);
+                entity_scope_map
+                    .entry(me.id.clone())
+                    .or_insert(current_scope);
                 entity_inner_scope.insert(me.id.clone(), mod_scope_idx);
 
                 // Register child entities in the module scope
@@ -677,18 +1123,24 @@ fn build_scopes_from_ast(
         let is_function_like = config.function_scope_nodes.contains(&kind);
 
         if is_function_like {
-            let func_name = node.child_by_field_name("name")
+            let func_name = node
+                .child_by_field_name("name")
                 .and_then(|n| n.utf8_text(source).ok())
                 .unwrap_or("");
 
             let parent_scope = if config.external_method && kind == "method_declaration" {
-                let receiver_type = node.utf8_text(source).ok()
+                let receiver_type = node
+                    .utf8_text(source)
+                    .ok()
                     .and_then(|t| extract_go_receiver_type(t));
                 if let Some(ref struct_name) = receiver_type {
                     let found = scopes.iter().enumerate().find(|(_, s)| {
-                        s.kind == "class" && s.owner_id.as_ref().map_or(false, |oid| {
-                            entity_map.get(oid).map_or(false, |e| e.name == *struct_name)
-                        })
+                        s.kind == "class"
+                            && s.owner_id.as_ref().map_or(false, |oid| {
+                                entity_map
+                                    .get(oid)
+                                    .map_or(false, |e| e.name == *struct_name)
+                            })
                     });
                     found.map(|(idx, _)| idx).unwrap_or(current_scope)
                 } else {
@@ -703,25 +1155,29 @@ fn build_scopes_from_ast(
                 parent: Some(parent_scope),
                 defs: HashMap::new(),
                 bindings: HashSet::new(),
+                binding_rows: HashMap::new(),
                 types: HashMap::new(),
                 pending_call_types: HashMap::new(),
                 owner_id: None,
                 kind: "function",
             });
 
-            let func_entity = file_entities.iter().find(|e| {
-                e.name == func_name && {
-                    let line = node.start_position().row + 1;
-                    e.start_line <= line && line <= e.end_line
-                }
-            }).copied();
+            let line = node.start_position().row + 1;
+            let func_entity = file_lookup.find_at_line(func_name, line, |_| true);
 
             if let Some(fe) = func_entity {
                 scopes[func_scope_idx].owner_id = Some(fe.id.clone());
-                entity_scope_map.entry(fe.id.clone()).or_insert(parent_scope);
+                entity_scope_map
+                    .entry(fe.id.clone())
+                    .or_insert(parent_scope);
                 entity_inner_scope.insert(fe.id.clone(), func_scope_idx);
-                if config.external_method && kind == "method_declaration" && parent_scope != current_scope {
-                    scopes[parent_scope].defs.insert(fe.name.clone(), fe.id.clone());
+                if config.external_method
+                    && kind == "method_declaration"
+                    && parent_scope != current_scope
+                {
+                    scopes[parent_scope]
+                        .defs
+                        .insert(fe.name.clone(), fe.id.clone());
                 }
             }
 
@@ -812,6 +1268,15 @@ fn scan_assignments(
     }
 }
 
+fn record_binding(scopes: &mut [Scope], scope_idx: usize, name: &str, row: usize) {
+    scopes[scope_idx].bindings.insert(name.to_string());
+    scopes[scope_idx]
+        .binding_rows
+        .entry(name.to_string())
+        .or_default()
+        .push(row);
+}
+
 /// Scan function parameter type annotations and add them as type bindings.
 /// e.g. `def foo(shelter: Shelter)` -> types["shelter"] = "Shelter"
 fn scan_function_params(
@@ -847,7 +1312,10 @@ fn scan_function_params(
     for child in iter_node.named_children(&mut cursor) {
         // When using direct children, only process param-like nodes
         if use_direct {
-            let is_param = config.param_rules.iter().any(|r| child.kind() == r.node_kind);
+            let is_param = config
+                .param_rules
+                .iter()
+                .any(|r| child.kind() == r.node_kind);
             if !is_param {
                 continue;
             }
@@ -858,46 +1326,43 @@ fn scan_function_params(
             }
 
             let param_name = match &rule.name_field {
-                ParamNameField::Simple(field) => {
-                    child.child_by_field_name(field)
-                        .and_then(|n| n.utf8_text(source).ok())
-                        .unwrap_or("")
-                }
-                ParamNameField::WithFallback(field) => {
-                    child.child_by_field_name(field)
-                        .or_else(|| child.named_child(0).filter(|n| n.kind() == "identifier"))
-                        .and_then(|n| n.utf8_text(source).ok())
-                        .unwrap_or("")
-                }
-                ParamNameField::RustPattern => {
-                    child.child_by_field_name("pattern")
-                        .and_then(|n| {
-                            if n.kind() == "identifier" {
-                                n.utf8_text(source).ok()
-                            } else if n.kind() == "mut_pattern" {
-                                n.named_child(0).and_then(|c| c.utf8_text(source).ok())
-                            } else if n.kind() == "reference_pattern" {
-                                n.named_child(0).and_then(|c| {
-                                    if c.kind() == "identifier" {
-                                        c.utf8_text(source).ok()
-                                    } else if c.kind() == "mut_pattern" {
-                                        c.named_child(0).and_then(|cc| cc.utf8_text(source).ok())
-                                    } else {
-                                        None
-                                    }
-                                })
-                            } else {
-                                None
-                            }
-                        })
-                        .unwrap_or("")
-                }
+                ParamNameField::Simple(field) => child
+                    .child_by_field_name(field)
+                    .and_then(|n| n.utf8_text(source).ok())
+                    .unwrap_or(""),
+                ParamNameField::WithFallback(field) => child
+                    .child_by_field_name(field)
+                    .or_else(|| child.named_child(0).filter(|n| n.kind() == "identifier"))
+                    .and_then(|n| n.utf8_text(source).ok())
+                    .unwrap_or(""),
+                ParamNameField::RustPattern => child
+                    .child_by_field_name("pattern")
+                    .and_then(|n| {
+                        if n.kind() == "identifier" {
+                            n.utf8_text(source).ok()
+                        } else if n.kind() == "mut_pattern" {
+                            n.named_child(0).and_then(|c| c.utf8_text(source).ok())
+                        } else if n.kind() == "reference_pattern" {
+                            n.named_child(0).and_then(|c| {
+                                if c.kind() == "identifier" {
+                                    c.utf8_text(source).ok()
+                                } else if c.kind() == "mut_pattern" {
+                                    c.named_child(0).and_then(|cc| cc.utf8_text(source).ok())
+                                } else {
+                                    None
+                                }
+                            })
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or(""),
             };
 
             if param_name.is_empty() || rule.skip_names.contains(&param_name) {
                 continue;
             }
-            scopes[scope_idx].bindings.insert(param_name.to_string());
+            record_binding(scopes, scope_idx, param_name, child.start_position().row);
 
             // Try the configured type field first, then fall back to child type nodes
             // (Swift parameters have user_type children instead of a "type" field)
@@ -905,7 +1370,10 @@ fn scan_function_params(
             if type_node.is_none() {
                 let mut tc = child.walk();
                 for ch in child.named_children(&mut tc) {
-                    if matches!(ch.kind(), "user_type" | "type_annotation" | "type_identifier") {
+                    if matches!(
+                        ch.kind(),
+                        "user_type" | "type_annotation" | "type_identifier"
+                    ) {
                         type_node = Some(ch);
                         break;
                     }
@@ -937,7 +1405,10 @@ fn scan_single_assignment(
     } else {
         let mut cursor = node.walk();
         let children: Vec<_> = node.named_children(&mut cursor).collect();
-        match children.into_iter().find(|c| c.kind() == "assignment" || c.kind() == "assignment_expression") {
+        match children
+            .into_iter()
+            .find(|c| c.kind() == "assignment" || c.kind() == "assignment_expression")
+        {
             Some(a) => a,
             None => return,
         }
@@ -959,7 +1430,7 @@ fn scan_single_assignment(
         Ok(n) => n.to_string(),
         Err(_) => return,
     };
-    scopes[scope_idx].bindings.insert(var_name.clone());
+    record_binding(scopes, scope_idx, &var_name, left.start_position().row);
 
     record_type_from_rhs(right, &var_name, scope_idx, scopes, source);
 }
@@ -983,7 +1454,11 @@ fn scan_ts_var_declaration(
             if var_name.is_empty() {
                 continue;
             }
-            scopes[scope_idx].bindings.insert(var_name.clone());
+            let binding_row = child
+                .child_by_field_name("name")
+                .map(|n| n.start_position().row)
+                .unwrap_or_else(|| child.start_position().row);
+            record_binding(scopes, scope_idx, &var_name, binding_row);
 
             // Check for explicit type annotation: `const x: Foo = ...`
             if let Some(type_ann) = child.child_by_field_name("type") {
@@ -991,9 +1466,7 @@ fn scan_ts_var_declaration(
                 if !type_text.is_empty()
                     && type_text.chars().next().map_or(false, |c| c.is_uppercase())
                 {
-                    scopes[scope_idx]
-                        .types
-                        .insert(var_name.clone(), type_text);
+                    scopes[scope_idx].types.insert(var_name.clone(), type_text);
                     continue;
                 }
             }
@@ -1079,14 +1552,17 @@ fn scan_ts_var_declaration(
                         if !type_text.is_empty()
                             && type_text.chars().next().map_or(false, |c| c.is_uppercase())
                         {
-                            scopes[scope_idx].types.insert(var_name_kt.clone(), type_text);
+                            scopes[scope_idx]
+                                .types
+                                .insert(var_name_kt.clone(), type_text);
                             return;
                         }
                     }
                     // Find the value (sibling call_expression or other expression)
                     let mut c2 = node.walk();
                     for sibling in node.named_children(&mut c2) {
-                        if sibling.kind() == "call_expression" || sibling.kind() == "new_expression" {
+                        if sibling.kind() == "call_expression" || sibling.kind() == "new_expression"
+                        {
                             record_type_from_rhs(sibling, &var_name_kt, scope_idx, scopes, source);
                             break;
                         }
@@ -1123,17 +1599,13 @@ fn scan_rust_let_declaration(
     if var_name.is_empty() {
         return;
     }
-    scopes[scope_idx].bindings.insert(var_name.clone());
+    record_binding(scopes, scope_idx, &var_name, node.start_position().row);
 
     // Check for explicit type annotation: `let x: Connection = ...`
     if let Some(type_node) = node.child_by_field_name("type") {
         let type_text = extract_base_type(type_node, source);
-        if !type_text.is_empty()
-            && type_text.chars().next().map_or(false, |c| c.is_uppercase())
-        {
-            scopes[scope_idx]
-                .types
-                .insert(var_name, type_text);
+        if !type_text.is_empty() && type_text.chars().next().map_or(false, |c| c.is_uppercase()) {
+            scopes[scope_idx].types.insert(var_name, type_text);
             return;
         }
     }
@@ -1173,7 +1645,7 @@ fn scan_go_short_var(
     if var_name.is_empty() {
         return;
     }
-    scopes[scope_idx].bindings.insert(var_name.clone());
+    record_binding(scopes, scope_idx, &var_name, left.start_position().row);
 
     let rhs = if right.kind() == "expression_list" {
         match right.named_child(0) {
@@ -1208,7 +1680,7 @@ fn scan_go_var_declaration(
                     if first.kind() == "identifier" {
                         let name = first.utf8_text(source).unwrap_or("").to_string();
                         if !name.is_empty() {
-                            scopes[scope_idx].bindings.insert(name.clone());
+                            record_binding(scopes, scope_idx, &name, first.start_position().row);
                             // Check for type child
                             if let Some(type_node) = child.child_by_field_name("type") {
                                 let type_text = extract_base_type(type_node, source);
@@ -1223,7 +1695,11 @@ fn scan_go_var_declaration(
                 }
                 continue;
             }
-            scopes[scope_idx].bindings.insert(var_name.clone());
+            let binding_row = child
+                .child_by_field_name("name")
+                .map(|n| n.start_position().row)
+                .unwrap_or_else(|| child.start_position().row);
+            record_binding(scopes, scope_idx, &var_name, binding_row);
 
             // Check for explicit type
             if let Some(type_node) = child.child_by_field_name("type") {
@@ -1231,9 +1707,7 @@ fn scan_go_var_declaration(
                 if !type_text.is_empty()
                     && type_text.chars().next().map_or(false, |c| c.is_uppercase())
                 {
-                    scopes[scope_idx]
-                        .types
-                        .insert(var_name, type_text);
+                    scopes[scope_idx].types.insert(var_name, type_text);
                     continue;
                 }
             }
@@ -1267,7 +1741,10 @@ fn record_type_from_rhs(
                 .child_by_field_name("function")
                 .or_else(|| rhs.named_child(0));
             if let Some(func) = func_node {
-                if func.kind() == "identifier" || func.kind() == "simple_identifier" || func.kind() == "type_identifier" {
+                if func.kind() == "identifier"
+                    || func.kind() == "simple_identifier"
+                    || func.kind() == "type_identifier"
+                {
                     let name = func.utf8_text(source).unwrap_or("");
                     if name.chars().next().map_or(false, |c| c.is_uppercase()) {
                         scopes[scope_idx]
@@ -1312,7 +1789,9 @@ fn record_type_from_rhs(
                                 .types
                                 .insert(var_name.to_string(), type_name.to_string());
                         }
-                    } else if field.starts_with("Get") || field.chars().next().map_or(false, |c| c.is_uppercase()) {
+                    } else if field.starts_with("Get")
+                        || field.chars().next().map_or(false, |c| c.is_uppercase())
+                    {
                         // Other Go package functions: record for return type resolution
                         scopes[scope_idx]
                             .pending_call_types
@@ -1399,7 +1878,11 @@ fn build_go_pkg_index(
                 if !entity.file_path.ends_with(".go") {
                     continue;
                 }
-                let file_stem = entity.file_path.rsplit('/').next().unwrap_or(&entity.file_path);
+                let file_stem = entity
+                    .file_path
+                    .rsplit('/')
+                    .next()
+                    .unwrap_or(&entity.file_path);
                 let file_stem = file_stem.strip_suffix(".go").unwrap_or(file_stem);
                 idx.entry(file_stem.to_string())
                     .or_default()
@@ -1429,7 +1912,7 @@ fn build_go_pkg_index(
 fn scan_return_types(
     root: tree_sitter::Node,
     _file_path: &str,
-    file_entities: &[&SemanticEntity],
+    file_lookup: &FileEntityLookup<'_>,
     source: &[u8],
     return_type_map: &mut HashMap<String, String>,
     config: &ScopeResolveConfig,
@@ -1446,19 +1929,17 @@ fn scan_return_types(
                 .and_then(|n| n.utf8_text(source).ok())
                 .unwrap_or("");
 
-            let func_entity = file_entities.iter().find(|e| {
-                e.name == func_name && {
-                    let line = node.start_position().row + 1;
-                    e.start_line <= line && line <= e.end_line
-                }
-            }).copied();
+            let line = node.start_position().row + 1;
+            let func_entity = file_lookup.find_at_line(func_name, line, |_| true);
 
             if let Some(fe) = func_entity {
                 // Try explicit return type annotation first
                 let ret_type = config.return_type_field.and_then(|field| {
                     node.child_by_field_name(field)
                         .map(|n| extract_base_type(n, source))
-                        .filter(|t| !t.is_empty() && t.chars().next().map_or(false, |c| c.is_uppercase()))
+                        .filter(|t| {
+                            !t.is_empty() && t.chars().next().map_or(false, |c| c.is_uppercase())
+                        })
                 });
 
                 if let Some(rt) = ret_type {
@@ -1548,7 +2029,12 @@ fn scan_init_self_attrs(
         let kind = node.kind();
 
         match &config.init_strategy {
-            InitStrategy::ConstructorBody { class_nodes, init_node_kind, self_keyword: _, .. } => {
+            InitStrategy::ConstructorBody {
+                class_nodes,
+                init_node_kind,
+                self_keyword: _,
+                ..
+            } => {
                 if class_nodes.contains(&kind) {
                     let class_name = node
                         .child_by_field_name("name")
@@ -1565,7 +2051,15 @@ fn scan_init_self_attrs(
                             "anonymous_initializer" => "kotlin",
                             _ => "typescript",
                         };
-                        scan_class_for_init(node, &class_name, source, instance_attr_types, init_params_map, attr_to_param_map, lang);
+                        scan_class_for_init(
+                            node,
+                            &class_name,
+                            source,
+                            instance_attr_types,
+                            init_params_map,
+                            attr_to_param_map,
+                            lang,
+                        );
                     }
                 }
             }
@@ -1580,7 +2074,12 @@ fn scan_init_self_attrs(
                             .to_string();
 
                         if !struct_name.is_empty() {
-                            scan_rust_struct_fields(node, &struct_name, source, instance_attr_types);
+                            scan_rust_struct_fields(
+                                node,
+                                &struct_name,
+                                source,
+                                instance_attr_types,
+                            );
                         }
                     }
                     // Go: extract field types from type declarations
@@ -1624,7 +2123,10 @@ fn scan_rust_struct_fields(
 
                     if !field_name.is_empty()
                         && !field_type.is_empty()
-                        && field_type.chars().next().map_or(false, |c| c.is_uppercase())
+                        && field_type
+                            .chars()
+                            .next()
+                            .map_or(false, |c| c.is_uppercase())
                     {
                         instance_attr_types.insert(
                             (struct_name.to_string(), field_name.to_string()),
@@ -1677,7 +2179,10 @@ fn scan_go_struct_fields(
 
                                     if !field_name.is_empty()
                                         && !field_type.is_empty()
-                                        && field_type.chars().next().map_or(false, |c| c.is_uppercase())
+                                        && field_type
+                                            .chars()
+                                            .next()
+                                            .map_or(false, |c| c.is_uppercase())
                                     {
                                         instance_attr_types.insert(
                                             (struct_name.clone(), field_name.to_string()),
@@ -1724,7 +2229,14 @@ fn scan_class_for_init(
                     let params = extract_init_params(child, source);
                     let ordered_params = extract_init_param_names_ordered(child, source);
                     init_params_map.insert(class_name.to_string(), ordered_params);
-                    scan_init_body(child, class_name, &params, source, instance_attr_types, attr_to_param_map);
+                    scan_init_body(
+                        child,
+                        class_name,
+                        &params,
+                        source,
+                        instance_attr_types,
+                        attr_to_param_map,
+                    );
                 }
             }
 
@@ -1736,22 +2248,46 @@ fn scan_class_for_init(
                     .unwrap_or("");
                 if name == "constructor" {
                     // Scan for this.attr = param patterns
-                    scan_ts_constructor_body(child, class_name, source, instance_attr_types, init_params_map, attr_to_param_map);
+                    scan_ts_constructor_body(
+                        child,
+                        class_name,
+                        source,
+                        instance_attr_types,
+                        init_params_map,
+                        attr_to_param_map,
+                    );
                 }
             }
 
             // Swift init_declaration
             if ck == "init_declaration" && lang == "swift" {
-                scan_swift_init_body(child, class_name, source, instance_attr_types, init_params_map, attr_to_param_map);
+                scan_swift_init_body(
+                    child,
+                    class_name,
+                    source,
+                    instance_attr_types,
+                    init_params_map,
+                    attr_to_param_map,
+                );
             }
 
             // Kotlin anonymous_initializer (init { ... } block)
             if ck == "anonymous_initializer" && lang == "kotlin" {
-                scan_kotlin_init_body(child, class_name, source, instance_attr_types, attr_to_param_map);
+                scan_kotlin_init_body(
+                    child,
+                    class_name,
+                    source,
+                    instance_attr_types,
+                    attr_to_param_map,
+                );
             }
 
             // TS: typed class field declarations `private conn: Connection`
-            if (ck == "public_field_definition" || ck == "property_declaration" || ck == "field_definition") && lang == "typescript" {
+            if (ck == "public_field_definition"
+                || ck == "property_declaration"
+                || ck == "field_definition")
+                && lang == "typescript"
+            {
                 let field_name = child
                     .child_by_field_name("name")
                     .and_then(|n| n.utf8_text(source).ok())
@@ -1762,10 +2298,8 @@ fn scan_class_for_init(
                         && !type_text.is_empty()
                         && type_text.chars().next().map_or(false, |c| c.is_uppercase())
                     {
-                        instance_attr_types.insert(
-                            (class_name.to_string(), field_name.to_string()),
-                            type_text,
-                        );
+                        instance_attr_types
+                            .insert((class_name.to_string(), field_name.to_string()), type_text);
                     }
                 }
             }
@@ -1780,9 +2314,14 @@ fn scan_class_for_init(
                 scan_kotlin_property_declaration(child, class_name, source, instance_attr_types);
             }
 
-            if ck == "block" || ck == "class_body" || ck == "statement_block"
-                || ck == "struct_body" || ck == "function_body" || ck == "code_block"
-                || ck == "statements" || ck == "enum_class_body"
+            if ck == "block"
+                || ck == "class_body"
+                || ck == "statement_block"
+                || ck == "struct_body"
+                || ck == "function_body"
+                || ck == "code_block"
+                || ck == "statements"
+                || ck == "enum_class_body"
             {
                 worklist.push(child);
             }
@@ -1811,17 +2350,28 @@ fn scan_swift_init_body(
             let ck = child.kind();
             // Look for assignment: self.X = Y via directly_assigned_expression or assignment
             if ck == "directly_assigned_expression" || ck == "assignment" {
-                if let Some(left) = child.child_by_field_name("left").or_else(|| child.named_child(0)) {
+                if let Some(left) = child
+                    .child_by_field_name("left")
+                    .or_else(|| child.named_child(0))
+                {
                     if left.kind() == "navigation_expression" {
-                        let obj = left.child_by_field_name("target")
+                        let obj = left
+                            .child_by_field_name("target")
                             .and_then(|n| n.utf8_text(source).ok())
                             .unwrap_or("");
-                        let prop = left.child_by_field_name("suffix")
+                        let prop = left
+                            .child_by_field_name("suffix")
                             .and_then(|n| n.utf8_text(source).ok())
+                            .map(|text| text.strip_prefix('.').unwrap_or(text))
                             .unwrap_or("");
                         if obj == "self" && !prop.is_empty() {
-                            if let Some(right) = child.child_by_field_name("right").or_else(|| child.named_child(1)) {
-                                if right.kind() == "simple_identifier" || right.kind() == "identifier" {
+                            if let Some(right) = child
+                                .child_by_field_name("right")
+                                .or_else(|| child.named_child(1))
+                            {
+                                if right.kind() == "simple_identifier"
+                                    || right.kind() == "identifier"
+                                {
                                     let rhs_name = right.utf8_text(source).unwrap_or("");
                                     if params.contains_key(rhs_name) {
                                         attr_to_param_map.insert(
@@ -1841,8 +2391,11 @@ fn scan_swift_init_body(
                     }
                 }
             }
-            if ck == "function_body" || ck == "code_block" || ck == "statements"
-                || ck == "expression_statement" || ck == "block"
+            if ck == "function_body"
+                || ck == "code_block"
+                || ck == "statements"
+                || ck == "expression_statement"
+                || ck == "block"
             {
                 worklist.push(child);
             }
@@ -1857,25 +2410,114 @@ fn scan_swift_property_declaration(
     source: &[u8],
     instance_attr_types: &mut HashMap<(String, String), String>,
 ) {
-    // Swift property_declaration has a "name" (via pattern binding) and type annotation
+    let mut processed_pattern_binding = false;
+
     let mut cursor = node.walk();
+
     for child in node.named_children(&mut cursor) {
-        if child.kind() == "pattern" || child.kind() == "simple_identifier" || child.kind() == "identifier" {
-            let field_name = child.utf8_text(source).unwrap_or("");
-            if let Some(type_ann) = node.child_by_field_name("type") {
-                let type_text = extract_base_type(type_ann, source);
-                if !field_name.is_empty()
-                    && !type_text.is_empty()
-                    && type_text.chars().next().map_or(false, |c| c.is_uppercase())
-                {
-                    instance_attr_types.insert(
-                        (class_name.to_string(), field_name.to_string()),
-                        type_text,
-                    );
-                }
-            }
+        if child.kind() == "pattern_binding" {
+            processed_pattern_binding = true;
+            scan_swift_property_binding(child, class_name, source, instance_attr_types);
         }
     }
+    if processed_pattern_binding {
+        return;
+    }
+
+    // Swift property_declaration nodes vary by grammar version. Some expose
+    // pattern/type_annotation pairs directly instead of pattern_binding nodes.
+    let mut pending_names = Vec::new();
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        match child.kind() {
+            "pattern" | "simple_identifier" | "identifier" => {
+                if let Some(name) = extract_swift_property_pattern_name(child, source) {
+                    pending_names.push(name);
+                }
+            }
+            "type_annotation" | "user_type" | "type_identifier" => {
+                let type_text = extract_base_type(child, source);
+                if !type_text.is_empty()
+                    && type_text.chars().next().map_or(false, |c| c.is_uppercase())
+                {
+                    for name in pending_names.drain(..) {
+                        instance_attr_types
+                            .insert((class_name.to_string(), name), type_text.clone());
+                    }
+                }
+            }
+            "call_expression" | "new_expression" | "value_argument" => pending_names.clear(),
+            _ => {}
+        }
+    }
+}
+
+fn scan_swift_property_binding(
+    node: tree_sitter::Node,
+    class_name: &str,
+    source: &[u8],
+    instance_attr_types: &mut HashMap<(String, String), String>,
+) {
+    let mut field_names = Vec::new();
+    let mut field_type = node.child_by_field_name("type").and_then(|type_node| {
+        let type_text = extract_base_type(type_node, source);
+        if type_text.is_empty() {
+            None
+        } else {
+            Some(type_text)
+        }
+    });
+
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        match child.kind() {
+            "pattern" | "simple_identifier" | "identifier" => {
+                if let Some(name) = extract_swift_property_pattern_name(child, source) {
+                    field_names.push(name);
+                }
+            }
+            "type_annotation" => {
+                if field_type.is_none() {
+                    let type_text = extract_base_type(child, source);
+                    if !type_text.is_empty() {
+                        field_type = Some(type_text);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let Some(type_text) = field_type else {
+        return;
+    };
+    if !type_text.chars().next().map_or(false, |c| c.is_uppercase()) {
+        return;
+    }
+
+    for field_name in field_names {
+        instance_attr_types.insert((class_name.to_string(), field_name), type_text.clone());
+    }
+}
+
+fn extract_swift_property_pattern_name(node: tree_sitter::Node, source: &[u8]) -> Option<String> {
+    if matches!(node.kind(), "simple_identifier" | "identifier") {
+        let name = node.utf8_text(source).ok()?.trim();
+        return (!name.is_empty()).then(|| name.to_string());
+    }
+
+    if let Some(name_node) = node.child_by_field_name("name") {
+        return extract_swift_property_pattern_name(name_node, source);
+    }
+
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        if matches!(child.kind(), "simple_identifier" | "identifier") {
+            return extract_swift_property_pattern_name(child, source);
+        }
+    }
+
+    None
 }
 
 /// Kotlin: extract typed property declarations `val conn: Connection`
@@ -1896,12 +2538,12 @@ fn scan_kotlin_property_declaration(
 
     if !field_name.is_empty()
         && !field_type.is_empty()
-        && field_type.chars().next().map_or(false, |c| c.is_uppercase())
+        && field_type
+            .chars()
+            .next()
+            .map_or(false, |c| c.is_uppercase())
     {
-        instance_attr_types.insert(
-            (class_name.to_string(), field_name.to_string()),
-            field_type,
-        );
+        instance_attr_types.insert((class_name.to_string(), field_name.to_string()), field_type);
     }
 }
 
@@ -1921,8 +2563,10 @@ fn scan_kotlin_primary_constructor(
                 if param.kind() == "class_parameter" {
                     // Check if this has val/var modifier (makes it a property)
                     let text = param.utf8_text(source).unwrap_or("");
-                    let has_val_var = text.starts_with("val ") || text.starts_with("var ")
-                        || text.contains("val ") || text.contains("var ");
+                    let has_val_var = text.starts_with("val ")
+                        || text.starts_with("var ")
+                        || text.contains("val ")
+                        || text.contains("var ");
                     if has_val_var {
                         let param_name = param
                             .child_by_field_name("name")
@@ -1934,7 +2578,10 @@ fn scan_kotlin_primary_constructor(
                             .unwrap_or_default();
                         if !param_name.is_empty()
                             && !param_type.is_empty()
-                            && param_type.chars().next().map_or(false, |c| c.is_uppercase())
+                            && param_type
+                                .chars()
+                                .next()
+                                .map_or(false, |c| c.is_uppercase())
                         {
                             instance_attr_types.insert(
                                 (class_name.to_string(), param_name.to_string()),
@@ -1962,17 +2609,27 @@ fn scan_kotlin_init_body(
         for child in wnode.named_children(&mut cursor) {
             let ck = child.kind();
             if ck == "assignment" || ck == "directly_assigned_expression" {
-                if let Some(left) = child.child_by_field_name("left").or_else(|| child.named_child(0)) {
+                if let Some(left) = child
+                    .child_by_field_name("left")
+                    .or_else(|| child.named_child(0))
+                {
                     if left.kind() == "navigation_expression" {
-                        let obj = left.child_by_field_name("expression")
+                        let obj = left
+                            .child_by_field_name("expression")
                             .and_then(|n| n.utf8_text(source).ok())
                             .unwrap_or("");
-                        let prop = left.child_by_field_name("navigation_suffix")
+                        let prop = left
+                            .child_by_field_name("navigation_suffix")
                             .and_then(|n| n.utf8_text(source).ok())
                             .unwrap_or("");
                         if obj == "this" && !prop.is_empty() {
-                            if let Some(right) = child.child_by_field_name("right").or_else(|| child.named_child(1)) {
-                                if right.kind() == "simple_identifier" || right.kind() == "identifier" {
+                            if let Some(right) = child
+                                .child_by_field_name("right")
+                                .or_else(|| child.named_child(1))
+                            {
+                                if right.kind() == "simple_identifier"
+                                    || right.kind() == "identifier"
+                                {
                                     let rhs_name = right.utf8_text(source).unwrap_or("");
                                     attr_to_param_map.insert(
                                         (class_name.to_string(), prop.to_string()),
@@ -1981,7 +2638,8 @@ fn scan_kotlin_init_body(
                                 }
                                 // If RHS is a constructor call, record type directly
                                 if right.kind() == "call_expression" {
-                                    let callee = right.child_by_field_name("function")
+                                    let callee = right
+                                        .child_by_field_name("function")
                                         .and_then(|n| n.utf8_text(source).ok())
                                         .unwrap_or("");
                                     if !callee.is_empty()
@@ -2020,7 +2678,14 @@ fn scan_ts_constructor_body(
     init_params_map.insert(class_name.to_string(), ordered_params);
 
     // Scan body for this.X = param
-    scan_init_body_this(node, class_name, &params, source, instance_attr_types, attr_to_param_map);
+    scan_init_body_this(
+        node,
+        class_name,
+        &params,
+        source,
+        instance_attr_types,
+        attr_to_param_map,
+    );
 }
 
 /// Scan constructor body for `this.attr = param` patterns (TS variant)
@@ -2044,10 +2709,12 @@ fn scan_init_body_this(
                     if inner.kind() == "assignment_expression" {
                         if let Some(left) = inner.child_by_field_name("left") {
                             if left.kind() == "member_expression" {
-                                let obj = left.child_by_field_name("object")
+                                let obj = left
+                                    .child_by_field_name("object")
                                     .and_then(|n| n.utf8_text(source).ok())
                                     .unwrap_or("");
-                                let prop = left.child_by_field_name("property")
+                                let prop = left
+                                    .child_by_field_name("property")
                                     .and_then(|n| n.utf8_text(source).ok())
                                     .unwrap_or("");
                                 if obj == "this" && !prop.is_empty() {
@@ -2059,7 +2726,8 @@ fn scan_init_body_this(
                                                     (class_name.to_string(), prop.to_string()),
                                                     rhs_name.to_string(),
                                                 );
-                                                if let Some(Some(type_hint)) = params.get(rhs_name) {
+                                                if let Some(Some(type_hint)) = params.get(rhs_name)
+                                                {
                                                     instance_attr_types.insert(
                                                         (class_name.to_string(), prop.to_string()),
                                                         type_hint.clone(),
@@ -2068,7 +2736,9 @@ fn scan_init_body_this(
                                             }
                                         }
                                         if right.kind() == "new_expression" {
-                                            if let Some(ctor) = right.child_by_field_name("constructor") {
+                                            if let Some(ctor) =
+                                                right.child_by_field_name("constructor")
+                                            {
                                                 let name = ctor.utf8_text(source).unwrap_or("");
                                                 if !name.is_empty() {
                                                     instance_attr_types.insert(
@@ -2100,8 +2770,10 @@ fn extract_init_param_names_ordered(func_node: tree_sitter::Node, source: &[u8])
         for child in params_node.named_children(&mut cursor) {
             let param_name = if child.kind() == "identifier" {
                 child.utf8_text(source).unwrap_or("").to_string()
-            } else if child.kind() == "typed_parameter" || child.kind() == "typed_default_parameter" {
-                child.child_by_field_name("name")
+            } else if child.kind() == "typed_parameter" || child.kind() == "typed_default_parameter"
+            {
+                child
+                    .child_by_field_name("name")
                     .or_else(|| child.named_child(0))
                     .and_then(|n| n.utf8_text(source).ok())
                     .unwrap_or("")
@@ -2117,15 +2789,20 @@ fn extract_init_param_names_ordered(func_node: tree_sitter::Node, source: &[u8])
     names
 }
 
-fn extract_init_params(func_node: tree_sitter::Node, source: &[u8]) -> HashMap<String, Option<String>> {
+fn extract_init_params(
+    func_node: tree_sitter::Node,
+    source: &[u8],
+) -> HashMap<String, Option<String>> {
     let mut params = HashMap::new();
     if let Some(params_node) = func_node.child_by_field_name("parameters") {
         let mut cursor = params_node.walk();
         for child in params_node.named_children(&mut cursor) {
             let param_name = if child.kind() == "identifier" {
                 child.utf8_text(source).unwrap_or("").to_string()
-            } else if child.kind() == "typed_parameter" || child.kind() == "typed_default_parameter" {
-                child.child_by_field_name("name")
+            } else if child.kind() == "typed_parameter" || child.kind() == "typed_default_parameter"
+            {
+                child
+                    .child_by_field_name("name")
                     .or_else(|| child.named_child(0))
                     .and_then(|n| n.utf8_text(source).ok())
                     .unwrap_or("")
@@ -2135,7 +2812,8 @@ fn extract_init_params(func_node: tree_sitter::Node, source: &[u8]) -> HashMap<S
             };
             if param_name != "self" && param_name != "cls" {
                 // Check for type annotation
-                let type_hint = child.child_by_field_name("type")
+                let type_hint = child
+                    .child_by_field_name("type")
                     .and_then(|n| n.utf8_text(source).ok())
                     .map(|s| s.to_string());
                 params.insert(param_name, type_hint);
@@ -2171,10 +2849,12 @@ fn scan_init_body(
 
                 if let Some(left) = assign.child_by_field_name("left") {
                     if left.kind() == "attribute" {
-                        let obj = left.child_by_field_name("object")
+                        let obj = left
+                            .child_by_field_name("object")
                             .and_then(|n| n.utf8_text(source).ok())
                             .unwrap_or("");
-                        let attr = left.child_by_field_name("attribute")
+                        let attr = left
+                            .child_by_field_name("attribute")
                             .and_then(|n| n.utf8_text(source).ok())
                             .unwrap_or("");
 
@@ -2201,7 +2881,11 @@ fn scan_init_body(
                                     if let Some(func) = right.child_by_field_name("function") {
                                         if func.kind() == "identifier" {
                                             let fname = func.utf8_text(source).unwrap_or("");
-                                            if fname.chars().next().map_or(false, |c| c.is_uppercase()) {
+                                            if fname
+                                                .chars()
+                                                .next()
+                                                .map_or(false, |c| c.is_uppercase())
+                                            {
                                                 instance_attr_types.insert(
                                                     (class_name.to_string(), attr.to_string()),
                                                     fname.to_string(),
@@ -2285,7 +2969,11 @@ fn scan_constructor_calls(
                 if func.kind() == "identifier" {
                     let class_name = func.utf8_text(source).unwrap_or("");
                     // Only process uppercase names (constructor calls)
-                    if class_name.chars().next().map_or(false, |c| c.is_uppercase()) {
+                    if class_name
+                        .chars()
+                        .next()
+                        .map_or(false, |c| c.is_uppercase())
+                    {
                         if let Some(param_names) = init_params.get(class_name) {
                             // Extract argument types
                             if let Some(args_node) = node.child_by_field_name("arguments") {
@@ -2423,25 +3111,69 @@ fn extract_imports_from_ast(
             let ck = child.kind();
             let handled = match ck {
                 "import_from_statement" => {
-                    extract_python_import(child, file_path, source, symbol_table, entity_map, import_table, scopes);
+                    extract_python_import(
+                        child,
+                        file_path,
+                        source,
+                        symbol_table,
+                        entity_map,
+                        import_table,
+                        scopes,
+                    );
                     true
                 }
-                "import_statement" if config.self_keywords.contains(&"self") && config.self_keywords.contains(&"cls") => {
+                "import_statement"
+                    if config.self_keywords.contains(&"self")
+                        && config.self_keywords.contains(&"cls") =>
+                {
                     // Python: `import mod` or `import mod as m`
-                    extract_python_module_import(child, file_path, source, symbol_table, entity_map, import_table, scopes);
+                    extract_python_module_import(
+                        child,
+                        file_path,
+                        source,
+                        symbol_table,
+                        entity_map,
+                        import_table,
+                        scopes,
+                    );
                     true
                 }
                 "import_statement" if !config.self_keywords.contains(&"cls") => {
                     // TS import_statement (not Python - Python uses import_from_statement)
-                    extract_ts_import(child, file_path, source, symbol_table, entity_map, import_table, scopes);
+                    extract_ts_import(
+                        child,
+                        file_path,
+                        source,
+                        symbol_table,
+                        entity_map,
+                        import_table,
+                        scopes,
+                    );
                     true
                 }
                 "use_declaration" => {
-                    extract_rust_use(child, file_path, source, symbol_table, entity_map, import_table, scopes);
+                    extract_rust_use(
+                        child,
+                        file_path,
+                        source,
+                        symbol_table,
+                        entity_map,
+                        import_table,
+                        scopes,
+                    );
                     true
                 }
                 "import_declaration" => {
-                    extract_go_import(child, file_path, source, symbol_table, entity_map, import_table, scopes, go_pkg_index);
+                    extract_go_import(
+                        child,
+                        file_path,
+                        source,
+                        symbol_table,
+                        entity_map,
+                        import_table,
+                        scopes,
+                        go_pkg_index,
+                    );
                     true
                 }
                 _ => false,
@@ -2495,7 +3227,17 @@ fn extract_ts_import(
                                 .unwrap_or(original);
 
                             if !original.is_empty() {
-                                resolve_import_name(original, local, source_path, file_path, &[".ts", ".tsx", ".js", ".jsx"], symbol_table, entity_map, import_table, scopes);
+                                resolve_import_name(
+                                    original,
+                                    local,
+                                    source_path,
+                                    file_path,
+                                    &[".ts", ".tsx", ".js", ".jsx"],
+                                    symbol_table,
+                                    entity_map,
+                                    import_table,
+                                    scopes,
+                                );
                             }
                         }
                     }
@@ -2506,19 +3248,39 @@ fn extract_ts_import(
                     let alias = clause_child
                         .child_by_field_name("alias")
                         .or_else(|| {
-                            clause_child.named_children(&mut ns_cursor)
+                            clause_child
+                                .named_children(&mut ns_cursor)
                                 .find(|c| c.kind() == "identifier")
                         })
                         .and_then(|n| n.utf8_text(source).ok())
                         .unwrap_or("");
                     if !alias.is_empty() {
-                        register_namespace_import(alias, source_path, file_path, &[".ts", ".tsx", ".js", ".jsx"], symbol_table, entity_map, import_table, scopes);
+                        register_namespace_import(
+                            alias,
+                            source_path,
+                            file_path,
+                            &[".ts", ".tsx", ".js", ".jsx"],
+                            symbol_table,
+                            entity_map,
+                            import_table,
+                            scopes,
+                        );
                     }
                 } else if clause_child.kind() == "identifier" {
                     // Default import: import Foo from './module'
                     let name = clause_child.utf8_text(source).unwrap_or("");
                     if !name.is_empty() {
-                        resolve_import_name(name, name, source_path, file_path, &[".ts", ".tsx", ".js", ".jsx"], symbol_table, entity_map, import_table, scopes);
+                        resolve_import_name(
+                            name,
+                            name,
+                            source_path,
+                            file_path,
+                            &[".ts", ".tsx", ".js", ".jsx"],
+                            symbol_table,
+                            entity_map,
+                            import_table,
+                            scopes,
+                        );
                     }
                 }
             }
@@ -2569,7 +3331,17 @@ fn extract_rust_use(
                 (name_part, name_part)
             };
             if !original.is_empty() {
-                resolve_import_name(original, local, source_module, file_path, &[".rs"], symbol_table, entity_map, import_table, scopes);
+                resolve_import_name(
+                    original,
+                    local,
+                    source_module,
+                    file_path,
+                    &[".rs"],
+                    symbol_table,
+                    entity_map,
+                    import_table,
+                    scopes,
+                );
             }
         }
     } else {
@@ -2590,7 +3362,17 @@ fn extract_rust_use(
             parts[0]
         };
         if !original.is_empty() && !source_module.is_empty() {
-            resolve_import_name(original, local, source_module, file_path, &[".rs"], symbol_table, entity_map, import_table, scopes);
+            resolve_import_name(
+                original,
+                local,
+                source_module,
+                file_path,
+                &[".rs"],
+                symbol_table,
+                entity_map,
+                import_table,
+                scopes,
+            );
         }
     }
 }
@@ -2609,12 +3391,34 @@ fn extract_go_import(
     let mut cursor = node.walk();
     for child in node.named_children(&mut cursor) {
         if child.kind() == "import_spec" || child.kind() == "import_spec_list" {
-            extract_go_import_specs(child, file_path, source, symbol_table, entity_map, import_table, scopes, go_pkg_index);
-        } else if child.kind() == "interpreted_string_literal" || child.kind() == "raw_string_literal" {
-            let path = child.utf8_text(source).unwrap_or("")
-                .trim_matches('"').trim_matches('`');
+            extract_go_import_specs(
+                child,
+                file_path,
+                source,
+                symbol_table,
+                entity_map,
+                import_table,
+                scopes,
+                go_pkg_index,
+            );
+        } else if child.kind() == "interpreted_string_literal"
+            || child.kind() == "raw_string_literal"
+        {
+            let path = child
+                .utf8_text(source)
+                .unwrap_or("")
+                .trim_matches('"')
+                .trim_matches('`');
             let pkg_name = path.rsplit('/').next().unwrap_or(path);
-            register_go_package_imports(pkg_name, file_path, symbol_table, entity_map, import_table, scopes, go_pkg_index);
+            register_go_package_imports(
+                pkg_name,
+                file_path,
+                symbol_table,
+                entity_map,
+                import_table,
+                scopes,
+                go_pkg_index,
+            );
         }
     }
 }
@@ -2634,13 +3438,25 @@ fn extract_go_import_specs(
         let mut cursor = node.walk();
         for child in node.named_children(&mut cursor) {
             if child.kind() == "import_spec" {
-                let path_node = child.child_by_field_name("path")
+                let path_node = child
+                    .child_by_field_name("path")
                     .or_else(|| child.named_child(0));
                 if let Some(pn) = path_node {
-                    let path = pn.utf8_text(source).unwrap_or("")
-                        .trim_matches('"').trim_matches('`');
+                    let path = pn
+                        .utf8_text(source)
+                        .unwrap_or("")
+                        .trim_matches('"')
+                        .trim_matches('`');
                     let pkg_name = path.rsplit('/').next().unwrap_or(path);
-                    register_go_package_imports(pkg_name, file_path, symbol_table, entity_map, import_table, scopes, go_pkg_index);
+                    register_go_package_imports(
+                        pkg_name,
+                        file_path,
+                        symbol_table,
+                        entity_map,
+                        import_table,
+                        scopes,
+                        go_pkg_index,
+                    );
                 }
             } else {
                 worklist.push(child);
@@ -2661,10 +3477,7 @@ fn register_go_package_imports(
     // Use pre-built package index for O(1) lookup instead of O(symbol_table) scan
     if let Some(entries) = go_pkg_index.get(pkg_name) {
         for (name, target_id) in entries {
-            import_table.insert(
-                (file_path.to_string(), name.clone()),
-                target_id.clone(),
-            );
+            import_table.insert((file_path.to_string(), name.clone()), target_id.clone());
             if !scopes.is_empty() {
                 scopes[0].defs.insert(name.clone(), target_id.clone());
             }
@@ -2685,13 +3498,7 @@ fn resolve_import_name(
     scopes: &mut Vec<Scope>,
 ) {
     if let Some(target_ids) = symbol_table.get(original_name) {
-        let target = find_import_target(
-            target_ids,
-            source_path,
-            file_path,
-            extensions,
-            entity_map,
-        );
+        let target = find_import_target(target_ids, source_path, file_path, extensions, entity_map);
 
         if let Some(target_id) = target {
             import_table.insert(
@@ -2725,7 +3532,8 @@ fn register_namespace_import(
         for target_id in target_ids {
             if let Some(info) = entity_map.get(target_id) {
                 if import_source_matches_file(file_path, source_path, extensions, &info.file_path)
-                    && info.parent_id.is_none() {
+                    && info.parent_id.is_none()
+                {
                     let qualified_name = format!("{alias}.{name}");
                     import_table.insert(
                         (file_path.to_string(), qualified_name.clone()),
@@ -2777,7 +3585,17 @@ fn extract_python_import(
                 continue;
             }
 
-            resolve_import_name(original, local, module_name, file_path, &[".py"], symbol_table, entity_map, import_table, scopes);
+            resolve_import_name(
+                original,
+                local,
+                module_name,
+                file_path,
+                &[".py"],
+                symbol_table,
+                entity_map,
+                import_table,
+                scopes,
+            );
         }
     }
 }
@@ -2832,6 +3650,314 @@ fn extract_python_module_import(
     }
 }
 
+fn build_swift_call_signatures(
+    parsed_files: &[(String, String, tree_sitter::Tree)],
+    all_entities: &[SemanticEntity],
+    entity_ranges: &HashMap<String, Vec<(usize, usize, String)>>,
+    entity_map: &HashMap<String, EntityInfo>,
+) -> HashMap<String, SwiftCallSignature> {
+    let mut signatures = HashMap::new();
+
+    for (file_path, content, tree) in parsed_files {
+        if !file_path.ends_with(".swift") {
+            continue;
+        }
+
+        let Some(ranges) = entity_ranges.get(file_path.as_str()) else {
+            continue;
+        };
+
+        let source = content.as_bytes();
+        let mut worklist = vec![tree.root_node()];
+        while let Some(node) = worklist.pop() {
+            if matches!(node.kind(), "function_declaration" | "init_declaration") {
+                if let Some(entity_id) =
+                    find_entity_id_for_swift_declaration(node, ranges, entity_map)
+                {
+                    let argument_labels = extract_swift_declaration_argument_labels(node, source);
+                    signatures.insert(entity_id, SwiftCallSignature { argument_labels });
+                }
+            }
+
+            let mut cursor = node.walk();
+            let children: Vec<_> = node.named_children(&mut cursor).collect();
+            for child in children.into_iter().rev() {
+                worklist.push(child);
+            }
+        }
+    }
+
+    let mut content_parser: Option<tree_sitter::Parser> = None;
+    for entity in all_entities {
+        if signatures.contains_key(&entity.id) || !is_swift_callable_entity_info(entity) {
+            continue;
+        }
+
+        if content_parser.is_none() {
+            content_parser = swift_signature_parser();
+        }
+        let Some(parser) = content_parser.as_mut() else {
+            break;
+        };
+
+        if let Some(argument_labels) = extract_swift_signature_from_entity_content(entity, parser) {
+            signatures.insert(entity.id.clone(), SwiftCallSignature { argument_labels });
+        }
+    }
+
+    signatures
+}
+
+fn find_entity_id_for_swift_declaration(
+    node: tree_sitter::Node,
+    ranges: &[(usize, usize, String)],
+    entity_map: &HashMap<String, EntityInfo>,
+) -> Option<String> {
+    let start_line = node.start_position().row + 1;
+    let end_line = node.end_position().row + 1;
+
+    ranges
+        .iter()
+        .filter(|(start, end, id)| {
+            *start <= start_line
+                && *end >= end_line
+                && entity_map.get(id).map_or(false, is_swift_callable_entity)
+        })
+        .min_by_key(|(start, end, _)| end.saturating_sub(*start))
+        .map(|(_, _, id)| id.clone())
+}
+
+fn is_swift_callable_entity(info: &EntityInfo) -> bool {
+    info.file_path.ends_with(".swift")
+        && matches!(
+            info.entity_type.as_str(),
+            "function" | "method" | "init" | "init_declaration"
+        )
+}
+
+fn is_swift_callable_entity_info(entity: &SemanticEntity) -> bool {
+    entity.file_path.ends_with(".swift")
+        && matches!(
+            entity.entity_type.as_str(),
+            "function" | "method" | "init" | "init_declaration"
+        )
+}
+
+fn swift_signature_parser() -> Option<tree_sitter::Parser> {
+    let language = get_language_config(".swift").and_then(|config| (config.get_language)())?;
+    let mut parser = tree_sitter::Parser::new();
+    parser.set_language(&language).ok()?;
+    Some(parser)
+}
+
+fn extract_swift_signature_from_entity_content(
+    entity: &SemanticEntity,
+    parser: &mut tree_sitter::Parser,
+) -> Option<Vec<Option<String>>> {
+    if let Some(argument_labels) = parse_swift_signature_source(parser, &entity.content) {
+        return Some(argument_labels);
+    }
+
+    if matches!(entity.entity_type.as_str(), "init" | "init_declaration") {
+        let wrapped = format!("struct __SemSignature {{\n{}\n}}\n", entity.content);
+        parse_swift_signature_source(parser, &wrapped)
+    } else {
+        None
+    }
+}
+
+fn parse_swift_signature_source(
+    parser: &mut tree_sitter::Parser,
+    source_text: &str,
+) -> Option<Vec<Option<String>>> {
+    let tree = parser.parse(source_text.as_bytes(), None)?;
+    let source = source_text.as_bytes();
+    find_first_swift_callable_declaration(tree.root_node())
+        .map(|node| extract_swift_declaration_argument_labels(node, source))
+}
+
+fn find_first_swift_callable_declaration<'a>(
+    root: tree_sitter::Node<'a>,
+) -> Option<tree_sitter::Node<'a>> {
+    let mut worklist = vec![root];
+    while let Some(node) = worklist.pop() {
+        if matches!(node.kind(), "function_declaration" | "init_declaration") {
+            return Some(node);
+        }
+
+        let mut cursor = node.walk();
+        let children: Vec<_> = node.named_children(&mut cursor).collect();
+        for child in children.into_iter().rev() {
+            worklist.push(child);
+        }
+    }
+
+    None
+}
+
+fn extract_swift_declaration_argument_labels(
+    node: tree_sitter::Node,
+    source: &[u8],
+) -> Vec<Option<String>> {
+    let mut labels = Vec::new();
+    let mut worklist = vec![node];
+
+    while let Some(current) = worklist.pop() {
+        if current.kind() == "function_body" {
+            continue;
+        }
+
+        if current.kind() == "parameter" {
+            labels.push(swift_parameter_argument_label(current, source));
+            continue;
+        }
+
+        let mut cursor = current.walk();
+        let children: Vec<_> = current.named_children(&mut cursor).collect();
+        for child in children.into_iter().rev() {
+            worklist.push(child);
+        }
+    }
+
+    labels
+}
+
+fn swift_parameter_argument_label(parameter: tree_sitter::Node, source: &[u8]) -> Option<String> {
+    parameter
+        .child_by_field_name("external_name")
+        .or_else(|| parameter.child_by_field_name("name"))
+        .and_then(|label| normalize_swift_label(label.utf8_text(source).ok()?))
+}
+
+fn extract_swift_call_argument_labels(
+    call: tree_sitter::Node,
+    source: &[u8],
+) -> Option<Vec<Option<String>>> {
+    let mut cursor = call.walk();
+    let call_suffix = call
+        .named_children(&mut cursor)
+        .find(|child| child.kind() == "call_suffix")?;
+
+    let mut suffix_cursor = call_suffix.walk();
+    let value_arguments = call_suffix
+        .named_children(&mut suffix_cursor)
+        .find(|child| child.kind() == "value_arguments")?;
+
+    let mut labels = Vec::new();
+    let mut arg_cursor = value_arguments.walk();
+    for argument in value_arguments
+        .named_children(&mut arg_cursor)
+        .filter(|child| child.kind() == "value_argument")
+    {
+        let label = argument
+            .child_by_field_name("name")
+            .and_then(|label| normalize_swift_label(label.utf8_text(source).ok()?));
+        labels.push(label);
+    }
+
+    Some(labels)
+}
+
+fn normalize_swift_label(label: &str) -> Option<String> {
+    let label = label.trim().trim_end_matches(':').trim();
+    if label.is_empty() || label == "_" {
+        None
+    } else {
+        Some(label.to_string())
+    }
+}
+
+fn select_member_candidate(
+    members: &[(String, String)],
+    method: &str,
+    argument_labels: Option<&[Option<String>]>,
+    swift_call_signatures: &HashMap<String, SwiftCallSignature>,
+) -> SwiftOverloadSelection {
+    let candidates: Vec<&String> = members
+        .iter()
+        .filter_map(|(name, id)| (name == method).then_some(id))
+        .collect();
+
+    if argument_labels.is_none()
+        && has_ambiguous_swift_signature_candidates(&candidates, swift_call_signatures)
+    {
+        return SwiftOverloadSelection::NoMatch;
+    }
+
+    match select_swift_overload_candidate(&candidates, argument_labels, swift_call_signatures) {
+        SwiftOverloadSelection::NotApplicable => candidates
+            .first()
+            .map(|id| SwiftOverloadSelection::Matched((*id).clone()))
+            .unwrap_or(SwiftOverloadSelection::NotApplicable),
+        selection => selection,
+    }
+}
+
+fn has_ambiguous_swift_signature_candidates(
+    candidates: &[&String],
+    swift_call_signatures: &HashMap<String, SwiftCallSignature>,
+) -> bool {
+    candidates
+        .iter()
+        .filter(|candidate| swift_call_signatures.contains_key(candidate.as_str()))
+        .take(2)
+        .count()
+        > 1
+}
+
+fn select_swift_overload_candidate(
+    candidates: &[&String],
+    argument_labels: Option<&[Option<String>]>,
+    swift_call_signatures: &HashMap<String, SwiftCallSignature>,
+) -> SwiftOverloadSelection {
+    let Some(argument_labels) = argument_labels else {
+        return SwiftOverloadSelection::NotApplicable;
+    };
+
+    let signature_candidates: Vec<(&String, &SwiftCallSignature)> = candidates
+        .iter()
+        .copied()
+        .filter_map(|candidate| {
+            swift_call_signatures
+                .get(candidate.as_str())
+                .map(|signature| (candidate, signature))
+        })
+        .collect();
+    if signature_candidates.is_empty() {
+        return SwiftOverloadSelection::NotApplicable;
+    }
+
+    let exact_matches: Vec<&String> = signature_candidates
+        .iter()
+        .filter_map(|(candidate, signature)| {
+            (signature.argument_labels.as_slice() == argument_labels).then_some(*candidate)
+        })
+        .collect();
+    if exact_matches.len() == 1 {
+        return SwiftOverloadSelection::Matched(exact_matches[0].clone());
+    }
+    if exact_matches.len() > 1 {
+        return SwiftOverloadSelection::NoMatch;
+    }
+
+    if argument_labels.iter().all(Option::is_none) {
+        let same_arity_matches: Vec<&String> = signature_candidates
+            .iter()
+            .filter_map(|(candidate, signature)| {
+                (signature.argument_labels.len() == argument_labels.len()).then_some(*candidate)
+            })
+            .collect();
+        if same_arity_matches.len() == 1 {
+            return SwiftOverloadSelection::Matched(same_arity_matches[0].clone());
+        }
+        if same_arity_matches.len() > 1 {
+            return SwiftOverloadSelection::NoMatch;
+        }
+    }
+
+    SwiftOverloadSelection::NoMatch
+}
+
 /// Collect ALL AST references in a file with a single tree walk.
 /// Each ref records its row so callers can bucket refs into entities by line range.
 fn collect_all_file_refs(
@@ -2851,17 +3977,34 @@ fn collect_all_file_refs(
                 CallNodeStyle::FunctionField(field) => {
                     if let Some(func) = node.child_by_field_name(field) {
                         // Pass empty entity_name — self-ref filtering is done at resolution time
-                        extract_call_ref(func, "", "", source, &mut refs, config, node_row);
+                        extract_call_ref(
+                            func, node, "", "", source, &mut refs, config, node_row, None,
+                        );
                     }
                 }
                 CallNodeStyle::FirstChild => {
                     // Swift/Kotlin: callee is the first named child (identifier or navigation_expression)
                     if let Some(func) = node.named_child(0) {
-                        extract_call_ref(func, "", "", source, &mut refs, config, node_row);
+                        let argument_labels = extract_swift_call_argument_labels(node, source);
+                        extract_call_ref(
+                            func,
+                            node,
+                            "",
+                            "",
+                            source,
+                            &mut refs,
+                            config,
+                            node_row,
+                            argument_labels,
+                        );
                     }
                 }
-                CallNodeStyle::DirectMethod { object_field, method_field } => {
-                    let method_name = node.child_by_field_name(method_field)
+                CallNodeStyle::DirectMethod {
+                    object_field,
+                    method_field,
+                } => {
+                    let method_name = node
+                        .child_by_field_name(method_field)
                         .and_then(|n| n.utf8_text(source).ok())
                         .unwrap_or("");
                     if !method_name.is_empty() && !is_builtin(method_name, config) {
@@ -2869,13 +4012,24 @@ fn collect_all_file_refs(
                             let receiver = obj_node.utf8_text(source).unwrap_or("").to_string();
                             let receiver = receiver.trim_end_matches('.').to_string();
                             refs.push(AstRef {
-                                kind: AstRefKind::MethodCall { receiver, method: method_name.to_string() },
+                                kind: AstRefKind::MethodCall {
+                                    receiver,
+                                    method: method_name.to_string(),
+                                    argument_labels: None,
+                                },
                                 row: node_row,
+                                start_byte: node.start_byte(),
+                                end_byte: node.end_byte(),
                             });
                         } else {
                             refs.push(AstRef {
-                                kind: AstRefKind::Call(method_name.to_string()),
+                                kind: AstRefKind::Call {
+                                    name: method_name.to_string(),
+                                    argument_labels: None,
+                                },
                                 row: node_row,
+                                start_byte: node.start_byte(),
+                                end_byte: node.end_byte(),
                             });
                         }
                     }
@@ -2895,8 +4049,13 @@ fn collect_all_file_refs(
                 let macro_name = macro_node.utf8_text(source).unwrap_or("");
                 if !macro_name.is_empty() && !is_builtin(macro_name, config) {
                     refs.push(AstRef {
-                        kind: AstRefKind::Call(macro_name.to_string()),
-                        row: node_row,
+                        kind: AstRefKind::Call {
+                            name: macro_name.to_string(),
+                            argument_labels: None,
+                        },
+                        row: macro_node.start_position().row,
+                        start_byte: macro_node.start_byte(),
+                        end_byte: macro_node.end_byte(),
                     });
                 }
             }
@@ -2915,8 +4074,13 @@ fn collect_all_file_refs(
                 let name = name.rsplit('.').next().unwrap_or(name);
                 if !name.is_empty() && !is_builtin(name, config) {
                     refs.push(AstRef {
-                        kind: AstRefKind::Call(name.to_string()),
-                        row: node_row,
+                        kind: AstRefKind::Call {
+                            name: name.to_string(),
+                            argument_labels: None,
+                        },
+                        row: type_node.start_position().row,
+                        start_byte: type_node.start_byte(),
+                        end_byte: type_node.end_byte(),
                     });
                 }
             }
@@ -2936,8 +4100,13 @@ fn collect_all_file_refs(
                     && !is_builtin(name, config)
                 {
                     refs.push(AstRef {
-                        kind: AstRefKind::Call(name.to_string()),
-                        row: node_row,
+                        kind: AstRefKind::Call {
+                            name: name.to_string(),
+                            argument_labels: None,
+                        },
+                        row: type_node.start_position().row,
+                        start_byte: type_node.start_byte(),
+                        end_byte: type_node.end_byte(),
                     });
                 }
             }
@@ -2953,24 +4122,43 @@ fn collect_all_file_refs(
     refs
 }
 
+fn build_refs_by_row(refs: &[AstRef]) -> Vec<Vec<usize>> {
+    let max_row = refs.iter().map(|r| r.row).max().unwrap_or(0);
+    let mut refs_by_row = vec![Vec::new(); max_row + 1];
+    for (idx, ast_ref) in refs.iter().enumerate() {
+        refs_by_row[ast_ref.row].push(idx);
+    }
+    refs_by_row
+}
+
 /// Extract a call reference from a function/callee node (shared across languages)
 fn extract_call_ref(
     func: tree_sitter::Node,
+    ref_node: tree_sitter::Node,
     _entity_id: &str,
     entity_name: &str,
     source: &[u8],
     refs: &mut Vec<AstRef>,
     config: &ScopeResolveConfig,
     row: usize,
+    argument_labels: Option<Vec<Option<String>>>,
 ) {
     let func_kind = func.kind();
 
-    if func_kind == "identifier" || func_kind == "simple_identifier" || func_kind == "type_identifier" {
+    if func_kind == "identifier"
+        || func_kind == "simple_identifier"
+        || func_kind == "type_identifier"
+    {
         let name = func.utf8_text(source).unwrap_or("");
         if !name.is_empty() && name != entity_name && !is_builtin(name, config) {
             refs.push(AstRef {
-                kind: AstRefKind::Call(name.to_string()),
+                kind: AstRefKind::Call {
+                    name: name.to_string(),
+                    argument_labels,
+                },
                 row,
+                start_byte: ref_node.start_byte(),
+                end_byte: ref_node.end_byte(),
             });
         }
         return;
@@ -2979,7 +4167,16 @@ fn extract_call_ref(
     // Check config member_access patterns
     for ma in config.member_access {
         if func_kind == ma.node_kind {
-            extract_member_call_ref(func, ma.object_field, ma.property_field, source, refs, row);
+            extract_member_call_ref(
+                func,
+                ref_node,
+                ma.object_field,
+                ma.property_field,
+                source,
+                refs,
+                row,
+                argument_labels,
+            );
             return;
         }
     }
@@ -2991,29 +4188,50 @@ fn extract_call_ref(
         if parts.len() >= 2 {
             // Handle super:: and self:: prefixed paths by emitting a call
             // to the final name so scope chain resolution can find it.
-            let is_path_prefix =
-                parts[0] == "super" || parts[0] == "self" || parts[0] == "crate";
+            let is_path_prefix = parts[0] == "super" || parts[0] == "self" || parts[0] == "crate";
             let method_name = parts[parts.len() - 1];
-            if is_path_prefix {
+            if is_path_prefix && parts.len() == 2 {
                 if !method_name.is_empty() && !is_builtin(method_name, config) {
                     refs.push(AstRef {
-                        kind: AstRefKind::Call(method_name.to_string()),
+                        kind: AstRefKind::Call {
+                            name: method_name.to_string(),
+                            argument_labels: None,
+                        },
                         row,
+                        start_byte: ref_node.start_byte(),
+                        end_byte: ref_node.end_byte(),
                     });
                 }
             } else {
-                let type_name = parts[parts.len() - 2];
-                if !type_name.is_empty() && !method_name.is_empty() {
-                    refs.push(AstRef {
-                        kind: AstRefKind::Call(method_name.to_string()),
-                        row,
-                    });
-                    if type_name.chars().next().map_or(false, |c| c.is_uppercase())
-                        && !is_builtin(type_name, config)
+                let receiver = parts[..parts.len() - 1].join("::");
+                let receiver_base = parts[parts.len() - 2];
+                if !receiver.is_empty() && !method_name.is_empty() {
+                    if parts.len() == 2
+                        && receiver_base
+                            .chars()
+                            .next()
+                            .map_or(false, |c| c.is_uppercase())
+                        && !is_builtin(receiver_base, config)
                     {
                         refs.push(AstRef {
-                            kind: AstRefKind::Call(type_name.to_string()),
+                            kind: AstRefKind::MethodCall {
+                                receiver: receiver_base.to_string(),
+                                method: method_name.to_string(),
+                                argument_labels: None,
+                            },
                             row,
+                            start_byte: ref_node.start_byte(),
+                            end_byte: ref_node.end_byte(),
+                        });
+                    } else if !is_builtin(method_name, config) {
+                        refs.push(AstRef {
+                            kind: AstRefKind::ScopedCall {
+                                path: receiver,
+                                name: method_name.to_string(),
+                            },
+                            row,
+                            start_byte: ref_node.start_byte(),
+                            end_byte: ref_node.end_byte(),
                         });
                     }
                 }
@@ -3027,11 +4245,13 @@ fn extract_call_ref(
 /// navigation_expression children don't have field names.
 fn extract_member_call_ref(
     node: tree_sitter::Node,
+    ref_node: tree_sitter::Node,
     object_field: &str,
     attr_field: &str,
     source: &[u8],
     refs: &mut Vec<AstRef>,
     row: usize,
+    argument_labels: Option<Vec<Option<String>>>,
 ) {
     let obj_text = node
         .child_by_field_name(object_field)
@@ -3048,33 +4268,45 @@ fn extract_member_call_ref(
         .unwrap_or("");
 
     if !obj_text.is_empty() && !attr_text.is_empty() {
-        push_method_call_ref(obj_text, attr_text, refs, row);
+        push_method_call_ref(obj_text, attr_text, refs, ref_node, row, argument_labels);
         return;
     }
 
     // Fallback: positional children (Kotlin navigation_expression has no field names)
     let child_count = node.named_child_count();
     if child_count >= 2 {
-        let obj = node.named_child(0)
+        let obj = node
+            .named_child(0)
             .and_then(|n| n.utf8_text(source).ok())
             .unwrap_or("");
         let last_idx = (child_count - 1) as u32;
-        let attr = node.named_child(last_idx)
+        let attr = node
+            .named_child(last_idx)
             .and_then(|n| n.utf8_text(source).ok())
             .unwrap_or("");
         if !obj.is_empty() && !attr.is_empty() {
-            push_method_call_ref(obj, attr, refs, row);
+            push_method_call_ref(obj, attr, refs, ref_node, row, argument_labels);
         }
     }
 }
 
-fn push_method_call_ref(obj: &str, method: &str, refs: &mut Vec<AstRef>, row: usize) {
+fn push_method_call_ref(
+    obj: &str,
+    method: &str,
+    refs: &mut Vec<AstRef>,
+    node: tree_sitter::Node,
+    row: usize,
+    argument_labels: Option<Vec<Option<String>>>,
+) {
     refs.push(AstRef {
         kind: AstRefKind::MethodCall {
             receiver: obj.to_string(),
             method: method.to_string(),
+            argument_labels,
         },
         row,
+        start_byte: node.start_byte(),
+        end_byte: node.end_byte(),
     });
 }
 
@@ -3088,18 +4320,84 @@ fn resolve_ref(
     import_table: &HashMap<(String, String), String>,
     instance_attr_types: &HashMap<(String, String), String>,
     entity_map: &HashMap<String, EntityInfo>,
+    swift_call_signatures: &HashMap<String, SwiftCallSignature>,
     file_path: &str,
     from_entity_id: &str,
     allow_cross_file_calls: bool,
+    allow_implicit_instance_member_receiver: bool,
+    lookup_cache: &mut ScopeLookupCache,
 ) -> Option<(String, RefType, &'static str)> {
     match &ast_ref.kind {
-        AstRefKind::Call(name) => {
-            if is_local_binding_in_scopes(scope_idx, scopes, name) {
+        AstRefKind::Call {
+            name,
+            argument_labels,
+        } => {
+            if is_local_binding_in_scopes_cached(scope_idx, scopes, name, lookup_cache) {
                 return None;
             }
 
+            if argument_labels.is_some() {
+                if let Some(target_ids) = symbol_table.get(name.as_str()) {
+                    let same_file_targets: Vec<&String> = target_ids
+                        .iter()
+                        .filter(|id| {
+                            entity_map
+                                .get(*id)
+                                .map_or(false, |e| e.file_path == file_path)
+                        })
+                        .collect();
+                    let visible_targets: Vec<&String> = if !same_file_targets.is_empty() {
+                        same_file_targets
+                    } else if allow_cross_file_calls {
+                        target_ids.iter().collect()
+                    } else {
+                        Vec::new()
+                    };
+                    match select_swift_overload_candidate(
+                        &visible_targets,
+                        argument_labels.as_deref(),
+                        swift_call_signatures,
+                    ) {
+                        SwiftOverloadSelection::Matched(target_id) => {
+                            let is_constructor =
+                                name.chars().next().map_or(false, |c| c.is_uppercase());
+                            let ref_type = if is_constructor {
+                                RefType::TypeRef
+                            } else {
+                                RefType::Calls
+                            };
+                            return Some((target_id, ref_type, "scope_chain"));
+                        }
+                        SwiftOverloadSelection::NoMatch => return None,
+                        SwiftOverloadSelection::NotApplicable => {}
+                    }
+                }
+            } else if let Some(target_ids) = symbol_table.get(name.as_str()) {
+                let same_file_targets: Vec<&String> = target_ids
+                    .iter()
+                    .filter(|id| {
+                        entity_map
+                            .get(*id)
+                            .map_or(false, |e| e.file_path == file_path)
+                    })
+                    .collect();
+                let visible_targets: Vec<&String> = if !same_file_targets.is_empty() {
+                    same_file_targets
+                } else if allow_cross_file_calls {
+                    target_ids.iter().collect()
+                } else {
+                    Vec::new()
+                };
+                if has_ambiguous_swift_signature_candidates(
+                    &visible_targets,
+                    swift_call_signatures,
+                ) {
+                    return None;
+                }
+            }
+
             // 1. Walk scope chain for the name
-            if let Some(eid) = lookup_scope_chain(scope_idx, scopes, name) {
+            if let Some(eid) = lookup_scope_chain_cached(scope_idx, scopes, name, lookup_cache) {
                 if eid != from_entity_id {
                     return Some((eid, RefType::Calls, "scope_chain"));
                 }
@@ -3114,34 +4412,52 @@ fn resolve_ref(
             // 3. Global symbol table fallback (constructor calls or cross-file functions)
             if let Some(target_ids) = symbol_table.get(name.as_str()) {
                 let is_constructor = name.chars().next().map_or(false, |c| c.is_uppercase());
-                let ref_type = if is_constructor { RefType::TypeRef } else { RefType::Calls };
-                // Prefer same-file, then any
-                let target = target_ids
+                let ref_type = if is_constructor {
+                    RefType::TypeRef
+                } else {
+                    RefType::Calls
+                };
+                let same_file_targets: Vec<&String> = target_ids
                     .iter()
-                    .find(|id| {
+                    .filter(|id| {
                         entity_map
                             .get(*id)
                             .map_or(false, |e| e.file_path == file_path)
                     })
-                    .or_else(|| {
-                        // Fall back to cross-file global for constructor calls.
-                        // For lowercase calls, require explicit imports to avoid false positives,
-                        // unless the language allows implicit cross-file visibility (Swift, Kotlin).
-                        if is_constructor || allow_cross_file_calls {
-                            target_ids.first()
-                        } else {
-                            None
-                        }
-                    });
+                    .collect();
+                let visible_targets: Vec<&String> = if !same_file_targets.is_empty() {
+                    same_file_targets
+                } else if is_constructor || allow_cross_file_calls {
+                    target_ids.iter().collect()
+                } else {
+                    Vec::new()
+                };
+                let target = match select_swift_overload_candidate(
+                    &visible_targets,
+                    argument_labels.as_deref(),
+                    swift_call_signatures,
+                ) {
+                    SwiftOverloadSelection::Matched(target_id) => Some(target_id),
+                    SwiftOverloadSelection::NoMatch => return None,
+                    SwiftOverloadSelection::NotApplicable => {
+                        visible_targets.first().map(|id| (*id).clone())
+                    }
+                };
                 if let Some(tid) = target {
-                    return Some((tid.clone(), ref_type, "scope_chain"));
+                    return Some((tid, ref_type, "scope_chain"));
                 }
             }
 
             None
         }
 
-        AstRefKind::MethodCall { receiver: raw_receiver, method } => {
+        AstRefKind::ScopedCall { .. } => None,
+
+        AstRefKind::MethodCall {
+            receiver: raw_receiver,
+            method,
+            argument_labels,
+        } => {
             // Strip prefix operators like ! (Swift: `!dog.validate()`)
             let receiver = raw_receiver.trim_start_matches('!').trim_start_matches('~');
             if receiver == "self" || receiver == "this" {
@@ -3149,6 +4465,31 @@ fn resolve_ref(
                 let mut idx = scope_idx;
                 loop {
                     if scopes[idx].kind == "class" {
+                        if let Some(class_name) = scopes[idx]
+                            .owner_id
+                            .as_ref()
+                            .and_then(|owner_id| entity_map.get(owner_id))
+                            .map(|owner| owner.name.as_str())
+                        {
+                            if let Some(members) = class_members.get(class_name) {
+                                match select_member_candidate(
+                                    members,
+                                    method,
+                                    argument_labels.as_deref(),
+                                    swift_call_signatures,
+                                ) {
+                                    SwiftOverloadSelection::Matched(eid) => {
+                                        return Some((eid, RefType::Calls, "scope_chain"));
+                                    }
+                                    SwiftOverloadSelection::NoMatch => return None,
+                                    SwiftOverloadSelection::NotApplicable => {
+                                        if argument_labels.is_some() {
+                                            return None;
+                                        }
+                                    }
+                                }
+                            }
+                        }
                         if let Some(eid) = scopes[idx].defs.get(method.as_str()) {
                             return Some((eid.clone(), RefType::Calls, "scope_chain"));
                         }
@@ -3166,14 +4507,24 @@ fn resolve_ref(
             // receiver is "self.X" where X is an instance attribute
             if receiver.starts_with("self.") || receiver.starts_with("this.") {
                 let attr_name = &receiver[5..]; // strip "self." or "this."
-                // Find the enclosing class name
-                let class_name = find_enclosing_class(scope_idx, scopes, entity_map);
+                                                // Find the enclosing class name
+                let class_name =
+                    find_enclosing_class_cached(scope_idx, scopes, entity_map, lookup_cache);
                 if let Some(cn) = class_name {
                     // Look up instance attribute type
                     if let Some(attr_type) = instance_attr_types.get(&(cn, attr_name.to_string())) {
                         if let Some(members) = class_members.get(attr_type.as_str()) {
-                            if let Some((_, mid)) = members.iter().find(|(n, _)| n == method) {
-                                return Some((mid.clone(), RefType::Calls, "type_tracking"));
+                            match select_member_candidate(
+                                members,
+                                method,
+                                argument_labels.as_deref(),
+                                swift_call_signatures,
+                            ) {
+                                SwiftOverloadSelection::Matched(mid) => {
+                                    return Some((mid, RefType::Calls, "type_tracking"));
+                                }
+                                SwiftOverloadSelection::NoMatch => return None,
+                                SwiftOverloadSelection::NotApplicable => {}
                             }
                         }
                     }
@@ -3181,15 +4532,31 @@ fn resolve_ref(
             }
 
             // Handle chained var.field.method() pattern (e.g. Go receiver: t.Conn.Execute())
-            if receiver.contains('.') && !receiver.starts_with("self.") && !receiver.starts_with("this.") {
+            if receiver.contains('.')
+                && !receiver.starts_with("self.")
+                && !receiver.starts_with("this.")
+            {
                 if let Some(dot_pos) = receiver.find('.') {
                     let var_part = &receiver[..dot_pos];
                     let field_part = &receiver[dot_pos + 1..];
-                    if let Some(var_type) = lookup_type_in_scopes(scope_idx, scopes, var_part) {
-                        if let Some(attr_type) = instance_attr_types.get(&(var_type, field_part.to_string())) {
+                    if let Some(var_type) =
+                        lookup_type_in_scopes_cached(scope_idx, scopes, var_part, lookup_cache)
+                    {
+                        if let Some(attr_type) =
+                            instance_attr_types.get(&(var_type, field_part.to_string()))
+                        {
                             if let Some(members) = class_members.get(attr_type.as_str()) {
-                                if let Some((_, mid)) = members.iter().find(|(n, _)| n == method) {
-                                    return Some((mid.clone(), RefType::Calls, "type_tracking"));
+                                match select_member_candidate(
+                                    members,
+                                    method,
+                                    argument_labels.as_deref(),
+                                    swift_call_signatures,
+                                ) {
+                                    SwiftOverloadSelection::Matched(mid) => {
+                                        return Some((mid, RefType::Calls, "type_tracking"));
+                                    }
+                                    SwiftOverloadSelection::NoMatch => return None,
+                                    SwiftOverloadSelection::NotApplicable => {}
                                 }
                             }
                         }
@@ -3198,27 +4565,107 @@ fn resolve_ref(
             }
 
             // receiver.method() -> look up receiver type, then resolve method
-            let receiver_type = lookup_type_in_scopes(scope_idx, scopes, receiver);
+            let receiver_type = if let Some(receiver_type) =
+                lookup_type_before_class_scope(scope_idx, scopes, receiver)
+            {
+                Some(receiver_type)
+            } else if allow_implicit_instance_member_receiver
+                && is_simple_identifier_name(receiver)
+                && !is_local_binding_in_scopes_cached(scope_idx, scopes, receiver, lookup_cache)
+            {
+                match find_enclosing_class_cached(scope_idx, scopes, entity_map, lookup_cache) {
+                    Some(class_name) => instance_attr_types
+                        .get(&(class_name, receiver.to_string()))
+                        .cloned(),
+                    None => None,
+                }
+            } else {
+                None
+            };
 
             if let Some(class_name) = receiver_type {
                 if let Some(members) = class_members.get(class_name.as_str()) {
-                    if let Some((_, mid)) = members.iter().find(|(n, _)| n == method) {
-                        return Some((mid.clone(), RefType::Calls, "type_tracking"));
+                    match select_member_candidate(
+                        members,
+                        method,
+                        argument_labels.as_deref(),
+                        swift_call_signatures,
+                    ) {
+                        SwiftOverloadSelection::Matched(mid) => {
+                            return Some((mid, RefType::Calls, "type_tracking"));
+                        }
+                        SwiftOverloadSelection::NoMatch => return None,
+                        SwiftOverloadSelection::NotApplicable => {}
+                    }
+                }
+            }
+
+            // Inside class methods, unqualified property receivers resolve
+            // against the enclosing instance when no local binding shadows them.
+            let from_entity_is_container_type =
+                entity_map.get(from_entity_id).map_or(false, |entity| {
+                    matches!(
+                        entity.entity_type.as_str(),
+                        "class"
+                            | "struct"
+                            | "interface"
+                            | "enum"
+                            | "protocol_declaration"
+                            | "object_declaration"
+                            | "companion_object"
+                    )
+                });
+
+            if allow_implicit_instance_member_receiver
+                && !from_entity_is_container_type
+                && !is_local_binding_in_scopes_cached(scope_idx, scopes, receiver, lookup_cache)
+            {
+                if let Some(class_name) =
+                    find_enclosing_class_cached(scope_idx, scopes, entity_map, lookup_cache)
+                {
+                    if let Some(attr_type) =
+                        instance_attr_types.get(&(class_name, receiver.to_string()))
+                    {
+                        if let Some(members) = class_members.get(attr_type.as_str()) {
+                            match select_member_candidate(
+                                members,
+                                method,
+                                argument_labels.as_deref(),
+                                swift_call_signatures,
+                            ) {
+                                SwiftOverloadSelection::Matched(mid) => {
+                                    return Some((mid, RefType::Calls, "type_tracking"));
+                                }
+                                SwiftOverloadSelection::NoMatch => return None,
+                                SwiftOverloadSelection::NotApplicable => {}
+                            }
+                        }
                     }
                 }
             }
 
             // ClassName.method() static call, only when ClassName is visible and
             // not shadowed by a local binding.
-            if !is_local_binding_in_scopes(scope_idx, scopes, receiver) {
-                if let Some(class_id) = lookup_scope_chain(scope_idx, scopes, receiver) {
+            if !is_local_binding_in_scopes_cached(scope_idx, scopes, receiver, lookup_cache) {
+                if let Some(class_id) =
+                    lookup_scope_chain_cached(scope_idx, scopes, receiver, lookup_cache)
+                {
                     if let Some(info) = entity_map.get(&class_id) {
                         if matches!(info.entity_type.as_str(), "class" | "struct" | "interface")
                             && info.name == receiver
                         {
                             if let Some(members) = class_members.get(&info.name) {
-                                if let Some((_, mid)) = members.iter().find(|(n, _)| n == method) {
-                                    return Some((mid.clone(), RefType::Calls, "scope_chain"));
+                                match select_member_candidate(
+                                    members,
+                                    method,
+                                    argument_labels.as_deref(),
+                                    swift_call_signatures,
+                                ) {
+                                    SwiftOverloadSelection::Matched(mid) => {
+                                        return Some((mid, RefType::Calls, "scope_chain"));
+                                    }
+                                    SwiftOverloadSelection::NoMatch => return None,
+                                    SwiftOverloadSelection::NotApplicable => {}
                                 }
                             }
                         }
@@ -3227,20 +4674,23 @@ fn resolve_ref(
             }
 
             // Fallback: check import table for the receiver
-            if !is_local_binding_in_scopes(scope_idx, scopes, receiver) {
+            if !is_local_binding_in_scopes_cached(scope_idx, scopes, receiver, lookup_cache) {
                 let key = (file_path.to_string(), receiver.to_string());
                 if let Some(target_id) = import_table.get(&key) {
                     if let Some(info) = entity_map.get(target_id) {
                         if matches!(info.entity_type.as_str(), "class" | "struct") {
                             if let Some(members) = class_members.get(&info.name) {
-                                if let Some((_, mid)) =
-                                    members.iter().find(|(n, _)| n == method)
-                                {
-                                    return Some((
-                                        mid.clone(),
-                                        RefType::Calls,
-                                        "type_tracking",
-                                    ));
+                                match select_member_candidate(
+                                    members,
+                                    method,
+                                    argument_labels.as_deref(),
+                                    swift_call_signatures,
+                                ) {
+                                    SwiftOverloadSelection::Matched(mid) => {
+                                        return Some((mid, RefType::Calls, "type_tracking"));
+                                    }
+                                    SwiftOverloadSelection::NoMatch => return None,
+                                    SwiftOverloadSelection::NotApplicable => {}
                                 }
                             }
                         }
@@ -3268,6 +4718,110 @@ fn resolve_ref(
     }
 }
 
+fn allows_implicit_instance_member_receiver(
+    file_path: &str,
+    entity_type: &str,
+    entity_content: &str,
+) -> bool {
+    let ext = file_path.rsplit('.').next().unwrap_or("");
+    let supports_implicit_receiver = matches!(
+        ext,
+        "swift"
+            | "kt"
+            | "kts"
+            | "java"
+            | "cs"
+            | "cpp"
+            | "cc"
+            | "cxx"
+            | "hpp"
+            | "hh"
+            | "hxx"
+            | "h"
+            | "scala"
+            | "dart"
+    );
+
+    supports_implicit_receiver
+        && matches!(
+            entity_type,
+            "function" | "method" | "init" | "init_declaration" | "constructor_declaration"
+        )
+        && !has_static_member_modifier(ext, entity_content)
+}
+
+fn has_static_member_modifier(ext: &str, entity_content: &str) -> bool {
+    let header = entity_content
+        .split(|ch| ch == '{' || ch == '=')
+        .next()
+        .unwrap_or(entity_content);
+    let header_without_comments = strip_member_header_comments(header);
+    let tokens = header_without_comments
+        .split(|ch: char| !ch.is_alphanumeric() && ch != '_')
+        .filter(|token| !token.is_empty())
+        .collect::<Vec<_>>();
+    let declaration_start = tokens
+        .iter()
+        .position(|token| {
+            matches!(
+                *token,
+                "func" | "function" | "fn" | "constructor" | "init" | "var" | "let" | "subscript"
+            )
+        })
+        .unwrap_or(tokens.len());
+
+    tokens[..declaration_start]
+        .iter()
+        .any(|token| *token == "static" || (ext == "swift" && *token == "class"))
+}
+
+fn strip_member_header_comments(header: &str) -> String {
+    let mut output = String::with_capacity(header.len());
+    let mut chars = header.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch != '/' {
+            output.push(ch);
+            continue;
+        }
+
+        match chars.peek().copied() {
+            Some('/') => {
+                chars.next();
+                for next in chars.by_ref() {
+                    if next == '\n' {
+                        output.push(' ');
+                        break;
+                    }
+                }
+            }
+            Some('*') => {
+                chars.next();
+                let mut previous = '\0';
+                for next in chars.by_ref() {
+                    if previous == '*' && next == '/' {
+                        break;
+                    }
+                    previous = next;
+                }
+                output.push(' ');
+            }
+            _ => output.push(ch),
+        }
+    }
+
+    output
+}
+
+fn is_simple_identifier_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+
+    (first == '_' || first.is_alphabetic()) && chars.all(|ch| ch == '_' || ch.is_alphanumeric())
+}
+
 /// Find the class name for the enclosing class scope.
 fn find_enclosing_class(
     start_scope: usize,
@@ -3288,12 +4842,22 @@ fn find_enclosing_class(
     }
 }
 
-/// Walk up the scope chain looking for a definition.
-fn lookup_scope_chain(
+fn find_enclosing_class_cached(
     start_scope: usize,
     scopes: &[Scope],
-    name: &str,
+    entity_map: &HashMap<String, EntityInfo>,
+    cache: &mut ScopeLookupCache,
 ) -> Option<String> {
+    if let Some(cached) = cache.enclosing_classes.get(&start_scope) {
+        return cached.clone();
+    }
+    let value = find_enclosing_class(start_scope, scopes, entity_map);
+    cache.enclosing_classes.insert(start_scope, value.clone());
+    value
+}
+
+/// Walk up the scope chain looking for a definition.
+fn lookup_scope_chain(start_scope: usize, scopes: &[Scope], name: &str) -> Option<String> {
     let mut idx = start_scope;
     loop {
         if let Some(eid) = scopes[idx].defs.get(name) {
@@ -3306,12 +4870,30 @@ fn lookup_scope_chain(
     }
 }
 
-/// Walk up the scope chain looking for a local binding that shadows a definition.
-fn is_local_binding_in_scopes(
+fn lookup_scope_chain_cached(
     start_scope: usize,
     scopes: &[Scope],
     name: &str,
-) -> bool {
+    cache: &mut ScopeLookupCache,
+) -> Option<String> {
+    if let Some(cached) = cache
+        .defs
+        .get(&start_scope)
+        .and_then(|scope_cache| scope_cache.get(name))
+    {
+        return cached.clone();
+    }
+    let value = lookup_scope_chain(start_scope, scopes, name);
+    cache
+        .defs
+        .entry(start_scope)
+        .or_default()
+        .insert(name.to_string(), value.clone());
+    value
+}
+
+/// Walk up the scope chain looking for a local binding that shadows a definition.
+fn is_local_binding_in_scopes(start_scope: usize, scopes: &[Scope], name: &str) -> bool {
     let mut idx = start_scope;
     loop {
         if scopes[idx].bindings.contains(name) {
@@ -3324,12 +4906,30 @@ fn is_local_binding_in_scopes(
     }
 }
 
-/// Walk up the scope chain looking for a type binding.
-fn lookup_type_in_scopes(
+fn is_local_binding_in_scopes_cached(
     start_scope: usize,
     scopes: &[Scope],
-    var_name: &str,
-) -> Option<String> {
+    name: &str,
+    cache: &mut ScopeLookupCache,
+) -> bool {
+    if let Some(cached) = cache
+        .local_bindings
+        .get(&start_scope)
+        .and_then(|scope_cache| scope_cache.get(name))
+    {
+        return *cached;
+    }
+    let value = is_local_binding_in_scopes(start_scope, scopes, name);
+    cache
+        .local_bindings
+        .entry(start_scope)
+        .or_default()
+        .insert(name.to_string(), value);
+    value
+}
+
+/// Walk up the scope chain looking for a type binding.
+fn lookup_type_in_scopes(start_scope: usize, scopes: &[Scope], var_name: &str) -> Option<String> {
     let mut idx = start_scope;
     loop {
         if let Some(type_name) = scopes[idx].types.get(var_name) {
@@ -3342,9 +4942,54 @@ fn lookup_type_in_scopes(
     }
 }
 
+fn lookup_type_before_class_scope(
+    start_scope: usize,
+    scopes: &[Scope],
+    var_name: &str,
+) -> Option<String> {
+    let mut idx = start_scope;
+    loop {
+        if scopes[idx].kind == "class" {
+            return None;
+        }
+        if let Some(type_name) = scopes[idx].types.get(var_name) {
+            return Some(type_name.clone());
+        }
+        match scopes[idx].parent {
+            Some(p) => idx = p,
+            None => return None,
+        }
+    }
+}
+
+fn lookup_type_in_scopes_cached(
+    start_scope: usize,
+    scopes: &[Scope],
+    var_name: &str,
+    cache: &mut ScopeLookupCache,
+) -> Option<String> {
+    if let Some(cached) = cache
+        .types
+        .get(&start_scope)
+        .and_then(|scope_cache| scope_cache.get(var_name))
+    {
+        return cached.clone();
+    }
+    let value = lookup_type_in_scopes(start_scope, scopes, var_name);
+    cache
+        .types
+        .entry(start_scope)
+        .or_default()
+        .insert(var_name.to_string(), value.clone());
+    value
+}
+
 fn is_builtin(name: &str, config: &ScopeResolveConfig) -> bool {
     // Common builtins across languages
-    if matches!(name, "None" | "True" | "False" | "null" | "undefined" | "nil") {
+    if matches!(
+        name,
+        "None" | "True" | "False" | "null" | "undefined" | "nil"
+    ) {
         return true;
     }
     config.builtins.contains(&name)

--- a/crates/sem-core/tests/fixtures/scope_test/swift/database.swift
+++ b/crates/sem-core/tests/fixtures/scope_test/swift/database.swift
@@ -8,6 +8,10 @@ class Connection {
     func close() {}
 }
 
+class Logger {
+    func record(message: String) {}
+}
+
 class Transaction {
     var conn: Connection
 
@@ -24,6 +28,34 @@ class Transaction {
     }
 
     func rollback() {}
+}
+
+class Replicator {
+    var primary, backup: Connection
+
+    init(primary: Connection, backup: Connection) {
+        self.primary = primary
+        self.backup = backup
+    }
+
+    func sync() {
+        primary.execute(query: "SELECT 1")
+        backup.commit()
+    }
+}
+
+class AuditedTransaction {
+    var conn: Connection, logger: Logger
+
+    init(conn: Connection, logger: Logger) {
+        self.conn = conn
+        self.logger = logger
+    }
+
+    func write() {
+        conn.commit()
+        logger.record(message: "done")
+    }
 }
 
 func getConnection() -> Connection {

--- a/crates/sem-core/tests/scope_resolve_bench.rs
+++ b/crates/sem-core/tests/scope_resolve_bench.rs
@@ -53,30 +53,60 @@ fn get_expected_edges() -> Vec<(&'static str, &'static str, &'static str)> {
         // service.py → models.py
         ("create_dog", "Dog", "service calls Dog constructor"),
         ("create_dog", "validate", "service calls dog.validate()"),
-        ("create_dog", "get_connection", "service calls get_connection()"),
+        (
+            "create_dog",
+            "get_connection",
+            "service calls get_connection()",
+        ),
         ("create_cat", "Cat", "service calls Cat constructor"),
         ("create_cat", "validate", "service calls cat.validate()"),
-        ("create_cat", "get_connection", "service calls get_connection()"),
-        ("transfer_animal", "Transaction", "service calls Transaction constructor"),
-        ("transfer_animal", "get_connection", "service calls get_connection()"),
+        (
+            "create_cat",
+            "get_connection",
+            "service calls get_connection()",
+        ),
+        (
+            "transfer_animal",
+            "Transaction",
+            "service calls Transaction constructor",
+        ),
+        (
+            "transfer_animal",
+            "get_connection",
+            "service calls get_connection()",
+        ),
         ("transfer_animal", "execute", "txn.execute() on Transaction"),
         ("transfer_animal", "commit", "txn.commit() on Transaction"),
         ("transfer_animal", "add", "shelter.add() on Shelter"),
-        ("list_animals", "get_connection", "service calls get_connection()"),
+        (
+            "list_animals",
+            "get_connection",
+            "service calls get_connection()",
+        ),
         ("list_animals", "execute", "conn.execute() on Connection"),
-
         // handlers.py → service.py
         ("handle_create_dog", "create_dog", "handler calls service"),
         ("handle_create_cat", "create_cat", "handler calls service"),
-        ("handle_transfer", "transfer_animal", "handler calls service"),
+        (
+            "handle_transfer",
+            "transfer_animal",
+            "handler calls service",
+        ),
         ("handle_transfer", "Shelter", "handler creates Shelter"),
         ("handle_transfer", "Dog", "handler creates Dog"),
         ("handle_transfer", "count", "shelter.count() on Shelter"),
         ("handle_list", "list_animals", "handler calls service"),
-
         // database.py internal
-        ("Transaction::execute", "execute", "Transaction.execute calls self.conn.execute"),
-        ("Transaction::commit", "commit", "Transaction.commit calls self.conn.commit"),
+        (
+            "Transaction::execute",
+            "execute",
+            "Transaction.execute calls self.conn.execute",
+        ),
+        (
+            "Transaction::commit",
+            "commit",
+            "Transaction.commit calls self.conn.commit",
+        ),
     ]
 }
 
@@ -87,16 +117,22 @@ fn get_false_positive_edges() -> Vec<(&'static str, &'static str, &'static str)>
         // to Cat.validate, that's a false positive.
         ("create_dog", "Cat", "create_dog shouldn't reference Cat"),
         ("create_cat", "Dog", "create_cat shouldn't reference Dog"),
-
         // validate() in handlers.py is a standalone function, not Dog.validate or Cat.validate
         // bag-of-words might link them
         ("validate", "Dog", "standalone validate != Dog.validate"),
         ("validate", "Cat", "standalone validate != Cat.validate"),
-
         // Transaction.execute and Connection.execute are different.
         // transfer_animal calls txn.execute() not conn.execute() directly
-        ("handle_create_dog", "Transaction", "handler doesn't use Transaction directly"),
-        ("handle_create_cat", "Transaction", "handler doesn't use Transaction directly"),
+        (
+            "handle_create_dog",
+            "Transaction",
+            "handler doesn't use Transaction directly",
+        ),
+        (
+            "handle_create_cat",
+            "Transaction",
+            "handler doesn't use Transaction directly",
+        ),
     ]
 }
 
@@ -107,10 +143,7 @@ fn edge_matches(
     to_pat: &str,
 ) -> bool {
     edges.iter().any(|(from, to)| {
-        let from_name = entity_map
-            .get(from)
-            .map(|e| e.name.as_str())
-            .unwrap_or("");
+        let from_name = entity_map.get(from).map(|e| e.name.as_str()).unwrap_or("");
         let to_name = entity_map.get(to).map(|e| e.name.as_str()).unwrap_or("");
 
         // Handle qualified patterns like "Transaction::execute"
@@ -131,8 +164,220 @@ fn edge_matches(
 }
 
 #[test]
+fn swift_overloaded_calls_resolve_by_argument_label() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    std::fs::write(
+        root.join("Example.swift"),
+        r#"func load(id: Int) -> String { return "id" }
+
+func load(name: String) -> String { return "name" }
+
+func byId() -> String { return load(id: 1) }
+
+func byName() -> String { return load(name: "x") }
+
+func byAge() -> String { return load(age: 1) }
+"#,
+    )
+    .unwrap();
+    init_git(root);
+
+    let registry = create_default_registry();
+    let file_refs = vec!["Example.swift".to_string()];
+    let (graph, _) = EntityGraph::build(root, &file_refs, &registry);
+
+    let entity_id = |name: &str, start_line: usize| {
+        graph
+            .entities
+            .values()
+            .find(|entity| entity.name == name && entity.start_line == start_line)
+            .unwrap_or_else(|| panic!("missing entity {name} at line {start_line}"))
+            .id
+            .clone()
+    };
+
+    let load_id = entity_id("load", 1);
+    let load_name = entity_id("load", 3);
+    let by_id = entity_id("byId", 5);
+    let by_name = entity_id("byName", 7);
+    let by_age = entity_id("byAge", 9);
+
+    let has_edge = |from: &str, to: &str| {
+        graph.edges.iter().any(|edge| {
+            edge.from_entity == from && edge.to_entity == to && edge.ref_type == RefType::Calls
+        })
+    };
+
+    assert!(has_edge(&by_id, &load_id), "byId should call load(id:)");
+    assert!(
+        !has_edge(&by_id, &load_name),
+        "byId should not call load(name:)"
+    );
+    assert!(
+        has_edge(&by_name, &load_name),
+        "byName should call load(name:)"
+    );
+    assert!(
+        !has_edge(&by_name, &load_id),
+        "byName should not call load(id:)"
+    );
+    assert!(
+        !has_edge(&by_age, &load_id),
+        "byAge should not fall back to load(id:)"
+    );
+    assert!(
+        !has_edge(&by_age, &load_name),
+        "byAge should not fall back to load(name:)"
+    );
+}
+
+#[test]
+fn swift_overloaded_method_calls_resolve_by_argument_label() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    std::fs::write(
+        root.join("Example.swift"),
+        r#"struct Loader {
+    func load(id: Int) -> String { return "id" }
+
+    func load(name: String) -> String { return "name" }
+}
+
+func byId(loader: Loader) -> String { return loader.load(id: 1) }
+
+func byName(loader: Loader) -> String { return loader.load(name: "x") }
+
+func byAge(loader: Loader) -> String { return loader.load(age: 1) }
+"#,
+    )
+    .unwrap();
+    init_git(root);
+
+    let registry = create_default_registry();
+    let file_refs = vec!["Example.swift".to_string()];
+    let (graph, _) = EntityGraph::build(root, &file_refs, &registry);
+
+    let entity_id = |name: &str, start_line: usize| {
+        graph
+            .entities
+            .values()
+            .find(|entity| entity.name == name && entity.start_line == start_line)
+            .unwrap_or_else(|| panic!("missing entity {name} at line {start_line}"))
+            .id
+            .clone()
+    };
+
+    let load_id = entity_id("load", 2);
+    let load_name = entity_id("load", 4);
+    let by_id = entity_id("byId", 7);
+    let by_name = entity_id("byName", 9);
+    let by_age = entity_id("byAge", 11);
+
+    let has_edge = |from: &str, to: &str| {
+        graph.edges.iter().any(|edge| {
+            edge.from_entity == from && edge.to_entity == to && edge.ref_type == RefType::Calls
+        })
+    };
+
+    assert!(has_edge(&by_id, &load_id), "byId should call load(id:)");
+    assert!(
+        !has_edge(&by_id, &load_name),
+        "byId should not call load(name:)"
+    );
+    assert!(
+        has_edge(&by_name, &load_name),
+        "byName should call load(name:)"
+    );
+    assert!(
+        !has_edge(&by_name, &load_id),
+        "byName should not call load(id:)"
+    );
+    assert!(
+        !has_edge(&by_age, &load_id),
+        "byAge should not fall back to load(id:)"
+    );
+    assert!(
+        !has_edge(&by_age, &load_name),
+        "byAge should not fall back to load(name:)"
+    );
+}
+
+#[test]
+fn swift_overloaded_initializers_resolve_by_argument_label() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    std::fs::write(
+        root.join("Example.swift"),
+        r#"struct Token {
+    init(id: Int) {}
+
+    init(text: String) {}
+
+    init(copyID: Int) { self.init(id: copyID) }
+
+    init(copyText: String) { self.init(text: copyText) }
+
+    init(copyAge: Double) { self.init(age: copyAge) }
+}
+"#,
+    )
+    .unwrap();
+    init_git(root);
+
+    let registry = create_default_registry();
+    let file_refs = vec!["Example.swift".to_string()];
+    let (graph, _) = EntityGraph::build(root, &file_refs, &registry);
+
+    let entity_id = |start_line: usize| {
+        graph
+            .entities
+            .values()
+            .find(|entity| entity.name == "init" && entity.start_line == start_line)
+            .unwrap_or_else(|| panic!("missing init at line {start_line}"))
+            .id
+            .clone()
+    };
+
+    let init_id = entity_id(2);
+    let init_text = entity_id(4);
+    let copy_id = entity_id(6);
+    let copy_text = entity_id(8);
+    let copy_age = entity_id(10);
+
+    let has_edge = |from: &str, to: &str| {
+        graph.edges.iter().any(|edge| {
+            edge.from_entity == from && edge.to_entity == to && edge.ref_type == RefType::Calls
+        })
+    };
+
+    assert!(has_edge(&copy_id, &init_id), "copyID should call init(id:)");
+    assert!(
+        !has_edge(&copy_id, &init_text),
+        "copyID should not call init(text:)"
+    );
+    assert!(
+        has_edge(&copy_text, &init_text),
+        "copyText should call init(text:)"
+    );
+    assert!(
+        !has_edge(&copy_text, &init_id),
+        "copyText should not call init(id:)"
+    );
+    assert!(
+        !has_edge(&copy_age, &init_id),
+        "copyAge should not fall back to init(id:)"
+    );
+    assert!(
+        !has_edge(&copy_age, &init_text),
+        "copyAge should not fall back to init(text:)"
+    );
+}
+
+#[test]
 fn scope_resolve_comparison() {
-    let fixture_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/scope_test/python");
+    let fixture_dir =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/scope_test/python");
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
 
@@ -207,18 +452,42 @@ fn scope_resolve_comparison() {
     for (from_pat, to_pat, desc) in &expected {
         let old_found = edge_matches(&old_edges, &entity_map, from_pat, to_pat);
         let new_found = edge_matches(&new_edges, &entity_map, from_pat, to_pat);
-        if old_found { old_tp += 1; } else { old_fn += 1; }
-        if new_found { new_tp += 1; } else { new_fn += 1; }
-        details.push((from_pat.to_string(), to_pat.to_string(), desc.to_string(), old_found, new_found));
+        if old_found {
+            old_tp += 1;
+        } else {
+            old_fn += 1;
+        }
+        if new_found {
+            new_tp += 1;
+        } else {
+            new_fn += 1;
+        }
+        details.push((
+            from_pat.to_string(),
+            to_pat.to_string(),
+            desc.to_string(),
+            old_found,
+            new_found,
+        ));
     }
 
     let mut fp_details: Vec<(String, String, String, bool, bool)> = Vec::new();
     for (from_pat, to_pat, desc) in &false_positives {
         let old_found = edge_matches(&old_edges, &entity_map, from_pat, to_pat);
         let new_found = edge_matches(&new_edges, &entity_map, from_pat, to_pat);
-        if old_found { old_fp += 1; }
-        if new_found { new_fp += 1; }
-        fp_details.push((from_pat.to_string(), to_pat.to_string(), desc.to_string(), old_found, new_found));
+        if old_found {
+            old_fp += 1;
+        }
+        if new_found {
+            new_fp += 1;
+        }
+        fp_details.push((
+            from_pat.to_string(),
+            to_pat.to_string(),
+            desc.to_string(),
+            old_found,
+            new_found,
+        ));
     }
 
     let old_precision = if old_tp + old_fp > 0 {
@@ -245,25 +514,56 @@ fn scope_resolve_comparison() {
 
     // Print summary
     eprintln!("\n=== Scope Resolution Comparison ===");
-    eprintln!("Old (bag-of-words): {} TP, {} FN, {} FP | {:.0}% recall, {:.0}% precision",
-        old_tp, old_fn, old_fp, old_recall * 100.0, old_precision * 100.0);
-    eprintln!("New (scope-aware):  {} TP, {} FN, {} FP | {:.0}% recall, {:.0}% precision",
-        new_tp, new_fn, new_fp, new_recall * 100.0, new_precision * 100.0);
-    eprintln!("Total edges: old={}, new={}", old_edges.len(), new_edges.len());
+    eprintln!(
+        "Old (bag-of-words): {} TP, {} FN, {} FP | {:.0}% recall, {:.0}% precision",
+        old_tp,
+        old_fn,
+        old_fp,
+        old_recall * 100.0,
+        old_precision * 100.0
+    );
+    eprintln!(
+        "New (scope-aware):  {} TP, {} FN, {} FP | {:.0}% recall, {:.0}% precision",
+        new_tp,
+        new_fn,
+        new_fp,
+        new_recall * 100.0,
+        new_precision * 100.0
+    );
+    eprintln!(
+        "Total edges: old={}, new={}",
+        old_edges.len(),
+        new_edges.len()
+    );
 
     // Generate HTML report
     let html = generate_html_report(
         &details,
         &fp_details,
-        old_tp, old_fn, old_fp, old_recall, old_precision,
-        new_tp, new_fn, new_fp, new_recall, new_precision,
-        old_edges.len(), new_edges.len(),
-        &old_edges, &new_edges, &entity_map,
+        old_tp,
+        old_fn,
+        old_fp,
+        old_recall,
+        old_precision,
+        new_tp,
+        new_fn,
+        new_fp,
+        new_recall,
+        new_precision,
+        old_edges.len(),
+        new_edges.len(),
+        &old_edges,
+        &new_edges,
+        &entity_map,
         &scope_result.resolution_log,
     );
 
-    let output_path = std::env::var("SCOPE_BENCH_OUTPUT")
-        .unwrap_or_else(|_| std::env::temp_dir().join("scope-resolve-bench.html").to_string_lossy().to_string());
+    let output_path = std::env::var("SCOPE_BENCH_OUTPUT").unwrap_or_else(|_| {
+        std::env::temp_dir()
+            .join("scope-resolve-bench.html")
+            .to_string_lossy()
+            .to_string()
+    });
     let _ = std::fs::write(&output_path, &html);
     eprintln!("Report written to {}", output_path);
 
@@ -274,9 +574,18 @@ fn scope_resolve_comparison() {
 fn generate_html_report(
     details: &[(String, String, String, bool, bool)],
     fp_details: &[(String, String, String, bool, bool)],
-    old_tp: usize, old_fn: usize, old_fp: usize, old_recall: f64, old_precision: f64,
-    new_tp: usize, new_fn: usize, new_fp: usize, new_recall: f64, new_precision: f64,
-    old_total: usize, new_total: usize,
+    old_tp: usize,
+    old_fn: usize,
+    old_fp: usize,
+    old_recall: f64,
+    old_precision: f64,
+    new_tp: usize,
+    new_fn: usize,
+    new_fp: usize,
+    new_recall: f64,
+    new_precision: f64,
+    old_total: usize,
+    new_total: usize,
     old_edges: &[(String, String)],
     new_edges: &[(String, String)],
     entity_map: &HashMap<String, EntityInfo>,
@@ -357,8 +666,14 @@ fn generate_html_report(
         .iter()
         .take(60)
         .map(|(from, to)| {
-            let f = entity_map.get(from).map(|e| format!("{} ({})", e.name, short_file(&e.file_path))).unwrap_or_else(|| from.clone());
-            let t = entity_map.get(to).map(|e| format!("{} ({})", e.name, short_file(&e.file_path))).unwrap_or_else(|| to.clone());
+            let f = entity_map
+                .get(from)
+                .map(|e| format!("{} ({})", e.name, short_file(&e.file_path)))
+                .unwrap_or_else(|| from.clone());
+            let t = entity_map
+                .get(to)
+                .map(|e| format!("{} ({})", e.name, short_file(&e.file_path)))
+                .unwrap_or_else(|| to.clone());
             format!("<tr><td>{}</td><td>{}</td></tr>", f, t)
         })
         .collect();
@@ -367,13 +682,20 @@ fn generate_html_report(
         .iter()
         .take(60)
         .map(|(from, to)| {
-            let f = entity_map.get(from).map(|e| format!("{} ({})", e.name, short_file(&e.file_path))).unwrap_or_else(|| from.clone());
-            let t = entity_map.get(to).map(|e| format!("{} ({})", e.name, short_file(&e.file_path))).unwrap_or_else(|| to.clone());
+            let f = entity_map
+                .get(from)
+                .map(|e| format!("{} ({})", e.name, short_file(&e.file_path)))
+                .unwrap_or_else(|| from.clone());
+            let t = entity_map
+                .get(to)
+                .map(|e| format!("{} ({})", e.name, short_file(&e.file_path)))
+                .unwrap_or_else(|| to.clone());
             format!("<tr><td>{}</td><td>{}</td></tr>", f, t)
         })
         .collect();
 
-    format!(r#"<!DOCTYPE html>
+    format!(
+        r#"<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
@@ -533,37 +855,126 @@ Test: 4 Python files with same-name methods, variable type tracking, cross-file 
 </body>
 </html>"#,
         // Old card winner class
-        if old_f1 > new_f1 {{ " winner" }} else {{ "" }},
+        if old_f1 > new_f1 {
+            {
+                " winner"
+            }
+        } else {
+            {
+                ""
+            }
+        },
         // Old recall color
-        if old_recall >= 0.8 {{ " green" }} else if old_recall >= 0.5 {{ " yellow" }} else {{ " red" }},
+        if old_recall >= 0.8 {
+            {
+                " green"
+            }
+        } else if old_recall >= 0.5 {
+            {
+                " yellow"
+            }
+        } else {
+            {
+                " red"
+            }
+        },
         old_recall * 100.0,
         // Old precision color
-        if old_precision >= 0.8 {{ " green" }} else if old_precision >= 0.5 {{ " yellow" }} else {{ " red" }},
+        if old_precision >= 0.8 {
+            {
+                " green"
+            }
+        } else if old_precision >= 0.5 {
+            {
+                " yellow"
+            }
+        } else {
+            {
+                " red"
+            }
+        },
         old_precision * 100.0,
         old_f1 * 100.0,
-        old_tp, old_fn, old_fp, old_total,
+        old_tp,
+        old_fn,
+        old_fp,
+        old_total,
         // New card winner class
-        if new_f1 >= old_f1 {{ " winner" }} else {{ "" }},
+        if new_f1 >= old_f1 {
+            {
+                " winner"
+            }
+        } else {
+            {
+                ""
+            }
+        },
         // New recall color
-        if new_recall >= 0.8 {{ " green" }} else if new_recall >= 0.5 {{ " yellow" }} else {{ " red" }},
+        if new_recall >= 0.8 {
+            {
+                " green"
+            }
+        } else if new_recall >= 0.5 {
+            {
+                " yellow"
+            }
+        } else {
+            {
+                " red"
+            }
+        },
         new_recall * 100.0,
         // New precision color
-        if new_precision >= 0.8 {{ " green" }} else if new_precision >= 0.5 {{ " yellow" }} else {{ " red" }},
+        if new_precision >= 0.8 {
+            {
+                " green"
+            }
+        } else if new_precision >= 0.5 {
+            {
+                " yellow"
+            }
+        } else {
+            {
+                " red"
+            }
+        },
         new_precision * 100.0,
         new_f1 * 100.0,
         new_tp,
         // New FN color
-        if new_fn < old_fn {{ " green" }} else {{ " red" }},
+        if new_fn < old_fn {
+            {
+                " green"
+            }
+        } else {
+            {
+                " red"
+            }
+        },
         new_fn,
         // New FP color
-        if new_fp < old_fp {{ " green" }} else if new_fp == 0 {{ " green" }} else {{ " red" }},
+        if new_fp < old_fp {
+            {
+                " green"
+            }
+        } else if new_fp == 0 {
+            {
+                " green"
+            }
+        } else {
+            {
+                " red"
+            }
+        },
         new_fp,
         new_total,
         expected_rows,
         fp_rows,
         log_rows,
-        old_total, all_old_edges,
-        new_total, all_new_edges,
+        old_total,
+        all_old_edges,
+        new_total,
+        all_new_edges,
     )
 }
 
@@ -578,18 +989,37 @@ fn get_ts_expected_edges() -> Vec<(&'static str, &'static str, &'static str)> {
         // service.ts -> models.ts
         ("createDog", "Dog", "service calls Dog constructor"),
         ("createDog", "validate", "service calls dog.validate()"),
-        ("createDog", "getConnection", "service calls getConnection()"),
+        (
+            "createDog",
+            "getConnection",
+            "service calls getConnection()",
+        ),
         ("createCat", "Cat", "service calls Cat constructor"),
         ("createCat", "validate", "service calls cat.validate()"),
-        ("createCat", "getConnection", "service calls getConnection()"),
-        ("transferAnimal", "Transaction", "service calls Transaction constructor"),
-        ("transferAnimal", "getConnection", "service calls getConnection()"),
+        (
+            "createCat",
+            "getConnection",
+            "service calls getConnection()",
+        ),
+        (
+            "transferAnimal",
+            "Transaction",
+            "service calls Transaction constructor",
+        ),
+        (
+            "transferAnimal",
+            "getConnection",
+            "service calls getConnection()",
+        ),
         ("transferAnimal", "execute", "txn.execute() on Transaction"),
         ("transferAnimal", "commit", "txn.commit() on Transaction"),
         ("transferAnimal", "add", "shelter.add() on Shelter"),
-        ("listAnimals", "getConnection", "service calls getConnection()"),
+        (
+            "listAnimals",
+            "getConnection",
+            "service calls getConnection()",
+        ),
         ("listAnimals", "execute", "conn.execute() on Connection"),
-
         // handlers.ts -> service.ts
         ("handleCreateDog", "createDog", "handler calls service"),
         ("handleCreateCat", "createCat", "handler calls service"),
@@ -598,10 +1028,17 @@ fn get_ts_expected_edges() -> Vec<(&'static str, &'static str, &'static str)> {
         ("handleTransfer", "Dog", "handler creates Dog"),
         ("handleTransfer", "count", "shelter.count() on Shelter"),
         ("handleList", "listAnimals", "handler calls service"),
-
         // database.ts internal
-        ("Transaction::execute", "execute", "Transaction.execute calls this.conn.execute"),
-        ("Transaction::commit", "commit", "Transaction.commit calls this.conn.commit"),
+        (
+            "Transaction::execute",
+            "execute",
+            "Transaction.execute calls this.conn.execute",
+        ),
+        (
+            "Transaction::commit",
+            "commit",
+            "Transaction.commit calls this.conn.commit",
+        ),
     ]
 }
 
@@ -611,8 +1048,16 @@ fn get_ts_false_positive_edges() -> Vec<(&'static str, &'static str, &'static st
         ("createCat", "Dog", "createCat shouldn't reference Dog"),
         ("validate", "Dog", "standalone validate != Dog.validate"),
         ("validate", "Cat", "standalone validate != Cat.validate"),
-        ("handleCreateDog", "Transaction", "handler doesn't use Transaction directly"),
-        ("handleCreateCat", "Transaction", "handler doesn't use Transaction directly"),
+        (
+            "handleCreateDog",
+            "Transaction",
+            "handler doesn't use Transaction directly",
+        ),
+        (
+            "handleCreateCat",
+            "Transaction",
+            "handler doesn't use Transaction directly",
+        ),
     ]
 }
 
@@ -621,30 +1066,60 @@ fn get_rust_expected_edges() -> Vec<(&'static str, &'static str, &'static str)> 
         // service.rs -> models.rs
         ("create_dog", "Dog", "service calls Dog::new"),
         ("create_dog", "validate", "service calls dog.validate()"),
-        ("create_dog", "get_connection", "service calls get_connection()"),
+        (
+            "create_dog",
+            "get_connection",
+            "service calls get_connection()",
+        ),
         ("create_cat", "Cat", "service calls Cat::new"),
         ("create_cat", "validate", "service calls cat.validate()"),
-        ("create_cat", "get_connection", "service calls get_connection()"),
-        ("transfer_animal", "Transaction", "service calls Transaction::new"),
-        ("transfer_animal", "get_connection", "service calls get_connection()"),
+        (
+            "create_cat",
+            "get_connection",
+            "service calls get_connection()",
+        ),
+        (
+            "transfer_animal",
+            "Transaction",
+            "service calls Transaction::new",
+        ),
+        (
+            "transfer_animal",
+            "get_connection",
+            "service calls get_connection()",
+        ),
         ("transfer_animal", "execute", "txn.execute() on Transaction"),
         ("transfer_animal", "commit", "txn.commit() on Transaction"),
         ("transfer_animal", "add", "shelter.add() on Shelter"),
-        ("list_animals", "get_connection", "service calls get_connection()"),
+        (
+            "list_animals",
+            "get_connection",
+            "service calls get_connection()",
+        ),
         ("list_animals", "execute", "conn.execute() on Connection"),
-
         // handlers.rs -> service.rs
         ("handle_create_dog", "create_dog", "handler calls service"),
         ("handle_create_cat", "create_cat", "handler calls service"),
-        ("handle_transfer", "transfer_animal", "handler calls service"),
+        (
+            "handle_transfer",
+            "transfer_animal",
+            "handler calls service",
+        ),
         ("handle_transfer", "Shelter", "handler creates Shelter"),
         ("handle_transfer", "Dog", "handler creates Dog"),
         ("handle_transfer", "count", "shelter.count() on Shelter"),
         ("handle_list", "list_animals", "handler calls service"),
-
         // database.rs internal
-        ("Transaction::execute", "execute", "Transaction.execute calls self.conn.execute"),
-        ("Transaction::commit", "commit", "Transaction.commit calls self.conn.commit"),
+        (
+            "Transaction::execute",
+            "execute",
+            "Transaction.execute calls self.conn.execute",
+        ),
+        (
+            "Transaction::commit",
+            "commit",
+            "Transaction.commit calls self.conn.commit",
+        ),
     ]
 }
 
@@ -654,8 +1129,16 @@ fn get_rust_false_positive_edges() -> Vec<(&'static str, &'static str, &'static 
         ("create_cat", "Dog", "create_cat shouldn't reference Dog"),
         ("validate", "Dog", "standalone validate != Dog.validate"),
         ("validate", "Cat", "standalone validate != Cat.validate"),
-        ("handle_create_dog", "Transaction", "handler doesn't use Transaction directly"),
-        ("handle_create_cat", "Transaction", "handler doesn't use Transaction directly"),
+        (
+            "handle_create_dog",
+            "Transaction",
+            "handler doesn't use Transaction directly",
+        ),
+        (
+            "handle_create_cat",
+            "Transaction",
+            "handler doesn't use Transaction directly",
+        ),
     ]
 }
 
@@ -664,18 +1147,37 @@ fn get_go_expected_edges() -> Vec<(&'static str, &'static str, &'static str)> {
         // service.go -> models.go
         ("CreateDog", "NewDog", "service calls NewDog()"),
         ("CreateDog", "Validate", "service calls dog.Validate()"),
-        ("CreateDog", "GetConnection", "service calls GetConnection()"),
+        (
+            "CreateDog",
+            "GetConnection",
+            "service calls GetConnection()",
+        ),
         ("CreateCat", "NewCat", "service calls NewCat()"),
         ("CreateCat", "Validate", "service calls cat.Validate()"),
-        ("CreateCat", "GetConnection", "service calls GetConnection()"),
-        ("TransferAnimal", "NewTransaction", "service calls NewTransaction()"),
-        ("TransferAnimal", "GetConnection", "service calls GetConnection()"),
+        (
+            "CreateCat",
+            "GetConnection",
+            "service calls GetConnection()",
+        ),
+        (
+            "TransferAnimal",
+            "NewTransaction",
+            "service calls NewTransaction()",
+        ),
+        (
+            "TransferAnimal",
+            "GetConnection",
+            "service calls GetConnection()",
+        ),
         ("TransferAnimal", "Execute", "txn.Execute() on Transaction"),
         ("TransferAnimal", "Commit", "txn.Commit() on Transaction"),
         ("TransferAnimal", "Add", "shelter.Add() on Shelter"),
-        ("ListAnimals", "GetConnection", "service calls GetConnection()"),
+        (
+            "ListAnimals",
+            "GetConnection",
+            "service calls GetConnection()",
+        ),
         ("ListAnimals", "Execute", "conn.Execute() on Connection"),
-
         // handlers.go -> service.go
         ("HandleCreateDog", "CreateDog", "handler calls service"),
         ("HandleCreateCat", "CreateCat", "handler calls service"),
@@ -684,10 +1186,17 @@ fn get_go_expected_edges() -> Vec<(&'static str, &'static str, &'static str)> {
         ("HandleTransfer", "NewDog", "handler creates Dog"),
         ("HandleTransfer", "Count", "shelter.Count() on Shelter"),
         ("HandleList", "ListAnimals", "handler calls service"),
-
         // database.go internal
-        ("Transaction::Execute", "Execute", "Transaction.Execute calls Conn.Execute"),
-        ("Transaction::Commit", "Commit", "Transaction.Commit calls Conn.Commit"),
+        (
+            "Transaction::Execute",
+            "Execute",
+            "Transaction.Execute calls Conn.Execute",
+        ),
+        (
+            "Transaction::Commit",
+            "Commit",
+            "Transaction.Commit calls Conn.Commit",
+        ),
     ]
 }
 
@@ -697,8 +1206,16 @@ fn get_go_false_positive_edges() -> Vec<(&'static str, &'static str, &'static st
         ("CreateCat", "Dog", "CreateCat shouldn't reference Dog"),
         ("Validate", "Dog", "standalone Validate != Dog.Validate"),
         ("Validate", "Cat", "standalone Validate != Cat.Validate"),
-        ("HandleCreateDog", "Transaction", "handler doesn't use Transaction directly"),
-        ("HandleCreateCat", "Transaction", "handler doesn't use Transaction directly"),
+        (
+            "HandleCreateDog",
+            "Transaction",
+            "handler doesn't use Transaction directly",
+        ),
+        (
+            "HandleCreateCat",
+            "Transaction",
+            "handler doesn't use Transaction directly",
+        ),
     ]
 }
 
@@ -721,12 +1238,15 @@ fn run_scope_resolve_for_lang(
 
     // Run old resolver (bag-of-words)
     let (old_graph, _) = EntityGraph::build(root, &file_refs, &registry);
-    let old_edges: Vec<(String, String)> = old_graph.edges.iter()
+    let old_edges: Vec<(String, String)> = old_graph
+        .edges
+        .iter()
         .map(|e| (e.from_entity.clone(), e.to_entity.clone()))
         .collect();
 
     // Run new scope resolver
-    let all_entities: Vec<SemanticEntity> = file_refs.iter()
+    let all_entities: Vec<SemanticEntity> = file_refs
+        .iter()
         .filter_map(|file_path| {
             let full_path = root.join(file_path);
             let content = std::fs::read_to_string(&full_path).ok()?;
@@ -736,65 +1256,136 @@ fn run_scope_resolve_for_lang(
         .flatten()
         .collect();
 
-    let entity_map: HashMap<String, EntityInfo> = all_entities.iter()
-        .map(|e| (e.id.clone(), EntityInfo {
-            id: e.id.clone(),
-            name: e.name.clone(),
-            entity_type: e.entity_type.clone(),
-            file_path: e.file_path.clone(),
-            parent_id: e.parent_id.clone(),
-            start_line: e.start_line,
-            end_line: e.end_line,
-        }))
+    let entity_map: HashMap<String, EntityInfo> = all_entities
+        .iter()
+        .map(|e| {
+            (
+                e.id.clone(),
+                EntityInfo {
+                    id: e.id.clone(),
+                    name: e.name.clone(),
+                    entity_type: e.entity_type.clone(),
+                    file_path: e.file_path.clone(),
+                    parent_id: e.parent_id.clone(),
+                    start_line: e.start_line,
+                    end_line: e.end_line,
+                },
+            )
+        })
         .collect();
 
-    let scope_result = scope_resolve::resolve_with_scopes(root, &file_refs, &all_entities, &entity_map, None);
-    let new_edges: Vec<(String, String)> = scope_result.edges.iter()
+    let scope_result =
+        scope_resolve::resolve_with_scopes(root, &file_refs, &all_entities, &entity_map, None);
+    let new_edges: Vec<(String, String)> = scope_result
+        .edges
+        .iter()
         .map(|(from, to, _)| (from.clone(), to.clone()))
         .collect();
 
     // Debug: dump edges for languages that need config tuning
     if new_edges.is_empty() && !old_edges.is_empty() {
-        eprintln!("  DEBUG [{}]: old_edges={}, new_edges=0, entities={}", lang_name, old_edges.len(), all_entities.len());
+        eprintln!(
+            "  DEBUG [{}]: old_edges={}, new_edges=0, entities={}",
+            lang_name,
+            old_edges.len(),
+            all_entities.len()
+        );
     }
 
     // Score
-    let mut old_tp = 0; let mut old_fn = 0; let mut old_fp = 0;
-    let mut new_tp = 0; let mut new_fn = 0; let mut new_fp = 0;
+    let mut old_tp = 0;
+    let mut old_fn = 0;
+    let mut old_fp = 0;
+    let mut new_tp = 0;
+    let mut new_fn = 0;
+    let mut new_fp = 0;
 
     for (from_pat, to_pat, desc) in expected {
         let old_found = edge_matches(&old_edges, &entity_map, from_pat, to_pat);
         let new_found = edge_matches(&new_edges, &entity_map, from_pat, to_pat);
-        if old_found { old_tp += 1; } else { old_fn += 1; }
-        if new_found { new_tp += 1; } else {
+        if old_found {
+            old_tp += 1;
+        } else {
+            old_fn += 1;
+        }
+        if new_found {
+            new_tp += 1;
+        } else {
             new_fn += 1;
-            eprintln!("  MISSED [{}]: {} -> {} ({})", lang_name, from_pat, to_pat, desc);
+            eprintln!(
+                "  MISSED [{}]: {} -> {} ({})",
+                lang_name, from_pat, to_pat, desc
+            );
         }
     }
 
     for (from_pat, to_pat, desc) in false_positives {
         let old_found = edge_matches(&old_edges, &entity_map, from_pat, to_pat);
         let new_found = edge_matches(&new_edges, &entity_map, from_pat, to_pat);
-        if old_found { old_fp += 1; }
+        if old_found {
+            old_fp += 1;
+        }
         if new_found {
             new_fp += 1;
-            eprintln!("  FALSE POSITIVE [{}]: {} -> {} ({})", lang_name, from_pat, to_pat, desc);
+            eprintln!(
+                "  FALSE POSITIVE [{}]: {} -> {} ({})",
+                lang_name, from_pat, to_pat, desc
+            );
         }
     }
 
-    let old_recall = if old_tp + old_fn > 0 { old_tp as f64 / (old_tp + old_fn) as f64 } else { 0.0 };
-    let new_recall = if new_tp + new_fn > 0 { new_tp as f64 / (new_tp + new_fn) as f64 } else { 0.0 };
+    let old_recall = if old_tp + old_fn > 0 {
+        old_tp as f64 / (old_tp + old_fn) as f64
+    } else {
+        0.0
+    };
+    let new_recall = if new_tp + new_fn > 0 {
+        new_tp as f64 / (new_tp + new_fn) as f64
+    } else {
+        0.0
+    };
 
     eprintln!("\n=== {} Scope Resolution ===", lang_name);
-    eprintln!("Old (bag-of-words): {} TP, {} FN, {} FP | {:.0}% recall",
-        old_tp, old_fn, old_fp, old_recall * 100.0);
-    eprintln!("New (scope-aware):  {} TP, {} FN, {} FP | {:.0}% recall",
-        new_tp, new_fn, new_fp, new_recall * 100.0);
-    eprintln!("Total edges: old={}, new={}", old_edges.len(), new_edges.len());
+    eprintln!(
+        "Old (bag-of-words): {} TP, {} FN, {} FP | {:.0}% recall",
+        old_tp,
+        old_fn,
+        old_fp,
+        old_recall * 100.0
+    );
+    eprintln!(
+        "New (scope-aware):  {} TP, {} FN, {} FP | {:.0}% recall",
+        new_tp,
+        new_fn,
+        new_fp,
+        new_recall * 100.0
+    );
+    eprintln!(
+        "Total edges: old={}, new={}",
+        old_edges.len(),
+        new_edges.len()
+    );
 
     // Report results - the scope resolver should be producing edges for supported languages
     if new_edges.is_empty() && !old_edges.is_empty() {
-        eprintln!("  NOTE [{}]: Scope resolver produced 0 edges (config may need tuning)", lang_name);
+        eprintln!(
+            "  NOTE [{}]: Scope resolver produced 0 edges (config may need tuning)",
+            lang_name
+        );
+    }
+
+    // Languages with complete expected coverage gate CI on the scored result.
+    if lang_name == "swift" {
+        assert_eq!(
+            new_fn, 0,
+            "{} scope resolver missed {} expected edges; see MISSED lines above",
+            lang_name, new_fn
+        );
+        assert_eq!(
+            new_fp, 0,
+            "{} scope resolver produced {} forbidden edges; see FALSE POSITIVE lines above",
+            lang_name, new_fp
+        );
     }
 }
 
@@ -823,7 +1414,8 @@ fn scope_resolve_go() {
 /// and produces the same high-quality edges as the standalone scope resolver.
 #[test]
 fn scope_resolve_integrated_graph() {
-    let fixture_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/scope_test/python");
+    let fixture_dir =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/scope_test/python");
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
 
@@ -859,7 +1451,12 @@ fn scope_resolve_integrated_graph() {
 
     let recall = tp as f64 / expected.len() as f64;
     eprintln!("\n=== Integrated Graph (scope resolver) ===");
-    eprintln!("{} / {} expected edges found ({:.0}% recall)", tp, expected.len(), recall * 100.0);
+    eprintln!(
+        "{} / {} expected edges found ({:.0}% recall)",
+        tp,
+        expected.len(),
+        recall * 100.0
+    );
     if !missed.is_empty() {
         eprintln!("Missed: {:?}", missed);
     }
@@ -878,7 +1475,8 @@ fn scope_resolve_integrated_graph() {
     assert!(
         recall >= 0.90,
         "Integrated graph recall {:.0}% should be >= 90%. Missed: {:?}",
-        recall * 100.0, missed
+        recall * 100.0,
+        missed
     );
 
     // Should have zero false positives from the known FP set
@@ -898,18 +1496,37 @@ fn get_java_expected_edges() -> Vec<(&'static str, &'static str, &'static str)> 
         // Service.java -> Models.java
         ("createDog", "Dog", "service creates Dog"),
         ("createDog", "validate", "service calls dog.validate()"),
-        ("createDog", "getConnection", "service calls DatabaseHelper.getConnection()"),
+        (
+            "createDog",
+            "getConnection",
+            "service calls DatabaseHelper.getConnection()",
+        ),
         ("createCat", "Cat", "service creates Cat"),
         ("createCat", "validate", "service calls cat.validate()"),
-        ("createCat", "getConnection", "service calls getConnection()"),
-        ("transferAnimal", "Transaction", "service creates Transaction"),
-        ("transferAnimal", "getConnection", "service calls getConnection()"),
+        (
+            "createCat",
+            "getConnection",
+            "service calls getConnection()",
+        ),
+        (
+            "transferAnimal",
+            "Transaction",
+            "service creates Transaction",
+        ),
+        (
+            "transferAnimal",
+            "getConnection",
+            "service calls getConnection()",
+        ),
         ("transferAnimal", "execute", "txn.execute() on Transaction"),
         ("transferAnimal", "commit", "txn.commit() on Transaction"),
         ("transferAnimal", "add", "shelter.add() on Shelter"),
-        ("listAnimals", "getConnection", "service calls getConnection()"),
+        (
+            "listAnimals",
+            "getConnection",
+            "service calls getConnection()",
+        ),
         ("listAnimals", "execute", "conn.execute() on Connection"),
-
         // Handlers.java -> Service.java
         ("handleCreateDog", "createDog", "handler calls service"),
         ("handleCreateCat", "createCat", "handler calls service"),
@@ -918,10 +1535,17 @@ fn get_java_expected_edges() -> Vec<(&'static str, &'static str, &'static str)> 
         ("handleTransfer", "Dog", "handler creates Dog"),
         ("handleTransfer", "count", "shelter.count() on Shelter"),
         ("handleList", "listAnimals", "handler calls service"),
-
         // Database.java internal
-        ("Transaction::execute", "execute", "Transaction.execute calls conn.execute"),
-        ("Transaction::commit", "commit", "Transaction.commit calls conn.commit"),
+        (
+            "Transaction::execute",
+            "execute",
+            "Transaction.execute calls conn.execute",
+        ),
+        (
+            "Transaction::commit",
+            "commit",
+            "Transaction.commit calls conn.commit",
+        ),
     ]
 }
 
@@ -931,8 +1555,16 @@ fn get_java_false_positive_edges() -> Vec<(&'static str, &'static str, &'static 
         ("createCat", "Dog", "createCat shouldn't reference Dog"),
         ("validate", "Dog", "standalone validate != Dog.validate"),
         ("validate", "Cat", "standalone validate != Cat.validate"),
-        ("handleCreateDog", "Transaction", "handler doesn't use Transaction directly"),
-        ("handleCreateCat", "Transaction", "handler doesn't use Transaction directly"),
+        (
+            "handleCreateDog",
+            "Transaction",
+            "handler doesn't use Transaction directly",
+        ),
+        (
+            "handleCreateCat",
+            "Transaction",
+            "handler doesn't use Transaction directly",
+        ),
     ]
 }
 
@@ -948,18 +1580,37 @@ fn get_csharp_expected_edges() -> Vec<(&'static str, &'static str, &'static str)
         // Service.cs -> Models.cs
         ("CreateDog", "Dog", "service creates Dog"),
         ("CreateDog", "Validate", "service calls dog.Validate()"),
-        ("CreateDog", "GetConnection", "service calls DatabaseHelper.GetConnection()"),
+        (
+            "CreateDog",
+            "GetConnection",
+            "service calls DatabaseHelper.GetConnection()",
+        ),
         ("CreateCat", "Cat", "service creates Cat"),
         ("CreateCat", "Validate", "service calls cat.Validate()"),
-        ("CreateCat", "GetConnection", "service calls GetConnection()"),
-        ("TransferAnimal", "Transaction", "service creates Transaction"),
-        ("TransferAnimal", "GetConnection", "service calls GetConnection()"),
+        (
+            "CreateCat",
+            "GetConnection",
+            "service calls GetConnection()",
+        ),
+        (
+            "TransferAnimal",
+            "Transaction",
+            "service creates Transaction",
+        ),
+        (
+            "TransferAnimal",
+            "GetConnection",
+            "service calls GetConnection()",
+        ),
         ("TransferAnimal", "Execute", "txn.Execute() on Transaction"),
         ("TransferAnimal", "Commit", "txn.Commit() on Transaction"),
         ("TransferAnimal", "Add", "shelter.Add() on Shelter"),
-        ("ListAnimals", "GetConnection", "service calls GetConnection()"),
+        (
+            "ListAnimals",
+            "GetConnection",
+            "service calls GetConnection()",
+        ),
         ("ListAnimals", "Execute", "conn.Execute() on Connection"),
-
         // Handlers.cs -> Service.cs
         ("HandleCreateDog", "CreateDog", "handler calls service"),
         ("HandleCreateCat", "CreateCat", "handler calls service"),
@@ -968,10 +1619,17 @@ fn get_csharp_expected_edges() -> Vec<(&'static str, &'static str, &'static str)
         ("HandleTransfer", "Dog", "handler creates Dog"),
         ("HandleTransfer", "Count", "shelter.Count() on Shelter"),
         ("HandleList", "ListAnimals", "handler calls service"),
-
         // Database.cs internal
-        ("Transaction::Execute", "Execute", "Transaction.Execute calls conn.Execute"),
-        ("Transaction::Commit", "Commit", "Transaction.Commit calls conn.Commit"),
+        (
+            "Transaction::Execute",
+            "Execute",
+            "Transaction.Execute calls conn.Execute",
+        ),
+        (
+            "Transaction::Commit",
+            "Commit",
+            "Transaction.Commit calls conn.Commit",
+        ),
     ]
 }
 
@@ -981,8 +1639,16 @@ fn get_csharp_false_positive_edges() -> Vec<(&'static str, &'static str, &'stati
         ("CreateCat", "Dog", "CreateCat shouldn't reference Dog"),
         ("Validate", "Dog", "standalone Validate != Dog.Validate"),
         ("Validate", "Cat", "standalone Validate != Cat.Validate"),
-        ("HandleCreateDog", "Transaction", "handler doesn't use Transaction directly"),
-        ("HandleCreateCat", "Transaction", "handler doesn't use Transaction directly"),
+        (
+            "HandleCreateDog",
+            "Transaction",
+            "handler doesn't use Transaction directly",
+        ),
+        (
+            "HandleCreateCat",
+            "Transaction",
+            "handler doesn't use Transaction directly",
+        ),
     ]
 }
 
@@ -998,18 +1664,37 @@ fn get_cpp_expected_edges() -> Vec<(&'static str, &'static str, &'static str)> {
         // service.cpp -> models.hpp
         ("createDog", "Dog", "service creates Dog"),
         ("createDog", "validate", "service calls dog.validate()"),
-        ("createDog", "getConnection", "service calls getConnection()"),
+        (
+            "createDog",
+            "getConnection",
+            "service calls getConnection()",
+        ),
         ("createCat", "Cat", "service creates Cat"),
         ("createCat", "validate", "service calls cat.validate()"),
-        ("createCat", "getConnection", "service calls getConnection()"),
-        ("transferAnimal", "Transaction", "service creates Transaction"),
-        ("transferAnimal", "getConnection", "service calls getConnection()"),
+        (
+            "createCat",
+            "getConnection",
+            "service calls getConnection()",
+        ),
+        (
+            "transferAnimal",
+            "Transaction",
+            "service creates Transaction",
+        ),
+        (
+            "transferAnimal",
+            "getConnection",
+            "service calls getConnection()",
+        ),
         ("transferAnimal", "execute", "txn.execute() on Transaction"),
         ("transferAnimal", "commit", "txn.commit() on Transaction"),
         ("transferAnimal", "add", "shelter->add() on Shelter"),
-        ("listAnimals", "getConnection", "service calls getConnection()"),
+        (
+            "listAnimals",
+            "getConnection",
+            "service calls getConnection()",
+        ),
         ("listAnimals", "execute", "conn->execute() on Connection"),
-
         // handlers.cpp -> service.cpp
         ("handleCreateDog", "createDog", "handler calls service"),
         ("handleCreateCat", "createCat", "handler calls service"),
@@ -1018,10 +1703,17 @@ fn get_cpp_expected_edges() -> Vec<(&'static str, &'static str, &'static str)> {
         ("handleTransfer", "Dog", "handler creates Dog"),
         ("handleTransfer", "count", "shelter.count() on Shelter"),
         ("handleList", "listAnimals", "handler calls service"),
-
         // database.hpp internal
-        ("Transaction::execute", "execute", "Transaction.execute calls conn->execute"),
-        ("Transaction::commit", "commit", "Transaction.commit calls conn->commit"),
+        (
+            "Transaction::execute",
+            "execute",
+            "Transaction.execute calls conn->execute",
+        ),
+        (
+            "Transaction::commit",
+            "commit",
+            "Transaction.commit calls conn->commit",
+        ),
     ]
 }
 
@@ -1031,8 +1723,16 @@ fn get_cpp_false_positive_edges() -> Vec<(&'static str, &'static str, &'static s
         ("createCat", "Dog", "createCat shouldn't reference Dog"),
         ("validate", "Dog", "standalone validate != Dog.validate"),
         ("validate", "Cat", "standalone validate != Cat.validate"),
-        ("handleCreateDog", "Transaction", "handler doesn't use Transaction directly"),
-        ("handleCreateCat", "Transaction", "handler doesn't use Transaction directly"),
+        (
+            "handleCreateDog",
+            "Transaction",
+            "handler doesn't use Transaction directly",
+        ),
+        (
+            "handleCreateCat",
+            "Transaction",
+            "handler doesn't use Transaction directly",
+        ),
     ]
 }
 
@@ -1048,30 +1748,60 @@ fn get_ruby_expected_edges() -> Vec<(&'static str, &'static str, &'static str)> 
         // service.rb -> models.rb
         ("create_dog", "Dog", "service creates Dog"),
         ("create_dog", "validate", "service calls dog.validate"),
-        ("create_dog", "get_connection", "service calls get_connection"),
+        (
+            "create_dog",
+            "get_connection",
+            "service calls get_connection",
+        ),
         ("create_cat", "Cat", "service creates Cat"),
         ("create_cat", "validate", "service calls cat.validate"),
-        ("create_cat", "get_connection", "service calls get_connection"),
-        ("transfer_animal", "Transaction", "service creates Transaction"),
-        ("transfer_animal", "get_connection", "service calls get_connection"),
+        (
+            "create_cat",
+            "get_connection",
+            "service calls get_connection",
+        ),
+        (
+            "transfer_animal",
+            "Transaction",
+            "service creates Transaction",
+        ),
+        (
+            "transfer_animal",
+            "get_connection",
+            "service calls get_connection",
+        ),
         ("transfer_animal", "execute", "txn.execute on Transaction"),
         ("transfer_animal", "commit", "txn.commit on Transaction"),
         ("transfer_animal", "add", "shelter.add on Shelter"),
-        ("list_animals", "get_connection", "service calls get_connection"),
+        (
+            "list_animals",
+            "get_connection",
+            "service calls get_connection",
+        ),
         ("list_animals", "execute", "conn.execute on Connection"),
-
         // handlers.rb -> service.rb
         ("handle_create_dog", "create_dog", "handler calls service"),
         ("handle_create_cat", "create_cat", "handler calls service"),
-        ("handle_transfer", "transfer_animal", "handler calls service"),
+        (
+            "handle_transfer",
+            "transfer_animal",
+            "handler calls service",
+        ),
         ("handle_transfer", "Shelter", "handler creates Shelter"),
         ("handle_transfer", "Dog", "handler creates Dog"),
         ("handle_transfer", "count", "shelter.count on Shelter"),
         ("handle_list", "list_animals", "handler calls service"),
-
         // database.rb internal
-        ("Transaction::execute", "execute", "Transaction#execute calls @conn.execute"),
-        ("Transaction::commit", "commit", "Transaction#commit calls @conn.commit"),
+        (
+            "Transaction::execute",
+            "execute",
+            "Transaction#execute calls @conn.execute",
+        ),
+        (
+            "Transaction::commit",
+            "commit",
+            "Transaction#commit calls @conn.commit",
+        ),
     ]
 }
 
@@ -1081,8 +1811,16 @@ fn get_ruby_false_positive_edges() -> Vec<(&'static str, &'static str, &'static 
         ("create_cat", "Dog", "create_cat shouldn't reference Dog"),
         ("validate", "Dog", "standalone validate != Dog#validate"),
         ("validate", "Cat", "standalone validate != Cat#validate"),
-        ("handle_create_dog", "Transaction", "handler doesn't use Transaction directly"),
-        ("handle_create_cat", "Transaction", "handler doesn't use Transaction directly"),
+        (
+            "handle_create_dog",
+            "Transaction",
+            "handler doesn't use Transaction directly",
+        ),
+        (
+            "handle_create_cat",
+            "Transaction",
+            "handler doesn't use Transaction directly",
+        ),
     ]
 }
 
@@ -1102,18 +1840,37 @@ fn get_swift_expected_edges() -> Vec<(&'static str, &'static str, &'static str)>
         // service.swift -> models.swift
         ("createDog", "Dog", "service creates Dog"),
         ("createDog", "validate", "service calls dog.validate()"),
-        ("createDog", "getConnection", "service calls getConnection()"),
+        (
+            "createDog",
+            "getConnection",
+            "service calls getConnection()",
+        ),
         ("createCat", "Cat", "service creates Cat"),
         ("createCat", "validate", "service calls cat.validate()"),
-        ("createCat", "getConnection", "service calls getConnection()"),
-        ("transferAnimal", "Transaction", "service creates Transaction"),
-        ("transferAnimal", "getConnection", "service calls getConnection()"),
+        (
+            "createCat",
+            "getConnection",
+            "service calls getConnection()",
+        ),
+        (
+            "transferAnimal",
+            "Transaction",
+            "service creates Transaction",
+        ),
+        (
+            "transferAnimal",
+            "getConnection",
+            "service calls getConnection()",
+        ),
         ("transferAnimal", "execute", "txn.execute() on Transaction"),
         ("transferAnimal", "commit", "txn.commit() on Transaction"),
         ("transferAnimal", "add", "shelter.add() on Shelter"),
-        ("listAnimals", "getConnection", "service calls getConnection()"),
+        (
+            "listAnimals",
+            "getConnection",
+            "service calls getConnection()",
+        ),
         ("listAnimals", "execute", "conn.execute() on Connection"),
-
         // handlers.swift -> service.swift
         ("handleCreateDog", "createDog", "handler calls service"),
         ("handleCreateCat", "createCat", "handler calls service"),
@@ -1122,10 +1879,37 @@ fn get_swift_expected_edges() -> Vec<(&'static str, &'static str, &'static str)>
         ("handleTransfer", "Dog", "handler creates Dog"),
         ("handleTransfer", "count", "shelter.count() on Shelter"),
         ("handleList", "listAnimals", "handler calls service"),
-
         // database.swift internal
-        ("Transaction::execute", "execute", "Transaction.execute calls conn.execute"),
-        ("Transaction::commit", "commit", "Transaction.commit calls conn.commit"),
+        (
+            "Transaction::execute",
+            "execute",
+            "Transaction.execute calls conn.execute",
+        ),
+        (
+            "Transaction::commit",
+            "commit",
+            "Transaction.commit calls conn.commit",
+        ),
+        (
+            "Replicator::sync",
+            "execute",
+            "Replicator.sync calls primary.execute",
+        ),
+        (
+            "Replicator::sync",
+            "commit",
+            "Replicator.sync calls backup.commit",
+        ),
+        (
+            "AuditedTransaction::write",
+            "commit",
+            "AuditedTransaction.write calls conn.commit",
+        ),
+        (
+            "AuditedTransaction::write",
+            "record",
+            "AuditedTransaction.write calls logger.record",
+        ),
     ]
 }
 
@@ -1135,8 +1919,16 @@ fn get_swift_false_positive_edges() -> Vec<(&'static str, &'static str, &'static
         ("createCat", "Dog", "createCat shouldn't reference Dog"),
         ("validate", "Dog", "standalone validate != Dog.validate"),
         ("validate", "Cat", "standalone validate != Cat.validate"),
-        ("handleCreateDog", "Transaction", "handler doesn't use Transaction directly"),
-        ("handleCreateCat", "Transaction", "handler doesn't use Transaction directly"),
+        (
+            "handleCreateDog",
+            "Transaction",
+            "handler doesn't use Transaction directly",
+        ),
+        (
+            "handleCreateCat",
+            "Transaction",
+            "handler doesn't use Transaction directly",
+        ),
     ]
 }
 
@@ -1152,18 +1944,37 @@ fn get_kotlin_expected_edges() -> Vec<(&'static str, &'static str, &'static str)
         // Service.kt -> Models.kt
         ("createDog", "Dog", "service creates Dog"),
         ("createDog", "validate", "service calls dog.validate()"),
-        ("createDog", "getConnection", "service calls getConnection()"),
+        (
+            "createDog",
+            "getConnection",
+            "service calls getConnection()",
+        ),
         ("createCat", "Cat", "service creates Cat"),
         ("createCat", "validate", "service calls cat.validate()"),
-        ("createCat", "getConnection", "service calls getConnection()"),
-        ("transferAnimal", "Transaction", "service creates Transaction"),
-        ("transferAnimal", "getConnection", "service calls getConnection()"),
+        (
+            "createCat",
+            "getConnection",
+            "service calls getConnection()",
+        ),
+        (
+            "transferAnimal",
+            "Transaction",
+            "service creates Transaction",
+        ),
+        (
+            "transferAnimal",
+            "getConnection",
+            "service calls getConnection()",
+        ),
         ("transferAnimal", "execute", "txn.execute() on Transaction"),
         ("transferAnimal", "commit", "txn.commit() on Transaction"),
         ("transferAnimal", "add", "shelter.add() on Shelter"),
-        ("listAnimals", "getConnection", "service calls getConnection()"),
+        (
+            "listAnimals",
+            "getConnection",
+            "service calls getConnection()",
+        ),
         ("listAnimals", "execute", "conn.execute() on Connection"),
-
         // Handlers.kt -> Service.kt
         ("handleCreateDog", "createDog", "handler calls service"),
         ("handleCreateCat", "createCat", "handler calls service"),
@@ -1172,10 +1983,17 @@ fn get_kotlin_expected_edges() -> Vec<(&'static str, &'static str, &'static str)
         ("handleTransfer", "Dog", "handler creates Dog"),
         ("handleTransfer", "count", "shelter.count() on Shelter"),
         ("handleList", "listAnimals", "handler calls service"),
-
         // Database.kt internal
-        ("Transaction::execute", "execute", "Transaction.execute calls conn.execute"),
-        ("Transaction::commit", "commit", "Transaction.commit calls conn.commit"),
+        (
+            "Transaction::execute",
+            "execute",
+            "Transaction.execute calls conn.execute",
+        ),
+        (
+            "Transaction::commit",
+            "commit",
+            "Transaction.commit calls conn.commit",
+        ),
     ]
 }
 
@@ -1185,8 +2003,16 @@ fn get_kotlin_false_positive_edges() -> Vec<(&'static str, &'static str, &'stati
         ("createCat", "Dog", "createCat shouldn't reference Dog"),
         ("validate", "Dog", "standalone validate != Dog.validate"),
         ("validate", "Cat", "standalone validate != Cat.validate"),
-        ("handleCreateDog", "Transaction", "handler doesn't use Transaction directly"),
-        ("handleCreateCat", "Transaction", "handler doesn't use Transaction directly"),
+        (
+            "handleCreateDog",
+            "Transaction",
+            "handler doesn't use Transaction directly",
+        ),
+        (
+            "handleCreateCat",
+            "Transaction",
+            "handler doesn't use Transaction directly",
+        ),
     ]
 }
 


### PR DESCRIPTION
## Summary
- Consolidates the graph/scope resolution fixes from the parent PR set into one branch.
- Keeps deep scope resolution scaling, container-edge suppression, Swift entity normalization, Swift extension/member resolution, scoped fallback suppression, overload labels, and bare property receiver resolution together.
- Adds local-binding fallback guards so nested/local declarations do not reattach false import or same-file graph edges after scope resolution.

Supersedes #245, #282, #286, #296, #297, #298, #299, and #304.

closes https://github.com/Ataraxy-Labs/sem/issues/195
Fixes https://github.com/Ataraxy-Labs/sem/issues/261
Closes https://github.com/Ataraxy-Labs/sem/issues/248
Fixes https://github.com/Ataraxy-Labs/sem/issues/255
Fixes https://github.com/Ataraxy-Labs/sem/issues/258
Fixes https://github.com/Ataraxy-Labs/sem/issues/257
Closes https://github.com/Ataraxy-Labs/sem/issues/256
Fixes https://github.com/Ataraxy-Labs/sem/issues/252

## Test plan
- `cargo check --manifest-path crates/Cargo.toml -p sem-core`
- `cargo test --manifest-path crates/Cargo.toml -p sem-core scope_resolve_swift`
- `cargo test --manifest-path crates/Cargo.toml -p sem-core scope_resolve`
- `cargo test --manifest-path crates/Cargo.toml -p sem-core graph`
- `cargo test --manifest-path crates/Cargo.toml -p sem-core`