### PR TITLE
Consolidate diff output filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ sem diff --format json
     "moved": 0,
     "renamed": 0,
     "reordered": 0,
+    "binary": 0,
     "orphan": 0,
     "total": 3
   },
@@ -362,7 +363,8 @@ sem diff --format json
       "oldEndLine": null,
       "filePath": "src/auth.ts"
     }
-  ]
+  ],
+  "binaryChanges": []
 }
 ```
 

--- a/crates/sem-cli/src/commands/diff.rs
+++ b/crates/sem-cli/src/commands/diff.rs
@@ -8,7 +8,7 @@ use sem_core::git::bridge::GitBridge;
 use sem_core::git::jj::maybe_resolve_ref;
 use sem_core::git::types::{DiffScope, FileChange, FileStatus};
 use sem_core::model::change::ChangeType;
-use sem_core::parser::differ::{compute_semantic_diff, DiffResult};
+use sem_core::parser::differ::{collect_binary_file_changes, compute_semantic_diff, DiffResult};
 use sem_core::parser::plugins::code::languages::get_language_config;
 use sem_core::parser::registry::{detect_ext_from_content, ParserRegistry};
 
@@ -232,6 +232,28 @@ fn normalize_trailing_output_format(opts: &mut DiffOptions) {
     }
 
     opts.args = args;
+}
+
+fn bytes_look_binary(bytes: &[u8], complete: bool) -> bool {
+    if bytes.iter().any(|byte| *byte == 0) {
+        return true;
+    }
+
+    match std::str::from_utf8(bytes) {
+        Ok(_) => false,
+        Err(error) => complete || error.error_len().is_some(),
+    }
+}
+
+fn read_file_compare_content(path: &Path) -> Result<Option<String>, std::io::Error> {
+    let bytes = std::fs::read(path)?;
+    if bytes_look_binary(&bytes, true) {
+        Ok(None)
+    } else {
+        let content = String::from_utf8(bytes)
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
+        Ok(Some(content))
+    }
 }
 
 fn parse_args(args: Vec<String>, cwd: &str) -> ParsedArgs {
@@ -603,17 +625,31 @@ fn parse_unified_diff(
     Ok(entries
         .into_iter()
         .map(|e| {
-            let before_content = e.old_sha.as_deref().and_then(&git_show);
-            let mut after_content = e.new_sha.as_deref().and_then(&git_show);
+            let is_binary = e.has_binary_marker || e.has_git_binary_patch;
+            let mut has_binary_content = is_binary;
+            let before_content = if is_binary {
+                None
+            } else {
+                e.old_sha.as_deref().and_then(&git_show)
+            };
+            let mut after_content = if is_binary {
+                None
+            } else {
+                e.new_sha.as_deref().and_then(&git_show)
+            };
 
             // Fallback: if git show fails for the new SHA (e.g. unstaged working
             // tree changes where the blob doesn't exist yet), read from disk.
-            if after_content.is_none() && e.new_sha.is_some() {
+            if !is_binary && after_content.is_none() && e.new_sha.is_some() {
                 let file = worktree_root.join(&e.file_path);
-                after_content = std::fs::read_to_string(&file).ok();
+                match read_file_compare_content(&file) {
+                    Ok(Some(content)) => after_content = Some(content),
+                    Ok(None) => has_binary_content = true,
+                    Err(_) => {}
+                }
             }
 
-            if before_content.is_none() && after_content.is_none() {
+            if !has_binary_content && before_content.is_none() && after_content.is_none() {
                 eprintln!(
                     "\x1b[33mwarning:\x1b[0m could not resolve contents for \x1b[1m{}\x1b[0m. \
                      Try running from inside the repo, or use \x1b[1m-C /path/to/repo\x1b[0m.",
@@ -843,11 +879,11 @@ pub fn diff_command(mut opts: DiffOptions) {
             }
         }
 
-        let content_a = std::fs::read_to_string(&path_a).unwrap_or_else(|e| {
+        let content_a = read_file_compare_content(&path_a).unwrap_or_else(|e| {
             eprintln!("\x1b[31mError reading {}: {e}\x1b[0m", path_a.display());
             process::exit(1);
         });
-        let content_b = std::fs::read_to_string(&path_b).unwrap_or_else(|e| {
+        let content_b = read_file_compare_content(&path_b).unwrap_or_else(|e| {
             eprintln!("\x1b[31mError reading {}: {e}\x1b[0m", path_b.display());
             process::exit(1);
         });
@@ -857,16 +893,34 @@ pub fn diff_command(mut opts: DiffOptions) {
             .clone()
             .or_else(|| label.clone())
             .unwrap_or_else(|| after.clone());
-        let registry = super::create_registry(&opts.cwd);
-        let (changes, language_mismatch) =
-            file_compare_changes(before, &target_label, content_a, content_b, &registry);
-        if let Some((language_a, language_b)) = language_mismatch {
-            eprintln!(
-                "warning: comparing files with different languages: {} ({}) and {} ({}); rendering as delete/add",
-                before, language_a, after, language_b
+        if content_a.is_none() || content_b.is_none() {
+            // A None side is binary or otherwise not UTF-8; emit a file-level
+            // change so the diff pipeline reports it as a binary change.
+            let change = FileChange {
+                file_path: target_label,
+                old_file_path: None,
+                status: FileStatus::Modified,
+                before_content: content_a,
+                after_content: content_b,
+            };
+            (vec![change], false)
+        } else {
+            let registry = super::create_registry(&opts.cwd);
+            let (changes, language_mismatch) = file_compare_changes(
+                before,
+                &target_label,
+                content_a.unwrap(),
+                content_b.unwrap(),
+                &registry,
             );
+            if let Some((language_a, language_b)) = language_mismatch {
+                eprintln!(
+                    "warning: comparing files with different languages: {} ({}) and {} ({}); rendering as delete/add",
+                    before, language_a, after, language_b
+                );
+            }
+            (changes, false)
         }
-        (changes, false)
     } else if opts.patch {
         // Read unified diff from stdin and parse it
         let mut input = String::new();
@@ -1045,7 +1099,7 @@ fn run_diff_pipeline(
     if file_changes.is_empty() {
         match opts.format {
             OutputFormat::Json => {
-                println!("{{\"summary\":{{\"fileCount\":0,\"added\":0,\"modified\":0,\"deleted\":0,\"moved\":0,\"renamed\":0,\"reordered\":0,\"orphan\":0,\"total\":0}},\"changes\":[]}}");
+                println!("{{\"summary\":{{\"fileCount\":0,\"added\":0,\"modified\":0,\"deleted\":0,\"moved\":0,\"renamed\":0,\"reordered\":0,\"binary\":0,\"orphan\":0,\"total\":0}},\"changes\":[],\"binaryChanges\":[]}}");
             }
             _ => {
                 println!("\x1b[2mNo semantic changes detected.\x1b[0m");
@@ -1059,6 +1113,7 @@ fn run_diff_pipeline(
     let registry_ms = t2.elapsed().as_secs_f64() * 1000.0;
 
     let t3 = Instant::now();
+    let binary_changes = collect_binary_file_changes(&file_changes);
     let mut result = compute_semantic_diff(&file_changes, &registry, None, None);
     let parse_diff_ms = t3.elapsed().as_secs_f64() * 1000.0;
 
@@ -1068,14 +1123,16 @@ fn run_diff_pipeline(
     }
 
     // Record lifetime stats (best-effort)
-    let _ = SemLifetimeStats::load().record_diff(&result).save();
+    let _ = SemLifetimeStats::load()
+        .record_diff(&result, binary_changes.len())
+        .save();
 
     let t4 = Instant::now();
     let output = match opts.format {
-        OutputFormat::Json => format_json(&result),
-        OutputFormat::Markdown => format_markdown(&result, opts.verbose),
-        OutputFormat::Plain => format_plain(&result),
-        OutputFormat::Terminal => format_terminal(&result, opts.verbose),
+        OutputFormat::Json => format_json(&result, &binary_changes),
+        OutputFormat::Markdown => format_markdown(&result, &binary_changes, opts.verbose),
+        OutputFormat::Plain => format_plain(&result, &binary_changes),
+        OutputFormat::Terminal => format_terminal(&result, &binary_changes, opts.verbose),
     };
     let format_ms = t4.elapsed().as_secs_f64() * 1000.0;
 
@@ -1104,6 +1161,7 @@ fn run_diff_pipeline(
                 + result.moved_count
                 + result.renamed_count
                 + result.reordered_count
+                + binary_changes.len()
         );
         eprintln!("\x1b[2m─────────────────────────────────────────────\x1b[0m");
     }
@@ -1123,16 +1181,20 @@ fn retain_non_cosmetic_changes(result: &mut DiffResult) {
             change.after_content = None;
         }
     }
-    // Drop only purely cosmetic modifications; compound changes are preserved above.
-    result
-        .changes
-        .retain(|c| c.change_type != ChangeType::Modified || c.structural_change != Some(false));
+    // Drop purely cosmetic changes; compound moves/renames/reorders are preserved above.
+    result.changes.retain(|c| {
+        c.structural_change != Some(false)
+            || matches!(
+                c.change_type,
+                ChangeType::Moved | ChangeType::Renamed | ChangeType::Reordered
+            )
+    });
     recalculate_diff_summary(result);
 }
 
 fn recalculate_diff_summary(result: &mut DiffResult) {
-    // Mirrors compute_semantic_diff: any retained change, including an orphan,
-    // marks its file as changed. Orphans only skip the entity change-type buckets.
+    // Mirrors compute_semantic_diff: orphan_count is cross-cutting metadata,
+    // while retained orphans still contribute to change-type buckets.
     result.file_count = result
         .changes
         .iter()
@@ -1151,16 +1213,30 @@ fn recalculate_diff_summary(result: &mut DiffResult) {
     for change in &result.changes {
         if change.entity_type == "orphan" {
             orphan_count += 1;
-            continue;
         }
 
         match change.change_type {
             ChangeType::Added => added_count += 1,
             ChangeType::Modified => modified_count += 1,
             ChangeType::Deleted => deleted_count += 1,
-            ChangeType::Moved => moved_count += 1,
-            ChangeType::Renamed => renamed_count += 1,
-            ChangeType::Reordered => reordered_count += 1,
+            ChangeType::Moved => {
+                moved_count += 1;
+                if change.has_content_change() {
+                    modified_count += 1;
+                }
+            }
+            ChangeType::Renamed => {
+                renamed_count += 1;
+                if change.has_content_change() {
+                    modified_count += 1;
+                }
+            }
+            ChangeType::Reordered => {
+                reordered_count += 1;
+                if change.has_content_change() {
+                    modified_count += 1;
+                }
+            }
         }
     }
 
@@ -1241,12 +1317,27 @@ mod tests {
         assert_eq!(result.changes.len(), 3);
         assert_eq!(result.file_count, 2);
         assert_eq!(result.added_count, 1);
-        assert_eq!(result.modified_count, 1);
+        assert_eq!(result.modified_count, 2);
         assert_eq!(result.deleted_count, 0);
         assert_eq!(result.moved_count, 0);
         assert_eq!(result.renamed_count, 0);
         assert_eq!(result.reordered_count, 0);
         assert_eq!(result.orphan_count, 1);
+    }
+
+    #[test]
+    fn no_cosmetics_filter_drops_cosmetic_orphan_addition() {
+        let mut orphan = change("src/orphan.rs", ChangeType::Added, Some(false));
+        orphan.entity_type = "orphan".to_string();
+
+        let mut result = diff_result(vec![orphan]);
+
+        retain_non_cosmetic_changes(&mut result);
+
+        assert!(result.changes.is_empty());
+        assert_eq!(result.file_count, 0);
+        assert_eq!(result.added_count, 0);
+        assert_eq!(result.orphan_count, 0);
     }
 
     #[test]
@@ -1389,5 +1480,44 @@ mod tests {
                 PatchParseError::NoRecognizableHunks
             );
         }
+    }
+
+    #[test]
+    fn file_compare_binary_detection_handles_nuls_and_invalid_utf8() {
+        assert!(bytes_look_binary(b"\0png", true));
+        assert!(bytes_look_binary(&[0xff, 0xfe], true));
+        assert!(!bytes_look_binary("plain text".as_bytes(), true));
+    }
+
+    #[test]
+    fn file_compare_binary_detection_ignores_partial_utf8_at_scan_boundary() {
+        assert!(!bytes_look_binary(&[0xe2, 0x82], false));
+        assert!(bytes_look_binary(&[0xe2, 0x82], true));
+    }
+
+    #[test]
+    fn read_file_compare_content_preserves_text_side_for_mixed_binary_compare() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "sem-file-compare-test-{}-{unique}",
+            std::process::id()
+        ));
+        std::fs::create_dir(&dir).unwrap();
+
+        let text_path = dir.join("text.txt");
+        let binary_path = dir.join("image.bin");
+        std::fs::write(&text_path, "plain text\n").unwrap();
+        std::fs::write(&binary_path, b"\0binary").unwrap();
+
+        assert_eq!(
+            read_file_compare_content(&text_path).unwrap().as_deref(),
+            Some("plain text\n")
+        );
+        assert!(read_file_compare_content(&binary_path).unwrap().is_none());
+
+        std::fs::remove_dir_all(dir).unwrap();
     }
 }

--- a/crates/sem-cli/src/formatters/json.rs
+++ b/crates/sem-cli/src/formatters/json.rs
@@ -1,7 +1,7 @@
-use sem_core::parser::differ::DiffResult;
+use sem_core::parser::differ::{BinaryFileChange, DiffResult};
 
-pub fn format_json(result: &DiffResult) -> String {
-    sem_core::format::json::format_diff_json(result)
+pub fn format_json(result: &DiffResult, binary_changes: &[BinaryFileChange]) -> String {
+    sem_core::format::json::format_diff_json_with_binary_changes(result, binary_changes)
 }
 
 #[cfg(test)]
@@ -9,7 +9,7 @@ mod tests {
     use super::*;
     use sem_core::git::types::{FileChange, FileStatus};
     use sem_core::model::change::SemanticChange;
-    use sem_core::parser::differ::compute_semantic_diff;
+    use sem_core::parser::differ::{compute_semantic_diff, BinaryFileChange};
     use sem_core::parser::plugins::create_default_registry;
 
     fn modified_file(path: &str, before: &str, after: &str) -> FileChange {
@@ -36,7 +36,7 @@ mod tests {
             None,
         );
 
-        let output: serde_json::Value = serde_json::from_str(&format_json(&result)).unwrap();
+        let output: serde_json::Value = serde_json::from_str(&format_json(&result, &[])).unwrap();
         let summary = &output["summary"];
         let bucket_total = summary["added"].as_u64().unwrap()
             + summary["modified"].as_u64().unwrap()
@@ -83,12 +83,45 @@ mod tests {
             total_entities_after: 1,
         };
 
-        let output: serde_json::Value = serde_json::from_str(&format_json(&result)).unwrap();
+        let output: serde_json::Value = serde_json::from_str(&format_json(&result, &[])).unwrap();
         let change = &output["changes"][0];
 
         assert_eq!(change["startLine"], 7);
         assert_eq!(change["endLine"], 9);
         assert_eq!(change["oldStartLine"], 3);
         assert_eq!(change["oldEndLine"], 5);
+    }
+
+    #[test]
+    fn json_includes_binary_changes_in_summary_and_binary_changes() {
+        let result = DiffResult {
+            changes: Vec::new(),
+            file_count: 0,
+            added_count: 0,
+            modified_count: 0,
+            deleted_count: 0,
+            moved_count: 0,
+            renamed_count: 0,
+            reordered_count: 0,
+            orphan_count: 0,
+            total_entities_before: 0,
+            total_entities_after: 0,
+        };
+        let binary_changes = vec![BinaryFileChange {
+            file_path: "pic.png".to_string(),
+            status: FileStatus::Modified,
+            old_file_path: None,
+        }];
+
+        let value: serde_json::Value =
+            serde_json::from_str(&format_json(&result, &binary_changes)).unwrap();
+
+        assert_eq!(value["summary"]["fileCount"], 1);
+        assert_eq!(value["summary"]["binary"], 1);
+        assert_eq!(value["summary"]["total"], 1);
+        assert_eq!(value["changes"].as_array().unwrap().len(), 0);
+        assert_eq!(value["binaryChanges"][0]["changeType"], "binary");
+        assert_eq!(value["binaryChanges"][0]["filePath"], "pic.png");
+        assert_eq!(value["binaryChanges"][0]["fileStatus"], "modified");
     }
 }

--- a/crates/sem-cli/src/formatters/markdown.rs
+++ b/crates/sem-cli/src/formatters/markdown.rs
@@ -1,29 +1,78 @@
 use super::orphan_summary_parts;
 use sem_core::model::change::ChangeType;
-use sem_core::parser::differ::DiffResult;
+use sem_core::parser::differ::{BinaryFileChange, DiffResult};
 use similar::{ChangeTag, TextDiff};
 use std::collections::BTreeMap;
 
-pub fn format_markdown(result: &DiffResult, verbose: bool) -> String {
-    if result.changes.is_empty() {
+use super::{binary_display_name, file_count, has_reportable_changes};
+
+fn longest_backtick_run(input: &str) -> usize {
+    let mut longest = 0;
+    let mut current = 0;
+
+    for ch in input.chars() {
+        if ch == '`' {
+            current += 1;
+            longest = longest.max(current);
+        } else {
+            current = 0;
+        }
+    }
+
+    longest
+}
+
+fn push_diff_block(lines: &mut Vec<String>, diff_lines: Vec<String>) {
+    let fence_len = diff_lines
+        .iter()
+        .map(|line| longest_backtick_run(line))
+        .max()
+        .unwrap_or(0)
+        .saturating_add(1)
+        .max(3);
+    let fence = "`".repeat(fence_len);
+
+    lines.push(format!("{fence}diff"));
+    lines.extend(diff_lines);
+    lines.push(fence);
+}
+
+pub fn format_markdown(
+    result: &DiffResult,
+    binary_changes: &[BinaryFileChange],
+    verbose: bool,
+) -> String {
+    if !has_reportable_changes(result, binary_changes) {
         return "No semantic changes detected.".to_string();
     }
 
     let mut lines: Vec<String> = Vec::new();
 
     // Group changes by file (BTreeMap for sorted output)
-    let mut by_file: BTreeMap<&str, Vec<usize>> = BTreeMap::new();
+    let mut by_file: BTreeMap<&str, (Vec<usize>, Vec<usize>)> = BTreeMap::new();
     for (i, change) in result.changes.iter().enumerate() {
-        by_file.entry(&change.file_path).or_default().push(i);
+        by_file.entry(&change.file_path).or_default().0.push(i);
+    }
+    for (i, change) in binary_changes.iter().enumerate() {
+        by_file.entry(&change.file_path).or_default().1.push(i);
     }
 
-    for (file_path, indices) in &by_file {
+    for (file_path, (indices, binary_indices)) in &by_file {
         lines.push(format!("### {file_path}"));
         lines.push(String::new());
         lines.push("| Status | Type | Name |".to_string());
         lines.push("|--------|------|------|".to_string());
 
         let mut post_table: Vec<String> = Vec::new();
+
+        for &idx in binary_indices {
+            let change = &binary_changes[idx];
+            lines.push(format!(
+                "| B | file | {} `[binary {}]` |",
+                binary_display_name(change),
+                change.status,
+            ));
+        }
 
         for &idx in indices {
             let change = &result.changes[idx];
@@ -62,22 +111,20 @@ pub fn format_markdown(result: &DiffResult, verbose: bool) -> String {
                         if let Some(ref content) = change.after_content {
                             post_table.push(String::new());
                             post_table.push(format!("**`{}`**", change.entity_name));
-                            post_table.push("```diff".to_string());
-                            for line in content.lines() {
-                                post_table.push(format!("+ {line}"));
-                            }
-                            post_table.push("```".to_string());
+                            push_diff_block(
+                                &mut post_table,
+                                content.lines().map(|line| format!("+ {line}")).collect(),
+                            );
                         }
                     }
                     ChangeType::Deleted => {
                         if let Some(ref content) = change.before_content {
                             post_table.push(String::new());
                             post_table.push(format!("**`{}`**", change.entity_name));
-                            post_table.push("```diff".to_string());
-                            for line in content.lines() {
-                                post_table.push(format!("- {line}"));
-                            }
-                            post_table.push("```".to_string());
+                            push_diff_block(
+                                &mut post_table,
+                                content.lines().map(|line| format!("- {line}")).collect(),
+                            );
                         }
                     }
                     ChangeType::Modified | ChangeType::Moved | ChangeType::Renamed => {
@@ -86,10 +133,10 @@ pub fn format_markdown(result: &DiffResult, verbose: bool) -> String {
                         {
                             post_table.push(String::new());
                             post_table.push(format!("**`{}`**", change.entity_name));
-                            post_table.push("```diff".to_string());
+                            let mut diff_lines = Vec::new();
                             let diff = TextDiff::from_lines(before.as_str(), after.as_str());
                             for hunk in diff.unified_diff().context_radius(2).iter_hunks() {
-                                post_table.push(hunk.header().to_string());
+                                diff_lines.push(hunk.header().to_string());
                                 for op in hunk.ops() {
                                     let mut deletes: Vec<String> = Vec::new();
                                     let mut inserts: Vec<String> = Vec::new();
@@ -100,25 +147,25 @@ pub fn format_markdown(result: &DiffResult, verbose: bool) -> String {
                                             ChangeTag::Delete => deletes.push(line.to_string()),
                                             ChangeTag::Insert => inserts.push(line.to_string()),
                                             ChangeTag::Equal => {
-                                                post_table.push(format!("  {line}"))
+                                                diff_lines.push(format!("  {line}"))
                                             }
                                         }
                                     }
 
                                     let paired = deletes.len().min(inserts.len());
                                     for i in 0..paired {
-                                        post_table.push(format!("- {}", deletes[i]));
-                                        post_table.push(format!("+ {}", inserts[i]));
+                                        diff_lines.push(format!("- {}", deletes[i]));
+                                        diff_lines.push(format!("+ {}", inserts[i]));
                                     }
                                     for d in &deletes[paired..] {
-                                        post_table.push(format!("- {d}"));
+                                        diff_lines.push(format!("- {d}"));
                                     }
                                     for i in &inserts[paired..] {
-                                        post_table.push(format!("+ {i}"));
+                                        diff_lines.push(format!("+ {i}"));
                                     }
                                 }
                             }
-                            post_table.push("```".to_string());
+                            push_diff_block(&mut post_table, diff_lines);
                         }
                     }
                     _ => {}
@@ -132,14 +179,12 @@ pub fn format_markdown(result: &DiffResult, verbose: bool) -> String {
                     if before_lines.len() <= 3 && after_lines.len() <= 3 {
                         post_table.push(String::new());
                         post_table.push(format!("**`{}`**", change.entity_name));
-                        post_table.push("```diff".to_string());
-                        for line in &before_lines {
-                            post_table.push(format!("- {}", line.trim()));
-                        }
-                        for line in &after_lines {
-                            post_table.push(format!("+ {}", line.trim()));
-                        }
-                        post_table.push("```".to_string());
+                        let diff_lines = before_lines
+                            .iter()
+                            .map(|line| format!("- {}", line.trim()))
+                            .chain(after_lines.iter().map(|line| format!("+ {}", line.trim())))
+                            .collect();
+                        push_diff_block(&mut post_table, diff_lines);
                     }
                 }
             }
@@ -181,7 +226,12 @@ pub fn format_markdown(result: &DiffResult, verbose: bool) -> String {
     if result.reordered_count > 0 {
         parts.push(format!("{} reordered", result.reordered_count));
     }
-    let files_label = if result.file_count == 1 {
+    if !binary_changes.is_empty() {
+        parts.push(format!("{} binary", binary_changes.len()));
+    }
+
+    let reported_file_count = file_count(result, binary_changes);
+    let files_label = if reported_file_count == 1 {
         "file"
     } else {
         "files"
@@ -196,9 +246,65 @@ pub fn format_markdown(result: &DiffResult, verbose: bool) -> String {
     lines.push(format!(
         "**Summary:** {} across {} {files_label}{}",
         parts.join(", "),
-        result.file_count,
+        reported_file_count,
         orphan_suffix,
     ));
 
     lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sem_core::model::change::SemanticChange;
+
+    fn diff_result(change: SemanticChange) -> DiffResult {
+        DiffResult {
+            changes: vec![change],
+            file_count: 1,
+            added_count: 0,
+            modified_count: 1,
+            deleted_count: 0,
+            moved_count: 0,
+            renamed_count: 0,
+            reordered_count: 0,
+            orphan_count: 0,
+            total_entities_before: 1,
+            total_entities_after: 1,
+        }
+    }
+
+    #[test]
+    fn markdown_diff_fence_is_longer_than_embedded_backticks() {
+        let change: SemanticChange = serde_json::from_value(serde_json::json!({
+            "id": "change::app.py::function::foo",
+            "entityId": "app.py::function::foo",
+            "changeType": "modified",
+            "entityType": "function",
+            "entityName": "foo",
+            "entityLine": 1,
+            "filePath": "app.py",
+            "beforeContent": "def foo():\n    return \"plain\"\n",
+            "afterContent": "def foo():\n    return \"````\"\n",
+            "structuralChange": true
+        }))
+        .unwrap();
+
+        let output = format_markdown(&diff_result(change), &[], true);
+        let lines: Vec<&str> = output.lines().collect();
+        let opening = lines
+            .iter()
+            .position(|line| *line == "`````diff")
+            .expect("diff block should open with a 5-backtick fence");
+        let closing = lines[opening + 1..]
+            .iter()
+            .position(|line| *line == "`````")
+            .map(|offset| opening + 1 + offset)
+            .expect("diff block should close with a matching 5-backtick fence");
+
+        assert!(lines[opening + 1..closing]
+            .iter()
+            .any(|line| line.contains("````")));
+        assert!(!lines.iter().any(|line| *line == "````diff"));
+    }
 }

--- a/crates/sem-cli/src/formatters/mod.rs
+++ b/crates/sem-cli/src/formatters/mod.rs
@@ -1,10 +1,30 @@
 use sem_core::model::change::ChangeType;
-use sem_core::parser::differ::DiffResult;
+use sem_core::parser::differ::{BinaryFileChange, DiffResult};
 
 pub mod json;
 pub mod markdown;
 pub mod plain;
 pub mod terminal;
+
+pub(crate) fn binary_display_name(change: &BinaryFileChange) -> String {
+    match change.old_file_path.as_deref() {
+        Some(old_path) if old_path != change.file_path => {
+            format!("{old_path} -> {}", change.file_path)
+        }
+        _ => change.file_path.clone(),
+    }
+}
+
+pub(crate) fn has_reportable_changes(
+    result: &DiffResult,
+    binary_changes: &[BinaryFileChange],
+) -> bool {
+    !result.changes.is_empty() || !binary_changes.is_empty()
+}
+
+pub(crate) fn file_count(result: &DiffResult, binary_changes: &[BinaryFileChange]) -> usize {
+    result.file_count + binary_changes.len()
+}
 
 pub(crate) fn orphan_summary_parts(result: &DiffResult) -> Vec<String> {
     let mut added = 0;

--- a/crates/sem-cli/src/formatters/plain.rs
+++ b/crates/sem-cli/src/formatters/plain.rs
@@ -1,24 +1,43 @@
 use super::orphan_summary_parts;
 use colored::Colorize;
 use sem_core::model::change::ChangeType;
-use sem_core::parser::differ::DiffResult;
+use sem_core::parser::differ::{BinaryFileChange, DiffResult};
 use std::collections::BTreeMap;
 
-pub fn format_plain(result: &DiffResult) -> String {
-    if result.changes.is_empty() {
+use super::{binary_display_name, file_count, has_reportable_changes};
+
+pub fn format_plain(result: &DiffResult, binary_changes: &[BinaryFileChange]) -> String {
+    if !has_reportable_changes(result, binary_changes) {
         return "No semantic changes detected.".to_string();
     }
 
     let mut lines: Vec<String> = Vec::new();
 
     // Group changes by file (BTreeMap for sorted output)
-    let mut by_file: BTreeMap<&str, Vec<usize>> = BTreeMap::new();
+    let mut by_file: BTreeMap<&str, (Vec<usize>, Vec<usize>)> = BTreeMap::new();
     for (i, change) in result.changes.iter().enumerate() {
-        by_file.entry(&change.file_path).or_default().push(i);
+        by_file.entry(&change.file_path).or_default().0.push(i);
+    }
+    for (i, change) in binary_changes.iter().enumerate() {
+        by_file.entry(&change.file_path).or_default().1.push(i);
     }
 
-    for (file_path, indices) in &by_file {
+    for (file_path, (indices, binary_indices)) in &by_file {
         lines.push(file_path.bold().to_string());
+
+        for &idx in binary_indices {
+            let change = &binary_changes[idx];
+            let letter = "B".yellow().to_string();
+            let type_label = format!("{:<12}", "file");
+            let name_display = binary_display_name(change);
+            lines.push(format!(
+                "  {}  {}{} {}",
+                letter,
+                type_label.dimmed(),
+                name_display,
+                format!("[binary {}]", change.status).yellow(),
+            ));
+        }
 
         for &idx in indices {
             let change = &result.changes[idx];
@@ -99,7 +118,12 @@ pub fn format_plain(result: &DiffResult) -> String {
                 .to_string(),
         );
     }
-    let files_label = if result.file_count == 1 {
+    if !binary_changes.is_empty() {
+        parts.push(format!("{} binary", binary_changes.len()).yellow().to_string());
+    }
+
+    let reported_file_count = file_count(result, binary_changes);
+    let files_label = if reported_file_count == 1 {
         "file"
     } else {
         "files"
@@ -115,7 +139,7 @@ pub fn format_plain(result: &DiffResult) -> String {
     lines.push(format!(
         "{} across {} {files_label}{}",
         parts.join(", "),
-        result.file_count,
+        reported_file_count,
         orphan_suffix,
     ));
 

--- a/crates/sem-cli/src/formatters/terminal.rs
+++ b/crates/sem-cli/src/formatters/terminal.rs
@@ -1,9 +1,27 @@
 use super::orphan_summary_parts;
 use colored::Colorize;
 use sem_core::model::change::ChangeType;
-use sem_core::parser::differ::DiffResult;
+use sem_core::parser::differ::{BinaryFileChange, DiffResult};
 use similar::{ChangeTag, TextDiff};
 use std::collections::BTreeMap;
+
+use super::{binary_display_name, file_count, has_reportable_changes};
+
+fn sanitize_terminal_text(input: &str) -> String {
+    if !input.chars().any(char::is_control) {
+        return input.to_string();
+    }
+
+    let mut output = String::with_capacity(input.len());
+    for ch in input.chars() {
+        if ch.is_control() {
+            output.extend(ch.escape_debug());
+        } else {
+            output.push(ch);
+        }
+    }
+    output
+}
 
 /// Runs word-level diff on two lines and returns (delete_line, insert_line)
 /// with changed words highlighted (strikethrough+red / bold+green).
@@ -13,7 +31,7 @@ fn render_inline_diff(old_line: &str, new_line: &str) -> (String, String) {
     let mut ins = String::new();
 
     for change in diff.iter_all_changes() {
-        let val = change.value();
+        let val = sanitize_terminal_text(change.value());
         match change.tag() {
             ChangeTag::Equal => {
                 del.push_str(&val.dimmed().to_string());
@@ -31,22 +49,30 @@ fn render_inline_diff(old_line: &str, new_line: &str) -> (String, String) {
     (del, ins)
 }
 
-pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
-    if result.changes.is_empty() {
+pub fn format_terminal(
+    result: &DiffResult,
+    binary_changes: &[BinaryFileChange],
+    verbose: bool,
+) -> String {
+    if !has_reportable_changes(result, binary_changes) {
         return "No semantic changes detected.".dimmed().to_string();
     }
 
     let mut lines: Vec<String> = Vec::new();
 
     // Group changes by file (BTreeMap for sorted output)
-    let mut by_file: BTreeMap<&str, Vec<usize>> = BTreeMap::new();
+    let mut by_file: BTreeMap<&str, (Vec<usize>, Vec<usize>)> = BTreeMap::new();
     for (i, change) in result.changes.iter().enumerate() {
-        by_file.entry(&change.file_path).or_default().push(i);
+        by_file.entry(&change.file_path).or_default().0.push(i);
+    }
+    for (i, change) in binary_changes.iter().enumerate() {
+        by_file.entry(&change.file_path).or_default().1.push(i);
     }
 
-    for (file_path, indices) in &by_file {
+    for (file_path, (indices, binary_indices)) in &by_file {
         // Skip files where all changes are orphans in non-verbose mode
         if !verbose
+            && binary_indices.is_empty()
             && indices
                 .iter()
                 .all(|&i| result.changes[i].entity_type == "orphan")
@@ -54,7 +80,7 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
             continue;
         }
 
-        let header = format!("─ {file_path} ");
+        let header = format!("─ {} ", sanitize_terminal_text(file_path));
         let pad_len = 55usize.saturating_sub(header.len());
         lines.push(
             format!("┌{header}{}", "─".repeat(pad_len))
@@ -62,6 +88,23 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
                 .to_string(),
         );
         lines.push("│".dimmed().to_string());
+
+        for &idx in binary_indices {
+            let change = &binary_changes[idx];
+            let symbol = "■".yellow().to_string();
+            let tag = format!("[binary {}]", change.status).yellow().to_string();
+            let type_label = format!("{:<10}", "file");
+            let name_label = format!("{:<25}", binary_display_name(change));
+
+            lines.push(format!(
+                "{}  {} {} {} {}",
+                "│".dimmed(),
+                symbol,
+                type_label.dimmed(),
+                name_label.bold(),
+                tag,
+            ));
+        }
 
         for &idx in indices {
             let change = &result.changes[idx];
@@ -105,14 +148,18 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
                 ),
             };
 
-            let type_label = format!("{:<10}", change.entity_type);
+            let type_label = format!("{:<10}", sanitize_terminal_text(&change.entity_type));
             let base_name = if let Some(ref old_name) = change.old_entity_name {
-                format!("{old_name} -> {}", change.entity_name)
+                format!(
+                    "{} -> {}",
+                    sanitize_terminal_text(old_name),
+                    sanitize_terminal_text(&change.entity_name)
+                )
             } else {
-                change.entity_name.clone()
+                sanitize_terminal_text(&change.entity_name)
             };
             let display_name = match &change.parent_name {
-                Some(p) => format!("{p}::{base_name}"),
+                Some(p) => format!("{}::{base_name}", sanitize_terminal_text(p)),
                 None => base_name,
             };
             let name_label = format!("{:<25}", display_name);
@@ -132,6 +179,7 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
                     ChangeType::Added => {
                         if let Some(ref content) = change.after_content {
                             for line in content.lines() {
+                                let line = sanitize_terminal_text(line);
                                 lines.push(format!(
                                     "{}    {}",
                                     "│".dimmed(),
@@ -143,6 +191,7 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
                     ChangeType::Deleted => {
                         if let Some(ref content) = change.before_content {
                             for line in content.lines() {
+                                let line = sanitize_terminal_text(line);
                                 lines.push(format!(
                                     "{}    {}",
                                     "│".dimmed(),
@@ -167,10 +216,12 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
                                     let mut inserts: Vec<String> = Vec::new();
 
                                     for diff_change in diff.iter_changes(op) {
-                                        let line = diff_change.value().trim_end_matches('\n');
+                                        let line = sanitize_terminal_text(
+                                            diff_change.value().trim_end_matches('\n'),
+                                        );
                                         match diff_change.tag() {
-                                            ChangeTag::Delete => deletes.push(line.to_string()),
-                                            ChangeTag::Insert => inserts.push(line.to_string()),
+                                            ChangeTag::Delete => deletes.push(line),
+                                            ChangeTag::Insert => inserts.push(line),
                                             ChangeTag::Equal => {
                                                 lines.push(format!(
                                                     "{}    {}",
@@ -226,17 +277,19 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
 
                     if before_lines.len() <= 3 && after_lines.len() <= 3 {
                         for line in &before_lines {
+                            let line = sanitize_terminal_text(line.trim());
                             lines.push(format!(
                                 "{}    {}",
                                 "│".dimmed(),
-                                format!("- {}", line.trim()).red(),
+                                format!("- {line}").red(),
                             ));
                         }
                         for line in &after_lines {
+                            let line = sanitize_terminal_text(line.trim());
                             lines.push(format!(
                                 "{}    {}",
                                 "│".dimmed(),
-                                format!("+ {}", line.trim()).green(),
+                                format!("+ {line}").green(),
                             ));
                         }
                     }
@@ -249,7 +302,7 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
                     lines.push(format!(
                         "{}    {}",
                         "│".dimmed(),
-                        format!("from {old_path}").dimmed(),
+                        format!("from {}", sanitize_terminal_text(old_path)).dimmed(),
                     ));
                 } else if let Some(ref old_parent) = change.old_parent_id {
                     // Intra-file move: extract parent name from entity ID
@@ -257,7 +310,7 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
                     lines.push(format!(
                         "{}    {}",
                         "│".dimmed(),
-                        format!("moved from {parent_name}").dimmed(),
+                        format!("moved from {}", sanitize_terminal_text(parent_name)).dimmed(),
                     ));
                 }
             }
@@ -304,7 +357,12 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
                 .to_string(),
         );
     }
-    let files_label = if result.file_count == 1 {
+    if !binary_changes.is_empty() {
+        parts.push(format!("{} binary", binary_changes.len()).yellow().to_string());
+    }
+
+    let reported_file_count = file_count(result, binary_changes);
+    let files_label = if reported_file_count == 1 {
         "file"
     } else {
         "files"
@@ -321,7 +379,7 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
     lines.push(format!(
         "Summary: {} across {} {files_label}{}",
         parts.join(", "),
-        result.file_count,
+        reported_file_count,
         orphan_suffix,
     ));
 
@@ -334,7 +392,8 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
         + result.deleted_count
         + result.moved_count
         + result.renamed_count
-        + result.reordered_count;
+        + result.reordered_count
+        + binary_changes.len();
     if entities_analyzed > changes_detected {
         let noise = entities_analyzed - changes_detected;
         lines.push(
@@ -348,11 +407,11 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
     }
 
     // Warn if fallback chunking was used (unsupported file extension)
-    let chunk_files: Vec<&str> = result
+    let chunk_files: Vec<String> = result
         .changes
         .iter()
         .filter(|c| c.entity_type == "chunk")
-        .map(|c| c.file_path.as_str())
+        .map(|c| sanitize_terminal_text(&c.file_path))
         .collect::<std::collections::BTreeSet<_>>()
         .into_iter()
         .collect();
@@ -374,4 +433,61 @@ pub fn format_terminal(result: &DiffResult, verbose: bool) -> String {
     }
 
     lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sem_core::model::change::SemanticChange;
+
+    #[test]
+    fn terminal_source_content_escapes_control_characters() {
+        let output = sanitize_terminal_text("\u{1b}[31mRED\u{1b}[0m\t\r\n");
+
+        assert!(!output.contains('\u{1b}'));
+        assert!(output.contains("\\u{1b}[31mRED\\u{1b}[0m"));
+        assert!(output.contains("\\t\\r\\n"));
+    }
+
+    #[test]
+    fn terminal_chunk_warning_escapes_file_path_control_characters() {
+        colored::control::set_override(false);
+        let change: SemanticChange = serde_json::from_value(serde_json::json!({
+            "id": "change::bad.txt::chunk::1",
+            "entityId": "bad.txt::chunk::1",
+            "changeType": "modified",
+            "entityType": "chunk",
+            "entityName": "chunk 1",
+            "entityLine": 1,
+            "startLine": 1,
+            "endLine": 2,
+            "filePath": "bad\u{1b}[31m.txt",
+            "beforeContent": "alpha\nbeta\n",
+            "afterContent": "alpha\nchanged\n",
+            "structuralChange": true
+        }))
+        .unwrap();
+        let result = DiffResult {
+            changes: vec![change],
+            file_count: 1,
+            added_count: 0,
+            modified_count: 1,
+            deleted_count: 0,
+            moved_count: 0,
+            renamed_count: 0,
+            reordered_count: 0,
+            orphan_count: 0,
+            total_entities_before: 1,
+            total_entities_after: 1,
+        };
+
+        let output = format_terminal(&result, &[], true);
+
+        assert!(!output.contains('\u{1b}'), "{output}");
+        assert!(output.contains("bad\\u{1b}[31m.txt"), "{output}");
+        assert!(
+            output.contains("used line-based chunking (unsupported file extension)"),
+            "{output}"
+        );
+    }
 }

--- a/crates/sem-cli/src/stats.rs
+++ b/crates/sem-cli/src/stats.rs
@@ -101,7 +101,7 @@ impl SemLifetimeStats {
             .unwrap_or_default()
     }
 
-    pub fn record_diff(mut self, result: &DiffResult) -> Self {
+    pub fn record_diff(mut self, result: &DiffResult, binary_count: usize) -> Self {
         let now = now_iso();
         if self.first_run.is_none() {
             self.first_run = Some(now.clone());
@@ -122,7 +122,8 @@ impl SemLifetimeStats {
             + result.deleted_count
             + result.moved_count
             + result.renamed_count
-            + result.reordered_count) as u64;
+            + result.reordered_count
+            + binary_count) as u64;
         self.total_changes_detected += changes;
         self.noise_filtered += entities_analyzed.saturating_sub(changes);
 

--- a/crates/sem-cli/tests/diff_no_cosmetics.rs
+++ b/crates/sem-cli/tests/diff_no_cosmetics.rs
@@ -1,0 +1,197 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+struct TestRepo {
+    path: PathBuf,
+    home: PathBuf,
+}
+
+impl TestRepo {
+    fn new(name: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after UNIX epoch")
+            .as_nanos();
+        let path =
+            std::env::temp_dir().join(format!("sem-cli-{name}-{}-{nonce}", std::process::id()));
+        let home = std::env::temp_dir().join(format!(
+            "sem-cli-{name}-home-{}-{nonce}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path).expect("create temporary repo");
+        fs::create_dir_all(&home).expect("create temporary home");
+
+        git(&path, &["init", "-q"]);
+        git(&path, &["config", "user.email", "test@example.com"]);
+        git(&path, &["config", "user.name", "Test User"]);
+        git(&path, &["config", "commit.gpgsign", "false"]);
+
+        Self { path, home }
+    }
+}
+
+impl Drop for TestRepo {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+        let _ = fs::remove_dir_all(&self.home);
+    }
+}
+
+fn git(repo: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .expect("run git");
+
+    assert!(
+        output.status.success(),
+        "git {args:?} failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn sem(repo: &TestRepo, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_sem"))
+        .args(args)
+        .current_dir(&repo.path)
+        .env("HOME", &repo.home)
+        .output()
+        .expect("run sem")
+}
+
+#[test]
+fn no_cosmetics_hides_comment_only_orphan_change() {
+    let repo = TestRepo::new("diff-no-cosmetics-comment-orphan");
+    fs::write(
+        repo.path.join("app.py"),
+        "# original comment\ndef foo():\n    return 1\n",
+    )
+    .expect("write initial source");
+    git(&repo.path, &["add", "-A"]);
+    git(&repo.path, &["commit", "-q", "-m", "initial"]);
+
+    fs::write(
+        repo.path.join("app.py"),
+        "# changed comment text\ndef foo():\n    return 1\n",
+    )
+    .expect("write changed source");
+
+    let output = sem(&repo, &["diff", "--no-cosmetics", "--json"]);
+    assert!(
+        output.status.success(),
+        "sem diff failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be json");
+    assert_eq!(json["changes"].as_array().map(Vec::len), Some(0));
+    assert_eq!(json["summary"]["fileCount"], 0);
+    assert_eq!(json["summary"]["total"], 0);
+    assert_eq!(json["summary"]["orphan"], 0);
+}
+
+#[test]
+fn no_cosmetics_hides_added_comment_only_orphan() {
+    let repo = TestRepo::new("diff-no-cosmetics-added-comment-orphan");
+    fs::write(repo.path.join("app.py"), "def foo():\n    return 1\n")
+        .expect("write initial source");
+    git(&repo.path, &["add", "-A"]);
+    git(&repo.path, &["commit", "-q", "-m", "initial"]);
+
+    fs::write(
+        repo.path.join("app.py"),
+        "# added comment\ndef foo():\n    return 1\n",
+    )
+    .expect("write changed source");
+
+    let output = sem(&repo, &["diff", "--no-cosmetics", "--json"]);
+    assert!(
+        output.status.success(),
+        "sem diff failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be json");
+    assert_eq!(json["changes"].as_array().map(Vec::len), Some(0));
+    assert_eq!(json["summary"]["total"], 0);
+    assert_eq!(json["summary"]["orphan"], 0);
+}
+
+#[test]
+fn no_cosmetics_keeps_orphan_code_addition_in_summary_bucket() {
+    let repo = TestRepo::new("diff-no-cosmetics-code-orphan");
+    fs::write(repo.path.join("app.py"), "def foo():\n    return 1\n")
+        .expect("write initial source");
+    git(&repo.path, &["add", "-A"]);
+    git(&repo.path, &["commit", "-q", "-m", "initial"]);
+
+    fs::write(
+        repo.path.join("app.py"),
+        "import sys\n\ndef foo():\n    return 1\n",
+    )
+    .expect("write changed source");
+
+    let output = sem(&repo, &["diff", "--no-cosmetics", "--json"]);
+    assert!(
+        output.status.success(),
+        "sem diff failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be json");
+    assert_eq!(json["changes"].as_array().map(Vec::len), Some(1));
+    assert_eq!(json["changes"][0]["entityType"], "orphan");
+    assert_eq!(json["changes"][0]["changeType"], "added");
+    assert_eq!(json["changes"][0]["structuralChange"], true);
+    assert_eq!(json["summary"]["added"], 1);
+    assert_eq!(json["summary"]["total"], 1);
+    assert_eq!(json["summary"]["orphan"], 1);
+}
+
+#[test]
+fn no_cosmetics_keeps_shebang_change() {
+    let repo = TestRepo::new("diff-no-cosmetics-shebang");
+    fs::write(
+        repo.path.join("script"),
+        "#!/usr/bin/env python3\ndef foo():\n    return 1\n",
+    )
+    .expect("write initial source");
+    git(&repo.path, &["add", "-A"]);
+    git(&repo.path, &["commit", "-q", "-m", "initial"]);
+
+    fs::write(
+        repo.path.join("script"),
+        "#!/usr/bin/env python\ndef foo():\n    return 1\n",
+    )
+    .expect("write changed source");
+
+    let output = sem(&repo, &["diff", "--no-cosmetics", "--json"]);
+    assert!(
+        output.status.success(),
+        "sem diff failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be json");
+    assert_eq!(json["changes"].as_array().map(Vec::len), Some(1));
+    assert_eq!(json["changes"][0]["entityType"], "orphan");
+    assert_eq!(json["changes"][0]["changeType"], "modified");
+    assert_eq!(json["changes"][0]["structuralChange"], true);
+    assert_eq!(json["summary"]["modified"], 1);
+    assert_eq!(json["summary"]["total"], 1);
+    assert_eq!(json["summary"]["orphan"], 1);
+}

--- a/crates/sem-cli/tests/diff_output_hardening.rs
+++ b/crates/sem-cli/tests/diff_output_hardening.rs
@@ -1,0 +1,149 @@
+use std::path::Path;
+use std::process::{Command, Output};
+
+struct TempRepo {
+    repo: tempfile::TempDir,
+    home: tempfile::TempDir,
+}
+
+impl TempRepo {
+    fn new() -> Self {
+        let repo = tempfile::tempdir().expect("create temp repo");
+        let home = tempfile::tempdir().expect("create temp home");
+
+        run_git(repo.path(), &["init", "-q"]);
+        run_git(repo.path(), &["config", "user.name", "Test"]);
+        run_git(repo.path(), &["config", "user.email", "test@example.com"]);
+
+        Self { repo, home }
+    }
+
+    fn path(&self) -> &Path {
+        self.repo.path()
+    }
+
+    fn run_sem(&self, args: &[&str]) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .args(args)
+            .current_dir(self.repo.path())
+            .env("HOME", self.home.path())
+            .output()
+            .expect("run sem")
+    }
+}
+
+fn run_git(repo: &Path, args: &[&str]) -> Output {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn commit_file(repo: &TempRepo, path: &str, content: &str) {
+    std::fs::write(repo.path().join(path), content).expect("write file");
+    run_git(repo.path(), &["add", path]);
+    run_git(repo.path(), &["commit", "-qm", "init"]);
+}
+
+#[test]
+fn markdown_verbose_diff_uses_fence_longer_than_source_backticks() {
+    let repo = TempRepo::new();
+    commit_file(
+        &repo,
+        "app.py",
+        "def foo():\n    s = \"plain\"\n    return s\n",
+    );
+    std::fs::write(
+        repo.path().join("app.py"),
+        "def foo():\n    s = \"X``` Y ``` Z\"\n    return s\n",
+    )
+    .expect("write modified file");
+
+    let output = repo.run_sem(&["diff", "--format", "markdown", "-v"]);
+    assert!(
+        output.status.success(),
+        "sem failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf-8");
+    let lines: Vec<&str> = stdout.lines().collect();
+    let opening = lines
+        .iter()
+        .position(|line| *line == "````diff")
+        .expect("diff block should open with a 4-backtick fence");
+    let closing = lines[opening + 1..]
+        .iter()
+        .position(|line| *line == "````")
+        .map(|offset| opening + 1 + offset)
+        .expect("diff block should close with a matching 4-backtick fence");
+
+    assert!(lines[opening + 1..closing]
+        .iter()
+        .any(|line| line.contains("```")));
+    assert!(!lines.iter().any(|line| *line == "```diff"), "{stdout}");
+}
+
+#[test]
+fn terminal_verbose_diff_escapes_source_control_bytes_with_color_never() {
+    let repo = TempRepo::new();
+    commit_file(&repo, "app.py", "def foo():\n    return 1\n");
+    std::fs::write(
+        repo.path().join("app.py"),
+        "def foo():\n    s = \"\u{1b}[31mRED\u{1b}[0m\"\n    return s\n",
+    )
+    .expect("write modified file");
+
+    let output = repo.run_sem(&["diff", "-v", "--color", "never"]);
+    assert!(
+        output.status.success(),
+        "sem failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        !output.stdout.contains(&0x1b),
+        "stdout contains raw ESC bytes: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf-8");
+    assert!(stdout.contains("\\u{1b}[31mRED\\u{1b}[0m"), "{stdout}");
+}
+
+#[test]
+#[cfg(not(windows))]
+fn terminal_unsupported_file_warning_escapes_file_path_control_bytes() {
+    let repo = TempRepo::new();
+    let file_name = "bad\u{1b}[31m.txt";
+    commit_file(&repo, file_name, "alpha\nbeta\n");
+    std::fs::write(repo.path().join(file_name), "alpha\nchanged\n").expect("write modified file");
+
+    let output = repo.run_sem(&["diff", "-v", "--color", "never"]);
+    assert!(
+        output.status.success(),
+        "sem failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        !output.stdout.contains(&0x1b),
+        "stdout contains raw ESC bytes: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf-8");
+    assert!(stdout.contains("bad\\u{1b}[31m.txt"), "{stdout}");
+    assert!(
+        stdout.contains("used line-based chunking (unsupported file extension)"),
+        "{stdout}"
+    );
+}

--- a/crates/sem-core/src/format/json.rs
+++ b/crates/sem-core/src/format/json.rs
@@ -1,7 +1,22 @@
-use crate::parser::differ::DiffResult;
+use crate::parser::differ::{BinaryFileChange, DiffResult};
 use serde_json::{json, Value};
 
 pub fn diff_json_value(result: &DiffResult) -> Value {
+    diff_json_value_inner(result, &[], false)
+}
+
+pub fn diff_json_value_with_binary_changes(
+    result: &DiffResult,
+    binary_changes: &[BinaryFileChange],
+) -> Value {
+    diff_json_value_inner(result, binary_changes, true)
+}
+
+fn diff_json_value_inner(
+    result: &DiffResult,
+    binary_changes: &[BinaryFileChange],
+    include_binary_changes: bool,
+) -> Value {
     let changes: Vec<Value> = result
         .changes
         .iter()
@@ -28,24 +43,63 @@ pub fn diff_json_value(result: &DiffResult) -> Value {
         })
         .collect();
 
+    if !include_binary_changes {
+        return json!({
+            "summary": {
+                "fileCount": result.file_count,
+                "added": result.added_count,
+                "modified": result.modified_count,
+                "deleted": result.deleted_count,
+                "moved": result.moved_count,
+                "renamed": result.renamed_count,
+                "reordered": result.reordered_count,
+                "orphan": result.orphan_count,
+                "total": result.changes.len(),
+            },
+            "changes": changes,
+        });
+    }
+
+    let binary_changes_json: Vec<Value> = binary_changes
+        .iter()
+        .map(|c| {
+            json!({
+                "changeType": "binary",
+                "filePath": c.file_path,
+                "oldFilePath": c.old_file_path,
+                "fileStatus": c.status,
+            })
+        })
+        .collect();
+
     json!({
         "summary": {
-            "fileCount": result.file_count,
+            "fileCount": result.file_count + binary_changes.len(),
             "added": result.added_count,
             "modified": result.modified_count,
             "deleted": result.deleted_count,
             "moved": result.moved_count,
             "renamed": result.renamed_count,
             "reordered": result.reordered_count,
+            "binary": binary_changes.len(),
             "orphan": result.orphan_count,
-            "total": result.changes.len(),
+            "total": result.changes.len() + binary_changes.len(),
         },
         "changes": changes,
+        "binaryChanges": binary_changes_json,
     })
 }
 
 pub fn format_diff_json(result: &DiffResult) -> String {
     serde_json::to_string(&diff_json_value(result)).unwrap_or_default()
+}
+
+pub fn format_diff_json_with_binary_changes(
+    result: &DiffResult,
+    binary_changes: &[BinaryFileChange],
+) -> String {
+    serde_json::to_string(&diff_json_value_with_binary_changes(result, binary_changes))
+        .unwrap_or_default()
 }
 
 #[cfg(test)]
@@ -54,7 +108,7 @@ mod tests {
     use crate::model::change::{ChangeType, SemanticChange};
 
     #[test]
-    fn diff_json_value_matches_cli_envelope() {
+    fn diff_json_value_preserves_public_schema() {
         let result = DiffResult {
             changes: vec![SemanticChange {
                 id: "internal-change-id".to_string(),
@@ -125,6 +179,55 @@ mod tests {
                     "commitSha": "abc123",
                     "author": "Ada",
                     "structuralChange": true,
+                }],
+            })
+        );
+    }
+
+    #[test]
+    fn diff_json_value_with_binary_changes_matches_cli_envelope() {
+        let result = DiffResult {
+            changes: Vec::new(),
+            file_count: 0,
+            added_count: 0,
+            modified_count: 0,
+            deleted_count: 0,
+            moved_count: 0,
+            renamed_count: 0,
+            reordered_count: 0,
+            orphan_count: 0,
+            total_entities_before: 0,
+            total_entities_after: 0,
+        };
+        let binary_changes = vec![BinaryFileChange {
+            file_path: "pic.png".to_string(),
+            status: crate::git::types::FileStatus::Modified,
+            old_file_path: None,
+        }];
+
+        let value = diff_json_value_with_binary_changes(&result, &binary_changes);
+
+        assert_eq!(
+            value,
+            json!({
+                "summary": {
+                    "fileCount": 1,
+                    "added": 0,
+                    "modified": 0,
+                    "deleted": 0,
+                    "moved": 0,
+                    "renamed": 0,
+                    "reordered": 0,
+                    "binary": 1,
+                    "orphan": 0,
+                    "total": 1,
+                },
+                "changes": [],
+                "binaryChanges": [{
+                    "changeType": "binary",
+                    "filePath": "pic.png",
+                    "oldFilePath": null,
+                    "fileStatus": "modified",
                 }],
             })
         );

--- a/crates/sem-core/src/git/bridge.rs
+++ b/crates/sem-core/src/git/bridge.rs
@@ -487,6 +487,17 @@ impl GitBridge {
         files
     }
 
+    fn bytes_look_binary(bytes: &[u8], complete: bool) -> bool {
+        if bytes.iter().any(|byte| *byte == 0) {
+            return true;
+        }
+
+        match std::str::from_utf8(bytes) {
+            Ok(_) => false,
+            Err(error) => complete || error.error_len().is_some(),
+        }
+    }
+
     fn populate_contents(
         &self,
         files: &mut [FileChange],
@@ -605,14 +616,22 @@ impl GitBridge {
     fn read_blob_from_tree(&self, tree: &git2::Tree, file_path: &str) -> Option<String> {
         let entry = tree.get_path(Path::new(file_path)).ok()?;
         let blob = self.repo.find_blob(entry.id()).ok()?;
-        std::str::from_utf8(blob.content())
+        let bytes = blob.content();
+        if blob.is_binary() || Self::bytes_look_binary(bytes, true) {
+            return None;
+        }
+        std::str::from_utf8(bytes)
             .ok()
             .map(|s| Self::normalize_line_endings(s.to_string()))
     }
 
     fn read_working_file(&self, file_path: &str) -> Option<String> {
         let full_path = self.repo_root.join(file_path);
-        fs::read_to_string(full_path)
+        let bytes = fs::read(full_path).ok()?;
+        if Self::bytes_look_binary(&bytes, true) {
+            return None;
+        }
+        String::from_utf8(bytes)
             .ok()
             .map(Self::normalize_line_endings)
     }
@@ -621,7 +640,11 @@ impl GitBridge {
         let index = self.repo.index().ok()?;
         let entry = index.get_path(Path::new(file_path), 0)?;
         let blob = self.repo.find_blob(entry.id).ok()?;
-        std::str::from_utf8(blob.content())
+        let bytes = blob.content();
+        if blob.is_binary() || Self::bytes_look_binary(bytes, true) {
+            return None;
+        }
+        std::str::from_utf8(bytes)
             .ok()
             .map(|s| Self::normalize_line_endings(s.to_string()))
     }
@@ -1192,12 +1215,40 @@ fn normalize_lexical(path: &Path) -> PathBuf {
 mod tests {
     use super::*;
     use crate::model::change::ChangeType;
-    use crate::parser::differ::compute_semantic_diff;
+    use crate::parser::differ::{collect_binary_file_changes, compute_semantic_diff};
     use crate::parser::plugins::create_default_registry;
     use git2::{ErrorClass, Oid, Repository, Signature};
     use tempfile::TempDir;
 
     fn commit_file(repo: &Repository, file_path: &str, contents: &str, message: &str) -> Oid {
+        fs::write(repo.workdir().unwrap().join(file_path), contents).unwrap();
+
+        let mut index = repo.index().unwrap();
+        index.add_path(Path::new(file_path)).unwrap();
+        index.write().unwrap();
+
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let sig = Signature::now("Test User", "test@example.com").unwrap();
+
+        match repo.head() {
+            Ok(head) => {
+                let parent = repo.find_commit(head.target().unwrap()).unwrap();
+                repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &[&parent])
+                    .unwrap()
+            }
+            Err(_) => repo
+                .commit(Some("HEAD"), &sig, &sig, message, &tree, &[])
+                .unwrap(),
+        }
+    }
+
+    fn commit_binary_file(
+        repo: &Repository,
+        file_path: &str,
+        contents: &[u8],
+        message: &str,
+    ) -> Oid {
         fs::write(repo.workdir().unwrap().join(file_path), contents).unwrap();
 
         let mut index = repo.index().unwrap();
@@ -1414,6 +1465,81 @@ mod tests {
         let message = err.to_string();
         assert!(message.contains("pathspec"));
         assert!(message.contains("is outside repository"));
+    }
+
+    #[test]
+    fn working_binary_modification_is_reported_as_binary_change() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path()).unwrap();
+
+        commit_binary_file(&repo, "pic.png", b"\0png-v1\0", "init");
+        fs::write(temp.path().join("pic.png"), b"\0png-v2\0extra").unwrap();
+
+        let bridge = GitBridge::open(temp.path()).unwrap();
+        let files = bridge.get_changed_files(&DiffScope::Working, &[]).unwrap();
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].file_path, "pic.png");
+        assert_eq!(files[0].status, FileStatus::Modified);
+        assert!(files[0].before_content.is_none());
+        assert!(files[0].after_content.is_none());
+
+        let binary_changes = collect_binary_file_changes(&files);
+        let registry = create_default_registry();
+        let result = compute_semantic_diff(&files, &registry, None, None);
+
+        assert!(result.changes.is_empty());
+        assert_eq!(result.file_count, 0);
+        assert_eq!(binary_changes.len(), 1);
+        assert_eq!(binary_changes[0].file_path, "pic.png");
+        assert_eq!(binary_changes[0].status, FileStatus::Modified);
+    }
+
+    #[test]
+    fn staged_binary_add_and_delete_are_reported_as_binary_changes() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path()).unwrap();
+
+        fs::write(temp.path().join("added.png"), b"\0added-binary\0").unwrap();
+        let mut index = repo.index().unwrap();
+        index.add_path(Path::new("added.png")).unwrap();
+        index.write().unwrap();
+
+        let bridge = GitBridge::open(temp.path()).unwrap();
+        let added_files = bridge.get_changed_files(&DiffScope::Staged, &[]).unwrap();
+        assert_eq!(added_files.len(), 1);
+        assert_eq!(added_files[0].file_path, "added.png");
+        assert_eq!(added_files[0].status, FileStatus::Added);
+        assert!(added_files[0].before_content.is_none());
+        assert!(added_files[0].after_content.is_none());
+        let added_binary_changes = collect_binary_file_changes(&added_files);
+        assert_eq!(added_binary_changes.len(), 1);
+        assert_eq!(added_binary_changes[0].file_path, "added.png");
+
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path()).unwrap();
+        commit_binary_file(&repo, "deleted.png", b"\0deleted-binary\0", "init");
+        fs::remove_file(temp.path().join("deleted.png")).unwrap();
+        let mut index = repo.index().unwrap();
+        index.remove_path(Path::new("deleted.png")).unwrap();
+        index.write().unwrap();
+
+        let bridge = GitBridge::open(temp.path()).unwrap();
+        let deleted_files = bridge.get_changed_files(&DiffScope::Staged, &[]).unwrap();
+        assert_eq!(deleted_files.len(), 1);
+        assert_eq!(deleted_files[0].file_path, "deleted.png");
+        assert_eq!(deleted_files[0].status, FileStatus::Deleted);
+        assert!(deleted_files[0].before_content.is_none());
+        assert!(deleted_files[0].after_content.is_none());
+        let deleted_binary_changes = collect_binary_file_changes(&deleted_files);
+        assert_eq!(deleted_binary_changes.len(), 1);
+        assert_eq!(deleted_binary_changes[0].file_path, "deleted.png");
+    }
+
+    #[test]
+    fn partial_utf8_boundary_is_not_treated_as_binary() {
+        assert!(!GitBridge::bytes_look_binary(&[0xe2, 0x82], false));
+        assert!(GitBridge::bytes_look_binary(&[0xe2, 0x82], true));
     }
 
     #[test]

--- a/crates/sem-core/src/git/types.rs
+++ b/crates/sem-core/src/git/types.rs
@@ -19,6 +19,17 @@ pub enum FileStatus {
     Renamed,
 }
 
+impl std::fmt::Display for FileStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FileStatus::Added => write!(f, "added"),
+            FileStatus::Modified => write!(f, "modified"),
+            FileStatus::Deleted => write!(f, "deleted"),
+            FileStatus::Renamed => write!(f, "renamed"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct FileChange {

--- a/crates/sem-core/src/parser/differ.rs
+++ b/crates/sem-core/src/parser/differ.rs
@@ -2,7 +2,7 @@
 use rayon::prelude::*;
 use serde::Serialize;
 
-use crate::git::types::FileChange;
+use crate::git::types::{FileChange, FileStatus};
 
 macro_rules! maybe_par_iter {
     ($slice:expr) => {{
@@ -19,6 +19,7 @@ macro_rules! maybe_par_iter {
 use crate::model::change::{ChangeType, SemanticChange};
 use crate::model::entity::SemanticEntity;
 use crate::model::identity::match_entities;
+use crate::parser::plugin::SemanticParserPlugin;
 use crate::parser::registry::ParserRegistry;
 use std::collections::{HashMap, HashSet};
 
@@ -38,6 +39,42 @@ pub struct DiffResult {
     pub total_entities_after: usize,
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BinaryFileChange {
+    pub file_path: String,
+    pub status: FileStatus,
+    pub old_file_path: Option<String>,
+}
+
+impl From<&FileChange> for BinaryFileChange {
+    fn from(file: &FileChange) -> Self {
+        Self {
+            file_path: file.file_path.clone(),
+            status: file.status.clone(),
+            old_file_path: file.old_file_path.clone(),
+        }
+    }
+}
+
+pub fn collect_binary_file_changes(file_changes: &[FileChange]) -> Vec<BinaryFileChange> {
+    file_changes
+        .iter()
+        .filter(|file| lacks_diffable_content(file))
+        .map(BinaryFileChange::from)
+        .collect()
+}
+
+fn lacks_diffable_content(file: &FileChange) -> bool {
+    match &file.status {
+        FileStatus::Added => file.after_content.is_none(),
+        FileStatus::Deleted => file.before_content.is_none(),
+        FileStatus::Modified | FileStatus::Renamed => {
+            file.before_content.is_none() || file.after_content.is_none()
+        }
+    }
+}
+
 pub fn compute_semantic_diff(
     file_changes: &[FileChange],
     registry: &ParserRegistry,
@@ -47,6 +84,7 @@ pub fn compute_semantic_diff(
     // Process files in parallel: each file's entity extraction and matching is independent
     let per_file_changes: Vec<(String, Vec<SemanticChange>, usize, usize)> =
         maybe_par_iter!(file_changes)
+            .filter(|file| !lacks_diffable_content(file))
             .filter_map(|file| {
                 let content_hint = file
                     .after_content
@@ -107,6 +145,8 @@ pub fn compute_semantic_diff(
                     file,
                     &before_entities,
                     &after_entities,
+                    Some(plugin),
+                    detection_path,
                     commit_sha,
                     author,
                 );
@@ -367,6 +407,8 @@ fn detect_orphan_changes(
     file: &FileChange,
     before_entities: &[SemanticEntity],
     after_entities: &[SemanticEntity],
+    plugin: Option<&dyn SemanticParserPlugin>,
+    detection_path: &str,
     commit_sha: Option<&str>,
     author: Option<&str>,
 ) -> Vec<SemanticChange> {
@@ -448,11 +490,31 @@ fn detect_orphan_changes(
             commit_sha: commit_sha.map(String::from),
             author: author.map(String::from),
             timestamp: None,
-            structural_change: Some(true),
+            structural_change: orphan_structural_change(
+                before_content,
+                after_content,
+                plugin,
+                detection_path,
+            ),
         });
     }
 
     changes
+}
+
+fn orphan_structural_change(
+    before_content: Option<&str>,
+    after_content: Option<&str>,
+    plugin: Option<&dyn SemanticParserPlugin>,
+    detection_path: &str,
+) -> Option<bool> {
+    let plugin = plugin?;
+    let before_hash =
+        plugin.structural_hash_content(before_content.unwrap_or_default(), detection_path)?;
+    let after_hash =
+        plugin.structural_hash_content(after_content.unwrap_or_default(), detection_path)?;
+
+    Some(before_hash != after_hash)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -660,6 +722,45 @@ mod tests {
         assert_eq!(result.modified_count, 1);
         assert_eq!(result.changes[0].entity_type, "orphan");
         assert_eq!(result.changes[0].change_type, ChangeType::Modified);
+        assert_eq!(result.changes[0].structural_change, Some(false));
+    }
+
+    #[test]
+    fn orphan_code_change_is_structural() {
+        let before = "import os\n\ndef value():\n    return 1\n";
+        let after = "import sys\n\ndef value():\n    return 1\n";
+
+        let registry = create_default_registry();
+        let result = compute_semantic_diff(
+            &[modified_file("app.py", before, after)],
+            &registry,
+            None,
+            None,
+        );
+
+        assert_eq!(result.changes.len(), 1);
+        assert_eq!(result.changes[0].entity_type, "orphan");
+        assert_eq!(result.changes[0].change_type, ChangeType::Modified);
+        assert_eq!(result.changes[0].structural_change, Some(true));
+    }
+
+    #[test]
+    fn orphan_shebang_change_is_structural() {
+        let before = "#!/usr/bin/env python3\ndef value():\n    return 1\n";
+        let after = "#!/usr/bin/env python\ndef value():\n    return 1\n";
+
+        let registry = create_default_registry();
+        let result = compute_semantic_diff(
+            &[modified_file("script", before, after)],
+            &registry,
+            None,
+            None,
+        );
+
+        assert_eq!(result.changes.len(), 1);
+        assert_eq!(result.changes[0].entity_type, "orphan");
+        assert_eq!(result.changes[0].change_type, ChangeType::Modified);
+        assert_eq!(result.changes[0].structural_change, Some(true));
     }
 
     #[test]
@@ -849,6 +950,11 @@ mod tests {
             .changes
             .iter()
             .any(|c| c.entity_type == "orphan" && c.change_type == ChangeType::Added));
+        assert!(result.changes.iter().any(|c| {
+            c.entity_type == "orphan"
+                && c.change_type == ChangeType::Added
+                && c.structural_change == Some(false)
+        }));
 
         let named_bucket_total = result.added_count
             + result.modified_count
@@ -868,7 +974,7 @@ mod tests {
         );
         let entities = vec![entity_span("foo", 2, 2), entity_span("bar", 4, 4)];
 
-        let changes = detect_orphan_changes(&file, &entities, &entities, None, None);
+        let changes = detect_orphan_changes(&file, &entities, &entities, None, "a.rs", None, None);
 
         assert_eq!(changes.len(), 2);
         assert_eq!(changes[0].start_line, 1);
@@ -891,8 +997,15 @@ mod tests {
         let before_entities = vec![entity_span("foo", 1, 1)];
         let after_entities = vec![entity_span("foo", 2, 2)];
 
-        let changes =
-            detect_orphan_changes(&file, &before_entities, &after_entities, None, None);
+        let changes = detect_orphan_changes(
+            &file,
+            &before_entities,
+            &after_entities,
+            None,
+            "a.rs",
+            None,
+            None,
+        );
 
         assert!(changes.is_empty());
     }
@@ -907,8 +1020,15 @@ mod tests {
         let before_entities = vec![entity_span("foo", 1, 1), entity_span("bar", 3, 3)];
         let after_entities = vec![entity_span("foo", 2, 2), entity_span("bar", 4, 4)];
 
-        let changes =
-            detect_orphan_changes(&file, &before_entities, &after_entities, None, None);
+        let changes = detect_orphan_changes(
+            &file,
+            &before_entities,
+            &after_entities,
+            None,
+            "a.rs",
+            None,
+            None,
+        );
 
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].change_type, ChangeType::Added);
@@ -938,8 +1058,15 @@ mod tests {
             entity_span("bar", 8, 8),
         ];
 
-        let changes =
-            detect_orphan_changes(&file, &before_entities, &after_entities, None, None);
+        let changes = detect_orphan_changes(
+            &file,
+            &before_entities,
+            &after_entities,
+            None,
+            "a.rs",
+            None,
+            None,
+        );
 
         assert_eq!(changes.len(), 3);
         assert_eq!(changes[0].change_type, ChangeType::Deleted);

--- a/crates/sem-core/src/parser/plugin.rs
+++ b/crates/sem-core/src/parser/plugin.rs
@@ -13,6 +13,9 @@ pub trait SemanticParserPlugin: Send + Sync {
     ) -> (Vec<SemanticEntity>, Option<tree_sitter::Tree>) {
         (self.extract_entities(content, file_path), None)
     }
+    fn structural_hash_content(&self, _content: &str, _file_path: &str) -> Option<String> {
+        None
+    }
     fn compute_similarity(&self, a: &SemanticEntity, b: &SemanticEntity) -> f64 {
         crate::model::identity::default_similarity(a, b)
     }

--- a/crates/sem-core/src/parser/plugins/code/mod.rs
+++ b/crates/sem-core/src/parser/plugins/code/mod.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 
 use crate::model::entity::SemanticEntity;
 use crate::parser::plugin::SemanticParserPlugin;
+use crate::utils::hash::{content_hash, structural_hash};
 use languages::{get_all_code_extensions, get_language_config};
 use entity_extractor::extract_entities;
 
@@ -15,6 +16,81 @@ pub struct CodeParserPlugin;
 // Avoids creating a new Parser for every file during parallel graph builds.
 thread_local! {
     static PARSER_CACHE: RefCell<HashMap<&'static str, tree_sitter::Parser>> = RefCell::new(HashMap::new());
+}
+
+fn language_config_for_content(
+    content: &str,
+    file_path: &str,
+) -> Option<&'static languages::LanguageConfig> {
+    let ext = std::path::Path::new(file_path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| format!(".{}", e.to_lowercase()))
+        .unwrap_or_default();
+
+    get_language_config(&ext).or_else(|| {
+        detect_ext_from_content(content).and_then(|shebang_ext| get_language_config(&shebang_ext))
+    })
+}
+
+fn parse_tree(
+    config: &'static languages::LanguageConfig,
+    content: &str,
+) -> Option<tree_sitter::Tree> {
+    let language = (config.get_language)()?;
+
+    PARSER_CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        let parser = cache.entry(config.id).or_insert_with(|| {
+            let mut p = tree_sitter::Parser::new();
+            let _ = p.set_language(&language);
+            p
+        });
+
+        parser.parse(content.as_bytes(), None)
+    })
+}
+
+fn has_non_comment_content(node: tree_sitter::Node, source: &[u8]) -> bool {
+    let mut worklist = Vec::new();
+    let mut cursor = node.walk();
+    worklist.extend(node.children(&mut cursor));
+
+    while let Some(node) = worklist.pop() {
+        if is_comment_node(node.kind()) {
+            continue;
+        }
+
+        if node.child_count() == 0 {
+            let start = node.start_byte();
+            let end = node.end_byte();
+            if start < end
+                && end <= source.len()
+                && source[start..end].iter().any(|b| !b.is_ascii_whitespace())
+            {
+                return true;
+            }
+            continue;
+        }
+
+        let mut cursor = node.walk();
+        worklist.extend(node.children(&mut cursor));
+    }
+
+    false
+}
+
+fn is_comment_node(kind: &str) -> bool {
+    matches!(
+        kind,
+        "comment" | "line_comment" | "block_comment" | "doc_comment" | "tag_comment"
+    )
+}
+
+fn shebang_line(content: &str) -> Option<&str> {
+    content
+        .strip_prefix("#!")
+        .map(|rest| rest.lines().next().unwrap_or(""))
 }
 
 impl SemanticParserPlugin for CodeParserPlugin {
@@ -35,46 +111,30 @@ impl SemanticParserPlugin for CodeParserPlugin {
         content: &str,
         file_path: &str,
     ) -> (Vec<SemanticEntity>, Option<tree_sitter::Tree>) {
-        let ext = std::path::Path::new(file_path)
-            .extension()
-            .and_then(|e| e.to_str())
-            .map(|e| format!(".{}", e.to_lowercase()))
-            .unwrap_or_default();
-
-        let config = match get_language_config(&ext) {
-            Some(c) => c,
-            None => {
-                // Try shebang detection for extensionless files
-                match detect_ext_from_content(content)
-                    .and_then(|se| get_language_config(&se))
-                {
-                    Some(c) => c,
-                    None => return (Vec::new(), None),
-                }
-            }
+        let Some(config) = language_config_for_content(content, file_path) else {
+            return (Vec::new(), None);
         };
 
-        let language = match (config.get_language)() {
-            Some(lang) => lang,
-            None => return (Vec::new(), None),
+        let Some(tree) = parse_tree(config, content) else {
+            return (Vec::new(), None);
         };
 
-        PARSER_CACHE.with(|cache| {
-            let mut cache = cache.borrow_mut();
-            let parser = cache.entry(config.id).or_insert_with(|| {
-                let mut p = tree_sitter::Parser::new();
-                let _ = p.set_language(&language);
-                p
-            });
+        let entities = extract_entities(&tree, file_path, config, content);
+        (entities, Some(tree))
+    }
 
-            let tree = match parser.parse(content.as_bytes(), None) {
-                Some(t) => t,
-                None => return (Vec::new(), None),
-            };
-
-            let entities = extract_entities(&tree, file_path, config, content);
-            (entities, Some(tree))
-        })
+    fn structural_hash_content(&self, content: &str, file_path: &str) -> Option<String> {
+        let config = language_config_for_content(content, file_path)?;
+        let tree = parse_tree(config, content)?;
+        let shebang = shebang_line(content);
+        if shebang.is_none() && !has_non_comment_content(tree.root_node(), content.as_bytes()) {
+            return Some(String::new());
+        }
+        let structural = structural_hash(tree.root_node(), content.as_bytes());
+        match shebang {
+            Some(shebang) => Some(content_hash(&format!("shebang:{shebang}\n{structural}"))),
+            None => Some(structural),
+        }
     }
 }
 

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -10,11 +10,11 @@ use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{CallToolResult, Content, ServerCapabilities, ServerInfo};
 use rmcp::{tool, tool_handler, tool_router, ServerHandler};
-use sem_core::format::json::format_diff_json;
+use sem_core::format::json::format_diff_json_with_binary_changes;
 use sem_core::git::bridge::GitBridge;
 use sem_core::git::types::{BlameLineInfo, CommitInfo, DiffScope};
 use sem_core::model::entity::SemanticEntity;
-use sem_core::parser::differ::compute_semantic_diff;
+use sem_core::parser::differ::{collect_binary_file_changes, compute_semantic_diff};
 use sem_core::parser::graph::EntityGraph;
 use sem_core::parser::plugins::create_default_registry;
 use sem_core::parser::registry::ParserRegistry;
@@ -527,11 +527,12 @@ impl SemServer {
             Err(err) => return Ok(tool_error(err.to_string())),
         };
 
+        let binary_changes = collect_binary_file_changes(&file_changes);
         let diff_result =
             compute_semantic_diff(&file_changes, &self.registry, None, None);
 
         Ok(CallToolResult::success(vec![Content::text(
-            format_diff_json(&diff_result),
+            format_diff_json_with_binary_changes(&diff_result, &binary_changes),
         )]))
     }
 


### PR DESCRIPTION
## Summary
- consolidate binary file diff reporting, diff output escaping, and cosmetic orphan filtering into one branch
- keep diff formatter, JSON, CLI, and MCP reporting behavior aligned across the related changes

Supersedes #237, #290, #294.
Closes #181.
Closes #273.
Fixes #272.

## Test plan
- cargo test --manifest-path crates/Cargo.toml -p sem-cli --test diff_file_compare
- cargo test --manifest-path crates/Cargo.toml -p sem-cli --test diff_patch
- cargo test --manifest-path crates/Cargo.toml -p sem-cli --test diff_output_hardening
- cargo test --manifest-path crates/Cargo.toml -p sem-cli --test diff_no_cosmetics
- cargo test --manifest-path crates/Cargo.toml -p sem-cli commands::diff::tests
- cargo test --manifest-path crates/Cargo.toml -p sem-core parser::differ::tests
- cargo check --manifest-path crates/Cargo.toml -p sem-core -p sem-cli -p sem-mcp
