### PR TITLE
Improve graph cache and diff performance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,3 +216,7 @@ This prints the full AST with node types.
 ## Questions?
 
 Open an issue or check the existing language configs in `languages.rs` for reference. The simplest configs (Python, Bash) are good starting points. The Elixir config shows the call-based approach.
+
+## Performance Fixtures
+
+For graph-build performance work, use the generated JS/TS fixture benchmark in `benchmarks/large-js-fixture/`. It can regenerate large public fixtures and measure cold cache, warm cache, and one-file incremental rebuild timings without relying on private repositories.

--- a/benchmarks/large-js-fixture/.gitignore
+++ b/benchmarks/large-js-fixture/.gitignore
@@ -1,0 +1,2 @@
+.generated/
+results*.json

--- a/benchmarks/large-js-fixture/README.md
+++ b/benchmarks/large-js-fixture/README.md
@@ -1,0 +1,66 @@
+# Large JS/TS Fixture Benchmark
+
+This benchmark provides a public, repeatable TypeScript/JavaScript fixture for graph-build performance work. It can be paired with `SEM_TIMINGS=1` or `SEM_TIMINGS=json` to collect CLI phase timings while it measures cold cache, warm cache, and one-file incremental runs.
+
+## Generate a Fixture
+
+```bash
+node scripts/large-js-fixture.mjs \
+  --out /tmp/sem-large-js-fixture \
+  --files 1000 \
+  --entities-per-file 12 \
+  --fanout 5 \
+  --import-style-mix named:3,default:1,namespace:1,type:1 \
+  --nested-depth 3 \
+  --body-lines 40 \
+  --language mixed
+```
+
+The generator writes a standalone fixture root with `src/`, `package.json`, `tsconfig.json`, `fixture-manifest.json`, and a marker file. Existing marked fixture roots are replaced for repeatability. Non-empty unmarked directories are refused unless `--force` is supplied.
+
+## Time sem
+
+```bash
+node benchmarks/large-js-fixture/run.mjs \
+  --sem crates/target/debug/sem \
+  --files 1000 \
+  --entities-per-file 12 \
+  --fanout 5 \
+  --import-style-mix named:3,default:1,namespace:1,type:1 \
+  --nested-depth 3 \
+  --body-lines 40 \
+  --language mixed
+```
+
+The runner:
+
+1. regenerates the fixture,
+2. clears the benchmark cache root,
+3. runs a cold-cache command,
+4. runs the same command with a warm cache,
+5. mutates one marker inside the first source file,
+6. runs the same command again for one-file incremental rebuild timing.
+
+By default it runs:
+
+```bash
+sem graph . --json --file-exts .ts .js
+```
+
+It writes machine-readable results to `benchmarks/large-js-fixture/.generated/results.json`. Use `--json-out <path>` to choose another path or `--no-json-out` to print only the terminal summary.
+
+## Useful Knobs
+
+- `--files`: source file count.
+- `--entities-per-file`: top-level generated value entities in each source file.
+- `--fanout`: number of neighboring files imported by each file.
+- `--import-style-mix`: comma-separated style cycle with optional weights. Supported styles are `named`, `default`, `namespace`, `type`, and `side-effect`.
+- `--nested-depth`: nested local function depth inside each top-level entity.
+- `--body-lines`: extra executable lines in each top-level entity body.
+- `--language`: `ts`, `js`, or `mixed`.
+- `--command`: `graph`, `impact`, `context`, or `verify`.
+- `--impact-mode`: `deps`, `dependents`, `tests`, or `all`. The default is `deps` so `impact` benchmarks exercise the topology-only path.
+- `--timeout-ms`: per-run guard for commands under investigation.
+- `--cache-dir`: cache root. Keep it outside `--out` so sem accepts the override.
+
+The default output lives under `benchmarks/large-js-fixture/.generated/`. The generated fixture is initialized as its own Git repository by default so sem treats that directory as the repository root even when the fixture is inside this checkout.

--- a/benchmarks/large-js-fixture/run.mjs
+++ b/benchmarks/large-js-fixture/run.mjs
@@ -1,0 +1,450 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { performance } from 'node:perf_hooks';
+import { fileURLToPath } from 'node:url';
+import {
+  DEFAULT_LARGE_JS_FIXTURE_OPTIONS,
+  generateLargeJsFixture,
+  parseImportStyleMix,
+} from '../../scripts/large-js-fixture.mjs';
+
+const BENCHMARK_DIR = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_OUT_DIR = path.join(BENCHMARK_DIR, '.generated', 'repo');
+const DEFAULT_CACHE_DIR = path.join(BENCHMARK_DIR, '.generated', 'cache');
+const DEFAULT_RESULTS_PATH = path.join(BENCHMARK_DIR, '.generated', 'results.json');
+const COMMANDS = new Set(['graph', 'impact', 'context', 'verify']);
+const IMPACT_MODES = new Set(['deps', 'dependents', 'tests', 'all']);
+
+export const LARGE_JS_FIXTURE_BENCHMARK_HELP = `
+Run cold, warm, and one-file incremental sem timings on a generated JS/TS fixture.
+
+Usage:
+  node benchmarks/large-js-fixture/run.mjs [options]
+
+Fixture knobs:
+  --out <dir>                     Fixture root directory.
+  --files <count>                 Number of source files.
+  --entities-per-file <count>     Top-level value entities per file.
+  --fanout <count>                Imported neighbor files per source file.
+  --import-style-mix <mix>        Comma list or weights: named:3,default,namespace,type.
+  --nested-depth <count>          Nested local function depth inside each entity.
+  --body-lines <count>            Extra executable lines in each entity body.
+  --language <ts|js|mixed>        Source extension mix.
+
+Benchmark knobs:
+  --sem <path>                    sem binary to execute. Defaults to SEM_BIN or sem.
+  --cache-dir <dir>               Cache root outside the fixture root.
+  --command <graph|impact|context|verify>
+  --impact-mode <deps|dependents|tests|all>
+  --target-entity <name>          Entity for impact/context.
+  --target-file <path>            Fixture-relative file for impact/context.
+  --context-budget <tokens>       Token budget for context command.
+  --timeout-ms <millis>           Per-run timeout.
+  --json-out <path>               Write machine-readable results.
+  --no-json-out                   Do not write a results file.
+  --no-git-init                   Do not initialize the fixture as its own Git repo.
+  --force                         Allow deleting a non-empty output directory without marker.
+  -h, --help                      Show this help.
+
+Example:
+  node benchmarks/large-js-fixture/run.mjs --files 1000 --entities-per-file 12 --fanout 5 --body-lines 40
+`.trim();
+
+export function parseLargeJsFixtureBenchmarkArgs(argv, env = process.env) {
+  const options = {
+    sem: env.SEM_BIN || 'sem',
+    outDir: DEFAULT_OUT_DIR,
+    cacheDir: DEFAULT_CACHE_DIR,
+    command: 'graph',
+    impactMode: 'deps',
+    contextBudget: 8000,
+    timeoutMs: 120000,
+    jsonOut: DEFAULT_RESULTS_PATH,
+    fileCount: DEFAULT_LARGE_JS_FIXTURE_OPTIONS.fileCount,
+    entitiesPerFile: DEFAULT_LARGE_JS_FIXTURE_OPTIONS.entitiesPerFile,
+    importFanout: DEFAULT_LARGE_JS_FIXTURE_OPTIONS.importFanout,
+    importStyleMix: DEFAULT_LARGE_JS_FIXTURE_OPTIONS.importStyleMix,
+    nestedDepth: DEFAULT_LARGE_JS_FIXTURE_OPTIONS.nestedDepth,
+    bodyLines: DEFAULT_LARGE_JS_FIXTURE_OPTIONS.bodyLines,
+    language: DEFAULT_LARGE_JS_FIXTURE_OPTIONS.language,
+    gitInit: true,
+    force: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    switch (arg) {
+      case '-h':
+      case '--help':
+        return { help: true };
+      case '--sem':
+        options.sem = readFlagValue(argv, ++index, arg);
+        break;
+      case '--out':
+      case '-o':
+        options.outDir = readFlagValue(argv, ++index, arg);
+        break;
+      case '--cache-dir':
+        options.cacheDir = readFlagValue(argv, ++index, arg);
+        break;
+      case '--command':
+        options.command = readFlagValue(argv, ++index, arg);
+        break;
+      case '--impact-mode':
+        options.impactMode = readFlagValue(argv, ++index, arg);
+        break;
+      case '--target-entity':
+        options.targetEntity = readFlagValue(argv, ++index, arg);
+        break;
+      case '--target-file':
+        options.targetFile = readFlagValue(argv, ++index, arg);
+        break;
+      case '--context-budget':
+        options.contextBudget = parsePositiveInteger(readFlagValue(argv, ++index, arg), arg);
+        break;
+      case '--timeout-ms':
+        options.timeoutMs = parsePositiveInteger(readFlagValue(argv, ++index, arg), arg);
+        break;
+      case '--json-out':
+        options.jsonOut = readFlagValue(argv, ++index, arg);
+        break;
+      case '--no-json-out':
+        options.jsonOut = null;
+        break;
+      case '--files':
+      case '--file-count':
+        options.fileCount = parsePositiveInteger(readFlagValue(argv, ++index, arg), arg);
+        break;
+      case '--entities-per-file':
+        options.entitiesPerFile = parsePositiveInteger(readFlagValue(argv, ++index, arg), arg);
+        break;
+      case '--fanout':
+      case '--import-fanout':
+        options.importFanout = parseNonNegativeInteger(readFlagValue(argv, ++index, arg), arg);
+        break;
+      case '--import-styles':
+      case '--import-style-mix':
+        options.importStyleMix = parseImportStyleMix(readFlagValue(argv, ++index, arg));
+        break;
+      case '--nested-depth':
+        options.nestedDepth = parseNonNegativeInteger(readFlagValue(argv, ++index, arg), arg);
+        break;
+      case '--body-lines':
+      case '--large-body-lines':
+        options.bodyLines = parseNonNegativeInteger(readFlagValue(argv, ++index, arg), arg);
+        break;
+      case '--language':
+        options.language = readFlagValue(argv, ++index, arg);
+        break;
+      case '--no-git-init':
+        options.gitInit = false;
+        break;
+      case '--force':
+        options.force = true;
+        break;
+      default:
+        throw new Error(`Unknown option "${arg}". Run with --help for usage.`);
+    }
+  }
+
+  return normalizeLargeJsFixtureBenchmarkOptions(options);
+}
+
+export function normalizeLargeJsFixtureBenchmarkOptions(options) {
+  const normalized = {
+    ...options,
+    sem: normalizeSemExecutable(options.sem),
+    outDir: path.resolve(String(options.outDir)),
+    cacheDir: path.resolve(String(options.cacheDir)),
+    command: String(options.command),
+    impactMode: String(options.impactMode),
+    contextBudget: parsePositiveInteger(options.contextBudget, 'contextBudget'),
+    timeoutMs: parsePositiveInteger(options.timeoutMs, 'timeoutMs'),
+    jsonOut: options.jsonOut === null ? null : path.resolve(String(options.jsonOut)),
+    fileCount: parsePositiveInteger(options.fileCount, 'fileCount'),
+    entitiesPerFile: parsePositiveInteger(options.entitiesPerFile, 'entitiesPerFile'),
+    importFanout: parseNonNegativeInteger(options.importFanout, 'importFanout'),
+    importStyleMix: parseImportStyleMix(options.importStyleMix),
+    nestedDepth: parseNonNegativeInteger(options.nestedDepth, 'nestedDepth'),
+    bodyLines: parseNonNegativeInteger(options.bodyLines, 'bodyLines'),
+    language: String(options.language),
+    gitInit: Boolean(options.gitInit),
+    force: Boolean(options.force),
+  };
+
+  if (!COMMANDS.has(normalized.command)) {
+    throw new Error(`Unsupported command "${normalized.command}". Use graph, impact, context, or verify.`);
+  }
+  if (!IMPACT_MODES.has(normalized.impactMode)) {
+    throw new Error(`Unsupported --impact-mode "${normalized.impactMode}". Use deps, dependents, tests, or all.`);
+  }
+
+  assertCacheOutsideFixture(normalized.cacheDir, normalized.outDir);
+  return normalized;
+}
+
+function normalizeSemExecutable(value) {
+  const executable = String(value);
+  if (
+    executable.startsWith('.') ||
+    executable.includes('/') ||
+    executable.includes(path.sep)
+  ) {
+    return path.resolve(executable);
+  }
+  return executable;
+}
+
+export async function runLargeJsFixtureBenchmark(options) {
+  const normalized = normalizeLargeJsFixtureBenchmarkOptions(options);
+  const fixture = await generateLargeJsFixture({
+    outDir: normalized.outDir,
+    fileCount: normalized.fileCount,
+    entitiesPerFile: normalized.entitiesPerFile,
+    importFanout: normalized.importFanout,
+    importStyleMix: normalized.importStyleMix,
+    nestedDepth: normalized.nestedDepth,
+    bodyLines: normalized.bodyLines,
+    language: normalized.language,
+    gitInit: normalized.gitInit,
+    force: normalized.force,
+  });
+
+  await fs.rm(normalized.cacheDir, { recursive: true, force: true });
+  await fs.mkdir(normalized.cacheDir, { recursive: true });
+
+  const command = buildSemCommand(normalized, fixture.manifest);
+  const env = {
+    ...process.env,
+    SEM_CACHE_DIR: normalized.cacheDir,
+  };
+
+  const runs = [];
+  runs.push(await runSemTimed('cold-cache', normalized.sem, command.args, fixture.outDir, env, normalized.timeoutMs));
+  runs.push(await runSemTimed('warm-cache', normalized.sem, command.args, fixture.outDir, env, normalized.timeoutMs));
+
+  await applyIncrementalMutation(fixture.outDir, fixture.manifest.incremental);
+  runs.push(
+    await runSemTimed(
+      'incremental-one-file',
+      normalized.sem,
+      command.args,
+      fixture.outDir,
+      env,
+      normalized.timeoutMs,
+    ),
+  );
+
+  const result = {
+    schemaVersion: 1,
+    fixture: {
+      outDir: fixture.outDir,
+      cacheDir: normalized.cacheDir,
+      files: fixture.manifest.files.length,
+      config: fixture.manifest.config,
+      incremental: fixture.manifest.incremental,
+    },
+    command,
+    timings: Object.fromEntries(runs.map((run) => [run.phase, run.elapsedMs])),
+    runs,
+  };
+
+  if (normalized.jsonOut) {
+    await fs.mkdir(path.dirname(normalized.jsonOut), { recursive: true });
+    await fs.writeFile(normalized.jsonOut, `${JSON.stringify(result, null, 2)}\n`, 'utf8');
+    result.resultsPath = normalized.jsonOut;
+  }
+
+  return result;
+}
+
+export function buildSemCommand(options, manifest) {
+  const targetEntity = options.targetEntity || manifest.targetEntity;
+  const targetFile = options.targetFile || manifest.entryFile;
+  const common = ['--json', '--file-exts', '.ts', '.js'];
+
+  if (options.command === 'graph') {
+    return {
+      kind: 'graph',
+      args: ['graph', '.', ...common],
+    };
+  }
+
+  if (options.command === 'verify') {
+    return {
+      kind: 'verify',
+      args: ['verify', ...common],
+    };
+  }
+
+  if (options.command === 'impact') {
+    const modeFlag = {
+      deps: '--deps',
+      dependents: '--dependents',
+      tests: '--tests',
+      all: null,
+    }[options.impactMode || 'deps'];
+    const args = ['impact', targetEntity, '--file', targetFile];
+    if (modeFlag) {
+      args.push(modeFlag);
+    }
+    args.push(...common);
+    return {
+      kind: 'impact',
+      impactMode: options.impactMode || 'deps',
+      targetEntity,
+      targetFile,
+      args,
+    };
+  }
+
+  return {
+    kind: 'context',
+    targetEntity,
+    targetFile,
+    args: [
+      'context',
+      targetEntity,
+      '--file',
+      targetFile,
+      '--budget',
+      String(options.contextBudget),
+      ...common,
+    ],
+  };
+}
+
+async function runSemTimed(phase, sem, args, cwd, env, timeoutMs) {
+  const startedAt = performance.now();
+  let stderr = '';
+  let timedOut = false;
+
+  return await new Promise((resolve, reject) => {
+    const child = spawn(sem, args, {
+      cwd,
+      env,
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGTERM');
+      setTimeout(() => child.kill('SIGKILL'), 1000).unref();
+    }, timeoutMs);
+
+    child.stderr.on('data', (chunk) => {
+      if (stderr.length < 65536) {
+        stderr += chunk.toString('utf8');
+      }
+    });
+
+    child.on('error', (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+
+    child.on('close', (code, signal) => {
+      clearTimeout(timeout);
+      const elapsedMs = Number((performance.now() - startedAt).toFixed(3));
+
+      if (timedOut) {
+        reject(new Error(`${phase} timed out after ${timeoutMs} ms: ${sem} ${args.join(' ')}`));
+        return;
+      }
+
+      if (code !== 0) {
+        reject(
+          new Error(
+            `${phase} failed with exit ${code ?? signal}: ${sem} ${args.join(' ')}\n${stderr}`,
+          ),
+        );
+        return;
+      }
+
+      resolve({
+        phase,
+        elapsedMs,
+      });
+    });
+  });
+}
+
+async function applyIncrementalMutation(outDir, mutation) {
+  const target = path.join(outDir, mutation.file);
+  const source = await fs.readFile(target, 'utf8');
+  if (!source.includes(mutation.search)) {
+    throw new Error(`Incremental marker not found in ${mutation.file}: ${mutation.search}`);
+  }
+
+  await fs.writeFile(target, source.replace(mutation.search, mutation.replacement), 'utf8');
+  const timestamp = new Date(Date.now() + 1500);
+  await fs.utimes(target, timestamp, timestamp);
+}
+
+function assertCacheOutsideFixture(cacheDir, outDir) {
+  const relative = path.relative(outDir, cacheDir);
+  if (relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))) {
+    throw new Error(`--cache-dir must be outside --out so sem accepts it: ${cacheDir}`);
+  }
+}
+
+function readFlagValue(argv, index, flag) {
+  const value = argv[index];
+  if (value === undefined || value.startsWith('--')) {
+    throw new Error(`Missing value for ${flag}.`);
+  }
+  return value;
+}
+
+function parsePositiveInteger(value, label) {
+  const text = String(value).trim();
+  const parsed = Number.parseInt(text, 10);
+  if (!/^\d+$/.test(text) || !Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new Error(`${label} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+function parseNonNegativeInteger(value, label) {
+  const text = String(value).trim();
+  const parsed = Number.parseInt(text, 10);
+  if (!/^\d+$/.test(text) || !Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new Error(`${label} must be a non-negative integer.`);
+  }
+  return parsed;
+}
+
+function printSummary(result) {
+  console.log('Large JS/TS fixture benchmark');
+  console.log(`fixture: ${result.fixture.outDir}`);
+  console.log(`cache: ${result.fixture.cacheDir}`);
+  console.log(`command: ${result.command.args.join(' ')}`);
+  for (const run of result.runs) {
+    console.log(`${run.phase}: ${run.elapsedMs.toFixed(3)} ms`);
+  }
+  if (result.resultsPath) {
+    console.log(`results: ${result.resultsPath}`);
+  }
+}
+
+async function runCli() {
+  const parsed = parseLargeJsFixtureBenchmarkArgs(process.argv.slice(2));
+  if (parsed.help) {
+    console.log(LARGE_JS_FIXTURE_BENCHMARK_HELP);
+    return;
+  }
+
+  const result = await runLargeJsFixtureBenchmark(parsed);
+  printSummary(result);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  runCli().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/benchmarks/large-js-fixture/run.test.mjs
+++ b/benchmarks/large-js-fixture/run.test.mjs
@@ -1,0 +1,126 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { buildSemCommand, parseLargeJsFixtureBenchmarkArgs } from './run.mjs';
+
+test('normalizes path-like sem executables before fixture cwd changes', () => {
+  const parsed = parseLargeJsFixtureBenchmarkArgs([
+    '--sem',
+    'crates/target/debug/sem',
+    '--out',
+    '/tmp/sem-large-js-repo',
+    '--cache-dir',
+    '/tmp/sem-large-js-cache',
+  ]);
+
+  assert.equal(parsed.sem, path.resolve('crates/target/debug/sem'));
+});
+
+test('keeps plain sem executable names as PATH lookups', () => {
+  const parsed = parseLargeJsFixtureBenchmarkArgs([
+    '--sem',
+    'sem',
+    '--out',
+    '/tmp/sem-large-js-repo',
+    '--cache-dir',
+    '/tmp/sem-large-js-cache',
+  ]);
+
+  assert.equal(parsed.sem, 'sem');
+});
+
+test('rejects cache directories inside the fixture root', () => {
+  assert.throws(
+    () =>
+      parseLargeJsFixtureBenchmarkArgs([
+        '--out',
+        '/tmp/sem-large-js-repo',
+        '--cache-dir',
+        '/tmp/sem-large-js-repo/cache',
+      ]),
+    /--cache-dir must be outside --out/,
+  );
+});
+
+test('builds graph benchmark command', () => {
+  const command = buildSemCommand(
+    { command: 'graph' },
+    { entryFile: 'src/f0000.ts', targetEntity: 'f0000_e000' },
+  );
+
+  assert.deepEqual(command, {
+    kind: 'graph',
+    args: ['graph', '.', '--json', '--file-exts', '.ts', '.js'],
+  });
+});
+
+test('defaults impact benchmark command to deps mode', () => {
+  const command = buildSemCommand(
+    { command: 'impact' },
+    { entryFile: 'src/f0000.ts', targetEntity: 'f0000_e000' },
+  );
+
+  assert.equal(command.kind, 'impact');
+  assert.equal(command.impactMode, 'deps');
+  assert.deepEqual(command.args, [
+    'impact',
+    'f0000_e000',
+    '--file',
+    'src/f0000.ts',
+    '--deps',
+    '--json',
+    '--file-exts',
+    '.ts',
+    '.js',
+  ]);
+});
+
+test('builds requested impact benchmark mode', () => {
+  const command = buildSemCommand(
+    {
+      command: 'impact',
+      impactMode: 'dependents',
+      targetEntity: 'customEntity',
+      targetFile: 'src/custom.ts',
+    },
+    { entryFile: 'src/f0000.ts', targetEntity: 'f0000_e000' },
+  );
+
+  assert.deepEqual(command.args, [
+    'impact',
+    'customEntity',
+    '--file',
+    'src/custom.ts',
+    '--dependents',
+    '--json',
+    '--file-exts',
+    '.ts',
+    '.js',
+  ]);
+});
+
+test('builds context and verify benchmark commands', () => {
+  const manifest = { entryFile: 'src/f0000.ts', targetEntity: 'f0000_e000' };
+
+  assert.deepEqual(buildSemCommand({ command: 'verify' }, manifest), {
+    kind: 'verify',
+    args: ['verify', '--json', '--file-exts', '.ts', '.js'],
+  });
+  assert.deepEqual(buildSemCommand({ command: 'context', contextBudget: 1234 }, manifest), {
+    kind: 'context',
+    targetEntity: 'f0000_e000',
+    targetFile: 'src/f0000.ts',
+    args: [
+      'context',
+      'f0000_e000',
+      '--file',
+      'src/f0000.ts',
+      '--budget',
+      '1234',
+      '--json',
+      '--file-exts',
+      '.ts',
+      '.js',
+    ],
+  });
+});

--- a/crates/sem-cli/src/cache.rs
+++ b/crates/sem-cli/src/cache.rs
@@ -221,6 +221,104 @@ impl DiskCache {
         Some((graph, entities))
     }
 
+    /// Load only graph topology from a fresh cache.
+    pub fn load_graph_topology(&self, root: &Path, files: &[String]) -> Option<EntityGraph> {
+        if shared_cache::is_manifest_stale(&self.conn, root) {
+            return None;
+        }
+
+        let cached_count: i64 = self
+            .conn
+            .query_row("SELECT COUNT(*) FROM files", [], |row| row.get(0))
+            .ok()?;
+        if (cached_count - shared_cache::manifest_entry_count(&self.conn)) as usize
+            != shared_cache::source_file_count(files)
+        {
+            return None;
+        }
+
+        let mut stmt = self
+            .conn
+            .prepare("SELECT path, mtime_secs, mtime_nanos FROM files")
+            .ok()?;
+        let cached_mtimes: HashMap<String, (i64, i64)> = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    (row.get::<_, i64>(1)?, row.get::<_, i64>(2)?),
+                ))
+            })
+            .ok()?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        for file in files {
+            if shared_cache::is_manifest_file_name(file) {
+                continue;
+            }
+            let (secs, nanos) = cached_mtimes.get(file.as_str()).copied()?;
+            let full = root.join(file);
+            let (current_secs, current_nanos) = shared_cache::file_mtime_parts(&full)?;
+            if secs != current_secs || nanos != current_nanos {
+                return None;
+            }
+        }
+
+        let mut entity_stmt = self
+            .conn
+            .prepare(
+                "SELECT id, name, entity_type, file_path, start_line, end_line, parent_id FROM entities",
+            )
+            .ok()?;
+        let entity_map: HashMap<String, EntityInfo> = entity_stmt
+            .query_map([], |row| {
+                let id: String = row.get(0)?;
+                Ok((
+                    id.clone(),
+                    EntityInfo {
+                        id,
+                        name: row.get(1)?,
+                        entity_type: row.get(2)?,
+                        file_path: row.get(3)?,
+                        start_line: row.get::<_, i64>(4)? as usize,
+                        end_line: row.get::<_, i64>(5)? as usize,
+                        parent_id: row.get(6)?,
+                    },
+                ))
+            })
+            .ok()?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        let edges = self.load_edges()?;
+        Some(EntityGraph::from_parts(entity_map, edges))
+    }
+
+    fn load_edges(&self) -> Option<Vec<EntityRef>> {
+        let mut edge_stmt = self
+            .conn
+            .prepare("SELECT from_entity, to_entity, ref_type FROM edges")
+            .ok()?;
+        let edges: Vec<EntityRef> = edge_stmt
+            .query_map([], |row| {
+                let rt: String = row.get(2)?;
+                let ref_type = match rt.as_str() {
+                    "calls" => RefType::Calls,
+                    "imports" => RefType::Imports,
+                    _ => RefType::TypeRef,
+                };
+                Ok(EntityRef {
+                    from_entity: row.get(0)?,
+                    to_entity: row.get(1)?,
+                    ref_type,
+                })
+            })
+            .ok()?
+            .filter_map(|r| r.ok())
+            .collect();
+        Some(edges)
+    }
+
     /// Load a partial cache: identify stale files and return clean cached data.
     /// Returns None if cache is empty or ALL files are stale (full rebuild is better).
     pub fn load_partial(&self, root: &Path, files: &[String]) -> Option<PartialCache> {
@@ -383,6 +481,8 @@ impl DiskCache {
         graph: &EntityGraph,
         entities: &[SemanticEntity],
         repair_changed_clean_entity_ids: bool,
+        recomputed_edge_source_ids: &[String],
+        deleted_entity_ids: &[String],
     ) -> Result<(), rusqlite::Error> {
         let source_stale_files: Vec<&String> = stale_files
             .iter()
@@ -423,6 +523,29 @@ impl DiskCache {
                     && !current_set.contains(path.as_str())
             })
             .collect();
+        let use_legacy_edge_fallback = !repair_changed_clean_entity_ids
+            && recomputed_edge_source_ids.is_empty()
+            && deleted_entity_ids.is_empty();
+        let cached_rewritten_entity_ids: HashSet<String> = if use_legacy_edge_fallback {
+            let rewritten_file_paths: HashSet<&str> = source_stale_files
+                .iter()
+                .map(|file| file.as_str())
+                .chain(deleted_cached_files.iter().map(String::as_str))
+                .collect();
+            let mut stmt = tx.prepare("SELECT id, file_path FROM entities")?;
+            let rows = stmt.query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?;
+            rows.filter_map(|row| row.ok())
+                .filter_map(|(id, file_path)| {
+                    rewritten_file_paths
+                        .contains(file_path.as_str())
+                        .then_some(id)
+                })
+                .collect()
+        } else {
+            HashSet::new()
+        };
 
         // Delete files that are no longer in the file list (deleted from disk)
         {
@@ -490,15 +613,69 @@ impl DiskCache {
             }
         }
 
-        // Delete all edges and re-insert from graph
-        // (Edges are complex to incrementally update since affected clean entities
-        //  get re-resolved too. Simpler to just rewrite all edges.)
-        tx.execute("DELETE FROM edges", [])?;
-        {
+        if repair_changed_clean_entity_ids {
+            tx.execute("DELETE FROM edges", [])?;
             let mut ins = tx.prepare(
                 "INSERT INTO edges (from_entity, to_entity, ref_type) VALUES (?1, ?2, ?3)",
             )?;
             for edge in &graph.edges {
+                let rt = match edge.ref_type {
+                    RefType::Calls => "calls",
+                    RefType::TypeRef => "typeref",
+                    RefType::Imports => "imports",
+                };
+                ins.execute(params![edge.from_entity, edge.to_entity, rt])?;
+            }
+        } else {
+            let mut affected_sources: HashSet<String> =
+                recomputed_edge_source_ids.iter().cloned().collect();
+            let mut deleted_ids: HashSet<String> = deleted_entity_ids.iter().cloned().collect();
+            if use_legacy_edge_fallback {
+                let current_rewritten_entity_ids: HashSet<&str> = entities
+                    .iter()
+                    .filter(|entity| source_stale_set.contains(entity.file_path.as_str()))
+                    .map(|entity| entity.id.as_str())
+                    .collect();
+                affected_sources.extend(cached_rewritten_entity_ids.iter().cloned());
+                affected_sources.extend(
+                    current_rewritten_entity_ids
+                        .iter()
+                        .map(|entity_id| (*entity_id).to_string()),
+                );
+                deleted_ids.extend(
+                    cached_rewritten_entity_ids
+                        .iter()
+                        .filter(|entity_id| {
+                            !current_rewritten_entity_ids.contains(entity_id.as_str())
+                        })
+                        .cloned(),
+                );
+            }
+            affected_sources.extend(deleted_ids.iter().cloned());
+
+            {
+                let mut del_from = tx.prepare("DELETE FROM edges WHERE from_entity = ?1")?;
+                for entity_id in &affected_sources {
+                    del_from.execute(params![entity_id])?;
+                }
+            }
+            {
+                let mut del_to = tx.prepare("DELETE FROM edges WHERE to_entity = ?1")?;
+                for entity_id in &deleted_ids {
+                    del_to.execute(params![entity_id])?;
+                }
+            }
+
+            let mut ins = tx.prepare(
+                "INSERT INTO edges (from_entity, to_entity, ref_type) VALUES (?1, ?2, ?3)",
+            )?;
+            for edge in &graph.edges {
+                if !affected_sources.contains(&edge.from_entity)
+                    || deleted_ids.contains(&edge.from_entity)
+                    || deleted_ids.contains(&edge.to_entity)
+                {
+                    continue;
+                }
                 let rt = match edge.ref_type {
                     RefType::Calls => "calls",
                     RefType::TypeRef => "typeref",
@@ -583,6 +760,61 @@ mod tests {
             .unwrap();
         let mut rows = stmt.query(rusqlite::params![id]).unwrap();
         rows.next().unwrap().map(|row| row.get(0).unwrap())
+    }
+
+    fn entity_info(id: &str, file_path: &str, name: &str) -> EntityInfo {
+        EntityInfo {
+            id: id.to_string(),
+            file_path: file_path.to_string(),
+            entity_type: "function".to_string(),
+            name: name.to_string(),
+            parent_id: None,
+            start_line: 1,
+            end_line: 1,
+        }
+    }
+
+    fn graph_with_edges(entities: &[SemanticEntity], edges: Vec<EntityRef>) -> EntityGraph {
+        let entity_map = entities
+            .iter()
+            .map(|entity| {
+                (
+                    entity.id.clone(),
+                    entity_info(&entity.id, &entity.file_path, &entity.name),
+                )
+            })
+            .collect();
+        EntityGraph::from_parts(entity_map, edges)
+    }
+
+    fn edge(from_entity: &str, to_entity: &str) -> EntityRef {
+        EntityRef {
+            from_entity: from_entity.to_string(),
+            to_entity: to_entity.to_string(),
+            ref_type: RefType::Calls,
+        }
+    }
+
+    fn edge_rowid(cache: &DiskCache, from_entity: &str, to_entity: &str) -> Option<i64> {
+        cache
+            .conn
+            .query_row(
+                "SELECT rowid FROM edges WHERE from_entity = ?1 AND to_entity = ?2",
+                rusqlite::params![from_entity, to_entity],
+                |row| row.get(0),
+            )
+            .ok()
+    }
+
+    fn edge_count(cache: &DiskCache, from_entity: &str, to_entity: &str) -> i64 {
+        cache
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM edges WHERE from_entity = ?1 AND to_entity = ?2",
+                rusqlite::params![from_entity, to_entity],
+                |row| row.get(0),
+            )
+            .unwrap()
     }
 
     fn sample_files(root: &Path) -> Vec<String> {
@@ -787,6 +1019,8 @@ mod tests {
                 &empty_graph(),
                 &entities,
                 false,
+                &["stale-id".to_string()],
+                &[],
             )
             .unwrap();
 
@@ -834,6 +1068,8 @@ mod tests {
                 &empty_graph(),
                 &entities,
                 true,
+                &[],
+                &[],
             )
             .unwrap();
 
@@ -845,6 +1081,70 @@ mod tests {
         assert_eq!(
             entity_content(&cache, "stale-id"),
             Some("stale new".to_string())
+        );
+
+        drop(cache);
+        cleanup(root);
+    }
+
+    #[test]
+    fn save_incremental_rewrites_only_recomputed_edge_sources() {
+        let root = temp_repo_root("incremental-edge-sources");
+        write_file(&root.join("stale.rs"), "fn stale() {}\n");
+        write_file(&root.join("clean.rs"), "fn clean() {}\n");
+        write_file(&root.join("other.rs"), "fn other() {}\n");
+        write_file(&root.join("target.rs"), "fn target() {}\n");
+        let files = vec![
+            "stale.rs".to_string(),
+            "clean.rs".to_string(),
+            "other.rs".to_string(),
+            "target.rs".to_string(),
+        ];
+        let cache = DiskCache::open(&root).unwrap();
+        let entities = vec![
+            entity("stale-id", "stale.rs", "stale", "stale old"),
+            entity("clean-id", "clean.rs", "clean", "clean old"),
+            entity("other-id", "other.rs", "other", "other"),
+            entity("old-target-id", "target.rs", "oldTarget", "old target"),
+            entity("new-target-id", "target.rs", "newTarget", "new target"),
+        ];
+        let initial_graph = graph_with_edges(
+            &entities,
+            vec![
+                edge("stale-id", "old-target-id"),
+                edge("clean-id", "other-id"),
+            ],
+        );
+        cache
+            .save(&root, &files, &initial_graph, &entities)
+            .unwrap();
+        let clean_edge_rowid = edge_rowid(&cache, "clean-id", "other-id").unwrap();
+
+        let updated_graph = graph_with_edges(
+            &entities,
+            vec![
+                edge("stale-id", "new-target-id"),
+                edge("clean-id", "other-id"),
+            ],
+        );
+        cache
+            .save_incremental_with_repair_metadata(
+                &root,
+                &files,
+                &["stale.rs".to_string()],
+                &updated_graph,
+                &entities,
+                false,
+                &["stale-id".to_string()],
+                &["old-target-id".to_string()],
+            )
+            .unwrap();
+
+        assert_eq!(edge_count(&cache, "stale-id", "old-target-id"), 0);
+        assert_eq!(edge_count(&cache, "stale-id", "new-target-id"), 1);
+        assert_eq!(
+            edge_rowid(&cache, "clean-id", "other-id"),
+            Some(clean_edge_rowid)
         );
 
         drop(cache);

--- a/crates/sem-cli/src/commands/diff.rs
+++ b/crates/sem-cli/src/commands/diff.rs
@@ -1,10 +1,11 @@
 use std::borrow::Cow;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io::Read;
 use std::path::Path;
 use std::process;
 use std::time::Instant;
 
+use git2::{ObjectType, Oid, Repository};
 use sem_core::git::bridge::GitBridge;
 use sem_core::git::jj::maybe_resolve_ref;
 use sem_core::git::types::{DiffScope, FileChange, FileStatus};
@@ -509,6 +510,52 @@ fn read_file_compare_content(path: &Path) -> Result<Option<String>, std::io::Err
             .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
         Ok(Some(content))
     }
+}
+
+enum WorktreePatchContent {
+    Text(String),
+    Binary,
+}
+
+fn read_git_blob_content(repo: &Repository, sha: &str) -> Option<String> {
+    let object = repo.revparse_single(sha).ok()?;
+    let blob = object.peel_to_blob().ok()?;
+
+    String::from_utf8(blob.content().to_vec()).ok()
+}
+
+fn cached_git_blob_content(
+    repo: Option<&Repository>,
+    blob_cache: &mut HashMap<String, Option<String>>,
+    sha: &str,
+) -> Option<String> {
+    if let Some(content) = blob_cache.get(sha) {
+        return content.clone();
+    }
+
+    let content = repo.and_then(|repo| read_git_blob_content(repo, sha));
+    blob_cache.insert(sha.to_string(), content.clone());
+    content
+}
+
+fn read_worktree_content_matching_sha(
+    worktree_root: &Path,
+    file_path: &str,
+    sha_prefix: &str,
+) -> Option<WorktreePatchContent> {
+    let bytes = std::fs::read(worktree_root.join(file_path)).ok()?;
+    let oid = Oid::hash_object(ObjectType::Blob, &bytes).ok()?;
+    if !oid.to_string().starts_with(sha_prefix) {
+        return None;
+    }
+
+    if bytes_look_binary(&bytes, true) {
+        return Some(WorktreePatchContent::Binary);
+    }
+
+    String::from_utf8(bytes)
+        .ok()
+        .map(WorktreePatchContent::Text)
 }
 
 fn parse_args(args: Vec<String>, cwd: &str) -> ParsedArgs {
@@ -1100,36 +1147,8 @@ fn parse_unified_diff(
         return Err(PatchParseError::NoRecognizableHunks);
     }
 
-    // Resolve blob contents via git show
-    let git_show = |sha: &str| -> Option<String> {
-        let output = process::Command::new("git")
-            .args(["show", sha])
-            .current_dir(worktree_root)
-            .output()
-            .ok()?;
-        if output.status.success() {
-            String::from_utf8(output.stdout).ok()
-        } else {
-            None
-        }
-    };
-    let git_hash_object_matches = |file_path: &str, sha_prefix: &str| -> bool {
-        if !worktree_root.join(file_path).exists() {
-            return false;
-        }
-        let output = process::Command::new("git")
-            .args(["hash-object", "--", file_path])
-            .current_dir(worktree_root)
-            .output();
-        let Ok(output) = output else {
-            return false;
-        };
-        if !output.status.success() {
-            return false;
-        }
-        let hash = String::from_utf8_lossy(&output.stdout);
-        hash.trim().starts_with(sha_prefix)
-    };
+    let repo = Repository::discover(worktree_root).ok();
+    let mut blob_cache: HashMap<String, Option<String>> = HashMap::new();
 
     Ok(entries
         .into_iter()
@@ -1139,12 +1158,16 @@ fn parse_unified_diff(
             let mut before_content = if is_binary {
                 None
             } else {
-                e.old_sha.as_deref().and_then(&git_show)
+                e.old_sha
+                    .as_deref()
+                    .and_then(|sha| cached_git_blob_content(repo.as_ref(), &mut blob_cache, sha))
             };
             let mut after_content = if is_binary {
                 None
             } else {
-                e.new_sha.as_deref().and_then(&git_show)
+                e.new_sha
+                    .as_deref()
+                    .and_then(|sha| cached_git_blob_content(repo.as_ref(), &mut blob_cache, sha))
             };
 
             // If git cannot resolve the target blob for a local worktree diff,
@@ -1152,14 +1175,15 @@ fn parse_unified_diff(
             if !is_binary
                 && after_content.is_none()
                 && before_content.is_some()
-                && e.new_sha
-                    .as_deref()
-                    .is_some_and(|sha| git_hash_object_matches(&e.file_path, sha))
+                && e.new_sha.is_some()
             {
-                match read_file_compare_content(&worktree_root.join(&e.file_path)) {
-                    Ok(Some(content)) => after_content = Some(content),
-                    Ok(None) => has_binary_content = true,
-                    Err(_) => {}
+                if let Some(content) = e.new_sha.as_deref().and_then(|sha| {
+                    read_worktree_content_matching_sha(worktree_root, &e.file_path, sha)
+                }) {
+                    match content {
+                        WorktreePatchContent::Text(content) => after_content = Some(content),
+                        WorktreePatchContent::Binary => has_binary_content = true,
+                    }
                 }
             }
 

--- a/crates/sem-cli/src/commands/graph.rs
+++ b/crates/sem-cli/src/commands/graph.rs
@@ -7,6 +7,7 @@ use sem_core::parser::graph::{EntityGraph, EntityRef, RefType};
 use sem_core::parser::registry::ParserRegistry;
 
 use crate::cache::DiskCache;
+use crate::timings::Timings;
 
 pub struct GraphOptions {
     pub cwd: String,
@@ -17,6 +18,7 @@ pub struct GraphOptions {
 }
 
 pub fn graph_command(opts: GraphOptions) {
+    let mut timings = Timings::from_env("graph");
     let root = match GitBridge::open(Path::new(&opts.cwd)) {
         Ok(git) => git.repo_root().to_path_buf(),
         Err(_) => Path::new(&opts.cwd).to_path_buf(),
@@ -26,7 +28,9 @@ pub fn graph_command(opts: GraphOptions) {
     let ext_filter = normalize_exts(&opts.file_exts);
     let file_paths =
         find_supported_files_inner(root, &registry, &ext_filter, opts.no_default_excludes);
-    let (graph, _entities) = get_or_build_graph(root, &file_paths, &registry, opts.no_cache);
+    timings.mark("file_discovery");
+    let (graph, _entities) =
+        get_or_build_graph_with_timings(root, &file_paths, &registry, opts.no_cache, &mut timings);
 
     if opts.json {
         let mut entities = graph.entities.values().collect::<Vec<_>>();
@@ -43,8 +47,11 @@ pub fn graph_command(opts: GraphOptions) {
                 "edgeCount": graph.edges.len()
             }
         });
-        println!("{}", serde_json::to_string(&output).unwrap());
+        let output = serde_json::to_string(&output).unwrap();
+        timings.mark("cli_output_serialization");
+        println!("{}", output);
     } else {
+        timings.mark("cli_output_serialization");
         println!(
             "{} {} entities, {} edges",
             "⊕".green(),
@@ -52,6 +59,7 @@ pub fn graph_command(opts: GraphOptions) {
             graph.edges.len().to_string().bold(),
         );
     }
+    timings.finish();
 }
 
 fn compare_entity_refs(a: &&EntityRef, b: &&EntityRef) -> std::cmp::Ordering {
@@ -123,15 +131,29 @@ pub fn get_or_build_graph(
     registry: &ParserRegistry,
     no_cache: bool,
 ) -> (EntityGraph, Vec<SemanticEntity>) {
+    let mut timings = Timings::disabled("graph");
+    get_or_build_graph_with_timings(root, file_paths, registry, no_cache, &mut timings)
+}
+
+pub fn get_or_build_graph_with_timings(
+    root: &Path,
+    file_paths: &[String],
+    registry: &ParserRegistry,
+    no_cache: bool,
+    timings: &mut Timings,
+) -> (EntityGraph, Vec<SemanticEntity>) {
     if !no_cache {
         if let Ok(disk) = DiskCache::open(root) {
+            timings.mark("cache_open");
             // Try full cache hit
             if let Some(cached) = disk.load(root, file_paths) {
+                timings.mark("cache_full_load");
                 return cached;
             }
 
             // Try incremental: load clean cached data, rebuild only stale files
             if let Some(partial) = disk.load_partial(root, file_paths) {
+                timings.mark("cache_partial_load");
                 let (graph, entities, metadata) = EntityGraph::build_incremental_with_metadata(
                     root,
                     &partial.stale_files,
@@ -141,6 +163,7 @@ pub fn get_or_build_graph(
                     partial.stale_file_entities,
                     registry,
                 );
+                timings.mark("incremental_graph_rebuild");
                 let _ = disk.save_incremental_with_repair_metadata(
                     root,
                     file_paths,
@@ -148,7 +171,10 @@ pub fn get_or_build_graph(
                     &graph,
                     &entities,
                     metadata.repaired_clean_entity_ids,
+                    &metadata.recomputed_edge_source_ids,
+                    &metadata.deleted_entity_ids,
                 );
+                timings.mark("cache_incremental_save");
                 return (graph, entities);
             }
         }
@@ -156,12 +182,36 @@ pub fn get_or_build_graph(
 
     // Full rebuild
     let (graph, entities) = EntityGraph::build(root, file_paths, registry);
+    timings.mark("full_graph_build");
 
     if !no_cache {
         if let Ok(disk) = DiskCache::open(root) {
             let _ = disk.save(root, file_paths, &graph, &entities);
+            timings.mark("cache_full_save");
         }
     }
 
     (graph, entities)
+}
+
+pub fn get_or_build_graph_topology_with_timings(
+    root: &Path,
+    file_paths: &[String],
+    registry: &ParserRegistry,
+    no_cache: bool,
+    timings: &mut Timings,
+) -> EntityGraph {
+    if !no_cache {
+        if let Ok(disk) = DiskCache::open(root) {
+            timings.mark("cache_open");
+            if let Some(graph) = disk.load_graph_topology(root, file_paths) {
+                timings.mark("cache_topology_load");
+                return graph;
+            }
+        }
+    }
+
+    let (graph, _entities) =
+        get_or_build_graph_with_timings(root, file_paths, registry, no_cache, timings);
+    graph
 }

--- a/crates/sem-cli/src/commands/impact.rs
+++ b/crates/sem-cli/src/commands/impact.rs
@@ -4,6 +4,8 @@ use colored::Colorize;
 use sem_core::git::bridge::GitBridge;
 use sem_core::parser::graph::EntityGraph;
 
+use crate::timings::Timings;
+
 pub struct ImpactOptions {
     pub cwd: String,
     pub entity_name: Option<String>,
@@ -25,6 +27,7 @@ pub enum ImpactMode {
 }
 
 pub fn impact_command(opts: ImpactOptions) {
+    let mut timings = Timings::from_env("impact");
     let root = match GitBridge::open(Path::new(&opts.cwd)) {
         Ok(git) => git.repo_root().to_path_buf(),
         Err(_) => Path::new(&opts.cwd).to_path_buf(),
@@ -39,25 +42,60 @@ pub fn impact_command(opts: ImpactOptions) {
         &ext_filter,
         opts.no_default_excludes,
     );
-    let (graph, all_entities) = super::graph::get_or_build_graph(root, &file_paths, &registry, opts.no_cache);
+    timings.mark("file_discovery");
 
     let file_hint = opts
         .file_hint
         .as_deref()
         .map(|file| super::normalize_repo_relative_path(Path::new(&opts.cwd), root, file));
-    let entity = find_entity(
-        &graph,
-        opts.entity_name.as_deref(),
-        opts.entity_id.as_deref(),
-        file_hint.as_deref(),
-    );
 
     match opts.mode {
-        ImpactMode::Deps => print_deps(&graph, entity, opts.json),
-        ImpactMode::Dependents => print_dependents(&graph, entity, opts.json),
-        ImpactMode::Tests => print_tests(&graph, entity, &all_entities, opts.json),
-        ImpactMode::All => print_all(&graph, entity, &all_entities, opts.json, opts.depth),
+        ImpactMode::Deps | ImpactMode::Dependents => {
+            let graph = super::graph::get_or_build_graph_topology_with_timings(
+                root,
+                &file_paths,
+                &registry,
+                opts.no_cache,
+                &mut timings,
+            );
+            let entity = find_entity(
+                &graph,
+                opts.entity_name.as_deref(),
+                opts.entity_id.as_deref(),
+                file_hint.as_deref(),
+            );
+            timings.mark("entity_lookup");
+            match opts.mode {
+                ImpactMode::Deps => print_deps(&graph, entity, opts.json),
+                ImpactMode::Dependents => print_dependents(&graph, entity, opts.json),
+                _ => unreachable!(),
+            }
+            timings.mark("cli_output_serialization");
+        }
+        ImpactMode::Tests | ImpactMode::All => {
+            let (graph, all_entities) = super::graph::get_or_build_graph_with_timings(
+                root,
+                &file_paths,
+                &registry,
+                opts.no_cache,
+                &mut timings,
+            );
+            let entity = find_entity(
+                &graph,
+                opts.entity_name.as_deref(),
+                opts.entity_id.as_deref(),
+                file_hint.as_deref(),
+            );
+            timings.mark("entity_lookup");
+            match opts.mode {
+                ImpactMode::Tests => print_tests(&graph, entity, &all_entities, opts.json),
+                ImpactMode::All => print_all(&graph, entity, &all_entities, opts.json, opts.depth),
+                _ => unreachable!(),
+            }
+            timings.mark("cli_output_serialization");
+        }
     }
+    timings.finish();
 }
 
 fn find_entity<'a>(
@@ -76,7 +114,10 @@ fn find_entity<'a>(
     }
 
     let name = name.unwrap_or_else(|| {
-        eprintln!("{} Either entity name or --entity-id is required", "error:".red().bold());
+        eprintln!(
+            "{} Either entity name or --entity-id is required",
+            "error:".red().bold()
+        );
         std::process::exit(1);
     });
 
@@ -92,12 +133,21 @@ fn find_entity<'a>(
     }
 
     if let Some(file) = file_hint {
-        let filtered: Vec<_> = matching.iter().filter(|e| e.file_path == file).copied().collect();
+        let filtered: Vec<_> = matching
+            .iter()
+            .filter(|e| e.file_path == file)
+            .copied()
+            .collect();
         if filtered.len() == 1 {
             return filtered[0];
         }
         if filtered.is_empty() {
-            eprintln!("{} Entity '{}' not found in file '{}'", "error:".red().bold(), name, file);
+            eprintln!(
+                "{} Entity '{}' not found in file '{}'",
+                "error:".red().bold(),
+                name,
+                file
+            );
             std::process::exit(1);
         }
         // Multiple matches even within the file — fall through to ambiguity error
@@ -110,7 +160,12 @@ fn find_entity<'a>(
 
     // Multiple matches — report ambiguity
     matching.sort_by_key(|e| (&e.file_path, e.start_line));
-    eprintln!("{} Entity name '{}' is ambiguous ({} matches). Specify --file or --entity-id:", "error:".red().bold(), name, matching.len());
+    eprintln!(
+        "{} Entity name '{}' is ambiguous ({} matches). Specify --file or --entity-id:",
+        "error:".red().bold(),
+        name,
+        matching.len()
+    );
     for m in &matching {
         eprintln!(
             "  {} {} ({}:L{})",
@@ -264,11 +319,16 @@ fn print_all(
     let tests = graph.test_impact(&entity.id, all_entities);
 
     if json {
-        let impact_entities: Vec<serde_json::Value> = impact_bounded.iter().map(|(e, d)| {
-            let mut v = entity_json(e);
-            v.as_object_mut().unwrap().insert("depth".to_string(), serde_json::json!(d));
-            v
-        }).collect();
+        let impact_entities: Vec<serde_json::Value> = impact_bounded
+            .iter()
+            .map(|(e, d)| {
+                let mut v = entity_json(e);
+                v.as_object_mut()
+                    .unwrap()
+                    .insert("depth".to_string(), serde_json::json!(d));
+                v
+            })
+            .collect();
         let output = serde_json::json!({
             "entity": entity_json(entity),
             "dependencies": entity_list_json(&deps),
@@ -317,23 +377,41 @@ fn print_all(
             println!(
                 "\n  {} {}",
                 "✓".green().bold(),
-                "No other entities are affected by changes to this entity."
-                    .dimmed()
+                "No other entities are affected by changes to this entity.".dimmed()
             );
         } else {
             let max_depth_seen = impact_bounded.iter().map(|(_, d)| *d).max().unwrap_or(0);
-            let depth_label = if depth == 0 { "unlimited".to_string() } else { format!("depth {}", depth) };
+            let depth_label = if depth == 0 {
+                "unlimited".to_string()
+            } else {
+                format!("depth {}", depth)
+            };
             println!(
                 "\n  {} {}",
                 "!".red().bold(),
-                format!("{} entities transitively affected ({}):", impact_bounded.len(), depth_label).red(),
+                format!(
+                    "{} entities transitively affected ({}):",
+                    impact_bounded.len(),
+                    depth_label
+                )
+                .red(),
             );
 
             for d in 1..=max_depth_seen {
-                let at_depth: Vec<_> = impact_bounded.iter().filter(|(_, dd)| *dd == d).map(|(e, _)| *e).collect();
-                if at_depth.is_empty() { continue; }
+                let at_depth: Vec<_> = impact_bounded
+                    .iter()
+                    .filter(|(_, dd)| *dd == d)
+                    .map(|(e, _)| *e)
+                    .collect();
+                if at_depth.is_empty() {
+                    continue;
+                }
 
-                let label = if d == 1 { "Direct dependents".to_string() } else { format!("Depth {}", d) };
+                let label = if d == 1 {
+                    "Direct dependents".to_string()
+                } else {
+                    format!("Depth {}", d)
+                };
                 println!("\n    {} ({})", label.bold(), at_depth.len());
                 for imp in &at_depth {
                     println!(

--- a/crates/sem-cli/src/formatters/markdown.rs
+++ b/crates/sem-cli/src/formatters/markdown.rs
@@ -1,4 +1,4 @@
-use super::orphan_summary_parts;
+use super::{estimated_output_capacity, orphan_summary_parts, push_line};
 use sem_core::model::change::ChangeType;
 use sem_core::parser::differ::{BinaryFileChange, DiffResult};
 use similar::{ChangeTag, TextDiff};
@@ -22,7 +22,7 @@ fn longest_backtick_run(input: &str) -> usize {
     longest
 }
 
-fn push_diff_block(lines: &mut Vec<String>, diff_lines: Vec<String>) {
+fn push_diff_block(output: &mut String, diff_lines: Vec<String>) {
     let fence_len = diff_lines
         .iter()
         .map(|line| longest_backtick_run(line))
@@ -32,9 +32,11 @@ fn push_diff_block(lines: &mut Vec<String>, diff_lines: Vec<String>) {
         .max(3);
     let fence = "`".repeat(fence_len);
 
-    lines.push(format!("{fence}diff"));
-    lines.extend(diff_lines);
-    lines.push(fence);
+    push_line(output, format!("{fence}diff"));
+    for line in diff_lines {
+        push_line(output, line);
+    }
+    push_line(output, fence);
 }
 
 pub fn format_markdown(
@@ -46,7 +48,8 @@ pub fn format_markdown(
         return "No semantic changes detected.".to_string();
     }
 
-    let mut lines: Vec<String> = Vec::new();
+    let mut output =
+        String::with_capacity(estimated_output_capacity(result, binary_changes, verbose));
 
     // Group changes by file (BTreeMap for sorted output)
     let mut by_file: BTreeMap<&str, (Vec<usize>, Vec<usize>)> = BTreeMap::new();
@@ -58,20 +61,23 @@ pub fn format_markdown(
     }
 
     for (file_path, (indices, binary_indices)) in &by_file {
-        lines.push(format!("### {file_path}"));
-        lines.push(String::new());
-        lines.push("| Status | Type | Name |".to_string());
-        lines.push("|--------|------|------|".to_string());
+        push_line(&mut output, format!("### {file_path}"));
+        push_line(&mut output, "");
+        push_line(&mut output, "| Status | Type | Name |");
+        push_line(&mut output, "|--------|------|------|");
 
-        let mut post_table: Vec<String> = Vec::new();
+        let mut post_table = String::new();
 
         for &idx in binary_indices {
             let change = &binary_changes[idx];
-            lines.push(format!(
-                "| B | file | {} `[binary {}]` |",
-                binary_display_name(change),
-                change.status,
-            ));
+            push_line(
+                &mut output,
+                format!(
+                    "| B | file | {} `[binary {}]` |",
+                    binary_display_name(change),
+                    change.status,
+                ),
+            );
         }
 
         for &idx in indices {
@@ -99,18 +105,18 @@ pub fn format_markdown(
             } else {
                 change.entity_name.clone()
             };
-            lines.push(format!(
-                "| {} | {} | {} |",
-                status, change.entity_type, name_display
-            ));
+            push_line(
+                &mut output,
+                format!("| {} | {} | {} |", status, change.entity_type, name_display),
+            );
 
             // Show content diff
             if verbose {
                 match change.change_type {
                     ChangeType::Added => {
                         if let Some(ref content) = change.after_content {
-                            post_table.push(String::new());
-                            post_table.push(format!("**`{}`**", change.entity_name));
+                            push_line(&mut post_table, "");
+                            push_line(&mut post_table, format!("**`{}`**", change.entity_name));
                             push_diff_block(
                                 &mut post_table,
                                 content.lines().map(|line| format!("+ {line}")).collect(),
@@ -119,8 +125,8 @@ pub fn format_markdown(
                     }
                     ChangeType::Deleted => {
                         if let Some(ref content) = change.before_content {
-                            post_table.push(String::new());
-                            post_table.push(format!("**`{}`**", change.entity_name));
+                            push_line(&mut post_table, "");
+                            push_line(&mut post_table, format!("**`{}`**", change.entity_name));
                             push_diff_block(
                                 &mut post_table,
                                 content.lines().map(|line| format!("- {line}")).collect(),
@@ -131,8 +137,8 @@ pub fn format_markdown(
                         if let (Some(before), Some(after)) =
                             (&change.before_content, &change.after_content)
                         {
-                            post_table.push(String::new());
-                            post_table.push(format!("**`{}`**", change.entity_name));
+                            push_line(&mut post_table, "");
+                            push_line(&mut post_table, format!("**`{}`**", change.entity_name));
                             let mut diff_lines = Vec::new();
                             let diff = TextDiff::from_lines(before.as_str(), after.as_str());
                             for hunk in diff.unified_diff().context_radius(2).iter_hunks() {
@@ -173,16 +179,16 @@ pub fn format_markdown(
             } else if change.change_type == ChangeType::Modified {
                 if let (Some(before), Some(after)) = (&change.before_content, &change.after_content)
                 {
-                    let before_lines: Vec<&str> = before.lines().collect();
-                    let after_lines: Vec<&str> = after.lines().collect();
+                    let before_line_count = before.lines().count();
+                    let after_line_count = after.lines().count();
 
-                    if before_lines.len() <= 3 && after_lines.len() <= 3 {
-                        post_table.push(String::new());
-                        post_table.push(format!("**`{}`**", change.entity_name));
-                        let diff_lines = before_lines
-                            .iter()
+                    if before_line_count <= 3 && after_line_count <= 3 {
+                        push_line(&mut post_table, "");
+                        push_line(&mut post_table, format!("**`{}`**", change.entity_name));
+                        let diff_lines = before
+                            .lines()
                             .map(|line| format!("- {}", line.trim()))
-                            .chain(after_lines.iter().map(|line| format!("+ {}", line.trim())))
+                            .chain(after.lines().map(|line| format!("+ {}", line.trim())))
                             .collect();
                         push_diff_block(&mut post_table, diff_lines);
                     }
@@ -192,18 +198,21 @@ pub fn format_markdown(
             // Show rename/move details
             if matches!(change.change_type, ChangeType::Renamed | ChangeType::Moved) {
                 if let Some(ref old_path) = change.old_file_path {
-                    post_table.push(String::new());
-                    post_table.push(format!("> from {old_path}"));
+                    push_line(&mut post_table, "");
+                    push_line(&mut post_table, format!("> from {old_path}"));
                 } else if let Some(ref old_parent) = change.old_parent_id {
                     let parent_name = old_parent.rsplit("::").next().unwrap_or(old_parent);
-                    post_table.push(String::new());
-                    post_table.push(format!("> moved from {parent_name}"));
+                    push_line(&mut post_table, "");
+                    push_line(&mut post_table, format!("> moved from {parent_name}"));
                 }
             }
         }
 
-        lines.extend(post_table);
-        lines.push(String::new());
+        if !post_table.is_empty() {
+            push_line(&mut output, "");
+            push_line(&mut output, post_table);
+        }
+        push_line(&mut output, "");
     }
 
     // Summary
@@ -243,14 +252,17 @@ pub fn format_markdown(
         format!(" ({})", orphan_parts.join(", "))
     };
 
-    lines.push(format!(
-        "**Summary:** {} across {} {files_label}{}",
-        parts.join(", "),
-        reported_file_count,
-        orphan_suffix,
-    ));
+    push_line(
+        &mut output,
+        format!(
+            "**Summary:** {} across {} {files_label}{}",
+            parts.join(", "),
+            reported_file_count,
+            orphan_suffix,
+        ),
+    );
 
-    lines.join("\n")
+    output
 }
 
 #[cfg(test)]

--- a/crates/sem-cli/src/formatters/mod.rs
+++ b/crates/sem-cli/src/formatters/mod.rs
@@ -26,6 +26,34 @@ pub(crate) fn file_count(result: &DiffResult, binary_changes: &[BinaryFileChange
     result.file_count + binary_changes.len()
 }
 
+pub(crate) fn estimated_output_capacity(
+    result: &DiffResult,
+    binary_changes: &[BinaryFileChange],
+    verbose: bool,
+) -> usize {
+    let content_len = if verbose {
+        result
+            .changes
+            .iter()
+            .map(|change| {
+                change.before_content.as_ref().map_or(0, String::len)
+                    + change.after_content.as_ref().map_or(0, String::len)
+            })
+            .sum()
+    } else {
+        0
+    };
+
+    256 + content_len + result.changes.len() * 160 + binary_changes.len() * 96
+}
+
+pub(crate) fn push_line(output: &mut String, line: impl AsRef<str>) {
+    if !output.is_empty() {
+        output.push('\n');
+    }
+    output.push_str(line.as_ref());
+}
+
 pub(crate) fn orphan_summary_parts(result: &DiffResult) -> Vec<String> {
     let mut added = 0;
     let mut modified = 0;

--- a/crates/sem-cli/src/formatters/plain.rs
+++ b/crates/sem-cli/src/formatters/plain.rs
@@ -1,4 +1,4 @@
-use super::orphan_summary_parts;
+use super::{estimated_output_capacity, orphan_summary_parts, push_line};
 use colored::Colorize;
 use sem_core::model::change::ChangeType;
 use sem_core::parser::differ::{BinaryFileChange, DiffResult};
@@ -11,7 +11,8 @@ pub fn format_plain(result: &DiffResult, binary_changes: &[BinaryFileChange]) ->
         return "No semantic changes detected.".to_string();
     }
 
-    let mut lines: Vec<String> = Vec::new();
+    let mut output =
+        String::with_capacity(estimated_output_capacity(result, binary_changes, false));
 
     // Group changes by file (BTreeMap for sorted output)
     let mut by_file: BTreeMap<&str, (Vec<usize>, Vec<usize>)> = BTreeMap::new();
@@ -23,20 +24,23 @@ pub fn format_plain(result: &DiffResult, binary_changes: &[BinaryFileChange]) ->
     }
 
     for (file_path, (indices, binary_indices)) in &by_file {
-        lines.push(file_path.bold().to_string());
+        push_line(&mut output, file_path.bold().to_string());
 
         for &idx in binary_indices {
             let change = &binary_changes[idx];
             let letter = "B".yellow().to_string();
             let type_label = format!("{:<12}", "file");
             let name_display = binary_display_name(change);
-            lines.push(format!(
-                "  {}  {}{} {}",
-                letter,
-                type_label.dimmed(),
-                name_display,
-                format!("[binary {}]", change.status).yellow(),
-            ));
+            push_line(
+                &mut output,
+                format!(
+                    "  {}  {}{} {}",
+                    letter,
+                    type_label.dimmed(),
+                    name_display,
+                    format!("[binary {}]", change.status).yellow(),
+                ),
+            );
         }
 
         for &idx in indices {
@@ -59,27 +63,28 @@ pub fn format_plain(result: &DiffResult, binary_changes: &[BinaryFileChange]) ->
             } else {
                 change.entity_name.clone()
             };
-            lines.push(format!(
-                "  {}  {}{}",
-                letter,
-                type_label.dimmed(),
-                name_display,
-            ));
+            push_line(
+                &mut output,
+                format!("  {}  {}{}", letter, type_label.dimmed(), name_display),
+            );
 
             if matches!(change.change_type, ChangeType::Renamed | ChangeType::Moved) {
                 if let Some(ref old_path) = change.old_file_path {
-                    lines.push(format!("       {}", format!("from {old_path}").dimmed()));
+                    push_line(
+                        &mut output,
+                        format!("       {}", format!("from {old_path}").dimmed()),
+                    );
                 } else if let Some(ref old_parent) = change.old_parent_id {
                     let parent_name = old_parent.rsplit("::").next().unwrap_or(old_parent);
-                    lines.push(format!(
-                        "       {}",
-                        format!("moved from {parent_name}").dimmed()
-                    ));
+                    push_line(
+                        &mut output,
+                        format!("       {}", format!("moved from {parent_name}").dimmed()),
+                    );
                 }
             }
         }
 
-        lines.push(String::new());
+        push_line(&mut output, "");
     }
 
     // Summary
@@ -119,7 +124,11 @@ pub fn format_plain(result: &DiffResult, binary_changes: &[BinaryFileChange]) ->
         );
     }
     if !binary_changes.is_empty() {
-        parts.push(format!("{} binary", binary_changes.len()).yellow().to_string());
+        parts.push(
+            format!("{} binary", binary_changes.len())
+                .yellow()
+                .to_string(),
+        );
     }
 
     let reported_file_count = file_count(result, binary_changes);
@@ -136,12 +145,15 @@ pub fn format_plain(result: &DiffResult, binary_changes: &[BinaryFileChange]) ->
             .dimmed()
             .to_string()
     };
-    lines.push(format!(
-        "{} across {} {files_label}{}",
-        parts.join(", "),
-        reported_file_count,
-        orphan_suffix,
-    ));
+    push_line(
+        &mut output,
+        format!(
+            "{} across {} {files_label}{}",
+            parts.join(", "),
+            reported_file_count,
+            orphan_suffix,
+        ),
+    );
 
-    lines.join("\n")
+    output
 }

--- a/crates/sem-cli/src/formatters/terminal.rs
+++ b/crates/sem-cli/src/formatters/terminal.rs
@@ -1,4 +1,4 @@
-use super::orphan_summary_parts;
+use super::{estimated_output_capacity, orphan_summary_parts, push_line};
 use colored::Colorize;
 use sem_core::model::change::ChangeType;
 use sem_core::parser::differ::{BinaryFileChange, DiffResult};
@@ -58,7 +58,8 @@ pub fn format_terminal(
         return "No semantic changes detected.".dimmed().to_string();
     }
 
-    let mut lines: Vec<String> = Vec::new();
+    let mut output =
+        String::with_capacity(estimated_output_capacity(result, binary_changes, verbose));
 
     // Group changes by file (BTreeMap for sorted output)
     let mut by_file: BTreeMap<&str, (Vec<usize>, Vec<usize>)> = BTreeMap::new();
@@ -82,12 +83,13 @@ pub fn format_terminal(
 
         let header = format!("─ {} ", sanitize_terminal_text(file_path));
         let pad_len = 55usize.saturating_sub(header.len());
-        lines.push(
+        push_line(
+            &mut output,
             format!("┌{header}{}", "─".repeat(pad_len))
                 .dimmed()
                 .to_string(),
         );
-        lines.push("│".dimmed().to_string());
+        push_line(&mut output, "│".dimmed().to_string());
 
         for &idx in binary_indices {
             let change = &binary_changes[idx];
@@ -96,14 +98,17 @@ pub fn format_terminal(
             let type_label = format!("{:<10}", "file");
             let name_label = format!("{:<25}", binary_display_name(change));
 
-            lines.push(format!(
-                "{}  {} {} {} {}",
-                "│".dimmed(),
-                symbol,
-                type_label.dimmed(),
-                name_label.bold(),
-                tag,
-            ));
+            push_line(
+                &mut output,
+                format!(
+                    "{}  {} {} {} {}",
+                    "│".dimmed(),
+                    symbol,
+                    type_label.dimmed(),
+                    name_label.bold(),
+                    tag,
+                ),
+            );
         }
 
         for &idx in indices {
@@ -164,14 +169,17 @@ pub fn format_terminal(
             };
             let name_label = format!("{:<25}", display_name);
 
-            lines.push(format!(
-                "{}  {} {} {} {}",
-                "│".dimmed(),
-                symbol,
-                type_label.dimmed(),
-                name_label.bold(),
-                tag,
-            ));
+            push_line(
+                &mut output,
+                format!(
+                    "{}  {} {} {} {}",
+                    "│".dimmed(),
+                    symbol,
+                    type_label.dimmed(),
+                    name_label.bold(),
+                    tag,
+                ),
+            );
 
             // Show content diff
             if verbose {
@@ -180,11 +188,10 @@ pub fn format_terminal(
                         if let Some(ref content) = change.after_content {
                             for line in content.lines() {
                                 let line = sanitize_terminal_text(line);
-                                lines.push(format!(
-                                    "{}    {}",
-                                    "│".dimmed(),
-                                    format!("+ {line}").green(),
-                                ));
+                                push_line(
+                                    &mut output,
+                                    format!("{}    {}", "│".dimmed(), format!("+ {line}").green()),
+                                );
                             }
                         }
                     }
@@ -192,11 +199,10 @@ pub fn format_terminal(
                         if let Some(ref content) = change.before_content {
                             for line in content.lines() {
                                 let line = sanitize_terminal_text(line);
-                                lines.push(format!(
-                                    "{}    {}",
-                                    "│".dimmed(),
-                                    format!("- {line}").red(),
-                                ));
+                                push_line(
+                                    &mut output,
+                                    format!("{}    {}", "│".dimmed(), format!("- {line}").red()),
+                                );
                             }
                         }
                     }
@@ -206,11 +212,14 @@ pub fn format_terminal(
                         {
                             let diff = TextDiff::from_lines(before.as_str(), after.as_str());
                             for hunk in diff.unified_diff().context_radius(2).iter_hunks() {
-                                lines.push(format!(
-                                    "{}    {}",
-                                    "│".dimmed(),
-                                    format!("{}", hunk.header()).dimmed(),
-                                ));
+                                push_line(
+                                    &mut output,
+                                    format!(
+                                        "{}    {}",
+                                        "│".dimmed(),
+                                        format!("{}", hunk.header()).dimmed(),
+                                    ),
+                                );
                                 for op in hunk.ops() {
                                     let mut deletes: Vec<String> = Vec::new();
                                     let mut inserts: Vec<String> = Vec::new();
@@ -223,11 +232,14 @@ pub fn format_terminal(
                                             ChangeTag::Delete => deletes.push(line),
                                             ChangeTag::Insert => inserts.push(line),
                                             ChangeTag::Equal => {
-                                                lines.push(format!(
-                                                    "{}    {}",
-                                                    "│".dimmed(),
-                                                    format!("  {line}").dimmed(),
-                                                ));
+                                                push_line(
+                                                    &mut output,
+                                                    format!(
+                                                        "{}    {}",
+                                                        "│".dimmed(),
+                                                        format!("  {line}").dimmed(),
+                                                    ),
+                                                );
                                             }
                                         }
                                     }
@@ -236,32 +248,34 @@ pub fn format_terminal(
                                     for i in 0..paired {
                                         let (del, ins) =
                                             render_inline_diff(&deletes[i], &inserts[i]);
-                                        lines.push(format!(
-                                            "{}    {} {}",
-                                            "│".dimmed(),
-                                            "-".red(),
-                                            del,
-                                        ));
-                                        lines.push(format!(
-                                            "{}    {} {}",
-                                            "│".dimmed(),
-                                            "+".green(),
-                                            ins,
-                                        ));
+                                        push_line(
+                                            &mut output,
+                                            format!("{}    {} {}", "│".dimmed(), "-".red(), del),
+                                        );
+                                        push_line(
+                                            &mut output,
+                                            format!("{}    {} {}", "│".dimmed(), "+".green(), ins),
+                                        );
                                     }
                                     for d in &deletes[paired..] {
-                                        lines.push(format!(
-                                            "{}    {}",
-                                            "│".dimmed(),
-                                            format!("- {d}").red(),
-                                        ));
+                                        push_line(
+                                            &mut output,
+                                            format!(
+                                                "{}    {}",
+                                                "│".dimmed(),
+                                                format!("- {d}").red()
+                                            ),
+                                        );
                                     }
                                     for i in &inserts[paired..] {
-                                        lines.push(format!(
-                                            "{}    {}",
-                                            "│".dimmed(),
-                                            format!("+ {i}").green(),
-                                        ));
+                                        push_line(
+                                            &mut output,
+                                            format!(
+                                                "{}    {}",
+                                                "│".dimmed(),
+                                                format!("+ {i}").green()
+                                            ),
+                                        );
                                     }
                                 }
                             }
@@ -272,25 +286,23 @@ pub fn format_terminal(
             } else if change.change_type == ChangeType::Modified {
                 if let (Some(before), Some(after)) = (&change.before_content, &change.after_content)
                 {
-                    let before_lines: Vec<&str> = before.lines().collect();
-                    let after_lines: Vec<&str> = after.lines().collect();
+                    let before_line_count = before.lines().count();
+                    let after_line_count = after.lines().count();
 
-                    if before_lines.len() <= 3 && after_lines.len() <= 3 {
-                        for line in &before_lines {
+                    if before_line_count <= 3 && after_line_count <= 3 {
+                        for line in before.lines() {
                             let line = sanitize_terminal_text(line.trim());
-                            lines.push(format!(
-                                "{}    {}",
-                                "│".dimmed(),
-                                format!("- {line}").red(),
-                            ));
+                            push_line(
+                                &mut output,
+                                format!("{}    {}", "│".dimmed(), format!("- {line}").red()),
+                            );
                         }
-                        for line in &after_lines {
+                        for line in after.lines() {
                             let line = sanitize_terminal_text(line.trim());
-                            lines.push(format!(
-                                "{}    {}",
-                                "│".dimmed(),
-                                format!("+ {line}").green(),
-                            ));
+                            push_line(
+                                &mut output,
+                                format!("{}    {}", "│".dimmed(), format!("+ {line}").green()),
+                            );
                         }
                     }
                 }
@@ -299,26 +311,35 @@ pub fn format_terminal(
             // Show rename/move details
             if matches!(change.change_type, ChangeType::Renamed | ChangeType::Moved) {
                 if let Some(ref old_path) = change.old_file_path {
-                    lines.push(format!(
-                        "{}    {}",
-                        "│".dimmed(),
-                        format!("from {}", sanitize_terminal_text(old_path)).dimmed(),
-                    ));
+                    push_line(
+                        &mut output,
+                        format!(
+                            "{}    {}",
+                            "│".dimmed(),
+                            format!("from {}", sanitize_terminal_text(old_path)).dimmed(),
+                        ),
+                    );
                 } else if let Some(ref old_parent) = change.old_parent_id {
                     // Intra-file move: extract parent name from entity ID
                     let parent_name = old_parent.rsplit("::").next().unwrap_or(old_parent);
-                    lines.push(format!(
-                        "{}    {}",
-                        "│".dimmed(),
-                        format!("moved from {}", sanitize_terminal_text(parent_name)).dimmed(),
-                    ));
+                    push_line(
+                        &mut output,
+                        format!(
+                            "{}    {}",
+                            "│".dimmed(),
+                            format!("moved from {}", sanitize_terminal_text(parent_name)).dimmed(),
+                        ),
+                    );
                 }
             }
         }
 
-        lines.push("│".dimmed().to_string());
-        lines.push(format!("└{}", "─".repeat(55)).dimmed().to_string());
-        lines.push(String::new());
+        push_line(&mut output, "│".dimmed().to_string());
+        push_line(
+            &mut output,
+            format!("└{}", "─".repeat(55)).dimmed().to_string(),
+        );
+        push_line(&mut output, "");
     }
 
     // Summary
@@ -358,7 +379,11 @@ pub fn format_terminal(
         );
     }
     if !binary_changes.is_empty() {
-        parts.push(format!("{} binary", binary_changes.len()).yellow().to_string());
+        parts.push(
+            format!("{} binary", binary_changes.len())
+                .yellow()
+                .to_string(),
+        );
     }
 
     let reported_file_count = file_count(result, binary_changes);
@@ -376,12 +401,15 @@ pub fn format_terminal(
             .to_string()
     };
 
-    lines.push(format!(
-        "Summary: {} across {} {files_label}{}",
-        parts.join(", "),
-        reported_file_count,
-        orphan_suffix,
-    ));
+    push_line(
+        &mut output,
+        format!(
+            "Summary: {} across {} {files_label}{}",
+            parts.join(", "),
+            reported_file_count,
+            orphan_suffix,
+        ),
+    );
 
     // Show noise-filtered line when entities were analyzed
     let entities_analyzed = result
@@ -396,7 +424,8 @@ pub fn format_terminal(
         + binary_changes.len();
     if entities_analyzed > changes_detected {
         let noise = entities_analyzed - changes_detected;
-        lines.push(
+        push_line(
+            &mut output,
             format!(
                 "Analyzed {} entities, {} unchanged filtered out",
                 entities_analyzed, noise
@@ -416,8 +445,9 @@ pub fn format_terminal(
         .into_iter()
         .collect();
     if !chunk_files.is_empty() {
-        lines.push(String::new());
-        lines.push(
+        push_line(&mut output, "");
+        push_line(
+            &mut output,
             format!(
                 "Warning: {} used line-based chunking (unsupported file extension).",
                 chunk_files.join(", ")
@@ -425,14 +455,15 @@ pub fn format_terminal(
             .yellow()
             .to_string(),
         );
-        lines.push(
+        push_line(
+            &mut output,
             "If this language should be supported, open an issue: https://github.com/Ataraxy-Labs/sem/issues"
                 .dimmed()
                 .to_string(),
         );
     }
 
-    lines.join("\n")
+    output
 }
 
 #[cfg(test)]

--- a/crates/sem-cli/src/main.rs
+++ b/crates/sem-cli/src/main.rs
@@ -2,6 +2,7 @@ mod cache;
 mod commands;
 mod formatters;
 mod stats;
+mod timings;
 
 use clap::CommandFactory;
 use clap::{Parser, Subcommand, ValueEnum};

--- a/crates/sem-cli/src/timings.rs
+++ b/crates/sem-cli/src/timings.rs
@@ -1,0 +1,90 @@
+use std::time::Instant;
+
+pub struct Timings {
+    command: &'static str,
+    enabled: bool,
+    json: bool,
+    start: Instant,
+    last: Instant,
+    entries: Vec<TimingEntry>,
+}
+
+struct TimingEntry {
+    name: &'static str,
+    duration_ms: f64,
+}
+
+impl Timings {
+    pub fn from_env(command: &'static str) -> Self {
+        let value = std::env::var("SEM_TIMINGS").unwrap_or_default();
+        let enabled = !matches!(value.as_str(), "" | "0" | "false" | "off");
+        let now = Instant::now();
+        Self {
+            command,
+            enabled,
+            json: value == "json",
+            start: now,
+            last: now,
+            entries: Vec::new(),
+        }
+    }
+
+    pub fn disabled(command: &'static str) -> Self {
+        let now = Instant::now();
+        Self {
+            command,
+            enabled: false,
+            json: false,
+            start: now,
+            last: now,
+            entries: Vec::new(),
+        }
+    }
+
+    pub fn mark(&mut self, name: &'static str) {
+        if !self.enabled {
+            return;
+        }
+        let now = Instant::now();
+        self.entries.push(TimingEntry {
+            name,
+            duration_ms: elapsed_ms(now.duration_since(self.last)),
+        });
+        self.last = now;
+    }
+
+    pub fn finish(&self) {
+        if !self.enabled {
+            return;
+        }
+        let total_ms = elapsed_ms(self.start.elapsed());
+        if self.json {
+            let phases = self
+                .entries
+                .iter()
+                .map(|entry| {
+                    serde_json::json!({
+                        "name": entry.name,
+                        "durationMs": entry.duration_ms,
+                    })
+                })
+                .collect::<Vec<_>>();
+            let output = serde_json::json!({
+                "command": self.command,
+                "phases": phases,
+                "totalMs": total_ms,
+            });
+            eprintln!("{}", serde_json::to_string(&output).unwrap());
+        } else {
+            eprintln!("sem timings ({})", self.command);
+            for entry in &self.entries {
+                eprintln!("  {:<32} {:>8.3} ms", entry.name, entry.duration_ms);
+            }
+            eprintln!("  {:<32} {:>8.3} ms", "total", total_ms);
+        }
+    }
+}
+
+fn elapsed_ms(duration: std::time::Duration) -> f64 {
+    duration.as_secs_f64() * 1000.0
+}

--- a/crates/sem-cli/tests/diff_patch.rs
+++ b/crates/sem-cli/tests/diff_patch.rs
@@ -51,15 +51,24 @@ fn run_git(repo: &Path, args: &[&str]) -> Output {
     output
 }
 
-fn run_sem(args: &[&str], input: &[u8], cwd: Option<&Path>) -> Output {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_sem"))
+fn run_sem_with_path(
+    args: &[&str],
+    input: &[u8],
+    cwd: Option<&Path>,
+    path: Option<&Path>,
+) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_sem"));
+    command
         .args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .current_dir(cwd.unwrap_or_else(|| Path::new(".")))
-        .spawn()
-        .expect("spawn sem");
+        .current_dir(cwd.unwrap_or_else(|| Path::new(".")));
+    if let Some(path) = path {
+        command.env("PATH", path);
+    }
+
+    let mut child = command.spawn().expect("spawn sem");
 
     child
         .stdin
@@ -69,6 +78,10 @@ fn run_sem(args: &[&str], input: &[u8], cwd: Option<&Path>) -> Output {
         .expect("write stdin");
 
     child.wait_with_output().expect("wait for sem")
+}
+
+fn run_sem(args: &[&str], input: &[u8], cwd: Option<&Path>) -> Output {
+    run_sem_with_path(args, input, cwd, None)
 }
 
 fn run_diff_patch(input: &str) -> Output {
@@ -333,6 +346,60 @@ fn patch_mode_uses_hunks_when_new_blob_is_absent() {
     assert_eq!(changes[0]["filePath"].as_str(), Some("app.py"));
     assert_eq!(changes[0]["entityName"].as_str(), Some("foo"));
     assert_eq!(changes[0]["changeType"].as_str(), Some("modified"));
+}
+
+#[test]
+fn patch_mode_resolves_blobs_and_worktree_hash_without_git_executable() {
+    let repo = TempRepo::new();
+    std::fs::write(repo.path.join("app.py"), "def foo():\n    return 1\n")
+        .expect("write initial file");
+    run_git(&repo.path, &["add", "app.py"]);
+    run_git(&repo.path, &["commit", "-qm", "init"]);
+    let old_sha = run_git(&repo.path, &["rev-parse", "HEAD:app.py"]).stdout;
+    let old_sha = String::from_utf8(old_sha).expect("old sha should be utf8");
+
+    std::fs::write(repo.path.join("app.py"), "def foo():\n    return 2\n")
+        .expect("write changed file");
+    let new_sha = run_git(&repo.path, &["hash-object", "--", "app.py"]).stdout;
+    let new_sha = String::from_utf8(new_sha).expect("new sha should be utf8");
+    let patch = format!(
+        concat!(
+            "diff --git a/app.py b/app.py\n",
+            "old mode 100644\n",
+            "new mode 100755\n",
+            "index {}..{} 100644\n",
+        ),
+        old_sha.trim(),
+        new_sha.trim()
+    );
+
+    let empty_path = repo.path.join("empty-path");
+    std::fs::create_dir(&empty_path).expect("create empty PATH directory");
+    let output = run_sem_with_path(
+        &["diff", "--patch", "--json"],
+        patch.as_bytes(),
+        Some(&repo.path),
+        Some(&empty_path),
+    );
+    assert!(
+        output.status.success(),
+        "sem diff --patch --json failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!stderr.contains("could not resolve contents"), "{stderr}");
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be json");
+    let changes = json["changes"]
+        .as_array()
+        .expect("changes should be an array");
+    assert_eq!(changes.len(), 1);
+    assert_eq!(changes[0]["filePath"].as_str(), Some("app.py"));
+    assert_eq!(changes[0]["entityName"].as_str(), Some("foo"));
+    assert_eq!(changes[0]["changeType"].as_str(), Some("modified"));
+    assert_eq!(json["binaryChanges"].as_array().unwrap().len(), 0);
 }
 
 #[test]

--- a/crates/sem-core/src/format/json.rs
+++ b/crates/sem-core/src/format/json.rs
@@ -1,5 +1,154 @@
 use crate::parser::differ::{BinaryFileChange, DiffResult};
-use serde_json::{json, Value};
+use serde::ser::{Serialize, SerializeSeq, SerializeStruct, Serializer};
+use serde_json::Value;
+
+struct DiffJsonEnvelope<'a> {
+    result: &'a DiffResult,
+    binary_changes: &'a [BinaryFileChange],
+    include_binary_changes: bool,
+}
+
+impl Serialize for DiffJsonEnvelope<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let field_count = if self.include_binary_changes { 3 } else { 2 };
+        let mut fields = serializer.serialize_struct("DiffJsonEnvelope", field_count)?;
+        fields.serialize_field(
+            "summary",
+            &DiffJsonSummary {
+                result: self.result,
+                binary_count: self.binary_changes.len(),
+                include_binary_count: self.include_binary_changes,
+            },
+        )?;
+        fields.serialize_field("changes", &SemanticChangesJson(&self.result.changes))?;
+        if self.include_binary_changes {
+            fields.serialize_field("binaryChanges", &BinaryChangesJson(self.binary_changes))?;
+        }
+        fields.end()
+    }
+}
+
+struct DiffJsonSummary<'a> {
+    result: &'a DiffResult,
+    binary_count: usize,
+    include_binary_count: bool,
+}
+
+impl Serialize for DiffJsonSummary<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let field_count = if self.include_binary_count { 10 } else { 9 };
+        let mut fields = serializer.serialize_struct("DiffJsonSummary", field_count)?;
+        fields.serialize_field("fileCount", &(self.result.file_count + self.binary_count))?;
+        fields.serialize_field("added", &self.result.added_count)?;
+        fields.serialize_field("modified", &self.result.modified_count)?;
+        fields.serialize_field("deleted", &self.result.deleted_count)?;
+        fields.serialize_field("moved", &self.result.moved_count)?;
+        fields.serialize_field("renamed", &self.result.renamed_count)?;
+        fields.serialize_field("reordered", &self.result.reordered_count)?;
+        if self.include_binary_count {
+            fields.serialize_field("binary", &self.binary_count)?;
+        }
+        fields.serialize_field("orphan", &self.result.orphan_count)?;
+        fields.serialize_field("total", &(self.result.changes.len() + self.binary_count))?;
+        fields.end()
+    }
+}
+
+struct SemanticChangesJson<'a>(&'a [crate::model::change::SemanticChange]);
+
+impl Serialize for SemanticChangesJson<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for change in self.0 {
+            sequence.serialize_element(&SemanticChangeJson(change))?;
+        }
+        sequence.end()
+    }
+}
+
+struct SemanticChangeJson<'a>(&'a crate::model::change::SemanticChange);
+
+impl Serialize for SemanticChangeJson<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let change = self.0;
+        let mut fields = serializer.serialize_struct("SemanticChangeJson", 17)?;
+        fields.serialize_field("entityId", &change.entity_id)?;
+        fields.serialize_field("changeType", &change.change_type)?;
+        fields.serialize_field("entityType", &change.entity_type)?;
+        fields.serialize_field("entityName", &change.entity_name)?;
+        fields.serialize_field("startLine", &change.start_line)?;
+        fields.serialize_field("endLine", &change.end_line)?;
+        fields.serialize_field("oldStartLine", &change.old_start_line)?;
+        fields.serialize_field("oldEndLine", &change.old_end_line)?;
+        fields.serialize_field("oldEntityName", &change.old_entity_name)?;
+        fields.serialize_field("filePath", &change.file_path)?;
+        fields.serialize_field("oldFilePath", &change.old_file_path)?;
+        fields.serialize_field("oldParentId", &change.old_parent_id)?;
+        fields.serialize_field("beforeContent", &change.before_content)?;
+        fields.serialize_field("afterContent", &change.after_content)?;
+        fields.serialize_field("commitSha", &change.commit_sha)?;
+        fields.serialize_field("author", &change.author)?;
+        fields.serialize_field("structuralChange", &change.structural_change)?;
+        fields.end()
+    }
+}
+
+struct BinaryChangesJson<'a>(&'a [BinaryFileChange]);
+
+impl Serialize for BinaryChangesJson<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for change in self.0 {
+            sequence.serialize_element(&BinaryChangeJson(change))?;
+        }
+        sequence.end()
+    }
+}
+
+struct BinaryChangeJson<'a>(&'a BinaryFileChange);
+
+impl Serialize for BinaryChangeJson<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let change = self.0;
+        let mut fields = serializer.serialize_struct("BinaryChangeJson", 4)?;
+        fields.serialize_field("changeType", "binary")?;
+        fields.serialize_field("filePath", &change.file_path)?;
+        fields.serialize_field("oldFilePath", &change.old_file_path)?;
+        fields.serialize_field("fileStatus", &change.status)?;
+        fields.end()
+    }
+}
+
+fn estimate_json_capacity(result: &DiffResult, binary_changes: &[BinaryFileChange]) -> usize {
+    let content_len = result
+        .changes
+        .iter()
+        .map(|change| {
+            change.before_content.as_ref().map_or(0, String::len)
+                + change.after_content.as_ref().map_or(0, String::len)
+        })
+        .sum::<usize>();
+
+    256 + content_len + result.changes.len() * 256 + binary_changes.len() * 128
+}
 
 pub fn diff_json_value(result: &DiffResult) -> Value {
     diff_json_value_inner(result, &[], false)
@@ -17,95 +166,47 @@ fn diff_json_value_inner(
     binary_changes: &[BinaryFileChange],
     include_binary_changes: bool,
 ) -> Value {
-    let changes: Vec<Value> = result
-        .changes
-        .iter()
-        .map(|c| {
-            json!({
-                "entityId": c.entity_id,
-                "changeType": c.change_type,
-                "entityType": c.entity_type,
-                "entityName": c.entity_name,
-                "startLine": c.start_line,
-                "endLine": c.end_line,
-                "oldStartLine": c.old_start_line,
-                "oldEndLine": c.old_end_line,
-                "oldEntityName": c.old_entity_name,
-                "filePath": c.file_path,
-                "oldFilePath": c.old_file_path,
-                "oldParentId": c.old_parent_id,
-                "beforeContent": c.before_content,
-                "afterContent": c.after_content,
-                "commitSha": c.commit_sha,
-                "author": c.author,
-                "structuralChange": c.structural_change,
-            })
-        })
-        .collect();
-
-    if !include_binary_changes {
-        return json!({
-            "summary": {
-                "fileCount": result.file_count,
-                "added": result.added_count,
-                "modified": result.modified_count,
-                "deleted": result.deleted_count,
-                "moved": result.moved_count,
-                "renamed": result.renamed_count,
-                "reordered": result.reordered_count,
-                "orphan": result.orphan_count,
-                "total": result.changes.len(),
-            },
-            "changes": changes,
-        });
-    }
-
-    let binary_changes_json: Vec<Value> = binary_changes
-        .iter()
-        .map(|c| {
-            json!({
-                "changeType": "binary",
-                "filePath": c.file_path,
-                "oldFilePath": c.old_file_path,
-                "fileStatus": c.status,
-            })
-        })
-        .collect();
-
-    json!({
-        "summary": {
-            "fileCount": result.file_count + binary_changes.len(),
-            "added": result.added_count,
-            "modified": result.modified_count,
-            "deleted": result.deleted_count,
-            "moved": result.moved_count,
-            "renamed": result.renamed_count,
-            "reordered": result.reordered_count,
-            "binary": binary_changes.len(),
-            "orphan": result.orphan_count,
-            "total": result.changes.len() + binary_changes.len(),
-        },
-        "changes": changes,
-        "binaryChanges": binary_changes_json,
+    serde_json::to_value(DiffJsonEnvelope {
+        result,
+        binary_changes,
+        include_binary_changes,
     })
+    .unwrap_or(Value::Null)
+}
+
+fn format_diff_json_inner(
+    result: &DiffResult,
+    binary_changes: &[BinaryFileChange],
+    include_binary_changes: bool,
+) -> String {
+    let mut output = Vec::with_capacity(estimate_json_capacity(result, binary_changes));
+    let envelope = DiffJsonEnvelope {
+        result,
+        binary_changes,
+        include_binary_changes,
+    };
+    if serde_json::to_writer(&mut output, &envelope).is_err() {
+        return String::new();
+    }
+    String::from_utf8(output).unwrap_or_default()
 }
 
 pub fn format_diff_json(result: &DiffResult) -> String {
-    serde_json::to_string(&diff_json_value(result)).unwrap_or_default()
+    format_diff_json_inner(result, &[], false)
 }
 
 pub fn format_diff_json_with_binary_changes(
     result: &DiffResult,
     binary_changes: &[BinaryFileChange],
 ) -> String {
-    serde_json::to_string(&diff_json_value_with_binary_changes(result, binary_changes))
-        .unwrap_or_default()
+    format_diff_json_inner(result, binary_changes, true)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::model::change::{ChangeType, SemanticChange};
+    use serde_json::json;
 
     #[test]
     fn diff_json_value_preserves_public_schema() {
@@ -146,6 +247,9 @@ mod tests {
         };
 
         let value = diff_json_value(&result);
+        let formatted_value: Value =
+            serde_json::from_str(&format_diff_json(&result)).expect("format should be valid json");
+        assert_eq!(formatted_value, value);
 
         assert_eq!(
             value,
@@ -206,6 +310,12 @@ mod tests {
         }];
 
         let value = diff_json_value_with_binary_changes(&result, &binary_changes);
+        let formatted_value: Value = serde_json::from_str(&format_diff_json_with_binary_changes(
+            &result,
+            &binary_changes,
+        ))
+        .expect("format should be valid json");
+        assert_eq!(formatted_value, value);
 
         assert_eq!(
             value,

--- a/crates/sem-core/src/parser/graph.rs
+++ b/crates/sem-core/src/parser/graph.rs
@@ -10,7 +10,7 @@
 use std::collections::{HashMap, HashSet};
 use std::io::BufRead;
 use std::path::Path;
-use std::sync::{Arc, LazyLock};
+use std::sync::{Arc, LazyLock, Mutex, OnceLock};
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -35,7 +35,7 @@ use crate::git::types::{FileChange, FileStatus};
 use crate::model::entity::SemanticEntity;
 use crate::parser::import_resolution::{
     find_import_file, find_import_target, import_source_matches_file, is_js_ts_file,
-    sort_import_candidate_files, JS_TS_EXTENSIONS,
+    js_ts_named_exports_from_content, sort_import_candidate_files, JS_TS_EXTENSIONS,
 };
 use crate::parser::registry::{resolve_go_method_parent_ids, ParserRegistry};
 use crate::parser::scope_resolve;
@@ -2788,7 +2788,9 @@ fn build_import_table(
     );
     let ts_default_exports =
         build_ts_default_export_table(file_paths, symbol_table, entity_map, &content_map);
-    let ts_top_level_entities = build_ts_top_level_entity_table(entity_map);
+    let ts_top_level_entities = OnceLock::new();
+    let ts_exported_names_by_file: Mutex<HashMap<String, Arc<HashSet<String>>>> =
+        Mutex::new(HashMap::new());
 
     // Go imports are handled entirely by the scope resolver (which uses an indexed approach).
     // We no longer need a go_pkg_index here since Go files are skipped below.
@@ -2961,6 +2963,8 @@ fn build_import_table(
                 for cap in JS_NAMESPACE_RE.captures_iter(content) {
                     let alias = cap.get(1).unwrap().as_str();
                     let module_path = cap.get(2).unwrap().as_str();
+                    let ts_top_level_entities = ts_top_level_entities
+                        .get_or_init(|| build_ts_top_level_entity_table(entity_map));
                     let Some(target_file) = find_import_file(
                         &ts_top_level_entities.sorted_files,
                         module_path,
@@ -2973,7 +2977,27 @@ fn build_import_table(
                     else {
                         continue;
                     };
+                    let exported_names = {
+                        let mut cache = ts_exported_names_by_file.lock().unwrap();
+                        cache
+                            .entry(target_file.to_string())
+                            .or_insert_with(|| {
+                                Arc::new(
+                                    content_map
+                                        .get(target_file)
+                                        .map(|content| js_ts_named_exports_from_content(content))
+                                        .unwrap_or_default(),
+                                )
+                            })
+                            .clone()
+                    };
                     for (name, target_id) in entries {
+                        let is_export_entity = entity_map
+                            .get(target_id)
+                            .map_or(false, |entity| entity.entity_type == "export");
+                        if !is_export_entity && !exported_names.contains(name) {
+                            continue;
+                        }
                         local_imports.push((
                             (file_path.clone(), format!("{alias}.{name}")),
                             target_id.clone(),
@@ -6478,6 +6502,66 @@ export function actual() { return lib.foo(); }
                 .any(|d| d.name == "foo" && d.file_path == "other.ts"),
             "lib.foo() should not resolve to other.ts. Deps: {:?}",
             actual_deps
+                .iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_js_ts_namespace_import_skips_unexported_top_level_entities() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "lib.ts",
+            "\
+function hidden() { return 1; }
+export function visible() { return 2; }
+",
+        );
+        write_file(
+            root,
+            "main.ts",
+            "\
+import * as lib from './lib';
+export function callVisible() { return lib.visible(); }
+export function callHidden() { return lib.hidden(); }
+",
+        );
+
+        let (graph, _) = EntityGraph::build(root, &["lib.ts".into(), "main.ts".into()], &registry);
+
+        let visible_id = graph
+            .entities
+            .keys()
+            .find(|id| id.contains("callVisible"))
+            .expect("callVisible entity should exist");
+        let visible_deps = graph.get_dependencies(visible_id);
+        assert!(
+            visible_deps
+                .iter()
+                .any(|d| d.name == "visible" && d.file_path == "lib.ts"),
+            "lib.visible() should resolve to the exported function. Deps: {:?}",
+            visible_deps
+                .iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
+        );
+
+        let hidden_id = graph
+            .entities
+            .keys()
+            .find(|id| id.contains("callHidden"))
+            .expect("callHidden entity should exist");
+        let hidden_deps = graph.get_dependencies(hidden_id);
+        assert!(
+            !hidden_deps
+                .iter()
+                .any(|d| d.name == "hidden" && d.file_path == "lib.ts"),
+            "lib.hidden() should not resolve to a module-private function. Deps: {:?}",
+            hidden_deps
                 .iter()
                 .map(|d| (&d.name, &d.file_path))
                 .collect::<Vec<_>>()

--- a/crates/sem-core/src/parser/graph.rs
+++ b/crates/sem-core/src/parser/graph.rs
@@ -2992,10 +2992,7 @@ fn build_import_table(
                             .clone()
                     };
                     for (name, target_id) in entries {
-                        let is_export_entity = entity_map
-                            .get(target_id)
-                            .map_or(false, |entity| entity.entity_type == "export");
-                        if !is_export_entity && !exported_names.contains(name) {
+                        if !exported_names.contains(name) {
                             continue;
                         }
                         local_imports.push((
@@ -6128,6 +6125,58 @@ export function usePublicCore(): string { return publicCore(); }
                 .iter()
                 .any(|d| d.name == "publicCore" && d.file_path == "barrel.ts"),
             "consumer should resolve publicCore through the barrel export. Deps: {:?}",
+            consumer_deps
+                .iter()
+                .map(|d| (&d.name, &d.file_path))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_js_ts_namespace_import_resolves_re_export_alias() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "lib.ts",
+            "\
+export function core(): string { return 'core'; }
+",
+        );
+        write_file(
+            root,
+            "barrel.ts",
+            "\
+export { core as publicCore } from './lib';
+",
+        );
+        write_file(
+            root,
+            "consumer.ts",
+            "\
+import * as barrel from './barrel';
+export function usePublicCore(): string { return barrel.publicCore(); }
+",
+        );
+
+        let (graph, _) = EntityGraph::build(
+            root,
+            &["lib.ts".into(), "barrel.ts".into(), "consumer.ts".into()],
+            &registry,
+        );
+
+        let use_public_core_id = graph
+            .entities
+            .keys()
+            .find(|id| id.contains("usePublicCore"))
+            .expect("usePublicCore entity should exist");
+        let consumer_deps = graph.get_dependencies(use_public_core_id);
+        assert!(
+            consumer_deps
+                .iter()
+                .any(|d| d.name == "publicCore" && d.file_path == "barrel.ts"),
+            "namespace import should resolve the exported barrel alias. Deps: {:?}",
             consumer_deps
                 .iter()
                 .map(|d| (&d.name, &d.file_path))

--- a/crates/sem-core/src/parser/graph.rs
+++ b/crates/sem-core/src/parser/graph.rs
@@ -298,9 +298,11 @@ pub struct EntityGraph {
 }
 
 /// Metadata describing repairs made during an incremental graph build.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct IncrementalBuildMetadata {
     pub repaired_clean_entity_ids: bool,
+    pub recomputed_edge_source_ids: Vec<String>,
+    pub deleted_entity_ids: Vec<String>,
 }
 
 /// Minimal entity info stored in the graph.
@@ -319,36 +321,53 @@ pub struct EntityInfo {
 
 #[derive(Debug)]
 struct LineReferenceIndex {
-    words: Vec<String>,
-    dot_chains: Vec<(String, String)>,
-    call_words: HashSet<String>,
-    import_words: HashSet<String>,
+    words: Vec<IndexedWordRef>,
+    dot_chains: Vec<(u32, u32)>,
 }
 
 #[derive(Debug)]
 struct FileReferenceIndex {
-    lines: Vec<LineReferenceIndex>,
+    tokens: Vec<String>,
+    token_ids: HashMap<String, u32>,
+    lines: Vec<Option<LineReferenceIndex>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct IndexedWordRef {
+    token_id: u32,
+    flags: u8,
+}
+
+impl IndexedWordRef {
+    const CALL: u8 = 0b01;
+    const IMPORT: u8 = 0b10;
 }
 
 impl FileReferenceIndex {
     fn from_content(content: &str) -> Self {
         let stripped = strip_comments_and_strings(content);
+        let mut index = Self {
+            tokens: Vec::new(),
+            token_ids: HashMap::new(),
+            lines: Vec::new(),
+        };
         let lines = stripped
             .lines()
-            .map(LineReferenceIndex::from_stripped_line)
+            .map(|line| LineReferenceIndex::from_stripped_line(line, &mut index))
             .collect();
-        Self { lines }
+        index.lines = lines;
+        index
     }
 
     fn dot_chains_in_ranges(&self, ranges: &[(usize, usize)]) -> Vec<(&str, &str)> {
         let mut chains = Vec::new();
-        let mut seen: HashSet<(&str, &str)> = HashSet::new();
+        let mut seen: HashSet<(u32, u32)> = HashSet::new();
         for &(start_line, end_line) in ranges {
             for line in self.line_range(start_line, end_line) {
                 for (receiver, member) in &line.dot_chains {
-                    let pair = (receiver.as_str(), member.as_str());
+                    let pair = (*receiver, *member);
                     if seen.insert(pair) {
-                        chains.push(pair);
+                        chains.push((self.token(*receiver), self.token(*member)));
                     }
                 }
             }
@@ -362,35 +381,34 @@ impl FileReferenceIndex {
         own_name: &str,
     ) -> Vec<(&str, RefType)> {
         let mut refs = Vec::new();
-        let mut seen: HashMap<&str, (bool, bool)> = HashMap::new();
+        let mut seen: HashMap<u32, u8> = HashMap::new();
         for &(start_line, end_line) in ranges {
             for line in self.line_range(start_line, end_line) {
                 for word in &line.words {
-                    let word = word.as_str();
-                    if word == own_name {
+                    let word_text = self.token(word.token_id);
+                    if word_text == own_name {
                         continue;
                     }
-                    let first_seen = !seen.contains_key(word);
-                    let flags = seen.entry(word).or_insert((false, false));
-                    flags.0 |= line.call_words.contains(word);
-                    flags.1 |= line.import_words.contains(word);
+                    let first_seen = !seen.contains_key(&word.token_id);
+                    let flags = seen.entry(word.token_id).or_insert(0);
+                    *flags |= word.flags;
                     if first_seen {
-                        refs.push(word);
+                        refs.push(word.token_id);
                     }
                 }
             }
         }
         refs.into_iter()
-            .map(|word| {
-                let (has_call, has_import) = seen.get(word).copied().unwrap_or_default();
-                let ref_type = if has_call {
+            .map(|token_id| {
+                let flags = seen.get(&token_id).copied().unwrap_or_default();
+                let ref_type = if flags & IndexedWordRef::CALL != 0 {
                     RefType::Calls
-                } else if has_import {
+                } else if flags & IndexedWordRef::IMPORT != 0 {
                     RefType::Imports
                 } else {
                     RefType::TypeRef
                 };
-                (word, ref_type)
+                (self.token(token_id), ref_type)
             })
             .collect()
     }
@@ -402,16 +420,31 @@ impl FileReferenceIndex {
     ) -> impl Iterator<Item = &LineReferenceIndex> {
         let start = start_line.saturating_sub(1).min(self.lines.len());
         let end = end_line.min(self.lines.len()).max(start);
-        self.lines[start..end].iter()
+        self.lines[start..end].iter().filter_map(Option::as_ref)
+    }
+
+    fn intern(&mut self, token: &str) -> u32 {
+        if let Some(id) = self.token_ids.get(token) {
+            return *id;
+        }
+        let id = self.tokens.len() as u32;
+        self.tokens.push(token.to_string());
+        self.token_ids.insert(token.to_string(), id);
+        id
+    }
+
+    fn token(&self, token_id: u32) -> &str {
+        self.tokens
+            .get(token_id as usize)
+            .map(String::as_str)
+            .unwrap_or("")
     }
 }
 
 impl LineReferenceIndex {
-    fn from_stripped_line(line: &str) -> Self {
+    fn from_stripped_line(line: &str, file_index: &mut FileReferenceIndex) -> Option<Self> {
         let mut words = Vec::new();
-        let mut seen_words = HashSet::new();
-        let mut call_words = HashSet::new();
-        let mut import_words = HashSet::new();
+        let mut seen_words: HashSet<u32> = HashSet::new();
         let import_like = {
             let trimmed = line.trim();
             trimmed.starts_with("import ")
@@ -424,28 +457,34 @@ impl LineReferenceIndex {
             if !is_reference_word(word) {
                 continue;
             }
-            if seen_words.insert(word) {
-                words.push(word.to_string());
-            }
+            let token_id = file_index.intern(word);
+            let mut flags = 0;
             if line.as_bytes().get(end_byte) == Some(&b'(') {
-                call_words.insert(word.to_string());
+                flags |= IndexedWordRef::CALL;
             }
             if import_like {
-                import_words.insert(word.to_string());
+                flags |= IndexedWordRef::IMPORT;
+            }
+            if seen_words.insert(token_id) {
+                words.push(IndexedWordRef { token_id, flags });
+            } else if let Some(indexed) = words
+                .iter_mut()
+                .find(|indexed| indexed.token_id == token_id)
+            {
+                indexed.flags |= flags;
             }
         }
 
-        let dot_chains = extract_dot_chains(line)
+        let dot_chains: Vec<(u32, u32)> = extract_dot_chains(line)
             .into_iter()
-            .map(|(receiver, member)| (receiver.to_string(), member.to_string()))
+            .map(|(receiver, member)| (file_index.intern(receiver), file_index.intern(member)))
             .collect();
 
-        Self {
-            words,
-            dot_chains,
-            call_words,
-            import_words,
+        if words.is_empty() && dot_chains.is_empty() {
+            return None;
         }
+
+        Some(Self { words, dot_chains })
     }
 }
 
@@ -1444,6 +1483,53 @@ impl EntityGraph {
             }
         }
 
+        let stale_js_ts_file_paths: Vec<&str> = stale_set
+            .iter()
+            .copied()
+            .filter(|file_path| is_js_ts_file(file_path))
+            .collect();
+        if !stale_js_ts_file_paths.is_empty() {
+            let clean_js_ts_import_tokens: HashMap<&str, Vec<String>> = all_file_paths
+                .iter()
+                .map(String::as_str)
+                .filter(|file_path| !stale_set.contains(*file_path) && is_js_ts_file(file_path))
+                .filter_map(|file_path| {
+                    let content = read_import_scan_prefix(&root.join(file_path))?;
+                    let mut tokens: Vec<String> = stale_js_ts_file_paths
+                        .iter()
+                        .flat_map(|stale_file_path| {
+                            content_import_tokens_for_file(file_path, &content, stale_file_path)
+                        })
+                        .collect();
+                    if tokens.is_empty() {
+                        return None;
+                    }
+                    tokens.sort_unstable();
+                    tokens.dedup();
+                    Some((file_path, tokens))
+                })
+                .collect();
+
+            for entity in all_entities
+                .iter()
+                .filter(|entity| !stale_set.contains(entity.file_path.as_str()))
+            {
+                if affected_clean_ids.contains(&entity.id) {
+                    continue;
+                }
+                let Some(tokens) = clean_js_ts_import_tokens.get(entity.file_path.as_str()) else {
+                    continue;
+                };
+                if tokens
+                    .iter()
+                    .any(|token| content_contains_identifier(&entity.content, token))
+                {
+                    affected_clean_ids.insert(entity.id.clone());
+                    affected_clean_file_paths.insert(entity.file_path.as_str());
+                }
+            }
+        }
+
         // Keep edges where both endpoints are in clean (non-stale) files and from_entity
         // is not affected by target changes. Drop ALL cached edges from stale-file entities
         // (even content_clean ones) because import/scope context may have changed even when
@@ -1856,11 +1942,25 @@ impl EntityGraph {
             dependencies,
         };
 
+        let mut recomputed_edge_source_ids: Vec<String> = needs_resolution
+            .iter()
+            .map(|id| (*id).to_string())
+            .collect();
+        recomputed_edge_source_ids.sort_unstable();
+        recomputed_edge_source_ids.dedup();
+
+        let mut deleted_entity_ids: Vec<String> =
+            deleted_ids.iter().map(|id| (*id).to_string()).collect();
+        deleted_entity_ids.sort_unstable();
+        deleted_entity_ids.dedup();
+
         (
             graph,
             all_entities,
             IncrementalBuildMetadata {
                 repaired_clean_entity_ids,
+                recomputed_edge_source_ids,
+                deleted_entity_ids,
             },
         )
     }
@@ -2364,6 +2464,11 @@ struct TsDefaultExportTable {
     sorted_files: Vec<String>,
 }
 
+struct TsTopLevelEntityTable {
+    entities_by_file: HashMap<String, Vec<(String, String)>>,
+    sorted_files: Vec<String>,
+}
+
 struct TsDefaultReExport {
     file_path: String,
     original_name: String,
@@ -2425,6 +2530,30 @@ fn sorted_default_export_files(default_exports: &HashMap<String, String>) -> Vec
     let mut sorted_files: Vec<String> = default_exports.keys().cloned().collect();
     sort_import_candidate_files(&mut sorted_files, JS_TS_EXTENSIONS);
     sorted_files
+}
+
+fn build_ts_top_level_entity_table(
+    entity_map: &HashMap<String, EntityInfo>,
+) -> TsTopLevelEntityTable {
+    let mut entities_by_file: HashMap<String, Vec<(String, String)>> = HashMap::new();
+    for entity in entity_map.values() {
+        if !is_js_ts_file(&entity.file_path) || entity.parent_id.is_some() {
+            continue;
+        }
+        entities_by_file
+            .entry(entity.file_path.clone())
+            .or_default()
+            .push((entity.name.clone(), entity.id.clone()));
+    }
+    for entries in entities_by_file.values_mut() {
+        entries.sort_unstable_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+    }
+    let mut sorted_files: Vec<String> = entities_by_file.keys().cloned().collect();
+    sort_import_candidate_files(&mut sorted_files, JS_TS_EXTENSIONS);
+    TsTopLevelEntityTable {
+        entities_by_file,
+        sorted_files,
+    }
 }
 
 fn resolve_ts_default_re_exports(
@@ -2645,6 +2774,7 @@ fn build_import_table(
     );
     let ts_default_exports =
         build_ts_default_export_table(file_paths, symbol_table, entity_map, &content_map);
+    let ts_top_level_entities = build_ts_top_level_entity_table(entity_map);
 
     // Go imports are handled entirely by the scope resolver (which uses an indexed approach).
     // We no longer need a go_pkg_index here since Go files are skipped below.
@@ -2764,6 +2894,12 @@ fn build_import_table(
                     Regex::new(r#"export\s+(?:type\s+)?\{([^}]+)\}\s*from\s*['"]([^'"]+)['"]"#)
                         .unwrap()
                 });
+                static JS_NAMESPACE_RE: LazyLock<Regex> = LazyLock::new(|| {
+                    Regex::new(
+                        r#"import\s+\*\s+as\s+([A-Za-z_$][\w$]*)\s*from\s*['"]([^'"]+)['"]"#,
+                    )
+                    .unwrap()
+                });
 
                 for cap in JS_NAMED_RE.captures_iter(content) {
                     let names_str = cap.get(1).unwrap().as_str();
@@ -2804,6 +2940,29 @@ fn build_import_table(
                         local_imports.push((
                             (file_path.clone(), local_name.to_string()),
                             target_id,
+                        ));
+                    }
+                }
+
+                for cap in JS_NAMESPACE_RE.captures_iter(content) {
+                    let alias = cap.get(1).unwrap().as_str();
+                    let module_path = cap.get(2).unwrap().as_str();
+                    let Some(target_file) = find_import_file(
+                        &ts_top_level_entities.sorted_files,
+                        module_path,
+                        file_path,
+                        JS_TS_EXTENSIONS,
+                    ) else {
+                        continue;
+                    };
+                    let Some(entries) = ts_top_level_entities.entities_by_file.get(target_file)
+                    else {
+                        continue;
+                    };
+                    for (name, target_id) in entries {
+                        local_imports.push((
+                            (file_path.clone(), format!("{alias}.{name}")),
+                            target_id.clone(),
                         ));
                     }
                 }
@@ -3383,13 +3542,23 @@ fn content_import_tokens_for_file(
         || importing_file_path.ends_with(".tsx")
     {
         static JS_NAMED_IMPORT_RE: LazyLock<Regex> = LazyLock::new(|| {
-            Regex::new(r#"import\s*\{([^}]+)\}\s*from\s*['"]([^'"]+)['"]"#).unwrap()
+            Regex::new(
+                r#"import\s+(?:type\s+)?(?:[A-Za-z_$][\w$]*\s*,\s*)?\{([^}]+)\}\s*from\s*['"]([^'"]+)['"]"#,
+            )
+            .unwrap()
         });
         static JS_NAMESPACE_IMPORT_RE: LazyLock<Regex> = LazyLock::new(|| {
-            Regex::new(r#"import\s+\*\s+as\s+([A-Za-z_]\w*)\s+from\s*['"]([^'"]+)['"]"#).unwrap()
+            Regex::new(r#"import\s+\*\s+as\s+([A-Za-z_$][\w$]*)\s+from\s*['"]([^'"]+)['"]"#)
+                .unwrap()
         });
         static JS_DEFAULT_IMPORT_RE: LazyLock<Regex> = LazyLock::new(|| {
-            Regex::new(r#"import\s+(?:type\s+)?([A-Za-z_]\w*)\s+from\s*['"]([^'"]+)['"]"#).unwrap()
+            Regex::new(
+                r#"import\s+(?:type\s+)?([A-Za-z_$][\w$]*)(?:\s*,\s*\{[^}]*\})?\s*from\s*['"]([^'"]+)['"]"#,
+            )
+            .unwrap()
+        });
+        static JS_REEXPORT_RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r#"export\s+(?:type\s+)?\{([^}]+)\}\s*from\s*['"]([^'"]+)['"]"#).unwrap()
         });
 
         for cap in JS_NAMED_IMPORT_RE.captures_iter(content) {
@@ -3434,6 +3603,26 @@ fn content_import_tokens_for_file(
                 &[".ts", ".tsx", ".js", ".jsx"],
                 candidate_file_path,
             ) {
+                push_import_token(&mut tokens, local);
+            }
+        }
+
+        for cap in JS_REEXPORT_RE.captures_iter(content) {
+            let names = cap.get(1).map(|m| m.as_str()).unwrap_or("");
+            let source_path = cap.get(2).map(|m| m.as_str()).unwrap_or("");
+            if !import_source_matches_file(
+                importing_file_path,
+                source_path,
+                &[".ts", ".tsx", ".js", ".jsx"],
+                candidate_file_path,
+            ) {
+                continue;
+            }
+            for name_part in names.split(',') {
+                let name_part = name_part.trim();
+                let name_part = name_part.strip_prefix("type ").unwrap_or(name_part);
+                let (original, local) = split_import_alias(name_part);
+                push_import_token(&mut tokens, original);
                 push_import_token(&mut tokens, local);
             }
         }
@@ -3921,6 +4110,37 @@ class Runner {
         assert!(refs
             .iter()
             .any(|(word, ref_type)| *word == "validate" && *ref_type == RefType::Calls));
+    }
+
+    #[test]
+    fn test_js_ts_import_token_scan_matches_supported_import_forms() {
+        let content = "\
+import type { X as TypeX } from './stale';
+import DefaultThing, { X as Y, Z } from './stale';
+import * as ns$ from './stale';
+export { default as PublicDefault, X as PublicX } from './stale';
+";
+
+        let mut tokens = content_import_tokens_for_file("consumer.ts", content, "stale.ts");
+        tokens.sort_unstable();
+        tokens.dedup();
+
+        for expected in [
+            "X",
+            "TypeX",
+            "DefaultThing",
+            "Y",
+            "Z",
+            "ns$",
+            "default",
+            "PublicDefault",
+            "PublicX",
+        ] {
+            assert!(
+                tokens.iter().any(|token| token == expected),
+                "missing token {expected}; tokens: {tokens:?}"
+            );
+        }
     }
 
     #[test]
@@ -4542,6 +4762,95 @@ comment with Helper
                 .any(|entity_id| *entity_id == "a.ts::function::useIt"),
             "namespace clean caller should resolve to added go. Dependents: {:?}",
             incremental_dependents
+        );
+    }
+
+    #[test]
+    fn test_incremental_stale_default_re_export_re_resolves_clean_barrel() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "a.ts",
+            "export default function targetA() { return 1; }\n",
+        );
+        write_file(
+            root,
+            "b.ts",
+            "export default function targetB() { return 2; }\n",
+        );
+        write_file(root, "stale.ts", "export { default } from './a';\n");
+        write_file(
+            root,
+            "barrel.ts",
+            "export { default as publicTarget } from './stale';\n",
+        );
+
+        let all_files = vec![
+            "a.ts".to_string(),
+            "b.ts".to_string(),
+            "stale.ts".to_string(),
+            "barrel.ts".to_string(),
+        ];
+        let (cached_graph, cached_entities) = EntityGraph::build(root, &all_files, &registry);
+        let initial_deps = cached_graph.get_dependencies("barrel.ts::export::publicTarget");
+        assert!(
+            initial_deps
+                .iter()
+                .any(|entity| entity.file_path == "a.ts" && entity.name == "targetA"),
+            "initial barrel export should resolve through stale.ts to a.ts. Deps: {:?}",
+            initial_deps
+                .iter()
+                .map(|entity| (&entity.file_path, &entity.name))
+                .collect::<Vec<_>>()
+        );
+
+        write_file(root, "stale.ts", "export { default } from './b';\n");
+
+        let cached_clean_entities = cached_entities
+            .iter()
+            .filter(|entity| entity.file_path != "stale.ts")
+            .cloned()
+            .collect();
+        let cached_stale_entities = cached_entities
+            .into_iter()
+            .filter(|entity| entity.file_path == "stale.ts")
+            .collect();
+
+        let (incremental_graph, _) = EntityGraph::build_incremental(
+            root,
+            &["stale.ts".into()],
+            &all_files,
+            cached_clean_entities,
+            cached_graph.edges,
+            cached_stale_entities,
+            &registry,
+        );
+        let (fresh_graph, _) = EntityGraph::build(root, &all_files, &registry);
+
+        let mut incremental_deps = incremental_graph
+            .get_dependencies("barrel.ts::export::publicTarget")
+            .iter()
+            .map(|entity| (entity.file_path.as_str(), entity.name.as_str()))
+            .collect::<Vec<_>>();
+        incremental_deps.sort_unstable();
+        let mut fresh_deps = fresh_graph
+            .get_dependencies("barrel.ts::export::publicTarget")
+            .iter()
+            .map(|entity| (entity.file_path.as_str(), entity.name.as_str()))
+            .collect::<Vec<_>>();
+        fresh_deps.sort_unstable();
+        assert_eq!(
+            incremental_deps, fresh_deps,
+            "incremental graph should match fresh re-export retargeting"
+        );
+        assert!(
+            incremental_deps
+                .iter()
+                .any(|(file_path, name)| *file_path == "b.ts" && *name == "targetB"),
+            "clean barrel export should retarget to b.ts. Deps: {:?}",
+            incremental_deps
         );
     }
 

--- a/crates/sem-core/src/parser/graph.rs
+++ b/crates/sem-core/src/parser/graph.rs
@@ -2481,39 +2481,53 @@ fn build_ts_default_export_table(
     entity_map: &HashMap<String, EntityInfo>,
     content_map: &HashMap<&str, &str>,
 ) -> TsDefaultExportTable {
+    // Per-file extraction is independent, so run it in parallel and merge. Each
+    // file contributes at most one default export (last name wins, as below) plus
+    // any default re-export records. Collecting preserves file order, so the merged
+    // result is identical to a sequential scan.
+    let per_file: Vec<(Option<(String, String)>, Vec<TsDefaultReExport>)> =
+        maybe_par_iter!(file_paths)
+            .filter_map(|file_path| {
+                if !is_js_ts_file(file_path) {
+                    return None;
+                }
+                let content = content_map.get(file_path.as_str()).copied()?;
+
+                let mut default_export: Option<(String, String)> = None;
+                for name in default_export_names_from_content(content) {
+                    let Some(target_ids) = symbol_table.get(name.as_str()) else {
+                        continue;
+                    };
+                    let target = target_ids.iter().find(|id| {
+                        entity_map.get(*id).map_or(false, |entity| {
+                            entity.file_path == *file_path && entity.parent_id.is_none()
+                        })
+                    });
+                    if let Some(target_id) = target {
+                        default_export = Some((file_path.clone(), target_id.clone()));
+                    }
+                }
+
+                let re_exports: Vec<TsDefaultReExport> = default_re_exports_from_content(content)
+                    .into_iter()
+                    .map(|(original_name, module_path)| TsDefaultReExport {
+                        file_path: file_path.clone(),
+                        original_name,
+                        module_path,
+                    })
+                    .collect();
+
+                Some((default_export, re_exports))
+            })
+            .collect();
+
     let mut default_exports = HashMap::new();
     let mut re_exports = Vec::new();
-
-    for file_path in file_paths {
-        if !is_js_ts_file(file_path) {
-            continue;
+    for (default_export, file_re_exports) in per_file {
+        if let Some((file_path, target_id)) = default_export {
+            default_exports.insert(file_path, target_id);
         }
-
-        let Some(content) = content_map.get(file_path.as_str()).copied() else {
-            continue;
-        };
-
-        for name in default_export_names_from_content(content) {
-            let Some(target_ids) = symbol_table.get(name.as_str()) else {
-                continue;
-            };
-            let target = target_ids.iter().find(|id| {
-                entity_map.get(*id).map_or(false, |entity| {
-                    entity.file_path == *file_path && entity.parent_id.is_none()
-                })
-            });
-            if let Some(target_id) = target {
-                default_exports.insert(file_path.clone(), target_id.clone());
-            }
-        }
-
-        for (original_name, module_path) in default_re_exports_from_content(content) {
-            re_exports.push(TsDefaultReExport {
-                file_path: file_path.clone(),
-                original_name,
-                module_path,
-            });
-        }
+        re_exports.extend(file_re_exports);
     }
 
     resolve_ts_default_re_exports(&mut default_exports, re_exports, symbol_table, entity_map);

--- a/crates/sem-core/src/parser/import_resolution.rs
+++ b/crates/sem-core/src/parser/import_resolution.rs
@@ -1,7 +1,9 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Component, Path, PathBuf};
+use std::sync::LazyLock;
 
 use crate::parser::graph::EntityInfo;
+use regex::Regex;
 
 pub(crate) const JS_TS_EXTENSIONS: &[&str] =
     &[".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"];
@@ -10,6 +12,103 @@ pub(crate) fn is_js_ts_file(file_path: &str) -> bool {
     JS_TS_EXTENSIONS
         .iter()
         .any(|extension| file_path.ends_with(extension))
+}
+
+pub(crate) fn js_ts_named_exports_from_content(content: &str) -> HashSet<String> {
+    static NAMED_DECL_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"\bexport\s+(?:declare\s+)?(?:async\s+)?(?:abstract\s+)?(?:function\s*\*?|class|interface|type|enum)\s+([A-Za-z_$][\w$]*)",
+        )
+        .unwrap()
+    });
+    static VAR_DECL_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"\bexport\s+(?:declare\s+)?(?:const|let|var)\s+([^;\n]+)").unwrap()
+    });
+    static SPECIFIER_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r#"export\s+(?:type\s+)?\{([^}]+)\}(?:\s*from\s*['"][^'"]+['"])?\s*;?"#).unwrap()
+    });
+
+    let mut names = HashSet::new();
+
+    for cap in NAMED_DECL_RE.captures_iter(content) {
+        names.insert(cap.get(1).unwrap().as_str().to_string());
+    }
+
+    for cap in VAR_DECL_RE.captures_iter(content) {
+        for declarator in split_js_ts_var_declarators(cap.get(1).unwrap().as_str()) {
+            if let Some(name) = js_ts_identifier_prefix(declarator) {
+                names.insert(name.to_string());
+            }
+        }
+    }
+
+    for cap in SPECIFIER_RE.captures_iter(content) {
+        for name_part in cap.get(1).unwrap().as_str().split(',') {
+            if let Some(exported_name) = js_ts_export_specifier_name(name_part) {
+                names.insert(exported_name.to_string());
+            }
+        }
+    }
+
+    names
+}
+
+fn split_js_ts_var_declarators(input: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let mut depth = 0usize;
+
+    for (idx, ch) in input.char_indices() {
+        match ch {
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                parts.push(&input[start..idx]);
+                start = idx + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+
+    parts.push(&input[start..]);
+    parts
+}
+
+fn js_ts_export_specifier_name(name_part: &str) -> Option<&str> {
+    let name_part = name_part.trim();
+    if name_part.is_empty() {
+        return None;
+    }
+
+    let exported = if let Some(pos) = name_part.find(" as ") {
+        &name_part[pos + 4..]
+    } else {
+        name_part
+    };
+    let exported = exported.trim();
+    let exported = exported.strip_prefix("type ").unwrap_or(exported).trim();
+
+    js_ts_identifier_prefix(exported)
+}
+
+fn js_ts_identifier_prefix(input: &str) -> Option<&str> {
+    let input = input.trim_start();
+    let mut chars = input.char_indices();
+    let (_, first) = chars.next()?;
+    if !(first == '_' || first == '$' || first.is_ascii_alphabetic()) {
+        return None;
+    }
+
+    let mut end = first.len_utf8();
+    for (idx, ch) in chars {
+        if ch == '_' || ch == '$' || ch.is_ascii_alphanumeric() {
+            end = idx + ch.len_utf8();
+        } else {
+            break;
+        }
+    }
+
+    Some(&input[..end])
 }
 
 pub(crate) fn sort_import_candidate_files<P: AsRef<str>>(paths: &mut [P], extensions: &[&str]) {

--- a/crates/sem-core/src/parser/scope_resolve.rs
+++ b/crates/sem-core/src/parser/scope_resolve.rs
@@ -13,7 +13,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -35,7 +35,7 @@ macro_rules! maybe_par_iter {
 use crate::parser::graph::{EntityInfo, RefType};
 use crate::parser::import_resolution::{
     find_import_file, find_import_target, import_source_matches_file, is_js_ts_file,
-    sort_import_candidate_files, JS_TS_EXTENSIONS,
+    js_ts_named_exports_from_content, sort_import_candidate_files, JS_TS_EXTENSIONS,
 };
 use crate::parser::plugins::code::languages::{
     get_language_config, AssignmentStrategy, CallNodeStyle, ClassNameField, InitStrategy,
@@ -654,6 +654,9 @@ pub(crate) fn resolve_with_scopes_full(
         }
     }
     let parsed_files: &[(String, String, tree_sitter::Tree)] = &owned_parsed_files;
+    let content_by_file = OnceLock::new();
+    let exported_names_by_file: Mutex<HashMap<String, Arc<HashSet<String>>>> =
+        Mutex::new(HashMap::new());
     // The default-export table is consulted only while resolving JS/TS imports.
     // When an import table is supplied (the graph-build path), those imports are
     // already resolved and `extract_ts_import`/`extract_ts_re_export` are skipped,
@@ -847,6 +850,9 @@ pub(crate) fn resolve_with_scopes_full(
                 &go_pkg_index,
                 &ts_default_exports,
                 &top_level_entities,
+                parsed_files,
+                &content_by_file,
+                &exported_names_by_file,
                 pre_built_import_table.is_some(),
             );
 
@@ -3693,7 +3699,7 @@ fn build_top_level_entity_index(
             let Some(info) = entity_map.get(target_id) else {
                 continue;
             };
-            if info.parent_id.is_some() {
+            if !is_js_ts_file(&info.file_path) || info.parent_id.is_some() {
                 continue;
             }
             entities_by_file
@@ -3903,7 +3909,7 @@ fn only_js_ts_statement_trivia(mut text: &str) -> bool {
 }
 
 /// Extract import statements from the AST.
-fn extract_imports_from_ast(
+fn extract_imports_from_ast<'a>(
     root: tree_sitter::Node,
     file_path: &str,
     source: &[u8],
@@ -3915,6 +3921,9 @@ fn extract_imports_from_ast(
     go_pkg_index: &HashMap<String, Vec<(String, String)>>,
     ts_default_exports: &TsDefaultExportTable,
     top_level_entities: &OnceLock<TopLevelEntityIndex>,
+    parsed_files: &'a [(String, String, tree_sitter::Tree)],
+    content_by_file: &OnceLock<HashMap<&'a str, &'a str>>,
+    exported_names_by_file: &Mutex<HashMap<String, Arc<HashSet<String>>>>,
     skip_js_ts_imports: bool,
 ) {
     let mut worklist = vec![root];
@@ -3963,6 +3972,9 @@ fn extract_imports_from_ast(
                             scopes,
                             ts_default_exports,
                             top_level_entities,
+                            parsed_files,
+                            content_by_file,
+                            exported_names_by_file,
                         );
                     }
                     true
@@ -4017,7 +4029,7 @@ fn extract_imports_from_ast(
 }
 
 /// TS: `import { Foo, Bar } from './module'` or `import Foo from './module'`
-fn extract_ts_import(
+fn extract_ts_import<'a>(
     node: tree_sitter::Node,
     file_path: &str,
     source: &[u8],
@@ -4027,6 +4039,9 @@ fn extract_ts_import(
     scopes: &mut Vec<Scope>,
     ts_default_exports: &TsDefaultExportTable,
     top_level_entities: &OnceLock<TopLevelEntityIndex>,
+    parsed_files: &'a [(String, String, tree_sitter::Tree)],
+    content_by_file: &OnceLock<HashMap<&'a str, &'a str>>,
+    exported_names_by_file: &Mutex<HashMap<String, Arc<HashSet<String>>>>,
 ) {
     // Extract the source module from the `from '...'` clause
     let source_path = node
@@ -4076,7 +4091,7 @@ fn extract_ts_import(
                     }
                 } else if clause_child.kind() == "namespace_import" {
                     // import * as m from './module'
-                    // Register all entities from source module so m.foo() resolves
+                    // Register exported source module entities so m.foo() resolves.
                     let mut ns_cursor = clause_child.walk();
                     let alias = clause_child
                         .child_by_field_name("alias")
@@ -4096,6 +4111,9 @@ fn extract_ts_import(
                             top_level_entities,
                             symbol_table,
                             entity_map,
+                            parsed_files,
+                            content_by_file,
+                            exported_names_by_file,
                             import_table,
                             scopes,
                         );
@@ -4447,10 +4465,10 @@ fn resolve_default_import(
     }
 }
 
-/// Register all entities from a source module under a namespace alias.
-/// For `import * as m from './module'`, all entities from the module
+/// Register exported source module entities under a namespace alias.
+/// For `import * as m from './module'`, exported entities from the module
 /// are registered so that `m.foo()` resolves via the method call path.
-fn register_ts_namespace_import(
+fn register_ts_namespace_import<'a>(
     alias: &str,
     source_path: &str,
     file_path: &str,
@@ -4458,6 +4476,9 @@ fn register_ts_namespace_import(
     top_level_entities: &OnceLock<TopLevelEntityIndex>,
     symbol_table: &HashMap<String, Vec<String>>,
     entity_map: &HashMap<String, EntityInfo>,
+    parsed_files: &'a [(String, String, tree_sitter::Tree)],
+    content_by_file: &OnceLock<HashMap<&'a str, &'a str>>,
+    exported_names_by_file: &Mutex<HashMap<String, Arc<HashSet<String>>>>,
     import_table: &mut HashMap<(String, String), String>,
     _scopes: &mut Vec<Scope>,
 ) {
@@ -4474,7 +4495,33 @@ fn register_ts_namespace_import(
     let Some(entries) = top_level_entities.entities_by_file.get(candidate_file) else {
         return;
     };
+    let exported_names = {
+        let mut cache = exported_names_by_file.lock().unwrap();
+        cache
+            .entry(candidate_file.to_string())
+            .or_insert_with(|| {
+                let content_by_file = content_by_file.get_or_init(|| {
+                    parsed_files
+                        .iter()
+                        .map(|(file_path, content, _)| (file_path.as_str(), content.as_str()))
+                        .collect()
+                });
+                Arc::new(
+                    content_by_file
+                        .get(candidate_file)
+                        .map(|content| js_ts_named_exports_from_content(content))
+                        .unwrap_or_default(),
+                )
+            })
+            .clone()
+    };
     for (name, target_id) in entries {
+        let is_export_entity = entity_map
+            .get(target_id)
+            .map_or(false, |entity| entity.entity_type == "export");
+        if !is_export_entity && !exported_names.contains(name) {
+            continue;
+        }
         let qualified_name = format!("{alias}.{name}");
         import_table
             .entry((file_path.to_string(), qualified_name))

--- a/crates/sem-core/src/parser/scope_resolve.rs
+++ b/crates/sem-core/src/parser/scope_resolve.rs
@@ -4516,10 +4516,7 @@ fn register_ts_namespace_import<'a>(
             .clone()
     };
     for (name, target_id) in entries {
-        let is_export_entity = entity_map
-            .get(target_id)
-            .map_or(false, |entity| entity.entity_type == "export");
-        if !is_export_entity && !exported_names.contains(name) {
+        if !exported_names.contains(name) {
             continue;
         }
         let qualified_name = format!("{alias}.{name}");

--- a/crates/sem-core/src/parser/scope_resolve.rs
+++ b/crates/sem-core/src/parser/scope_resolve.rs
@@ -808,6 +808,7 @@ pub(crate) fn resolve_with_scopes_full(
                 &go_pkg_index,
                 &ts_default_exports,
                 &top_level_entities,
+                pre_built_import_table.is_some(),
             );
 
             // Resolve pending call types using the complete return type map
@@ -3835,6 +3836,7 @@ fn extract_imports_from_ast(
     go_pkg_index: &HashMap<String, Vec<(String, String)>>,
     ts_default_exports: &TsDefaultExportTable,
     top_level_entities: &OnceLock<TopLevelEntityIndex>,
+    skip_js_ts_imports: bool,
 ) {
     let mut worklist = vec![root];
     while let Some(node) = worklist.pop() {
@@ -3871,31 +3873,34 @@ fn extract_imports_from_ast(
                     true
                 }
                 "import_statement" if !config.self_keywords.contains(&"cls") => {
-                    // TS import_statement (not Python - Python uses import_from_statement)
-                    extract_ts_import(
-                        child,
-                        file_path,
-                        source,
-                        symbol_table,
-                        entity_map,
-                        import_table,
-                        scopes,
-                        ts_default_exports,
-                        top_level_entities,
-                    );
+                    if !skip_js_ts_imports {
+                        extract_ts_import(
+                            child,
+                            file_path,
+                            source,
+                            symbol_table,
+                            entity_map,
+                            import_table,
+                            scopes,
+                            ts_default_exports,
+                            top_level_entities,
+                        );
+                    }
                     true
                 }
                 "export_statement" if !config.self_keywords.contains(&"cls") => {
-                    extract_ts_re_export(
-                        child,
-                        file_path,
-                        source,
-                        symbol_table,
-                        entity_map,
-                        import_table,
-                        scopes,
-                        ts_default_exports,
-                    );
+                    if !skip_js_ts_imports {
+                        extract_ts_re_export(
+                            child,
+                            file_path,
+                            source,
+                            symbol_table,
+                            entity_map,
+                            import_table,
+                            scopes,
+                            ts_default_exports,
+                        );
+                    }
                     true
                 }
                 "use_declaration" => {

--- a/crates/sem-core/src/parser/scope_resolve.rs
+++ b/crates/sem-core/src/parser/scope_resolve.rs
@@ -128,41 +128,40 @@ fn entity_creates_reference_scope(entity_type: &str) -> bool {
     )
 }
 
-fn entity_owns_ref(
-    entity: &SemanticEntity,
+/// A reference-scope child as needed to decide ref ownership: its line range and
+/// (if known) byte span. Precomputed once per entity so the per-ref ownership test
+/// does no HashMap lookups.
+type ChildRefCheck = (usize, usize, Option<(usize, usize)>);
+
+/// Whether `ast_ref` belongs directly to an entity (inside its span, not inside any
+/// of its reference-scope children). `entity_span` and `child_ref_checks` are fetched
+/// once per entity by the caller; this keeps the hot per-ref loop allocation- and
+/// hash-free.
+fn ref_owned_by_entity(
     ast_ref: &AstRef,
-    children_by_parent: &HashMap<&str, Vec<&SemanticEntity>>,
-    entity_spans: &HashMap<&str, SourceSpan>,
+    entity_span: Option<SourceSpan>,
+    child_ref_checks: &[ChildRefCheck],
 ) -> bool {
-    let source_line = ast_ref.row + 1;
-    if let Some(entity_span) = entity_spans.get(entity.id.as_str()) {
+    if let Some(entity_span) = entity_span {
         if ast_ref.end_byte <= entity_span.start_byte || ast_ref.start_byte >= entity_span.end_byte
         {
             return false;
         }
     }
 
-    children_by_parent
-        .get(entity.id.as_str())
-        .map_or(true, |children| {
-            children.iter().all(|child| {
-                if !entity_creates_reference_scope(&child.entity_type) {
-                    return true;
+    let source_line = ast_ref.row + 1;
+    child_ref_checks
+        .iter()
+        .all(|(child_start_line, child_end_line, child_span)| {
+            if source_line < *child_start_line || source_line > *child_end_line {
+                return true;
+            }
+            match child_span {
+                Some((start_byte, end_byte)) => {
+                    ast_ref.end_byte <= *start_byte || ast_ref.start_byte >= *end_byte
                 }
-                if child.file_path != entity.file_path
-                    || source_line < child.start_line
-                    || source_line > child.end_line
-                {
-                    return true;
-                }
-
-                if let Some(child_span) = entity_spans.get(child.id.as_str()) {
-                    ast_ref.end_byte <= child_span.start_byte
-                        || ast_ref.start_byte >= child_span.end_byte
-                } else {
-                    false
-                }
-            })
+                None => false,
+            }
         })
 }
 
@@ -429,6 +428,16 @@ impl<'a> FileEntityLookup<'a> {
         Self { by_name }
     }
 
+    /// First entity ID for `name` defined in this file, in entity-discovery order.
+    /// Equivalent to scanning the global symbol table for same-file candidates and
+    /// taking the first, but O(1) instead of O(entities-sharing-this-name).
+    fn first_id_by_name(&self, name: &str) -> Option<&'a str> {
+        self.by_name
+            .get(name)
+            .and_then(|entities| entities.first())
+            .map(|entity| entity.id.as_str())
+    }
+
     fn find_at_line<F>(
         &self,
         name: &str,
@@ -645,7 +654,18 @@ pub(crate) fn resolve_with_scopes_full(
         }
     }
     let parsed_files: &[(String, String, tree_sitter::Tree)] = &owned_parsed_files;
-    let ts_default_exports = build_ts_default_export_table(parsed_files, &symbol_table, entity_map);
+    // The default-export table is consulted only while resolving JS/TS imports.
+    // When an import table is supplied (the graph-build path), those imports are
+    // already resolved and `extract_ts_import`/`extract_ts_re_export` are skipped,
+    // so the table is never read — building it would be pure waste on a large repo.
+    let ts_default_exports = if pre_built_import_table.is_some() {
+        TsDefaultExportTable {
+            exports_by_file: HashMap::new(),
+            sorted_files: Vec::new(),
+        }
+    } else {
+        build_ts_default_export_table(parsed_files, &symbol_table, entity_map)
+    };
     let top_level_entities = OnceLock::new();
 
     // Pass 1: Scan ALL files for return types and instance attr types first
@@ -725,6 +745,24 @@ pub(crate) fn resolve_with_scopes_full(
     let swift_call_signatures =
         build_swift_call_signatures(parsed_files, all_entities, &entity_ranges, entity_map);
 
+    // Group the prebuilt import table by importing file once. Otherwise every file
+    // in Pass 2 would rescan the entire table to find its own entries — O(files ×
+    // imports), which is quadratic on a large repo. Grouping makes each file O(its
+    // own imports).
+    let import_table_by_file: HashMap<&str, Vec<(&str, &str)>> =
+        if let Some(import_table) = pre_built_import_table {
+            let mut grouped: HashMap<&str, Vec<(&str, &str)>> = HashMap::new();
+            for ((import_file_path, local_name), target_id) in import_table {
+                grouped
+                    .entry(import_file_path.as_str())
+                    .or_default()
+                    .push((local_name.as_str(), target_id.as_str()));
+            }
+            grouped
+        } else {
+            HashMap::new()
+        };
+
     // Pass 2: Build scopes, imports, and resolve references per file (parallel)
     let per_file_results: Vec<(
         Vec<(String, String, RefType)>,
@@ -784,16 +822,17 @@ pub(crate) fn resolve_with_scopes_full(
             );
 
             let mut local_import_table: HashMap<(String, String), String> = HashMap::new();
-            if let Some(import_table) = pre_built_import_table {
-                for ((import_file_path, local_name), target_id) in import_table {
-                    if import_file_path != file_path {
-                        continue;
+            if pre_built_import_table.is_some() {
+                if let Some(entries) = import_table_by_file.get(file_path.as_str()) {
+                    for (local_name, target_id) in entries {
+                        local_import_table.insert(
+                            (file_path.clone(), (*local_name).to_string()),
+                            (*target_id).to_string(),
+                        );
+                        scopes[0]
+                            .defs
+                            .insert((*local_name).to_string(), (*target_id).to_string());
                     }
-                    local_import_table.insert(
-                        (import_file_path.clone(), local_name.clone()),
-                        target_id.clone(),
-                    );
-                    scopes[0].defs.insert(local_name.clone(), target_id.clone());
                 }
             }
             extract_imports_from_ast(
@@ -820,6 +859,14 @@ pub(crate) fn resolve_with_scopes_full(
                 file_path,
                 entity_map,
             );
+
+            // The per-file import table is keyed by (file_path, name) but only ever
+            // holds this file's entries, so re-key it by name once. resolve_ref then
+            // looks up imports without allocating a key string per reference.
+            let local_import_by_name: HashMap<&str, &str> = local_import_table
+                .iter()
+                .map(|((_, name), target_id)| (name.as_str(), target_id.as_str()))
+                .collect();
 
             let mut file_edges: Vec<(String, String, RefType)> = Vec::new();
             let mut file_log: Vec<ResolutionEntry> = Vec::new();
@@ -851,11 +898,34 @@ pub(crate) fn resolve_with_scopes_full(
                         &descendant_ranges_by_entity,
                     );
                 }
-                add_local_bindings_to_consumed_words(
-                    file_consumed_words.entry(entity.id.clone()).or_default(),
-                    scope_idx,
-                    &scopes,
-                );
+                // Hoist per-entity lookups out of the per-reference loop. Each reference
+                // previously re-hashed the entity id against several maps (and every
+                // child id, once per ref); on dense, deeply nested files that hashing
+                // dominated resolution. Fetch them once per entity instead.
+                let entity_consumed = file_consumed_words.entry(entity.id.clone()).or_default();
+                add_local_bindings_to_consumed_words(entity_consumed, scope_idx, &scopes);
+
+                let entity_span = entity_spans.get(entity.id.as_str()).copied();
+                let child_ref_checks: Vec<ChildRefCheck> = children_by_parent
+                    .get(entity.id.as_str())
+                    .map(|children| {
+                        children
+                            .iter()
+                            .filter(|child| {
+                                entity_creates_reference_scope(&child.entity_type)
+                                    && child.file_path == entity.file_path
+                            })
+                            .map(|child| {
+                                let span = entity_spans
+                                    .get(child.id.as_str())
+                                    .map(|span| (span.start_byte, span.end_byte));
+                                (child.start_line, child.end_line, span)
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                let entity_descendant_ranges = descendant_ranges_by_entity.get(&entity.id);
+
                 let allow_implicit_instance_member_receiver =
                     allows_implicit_instance_member_receiver(
                         file_path,
@@ -867,14 +937,10 @@ pub(crate) fn resolve_with_scopes_full(
                 for row_refs in &refs_by_row[start_row..end_row] {
                     for &ref_idx in row_refs {
                         let ast_ref = &all_file_refs[ref_idx];
-                        if !entity_owns_ref(entity, ast_ref, &children_by_parent, &entity_spans) {
+                        if !ref_owned_by_entity(ast_ref, entity_span, &child_ref_checks) {
                             continue;
                         }
-                        if row_belongs_to_descendant(
-                            &descendant_ranges_by_entity,
-                            &entity.id,
-                            ast_ref.row,
-                        ) {
+                        if row_in_descendant_ranges(entity_descendant_ranges, ast_ref.row) {
                             continue;
                         }
                         // Skip self-name refs (was previously done during collection)
@@ -897,7 +963,7 @@ pub(crate) fn resolve_with_scopes_full(
                             &symbol_table,
                             &class_members,
                             &owner_members,
-                            &local_import_table,
+                            &local_import_by_name,
                             &instance_attr_types,
                             entity_map,
                             &swift_call_signatures,
@@ -905,6 +971,7 @@ pub(crate) fn resolve_with_scopes_full(
                             &entity.id,
                             allow_cross_file,
                             allow_implicit_instance_member_receiver,
+                            &file_lookup,
                             &mut lookup_cache,
                         );
 
@@ -925,10 +992,7 @@ pub(crate) fn resolve_with_scopes_full(
                                         target_id.clone(),
                                         ref_type,
                                     ));
-                                    add_scope_reference_words(
-                                        file_consumed_words.entry(entity.id.clone()).or_default(),
-                                        &reference,
-                                    );
+                                    add_scope_reference_words(entity_consumed, &reference);
                                     file_log.push(ResolutionEntry {
                                         from_entity: entity.id.clone(),
                                         reference,
@@ -939,10 +1003,7 @@ pub(crate) fn resolve_with_scopes_full(
                             }
                         } else {
                             let reference = ref_description(ast_ref);
-                            add_scope_reference_words(
-                                file_consumed_words.entry(entity.id.clone()).or_default(),
-                                &reference,
-                            );
+                            add_scope_reference_words(entity_consumed, &reference);
                             file_log.push(ResolutionEntry {
                                 from_entity: entity.id.clone(),
                                 reference,
@@ -1160,15 +1221,19 @@ fn row_belongs_to_descendant(
     entity_id: &str,
     row: usize,
 ) -> bool {
-    descendant_ranges_by_entity
-        .get(entity_id)
-        .map_or(false, |ranges| {
-            let eligible = ranges.partition_point(|(start, _)| *start <= row);
-            ranges[..eligible]
-                .iter()
-                .rev()
-                .any(|(start, end)| row >= *start && row < *end)
-        })
+    row_in_descendant_ranges(descendant_ranges_by_entity.get(entity_id), row)
+}
+
+/// Same check as [`row_belongs_to_descendant`], but over pre-fetched ranges so the
+/// per-ref loop avoids a HashMap lookup per reference.
+fn row_in_descendant_ranges(ranges: Option<&Vec<(usize, usize)>>, row: usize) -> bool {
+    ranges.map_or(false, |ranges| {
+        let eligible = ranges.partition_point(|(start, _)| *start <= row);
+        ranges[..eligible]
+            .iter()
+            .rev()
+            .any(|(start, end)| row >= *start && row < *end)
+    })
 }
 
 /// Build scope tree by walking the AST.
@@ -3502,38 +3567,52 @@ fn build_ts_default_export_table(
     symbol_table: &HashMap<String, Vec<String>>,
     entity_map: &HashMap<String, EntityInfo>,
 ) -> TsDefaultExportTable {
+    // Per-file AST extraction is independent, so run it in parallel and merge.
+    // Collecting preserves file order, so the merged result matches a sequential scan.
+    let per_file: Vec<(Option<(String, String)>, Vec<TsDefaultReExport>)> =
+        maybe_par_iter!(parsed_files)
+            .filter_map(|(file_path, content, tree)| {
+                if !is_js_ts_file(file_path) {
+                    return None;
+                }
+
+                let extracted = extract_ts_default_exports(tree.root_node(), content.as_bytes());
+                let mut default_export: Option<(String, String)> = None;
+                for name in extracted.names {
+                    let Some(target_ids) = symbol_table.get(&name) else {
+                        continue;
+                    };
+                    let target = target_ids.iter().find(|id| {
+                        entity_map.get(*id).map_or(false, |entity| {
+                            entity.file_path == *file_path && entity.parent_id.is_none()
+                        })
+                    });
+                    if let Some(target_id) = target {
+                        default_export = Some((file_path.clone(), target_id.clone()));
+                    }
+                }
+
+                let re_exports: Vec<TsDefaultReExport> = extracted
+                    .re_exports
+                    .into_iter()
+                    .map(|(original_name, module_path)| TsDefaultReExport {
+                        file_path: file_path.clone(),
+                        original_name,
+                        module_path,
+                    })
+                    .collect();
+
+                Some((default_export, re_exports))
+            })
+            .collect();
+
     let mut default_exports = HashMap::new();
     let mut re_exports = Vec::new();
-
-    for (file_path, content, tree) in parsed_files {
-        if !is_js_ts_file(file_path) {
-            continue;
+    for (default_export, file_re_exports) in per_file {
+        if let Some((file_path, target_id)) = default_export {
+            default_exports.insert(file_path, target_id);
         }
-
-        let extracted = extract_ts_default_exports(tree.root_node(), content.as_bytes());
-        for name in extracted.names {
-            let Some(target_ids) = symbol_table.get(&name) else {
-                continue;
-            };
-            let target = target_ids.iter().find(|id| {
-                entity_map.get(*id).map_or(false, |entity| {
-                    entity.file_path == *file_path && entity.parent_id.is_none()
-                })
-            });
-            if let Some(target_id) = target {
-                default_exports.insert(file_path.clone(), target_id.clone());
-            }
-        }
-        re_exports.extend(
-            extracted
-                .re_exports
-                .into_iter()
-                .map(|(original_name, module_path)| TsDefaultReExport {
-                    file_path: file_path.clone(),
-                    original_name,
-                    module_path,
-                }),
-        );
+        re_exports.extend(file_re_exports);
     }
 
     resolve_ts_default_re_exports(&mut default_exports, re_exports, symbol_table, entity_map);
@@ -5204,7 +5283,7 @@ fn resolve_ref(
     symbol_table: &HashMap<String, Vec<String>>,
     class_members: &HashMap<String, Vec<(String, String)>>,
     owner_members: &HashMap<String, Vec<(String, String)>>,
-    import_table: &HashMap<(String, String), String>,
+    import_table_by_name: &HashMap<&str, &str>,
     instance_attr_types: &HashMap<(String, String), String>,
     entity_map: &HashMap<String, EntityInfo>,
     swift_call_signatures: &HashMap<String, SwiftCallSignature>,
@@ -5212,6 +5291,7 @@ fn resolve_ref(
     from_entity_id: &str,
     allow_cross_file_calls: bool,
     allow_implicit_instance_member_receiver: bool,
+    file_lookup: &FileEntityLookup<'_>,
     lookup_cache: &mut ScopeLookupCache,
 ) -> Option<(String, RefType, &'static str)> {
     match &ast_ref.kind {
@@ -5223,8 +5303,50 @@ fn resolve_ref(
                 return None;
             }
 
-            if argument_labels.is_some() {
-                if let Some(target_ids) = symbol_table.get(name.as_str()) {
+            // Swift overload disambiguation needs call-signature data that is only
+            // built for Swift sources. For every other language the pre-resolution
+            // candidate scan below is inert, yet it scans the global symbol table —
+            // in a large monorepo a single common name maps to thousands of entities,
+            // so this scan dominates graph resolution. Skip it unless Swift
+            // signatures are present.
+            if !swift_call_signatures.is_empty() {
+                if argument_labels.is_some() {
+                    if let Some(target_ids) = symbol_table.get(name.as_str()) {
+                        let same_file_targets: Vec<&String> = target_ids
+                            .iter()
+                            .filter(|id| {
+                                entity_map
+                                    .get(*id)
+                                    .map_or(false, |e| e.file_path == file_path)
+                            })
+                            .collect();
+                        let visible_targets: Vec<&String> = if !same_file_targets.is_empty() {
+                            same_file_targets
+                        } else if allow_cross_file_calls {
+                            target_ids.iter().collect()
+                        } else {
+                            Vec::new()
+                        };
+                        match select_swift_overload_candidate(
+                            &visible_targets,
+                            argument_labels.as_deref(),
+                            swift_call_signatures,
+                        ) {
+                            SwiftOverloadSelection::Matched(target_id) => {
+                                let is_constructor =
+                                    name.chars().next().map_or(false, |c| c.is_uppercase());
+                                let ref_type = if is_constructor {
+                                    RefType::TypeRef
+                                } else {
+                                    RefType::Calls
+                                };
+                                return Some((target_id, ref_type, "scope_chain"));
+                            }
+                            SwiftOverloadSelection::NoMatch => return None,
+                            SwiftOverloadSelection::NotApplicable => {}
+                        }
+                    }
+                } else if let Some(target_ids) = symbol_table.get(name.as_str()) {
                     let same_file_targets: Vec<&String> = target_ids
                         .iter()
                         .filter(|id| {
@@ -5240,44 +5362,12 @@ fn resolve_ref(
                     } else {
                         Vec::new()
                     };
-                    match select_swift_overload_candidate(
+                    if has_ambiguous_swift_signature_candidates(
                         &visible_targets,
-                        argument_labels.as_deref(),
                         swift_call_signatures,
                     ) {
-                        SwiftOverloadSelection::Matched(target_id) => {
-                            let is_constructor =
-                                name.chars().next().map_or(false, |c| c.is_uppercase());
-                            let ref_type = if is_constructor {
-                                RefType::TypeRef
-                            } else {
-                                RefType::Calls
-                            };
-                            return Some((target_id, ref_type, "scope_chain"));
-                        }
-                        SwiftOverloadSelection::NoMatch => return None,
-                        SwiftOverloadSelection::NotApplicable => {}
+                        return None;
                     }
-                }
-            } else if let Some(target_ids) = symbol_table.get(name.as_str()) {
-                let same_file_targets: Vec<&String> = target_ids
-                    .iter()
-                    .filter(|id| {
-                        entity_map
-                            .get(*id)
-                            .map_or(false, |e| e.file_path == file_path)
-                    })
-                    .collect();
-                let visible_targets: Vec<&String> = if !same_file_targets.is_empty() {
-                    same_file_targets
-                } else if allow_cross_file_calls {
-                    target_ids.iter().collect()
-                } else {
-                    Vec::new()
-                };
-                if has_ambiguous_swift_signature_candidates(&visible_targets, swift_call_signatures)
-                {
-                    return None;
                 }
             }
 
@@ -5288,10 +5378,11 @@ fn resolve_ref(
                 }
             }
 
-            // 2. Check import table
-            let key = (file_path.to_string(), name.clone());
-            if let Some(target_id) = import_table.get(&key) {
-                return Some((target_id.clone(), RefType::Calls, "import"));
+            // 2. Check import table. The per-file table only holds this file's
+            // imports, so a name lookup suffices — avoiding a (path, name) key string
+            // allocated for every reference (millions on a large repo).
+            if let Some(target_id) = import_table_by_name.get(name.as_str()) {
+                return Some(((*target_id).to_string(), RefType::Calls, "import"));
             }
 
             // 3. Global symbol table fallback (constructor calls or cross-file functions)
@@ -5302,6 +5393,29 @@ fn resolve_ref(
                 } else {
                     RefType::Calls
                 };
+
+                if swift_call_signatures.is_empty() {
+                    // Fast path: the per-file name index gives the first same-file
+                    // definition in O(1); the cross-file fallback takes the first
+                    // global definition. Both preserve entity-discovery order, so the
+                    // result matches the candidate scan below without iterating the
+                    // thousands of same-named entities a monorepo accumulates.
+                    let target = file_lookup
+                        .first_id_by_name(name)
+                        .map(str::to_string)
+                        .or_else(|| {
+                            if is_constructor || allow_cross_file_calls {
+                                target_ids.first().cloned()
+                            } else {
+                                None
+                            }
+                        });
+                    if let Some(tid) = target {
+                        return Some((tid, ref_type, "scope_chain"));
+                    }
+                    return None;
+                }
+
                 let same_file_targets: Vec<&String> = target_ids
                     .iter()
                     .filter(|id| {
@@ -5572,9 +5686,8 @@ fn resolve_ref(
 
             // Fallback: check import table for the receiver
             if !is_local_binding_in_scopes_cached(scope_idx, scopes, receiver, lookup_cache) {
-                let key = (file_path.to_string(), receiver.to_string());
-                if let Some(target_id) = import_table.get(&key) {
-                    if let Some(info) = entity_map.get(target_id) {
+                if let Some(target_id) = import_table_by_name.get(receiver) {
+                    if let Some(info) = entity_map.get(*target_id) {
                         if matches!(info.entity_type.as_str(), "class" | "struct") {
                             if let Some(members) = class_members.get(&info.name) {
                                 match select_member_candidate(
@@ -5595,18 +5708,17 @@ fn resolve_ref(
                 }
 
                 // Namespace import: alias.method()
-                let key = (file_path.to_string(), format!("{receiver}.{method}"));
-                if let Some(target_id) = import_table.get(&key) {
-                    return Some((target_id.clone(), RefType::Calls, "import"));
+                let namespaced = format!("{receiver}.{method}");
+                if let Some(target_id) = import_table_by_name.get(namespaced.as_str()) {
+                    return Some(((*target_id).to_string(), RefType::Calls, "import"));
                 }
             }
 
             // Go package-qualified call: package.Function()
             // Try the method name directly in the import table
             if file_path.ends_with(".go") {
-                let key = (file_path.to_string(), method.clone());
-                if let Some(target_id) = import_table.get(&key) {
-                    return Some((target_id.clone(), RefType::Calls, "import"));
+                if let Some(target_id) = import_table_by_name.get(method.as_str()) {
+                    return Some(((*target_id).to_string(), RefType::Calls, "import"));
                 }
             }
 

--- a/crates/sem-mcp/src/cache.rs
+++ b/crates/sem-mcp/src/cache.rs
@@ -606,6 +606,102 @@ impl DiskCache {
         Some((graph, entities))
     }
 
+    /// Load only graph topology from a fresh cache.
+    pub fn load_graph_topology(&self, root: &Path, files: &[String]) -> Option<EntityGraph> {
+        if is_manifest_stale(&self.conn, root) {
+            return None;
+        }
+
+        let cached_count: i64 = self
+            .conn
+            .query_row("SELECT COUNT(*) FROM files", [], |row| row.get(0))
+            .ok()?;
+        if (cached_count - manifest_entry_count(&self.conn)) as usize != source_file_count(files) {
+            return None;
+        }
+
+        let mut stmt = self
+            .conn
+            .prepare("SELECT path, mtime_secs, mtime_nanos FROM files")
+            .ok()?;
+        let cached_mtimes: HashMap<String, (i64, i64)> = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    (row.get::<_, i64>(1)?, row.get::<_, i64>(2)?),
+                ))
+            })
+            .ok()?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        for file in files {
+            if is_manifest_file_name(file) {
+                continue;
+            }
+            let (secs, nanos) = cached_mtimes.get(file.as_str()).copied()?;
+            let full = root.join(file);
+            let (current_secs, current_nanos) = file_mtime_parts(&full)?;
+            if secs != current_secs || nanos != current_nanos {
+                return None;
+            }
+        }
+
+        let mut entity_stmt = self
+            .conn
+            .prepare(
+                "SELECT id, name, entity_type, file_path, start_line, end_line, parent_id FROM entities",
+            )
+            .ok()?;
+        let entity_map: HashMap<String, EntityInfo> = entity_stmt
+            .query_map([], |row| {
+                let id: String = row.get(0)?;
+                Ok((
+                    id.clone(),
+                    EntityInfo {
+                        id,
+                        name: row.get(1)?,
+                        entity_type: row.get(2)?,
+                        file_path: row.get(3)?,
+                        start_line: row.get::<_, i64>(4)? as usize,
+                        end_line: row.get::<_, i64>(5)? as usize,
+                        parent_id: row.get(6)?,
+                    },
+                ))
+            })
+            .ok()?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        let edges = self.load_edges()?;
+        Some(EntityGraph::from_parts(entity_map, edges))
+    }
+
+    fn load_edges(&self) -> Option<Vec<EntityRef>> {
+        let mut edge_stmt = self
+            .conn
+            .prepare("SELECT from_entity, to_entity, ref_type FROM edges")
+            .ok()?;
+        let edges: Vec<EntityRef> = edge_stmt
+            .query_map([], |row| {
+                let rt: String = row.get(2)?;
+                let ref_type = match rt.as_str() {
+                    "calls" => RefType::Calls,
+                    "imports" => RefType::Imports,
+                    _ => RefType::TypeRef,
+                };
+                Ok(EntityRef {
+                    from_entity: row.get(0)?,
+                    to_entity: row.get(1)?,
+                    ref_type,
+                })
+            })
+            .ok()?
+            .filter_map(|r| r.ok())
+            .collect();
+        Some(edges)
+    }
+
     /// Load a partial cache: identify stale files and return clean cached data.
     /// Returns None if cache is empty or ALL files are stale (full rebuild is better).
     pub fn load_partial(&self, root: &Path, files: &[String]) -> Option<PartialCache> {
@@ -771,6 +867,8 @@ impl DiskCache {
             graph,
             entities,
             false,
+            &[],
+            &[],
         )
     }
 
@@ -783,6 +881,8 @@ impl DiskCache {
         graph: &EntityGraph,
         entities: &[SemanticEntity],
         repair_changed_clean_entity_ids: bool,
+        recomputed_edge_source_ids: &[String],
+        deleted_entity_ids: &[String],
     ) -> Result<(), rusqlite::Error> {
         let source_stale_files: Vec<&String> = stale_files
             .iter()
@@ -822,6 +922,29 @@ impl DiskCache {
                     && !current_set.contains(path.as_str())
             })
             .collect();
+        let use_legacy_edge_fallback = !repair_changed_clean_entity_ids
+            && recomputed_edge_source_ids.is_empty()
+            && deleted_entity_ids.is_empty();
+        let cached_rewritten_entity_ids: HashSet<String> = if use_legacy_edge_fallback {
+            let rewritten_file_paths: HashSet<&str> = source_stale_files
+                .iter()
+                .map(|file| file.as_str())
+                .chain(deleted_cached_files.iter().map(String::as_str))
+                .collect();
+            let mut stmt = tx.prepare("SELECT id, file_path FROM entities")?;
+            let rows = stmt.query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?;
+            rows.filter_map(|row| row.ok())
+                .filter_map(|(id, file_path)| {
+                    rewritten_file_paths
+                        .contains(file_path.as_str())
+                        .then_some(id)
+                })
+                .collect()
+        } else {
+            HashSet::new()
+        };
 
         {
             let mut del_files = tx.prepare("DELETE FROM files WHERE path = ?1")?;
@@ -887,12 +1010,69 @@ impl DiskCache {
             }
         }
 
-        tx.execute("DELETE FROM edges", [])?;
-        {
+        if repair_changed_clean_entity_ids {
+            tx.execute("DELETE FROM edges", [])?;
             let mut ins = tx.prepare(
                 "INSERT INTO edges (from_entity, to_entity, ref_type) VALUES (?1, ?2, ?3)",
             )?;
             for edge in &graph.edges {
+                let rt = match edge.ref_type {
+                    RefType::Calls => "calls",
+                    RefType::TypeRef => "typeref",
+                    RefType::Imports => "imports",
+                };
+                ins.execute(params![edge.from_entity, edge.to_entity, rt])?;
+            }
+        } else {
+            let mut affected_sources: HashSet<String> =
+                recomputed_edge_source_ids.iter().cloned().collect();
+            let mut deleted_ids: HashSet<String> = deleted_entity_ids.iter().cloned().collect();
+            if use_legacy_edge_fallback {
+                let current_rewritten_entity_ids: HashSet<&str> = entities
+                    .iter()
+                    .filter(|entity| source_stale_set.contains(entity.file_path.as_str()))
+                    .map(|entity| entity.id.as_str())
+                    .collect();
+                affected_sources.extend(cached_rewritten_entity_ids.iter().cloned());
+                affected_sources.extend(
+                    current_rewritten_entity_ids
+                        .iter()
+                        .map(|entity_id| (*entity_id).to_string()),
+                );
+                deleted_ids.extend(
+                    cached_rewritten_entity_ids
+                        .iter()
+                        .filter(|entity_id| {
+                            !current_rewritten_entity_ids.contains(entity_id.as_str())
+                        })
+                        .cloned(),
+                );
+            }
+            affected_sources.extend(deleted_ids.iter().cloned());
+
+            {
+                let mut del_from = tx.prepare("DELETE FROM edges WHERE from_entity = ?1")?;
+                for entity_id in &affected_sources {
+                    del_from.execute(params![entity_id])?;
+                }
+            }
+            {
+                let mut del_to = tx.prepare("DELETE FROM edges WHERE to_entity = ?1")?;
+                for entity_id in &deleted_ids {
+                    del_to.execute(params![entity_id])?;
+                }
+            }
+
+            let mut ins = tx.prepare(
+                "INSERT INTO edges (from_entity, to_entity, ref_type) VALUES (?1, ?2, ?3)",
+            )?;
+            for edge in &graph.edges {
+                if !affected_sources.contains(&edge.from_entity)
+                    || deleted_ids.contains(&edge.from_entity)
+                    || deleted_ids.contains(&edge.to_entity)
+                {
+                    continue;
+                }
                 let rt = match edge.ref_type {
                     RefType::Calls => "calls",
                     RefType::TypeRef => "typeref",
@@ -977,6 +1157,50 @@ mod tests {
             .unwrap();
         let mut rows = stmt.query(rusqlite::params![id]).unwrap();
         rows.next().unwrap().map(|row| row.get(0).unwrap())
+    }
+
+    fn entity_info(id: &str, file_path: &str, name: &str) -> EntityInfo {
+        EntityInfo {
+            id: id.to_string(),
+            file_path: file_path.to_string(),
+            entity_type: "function".to_string(),
+            name: name.to_string(),
+            parent_id: None,
+            start_line: 1,
+            end_line: 1,
+        }
+    }
+
+    fn graph_with_edges(entities: &[SemanticEntity], edges: Vec<EntityRef>) -> EntityGraph {
+        let entity_map = entities
+            .iter()
+            .map(|entity| {
+                (
+                    entity.id.clone(),
+                    entity_info(&entity.id, &entity.file_path, &entity.name),
+                )
+            })
+            .collect();
+        EntityGraph::from_parts(entity_map, edges)
+    }
+
+    fn edge(from_entity: &str, to_entity: &str) -> EntityRef {
+        EntityRef {
+            from_entity: from_entity.to_string(),
+            to_entity: to_entity.to_string(),
+            ref_type: RefType::Calls,
+        }
+    }
+
+    fn edge_count(cache: &DiskCache, from_entity: &str, to_entity: &str) -> i64 {
+        cache
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM edges WHERE from_entity = ?1 AND to_entity = ?2",
+                rusqlite::params![from_entity, to_entity],
+                |row| row.get(0),
+            )
+            .unwrap()
     }
 
     fn sample_files(root: &Path) -> Vec<String> {
@@ -1213,6 +1437,72 @@ mod tests {
     }
 
     #[test]
+    fn save_incremental_wrapper_rewrites_stale_source_edges() {
+        let root = temp_repo_root("incremental-wrapper-edges");
+        write_file(&root.join("stale.rs"), "fn stale() {}\n");
+        write_file(&root.join("clean.rs"), "fn clean() {}\n");
+        write_file(&root.join("old.rs"), "fn old_target() {}\n");
+        write_file(&root.join("new.rs"), "fn new_target() {}\n");
+        let files = vec![
+            "stale.rs".to_string(),
+            "clean.rs".to_string(),
+            "old.rs".to_string(),
+            "new.rs".to_string(),
+        ];
+        let cache = DiskCache::open(&root).unwrap();
+        let entities = vec![
+            entity("stale-id", "stale.rs", "stale", "stale old"),
+            entity("clean-id", "clean.rs", "clean", "clean old"),
+            entity("old-target-id", "old.rs", "old_target", "old target"),
+            entity("new-target-id", "new.rs", "new_target", "new target"),
+        ];
+        let initial_graph = graph_with_edges(
+            &entities,
+            vec![
+                edge("stale-id", "old-target-id"),
+                edge("clean-id", "old-target-id"),
+            ],
+        );
+        cache
+            .save(&root, &files, &initial_graph, &entities)
+            .unwrap();
+
+        let updated_entities = vec![
+            entity("stale-id", "stale.rs", "stale", "stale new"),
+            entity("clean-id", "clean.rs", "clean", "clean should stay cached"),
+            entity("old-target-id", "old.rs", "old_target", "old target"),
+            entity("new-target-id", "new.rs", "new_target", "new target"),
+        ];
+        let updated_graph = graph_with_edges(
+            &updated_entities,
+            vec![
+                edge("stale-id", "new-target-id"),
+                edge("clean-id", "old-target-id"),
+            ],
+        );
+        cache
+            .save_incremental(
+                &root,
+                &files,
+                &["stale.rs".to_string()],
+                &updated_graph,
+                &updated_entities,
+            )
+            .unwrap();
+
+        assert_eq!(edge_count(&cache, "stale-id", "old-target-id"), 0);
+        assert_eq!(edge_count(&cache, "stale-id", "new-target-id"), 1);
+        assert_eq!(edge_count(&cache, "clean-id", "old-target-id"), 1);
+        assert_eq!(
+            entity_content(&cache, "clean-id"),
+            Some("clean old".to_string())
+        );
+
+        drop(cache);
+        cleanup(root);
+    }
+
+    #[test]
     fn save_incremental_rewrites_entities_after_clean_id_repair() {
         let root = temp_repo_root("incremental-clean-repair");
         write_file(&root.join("stale.rs"), "fn stale() {}\n");
@@ -1243,6 +1533,8 @@ mod tests {
                 &empty_graph(),
                 &entities,
                 true,
+                &[],
+                &[],
             )
             .unwrap();
 

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -60,12 +60,18 @@ struct CachedGraph {
     entities: Arc<Vec<SemanticEntity>>,
 }
 
+struct CachedTopology {
+    manifest_hash: u64,
+    graph: Arc<EntityGraph>,
+}
+
 #[derive(Clone)]
 pub struct SemServer {
     context: Arc<Mutex<Option<RepoContext>>>,
     registry: Arc<ParserRegistry>,
     entity_cache: Arc<Mutex<EntityCache>>,
     graph_cache: Arc<Mutex<Option<CachedGraph>>>,
+    topology_cache: Arc<Mutex<Option<CachedTopology>>>,
     _tool_router: ToolRouter<Self>,
 }
 
@@ -75,7 +81,11 @@ impl SemServer {
         if let Some(fp) = file_path_hint {
             let p = Path::new(fp);
             if p.is_absolute() {
-                let search_dir = if p.is_dir() { p } else { p.parent().unwrap_or(p) };
+                let search_dir = if p.is_dir() {
+                    p
+                } else {
+                    p.parent().unwrap_or(p)
+                };
                 if let Ok(bridge) = GitBridge::open(search_dir) {
                     return Ok(bridge.repo_root().to_path_buf());
                 }
@@ -97,13 +107,11 @@ impl SemServer {
             }
         }
 
-        Err(
-            "Cannot find git repository. Either:\n\
+        Err("Cannot find git repository. Either:\n\
              - Pass an absolute file path\n\
              - Set SEM_REPO env var to the repo root\n\
              - Run sem-mcp from within a git repo"
-                .to_string(),
-        )
+            .to_string())
     }
 
     fn resolve_file_path(repo_root: &Path, file_path: &str) -> (String, PathBuf) {
@@ -251,11 +259,7 @@ impl SemServer {
         Ok(entities)
     }
 
-    async fn cached_extract_entities(
-        &self,
-        content: &str,
-        rel_path: &str,
-    ) -> Vec<SemanticEntity> {
+    async fn cached_extract_entities(&self, content: &str, rel_path: &str) -> Vec<SemanticEntity> {
         let hash = content_hash_u64(content);
         let key = (rel_path.to_string(), hash);
 
@@ -348,6 +352,11 @@ impl SemServer {
                     graph: graph.clone(),
                     entities: entities.clone(),
                 });
+                let mut topology_guard = self.topology_cache.lock().await;
+                *topology_guard = Some(CachedTopology {
+                    manifest_hash,
+                    graph: graph.clone(),
+                });
                 return (graph, entities);
             }
 
@@ -369,6 +378,8 @@ impl SemServer {
                     &graph,
                     &entities,
                     metadata.repaired_clean_entity_ids,
+                    &metadata.recomputed_edge_source_ids,
+                    &metadata.deleted_entity_ids,
                 );
 
                 let graph = Arc::new(graph);
@@ -378,6 +389,11 @@ impl SemServer {
                     manifest_hash,
                     graph: graph.clone(),
                     entities: entities.clone(),
+                });
+                let mut topology_guard = self.topology_cache.lock().await;
+                *topology_guard = Some(CachedTopology {
+                    manifest_hash,
+                    graph: graph.clone(),
                 });
                 return (graph, entities);
             }
@@ -403,8 +419,56 @@ impl SemServer {
                 entities: entities.clone(),
             });
         }
+        {
+            let mut guard = self.topology_cache.lock().await;
+            *guard = Some(CachedTopology {
+                manifest_hash,
+                graph: graph.clone(),
+            });
+        }
 
         (graph, entities)
+    }
+
+    async fn get_or_build_graph_topology(
+        &self,
+        repo_root: &Path,
+        file_paths: &[String],
+    ) -> Arc<EntityGraph> {
+        let manifest_hash = cache::compute_manifest_hash(repo_root, file_paths).unwrap_or(0);
+
+        {
+            let guard = self.graph_cache.lock().await;
+            if let Some(ref cached) = *guard {
+                if cached.manifest_hash == manifest_hash {
+                    return cached.graph.clone();
+                }
+            }
+        }
+
+        {
+            let guard = self.topology_cache.lock().await;
+            if let Some(ref cached) = *guard {
+                if cached.manifest_hash == manifest_hash {
+                    return cached.graph.clone();
+                }
+            }
+        }
+
+        if let Ok(disk) = cache::DiskCache::open(repo_root) {
+            if let Some(graph) = disk.load_graph_topology(repo_root, file_paths) {
+                let graph = Arc::new(graph);
+                let mut guard = self.topology_cache.lock().await;
+                *guard = Some(CachedTopology {
+                    manifest_hash,
+                    graph: graph.clone(),
+                });
+                return graph;
+            }
+        }
+
+        let (graph, _) = self.get_or_build_graph(repo_root, file_paths).await;
+        graph
     }
 }
 
@@ -418,13 +482,16 @@ impl SemServer {
                 std::num::NonZeroUsize::new(500).unwrap(),
             ))),
             graph_cache: Arc::new(Mutex::new(None)),
+            topology_cache: Arc::new(Mutex::new(None)),
             _tool_router: Self::tool_router(),
         }
     }
 
     // ── Tool 1: Entities ──
 
-    #[tool(description = "List semantic entities (functions, classes, etc.) under a file or directory path. Defaults to '.'.")]
+    #[tool(
+        description = "List semantic entities (functions, classes, etc.) under a file or directory path. Defaults to '.'."
+    )]
     async fn sem_entities(
         &self,
         Parameters(params): Parameters<EntitiesParams>,
@@ -492,7 +559,9 @@ impl SemServer {
 
     // ── Tool 2: Diff ──
 
-    #[tool(description = "Semantic diff between two refs: shows entity-level changes (added, modified, deleted, renamed) instead of line-level diffs")]
+    #[tool(
+        description = "Semantic diff between two refs: shows entity-level changes (added, modified, deleted, renamed) instead of line-level diffs"
+    )]
     async fn sem_diff(
         &self,
         Parameters(params): Parameters<DiffParams>,
@@ -529,8 +598,7 @@ impl SemServer {
         };
 
         let binary_changes = collect_binary_file_changes(&file_changes);
-        let diff_result =
-            compute_semantic_diff(&file_changes, &self.registry, None, None);
+        let diff_result = compute_semantic_diff(&file_changes, &self.registry, None, None);
 
         Ok(CallToolResult::success(vec![Content::text(
             format_diff_json_with_binary_changes(&diff_result, &binary_changes),
@@ -539,7 +607,9 @@ impl SemServer {
 
     // ── Tool 3: Blame ──
 
-    #[tool(description = "Entity-level git blame: for each entity in a file, shows who last modified it, when, and why")]
+    #[tool(
+        description = "Entity-level git blame: for each entity in a file, shows who last modified it, when, and why"
+    )]
     async fn sem_blame(
         &self,
         Parameters(params): Parameters<BlameParams>,
@@ -561,10 +631,7 @@ impl SemServer {
             }
         }
 
-        let blame = match ctx
-            .git
-            .blame_file_porcelain(Path::new(&rel_path))
-        {
+        let blame = match ctx.git.blame_file_porcelain(Path::new(&rel_path)) {
             Ok(blame) => blame,
             Err(err) => return Ok(tool_error(format!("Cannot blame {}: {}", rel_path, err))),
         };
@@ -603,9 +670,7 @@ impl SemServer {
                     } else {
                         info.author.clone()
                     },
-                    info.author_time
-                        .map(chrono_lite_format)
-                        .unwrap_or_default(),
+                    info.author_time.map(chrono_lite_format).unwrap_or_default(),
                     info.commit_sha.clone(),
                     info.summary.clone(),
                 ),
@@ -635,7 +700,9 @@ impl SemServer {
 
     // ── Tool 4: Impact ──
 
-    #[tool(description = "Unified entity analysis: dependencies, dependents, transitive impact, and affected tests. Use 'mode' to narrow: 'all' (default), 'deps', 'dependents', 'tests'.")]
+    #[tool(
+        description = "Unified entity analysis: dependencies, dependents, transitive impact, and affected tests. Use 'mode' to narrow: 'all' (default), 'deps', 'dependents', 'tests'."
+    )]
     async fn sem_impact(
         &self,
         Parameters(params): Parameters<ImpactAnalysisParams>,
@@ -656,13 +723,6 @@ impl SemServer {
             Ok(file_paths) => file_paths,
             Err(err) => return Ok(tool_error(err)),
         };
-        let (graph, all_entities) = self.get_or_build_graph(&ctx.repo_root, &file_paths).await;
-
-        let entity_id = match Self::find_entity_in_graph(&graph, &params.entity_name, &rel_path) {
-            Ok(entity_id) => entity_id,
-            Err(err) => return Ok(tool_error(err)),
-        };
-
         let mode = params.mode.as_deref().unwrap_or("all");
         let valid_modes = ["all", "deps", "dependents", "tests"];
         if !valid_modes.contains(&mode) {
@@ -673,47 +733,79 @@ impl SemServer {
             )));
         }
 
+        if matches!(mode, "deps" | "dependents") {
+            let graph = self
+                .get_or_build_graph_topology(&ctx.repo_root, &file_paths)
+                .await;
+            let entity_id = match Self::find_entity_in_graph(&graph, &params.entity_name, &rel_path)
+            {
+                Ok(entity_id) => entity_id,
+                Err(err) => return Ok(tool_error(err)),
+            };
+
+            let output = match mode {
+                "deps" => {
+                    let deps = graph.get_dependencies(entity_id);
+                    let result: Vec<serde_json::Value> = deps
+                        .iter()
+                        .map(|d| {
+                            serde_json::json!({
+                                "name": d.name, "type": d.entity_type,
+                                "file": d.file_path, "lines": [d.start_line, d.end_line],
+                            })
+                        })
+                        .collect();
+                    serde_json::json!({
+                        "entity": params.entity_name,
+                        "file": rel_path,
+                        "mode": "deps",
+                        "dependencies": result,
+                    })
+                }
+                "dependents" => {
+                    let deps = graph.get_dependents(entity_id);
+                    let result: Vec<serde_json::Value> = deps
+                        .iter()
+                        .map(|d| {
+                            serde_json::json!({
+                                "name": d.name, "type": d.entity_type,
+                                "file": d.file_path, "lines": [d.start_line, d.end_line],
+                            })
+                        })
+                        .collect();
+                    serde_json::json!({
+                        "entity": params.entity_name,
+                        "file": rel_path,
+                        "mode": "dependents",
+                        "dependents": result,
+                    })
+                }
+                _ => unreachable!(),
+            };
+
+            return Ok(CallToolResult::success(vec![Content::text(
+                serde_json::to_string_pretty(&output).unwrap(),
+            )]));
+        }
+
+        let (graph, all_entities) = self.get_or_build_graph(&ctx.repo_root, &file_paths).await;
+
+        let entity_id = match Self::find_entity_in_graph(&graph, &params.entity_name, &rel_path) {
+            Ok(entity_id) => entity_id,
+            Err(err) => return Ok(tool_error(err)),
+        };
+
         let output = match mode {
-            "deps" => {
-                let deps = graph.get_dependencies(entity_id);
-                let result: Vec<serde_json::Value> = deps
-                    .iter()
-                    .map(|d| serde_json::json!({
-                        "name": d.name, "type": d.entity_type,
-                        "file": d.file_path, "lines": [d.start_line, d.end_line],
-                    }))
-                    .collect();
-                serde_json::json!({
-                    "entity": params.entity_name,
-                    "file": rel_path,
-                    "mode": "deps",
-                    "dependencies": result,
-                })
-            }
-            "dependents" => {
-                let deps = graph.get_dependents(entity_id);
-                let result: Vec<serde_json::Value> = deps
-                    .iter()
-                    .map(|d| serde_json::json!({
-                        "name": d.name, "type": d.entity_type,
-                        "file": d.file_path, "lines": [d.start_line, d.end_line],
-                    }))
-                    .collect();
-                serde_json::json!({
-                    "entity": params.entity_name,
-                    "file": rel_path,
-                    "mode": "dependents",
-                    "dependents": result,
-                })
-            }
             "tests" => {
                 let tests = graph.test_impact(entity_id, &all_entities);
                 let result: Vec<serde_json::Value> = tests
                     .iter()
-                    .map(|d| serde_json::json!({
-                        "name": d.name, "type": d.entity_type,
-                        "file": d.file_path, "lines": [d.start_line, d.end_line],
-                    }))
+                    .map(|d| {
+                        serde_json::json!({
+                            "name": d.name, "type": d.entity_type,
+                            "file": d.file_path, "lines": [d.start_line, d.end_line],
+                        })
+                    })
                     .collect();
                 serde_json::json!({
                     "entity": params.entity_name,
@@ -723,6 +815,7 @@ impl SemServer {
                     "tests": result,
                 })
             }
+            "deps" | "dependents" => unreachable!(),
             _ => {
                 // "all" mode: everything
                 let deps = graph.get_dependencies(entity_id);
@@ -730,12 +823,17 @@ impl SemServer {
                 let impact = graph.impact_analysis(entity_id);
                 let tests = graph.test_impact(entity_id, &all_entities);
 
-                let map_entities = |list: &[&sem_core::parser::graph::EntityInfo]| -> Vec<serde_json::Value> {
-                    list.iter().map(|d| serde_json::json!({
-                        "name": d.name, "type": d.entity_type,
-                        "file": d.file_path, "lines": [d.start_line, d.end_line],
-                    })).collect()
-                };
+                let map_entities =
+                    |list: &[&sem_core::parser::graph::EntityInfo]| -> Vec<serde_json::Value> {
+                        list.iter()
+                            .map(|d| {
+                                serde_json::json!({
+                                    "name": d.name, "type": d.entity_type,
+                                    "file": d.file_path, "lines": [d.start_line, d.end_line],
+                                })
+                            })
+                            .collect()
+                    };
 
                 serde_json::json!({
                     "entity": params.entity_name,
@@ -759,7 +857,9 @@ impl SemServer {
 
     // ── Tool 5: Log ──
 
-    #[tool(description = "Entity evolution history: trace how a specific entity changed across git commits, distinguishing logic changes from cosmetic ones")]
+    #[tool(
+        description = "Entity evolution history: trace how a specific entity changed across git commits, distinguishing logic changes from cosmetic ones"
+    )]
     async fn sem_log(
         &self,
         Parameters(params): Parameters<LogParams>,
@@ -864,7 +964,8 @@ impl SemServer {
         };
 
         let entity_type = seed.entity.entity_type.clone();
-        let mut entries = mcp_trace_back_to_origin(&ctx.git, &self.registry, &commits, seed.clone());
+        let mut entries =
+            mcp_trace_back_to_origin(&ctx.git, &self.registry, &commits, seed.clone());
         entries.extend(mcp_trace_forward_from_seed(
             &ctx.git,
             &self.registry,
@@ -890,7 +991,9 @@ impl SemServer {
 
     // ── Tool 6: Context ──
 
-    #[tool(description = "Pack optimal entity context into a token budget. Priority: target entity > direct dependencies > direct dependents > transitive dependencies > transitive dependents.")]
+    #[tool(
+        description = "Pack optimal entity context into a token budget. Priority: target entity > direct dependencies > direct dependents > transitive dependencies > transitive dependents."
+    )]
     async fn sem_context(
         &self,
         Parameters(params): Parameters<ContextParams>,
@@ -926,7 +1029,8 @@ impl SemServer {
             budget,
         );
 
-        let result: Vec<serde_json::Value> = context_result.entries
+        let result: Vec<serde_json::Value> = context_result
+            .entries
             .iter()
             .map(|e| {
                 serde_json::json!({
@@ -1016,7 +1120,9 @@ mod tests {
         let mut commits = if git
             .get_head_sha()
             .ok()
-            .and_then(|head| mcp_entity_by_name_at_ref(&git, &registry, &head, file_path, entity_name))
+            .and_then(|head| {
+                mcp_entity_by_name_at_ref(&git, &registry, &head, file_path, entity_name)
+            })
             .is_some()
         {
             git.get_file_commits_follow_renames(file_path, 0)
@@ -1058,12 +1164,8 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        let root = std::env::temp_dir().join(format!(
-            "sem-mcp-{}-{}-{}",
-            name,
-            std::process::id(),
-            nanos
-        ));
+        let root =
+            std::env::temp_dir().join(format!("sem-mcp-{}-{}-{}", name, std::process::id(), nanos));
         std::fs::create_dir_all(&root).unwrap();
         git2::Repository::init(&root).unwrap();
         root
@@ -1116,8 +1218,8 @@ mod tests {
     #[test]
     fn entity_lookup_candidate_list_is_bounded() {
         let candidates = [
-            "a.py", "b.py", "c.py", "d.py", "e.py", "f.py", "g.py", "h.py", "i.py", "j.py",
-            "k.py", "l.py",
+            "a.py", "b.py", "c.py", "d.py", "e.py", "f.py", "g.py", "h.py", "i.py", "j.py", "k.py",
+            "l.py",
         ];
 
         assert_eq!(
@@ -1136,10 +1238,8 @@ mod tests {
 
     #[test]
     fn find_supported_files_returns_walk_errors() {
-        let missing_root = std::env::temp_dir().join(format!(
-            "sem-mcp-missing-root-{}",
-            std::process::id()
-        ));
+        let missing_root =
+            std::env::temp_dir().join(format!("sem-mcp-missing-root-{}", std::process::id()));
         let registry = ParserRegistry::new();
 
         let err = SemServer::find_supported_files(&missing_root, &registry).unwrap_err();
@@ -1235,7 +1335,11 @@ mod tests {
         fs::write(root.join("src/app.js"), "export function app() {}\n").unwrap();
         fs::write(root.join("src/blob.weird"), b"abc\0def").unwrap();
         fs::write(root.join("src/icon.png"), b"\x89PNG\r\n").unwrap();
-        fs::write(root.join("dist/generated.js"), "export function generated() {}\n").unwrap();
+        fs::write(
+            root.join("dist/generated.js"),
+            "export function generated() {}\n",
+        )
+        .unwrap();
 
         let registry = create_default_registry();
         let files = SemServer::find_supported_files(&root, &registry).unwrap();
@@ -1419,7 +1523,11 @@ mod tests {
         let root = temp_git_repo("wrong-impact-file");
         let file_path = root.join("notes.txt");
         std::fs::write(&file_path, "known_entity\n").unwrap();
-        std::fs::write(root.join("sample.py"), "def known_entity():\n    return 1\n").unwrap();
+        std::fs::write(
+            root.join("sample.py"),
+            "def known_entity():\n    return 1\n",
+        )
+        .unwrap();
         let server = SemServer::new();
 
         let result = server
@@ -1441,7 +1549,11 @@ mod tests {
     #[tokio::test]
     async fn sem_impact_normalizes_relative_file_path_before_entity_lookup() {
         let root = temp_git_repo("normalized-impact-file");
-        std::fs::write(root.join("sample.py"), "def known_entity():\n    return 1\n").unwrap();
+        std::fs::write(
+            root.join("sample.py"),
+            "def known_entity():\n    return 1\n",
+        )
+        .unwrap();
         let server = server_for_repo(&root).await;
 
         let result = server
@@ -1462,7 +1574,11 @@ mod tests {
         let root = temp_git_repo("wrong-context-file");
         let file_path = root.join("notes.txt");
         std::fs::write(&file_path, "known_entity\n").unwrap();
-        std::fs::write(root.join("sample.py"), "def known_entity():\n    return 1\n").unwrap();
+        std::fs::write(
+            root.join("sample.py"),
+            "def known_entity():\n    return 1\n",
+        )
+        .unwrap();
         let server = SemServer::new();
 
         let result = server
@@ -1556,7 +1672,9 @@ fn format_entity_lookup_candidates(candidates: &[&str]) -> String {
         .copied()
         .collect::<Vec<_>>()
         .join(", ");
-    let remaining = candidates.len().saturating_sub(ENTITY_LOOKUP_CANDIDATE_LIMIT);
+    let remaining = candidates
+        .len()
+        .saturating_sub(ENTITY_LOOKUP_CANDIDATE_LIMIT);
 
     if remaining == 0 {
         shown
@@ -1621,17 +1739,15 @@ fn normalize_relative_path(path: &Path) -> PathBuf {
     for component in path.components() {
         match component {
             std::path::Component::CurDir => {}
-            std::path::Component::ParentDir => {
-                match normalized.components().next_back() {
-                    Some(std::path::Component::Normal(_)) => {
-                        normalized.pop();
-                    }
-                    Some(std::path::Component::ParentDir) | None => normalized.push(".."),
-                    Some(std::path::Component::RootDir)
-                    | Some(std::path::Component::Prefix(_))
-                    | Some(std::path::Component::CurDir) => {}
+            std::path::Component::ParentDir => match normalized.components().next_back() {
+                Some(std::path::Component::Normal(_)) => {
+                    normalized.pop();
                 }
-            }
+                Some(std::path::Component::ParentDir) | None => normalized.push(".."),
+                Some(std::path::Component::RootDir)
+                | Some(std::path::Component::Prefix(_))
+                | Some(std::path::Component::CurDir) => {}
+            },
             std::path::Component::Normal(part) => normalized.push(part),
             std::path::Component::RootDir | std::path::Component::Prefix(_) => {
                 normalized.push(component.as_os_str())
@@ -1663,13 +1779,19 @@ fn mcp_find_seed_occurrence(
     for (index, commit) in commits.iter().enumerate().rev() {
         let paths = match file_path {
             Some(path) => vec![path.to_string()],
-            None => git.get_commit_changed_files(&commit.sha).unwrap_or_default(),
+            None => git
+                .get_commit_changed_files(&commit.sha)
+                .unwrap_or_default(),
         };
         for path in paths {
             if let Some(entity) =
                 mcp_entity_by_name_at_ref(git, registry, &commit.sha, &path, entity_name)
             {
-                return Some(McpLogOccurrence { commit_index: index, file_path: path, entity });
+                return Some(McpLogOccurrence {
+                    commit_index: index,
+                    file_path: path,
+                    entity,
+                });
             }
         }
     }
@@ -1687,7 +1809,9 @@ fn mcp_trace_back_to_origin(
     for child_index in (1..=current.commit_index).rev() {
         let child_commit = &commits[child_index];
         let parent_commit = &commits[child_index - 1];
-        let changed_paths = git.get_commit_changed_files(&child_commit.sha).unwrap_or_default();
+        let changed_paths = git
+            .get_commit_changed_files(&child_commit.sha)
+            .unwrap_or_default();
         let previous = mcp_find_related_entity_at_ref(
             git,
             registry,
@@ -1705,7 +1829,10 @@ fn mcp_trace_back_to_origin(
         if let Some(entry) = mcp_transition_entry(child_commit, &previous, &current) {
             entries.push(entry);
         }
-        current = McpLogOccurrence { commit_index: child_index - 1, ..previous };
+        current = McpLogOccurrence {
+            commit_index: child_index - 1,
+            ..previous
+        };
     }
     entries.push(mcp_added_entry(&commits[current.commit_index], &current));
     entries.reverse();
@@ -1722,7 +1849,9 @@ fn mcp_trace_forward_from_seed(
     let mut entries = Vec::new();
     for child_index in current.commit_index + 1..commits.len() {
         let child_commit = &commits[child_index];
-        let changed_paths = git.get_commit_changed_files(&child_commit.sha).unwrap_or_default();
+        let changed_paths = git
+            .get_commit_changed_files(&child_commit.sha)
+            .unwrap_or_default();
         let next = mcp_find_related_entity_at_ref(
             git,
             registry,
@@ -1739,7 +1868,10 @@ fn mcp_trace_forward_from_seed(
         if let Some(entry) = mcp_transition_entry(child_commit, &current, &next) {
             entries.push(entry);
         }
-        current = McpLogOccurrence { commit_index: child_index, ..next };
+        current = McpLogOccurrence {
+            commit_index: child_index,
+            ..next
+        };
     }
     entries
 }
@@ -1756,7 +1888,11 @@ fn mcp_find_related_entity_at_ref(
     let paths = mcp_candidate_paths(preferred_file, changed_paths);
     for path in &paths {
         if let Some(entity) = mcp_entity_by_name_at_ref(git, registry, sha, path, entity_name) {
-            return Some(McpLogOccurrence { commit_index: 0, file_path: path.clone(), entity });
+            return Some(McpLogOccurrence {
+                commit_index: 0,
+                file_path: path.clone(),
+                entity,
+            });
         }
     }
     let structural_hash = structural_hash?;
@@ -1764,7 +1900,11 @@ fn mcp_find_related_entity_at_ref(
         if let Some(entity) =
             mcp_entity_by_structural_hash_at_ref(git, registry, sha, path, structural_hash)
         {
-            return Some(McpLogOccurrence { commit_index: 0, file_path: path.clone(), entity });
+            return Some(McpLogOccurrence {
+                commit_index: 0,
+                file_path: path.clone(),
+                entity,
+            });
         }
     }
     None

--- a/scripts/large-js-fixture.mjs
+++ b/scripts/large-js-fixture.mjs
@@ -1,0 +1,523 @@
+#!/usr/bin/env node
+
+import { execFile } from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+
+const execFileAsync = promisify(execFile);
+const MARKER_FILE = '.sem-large-js-fixture';
+const IMPORT_STYLES = new Set(['named', 'default', 'namespace', 'type', 'side-effect']);
+
+export const DEFAULT_LARGE_JS_FIXTURE_OPTIONS = {
+  outDir: path.resolve('benchmarks/large-js-fixture/.generated/repo'),
+  fileCount: 1000,
+  entitiesPerFile: 12,
+  importFanout: 5,
+  importStyleMix: ['named', 'named', 'named', 'default', 'namespace', 'type'],
+  nestedDepth: 3,
+  bodyLines: 40,
+  language: 'mixed',
+  gitInit: true,
+  force: false,
+};
+
+export function parseLargeJsFixtureArgs(argv) {
+  const options = { ...DEFAULT_LARGE_JS_FIXTURE_OPTIONS };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case '-h':
+      case '--help':
+        return { help: true };
+      case '--out':
+      case '-o':
+        options.outDir = path.resolve(readFlagValue(argv, ++index, arg));
+        break;
+      case '--files':
+      case '--file-count':
+        options.fileCount = parsePositiveInteger(readFlagValue(argv, ++index, arg), arg);
+        break;
+      case '--entities-per-file':
+        options.entitiesPerFile = parsePositiveInteger(readFlagValue(argv, ++index, arg), arg);
+        break;
+      case '--fanout':
+      case '--import-fanout':
+        options.importFanout = parseNonNegativeInteger(readFlagValue(argv, ++index, arg), arg);
+        break;
+      case '--import-style-mix':
+      case '--import-styles':
+        options.importStyleMix = parseImportStyleMix(readFlagValue(argv, ++index, arg));
+        break;
+      case '--nested-depth':
+        options.nestedDepth = parseNonNegativeInteger(readFlagValue(argv, ++index, arg), arg);
+        break;
+      case '--body-lines':
+      case '--large-body-lines':
+        options.bodyLines = parseNonNegativeInteger(readFlagValue(argv, ++index, arg), arg);
+        break;
+      case '--language':
+        options.language = readFlagValue(argv, ++index, arg);
+        break;
+      case '--no-git-init':
+        options.gitInit = false;
+        break;
+      case '--force':
+        options.force = true;
+        break;
+      default:
+        throw new Error(`Unknown option "${arg}". Run with --help for usage.`);
+    }
+  }
+
+  return normalizeLargeJsFixtureOptions(options);
+}
+
+export function parseImportStyleMix(value) {
+  if (Array.isArray(value)) {
+    return value.flatMap((style) => parseImportStyleMixPart(String(style)));
+  }
+
+  return String(value)
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .flatMap(parseImportStyleMixPart);
+}
+
+export async function generateLargeJsFixture(options = {}) {
+  const normalized = normalizeLargeJsFixtureOptions({
+    ...DEFAULT_LARGE_JS_FIXTURE_OPTIONS,
+    ...options,
+  });
+
+  await prepareOutputDirectory(normalized.outDir, normalized.force);
+
+  const srcDir = path.join(normalized.outDir, 'src');
+  await fs.mkdir(srcDir, { recursive: true });
+
+  const fileMetas = [];
+  for (let index = 0; index < normalized.fileCount; index += 1) {
+    const ext = extensionFor(index, normalized.language);
+    const id = fileId(index);
+    const relativePath = `src/${id}${ext}`;
+    const entityNames = Array.from(
+      { length: normalized.entitiesPerFile },
+      (_, entityIndex) => `${id}_e${pad(entityIndex, 3)}`,
+    );
+    const source = renderSourceFile(index, ext, normalized);
+
+    await fs.writeFile(path.join(normalized.outDir, relativePath), source, 'utf8');
+    fileMetas.push({
+      path: relativePath,
+      extension: ext,
+      entities: entityNames,
+    });
+  }
+
+  await writeProjectFiles(normalized.outDir, normalized);
+
+  const entryExt = extensionFor(0, normalized.language);
+  const entryFile = `src/${fileId(0)}${entryExt}`;
+  const targetEntity = `${fileId(0)}_e000`;
+  const markerSearch = incrementalMarkerLine(fileId(0), targetEntity, entryExt, 0);
+  const markerReplacement = incrementalMarkerLine(fileId(0), targetEntity, entryExt, 1);
+  const manifest = {
+    schemaVersion: 1,
+    config: {
+      fileCount: normalized.fileCount,
+      entitiesPerFile: normalized.entitiesPerFile,
+      importFanout: normalized.importFanout,
+      importStyleMix: normalized.importStyleMix,
+      nestedDepth: normalized.nestedDepth,
+      bodyLines: normalized.bodyLines,
+      language: normalized.language,
+    },
+    entryFile,
+    targetEntity,
+    incremental: {
+      file: entryFile,
+      search: markerSearch,
+      replacement: markerReplacement,
+    },
+    files: fileMetas,
+  };
+
+  await fs.writeFile(
+    path.join(normalized.outDir, 'fixture-manifest.json'),
+    `${stableJson(manifest)}\n`,
+    'utf8',
+  );
+
+  if (normalized.gitInit) {
+    await initializeGitRepository(normalized.outDir);
+  }
+
+  return {
+    outDir: normalized.outDir,
+    manifest,
+  };
+}
+
+function normalizeLargeJsFixtureOptions(options) {
+  const normalized = {
+    ...options,
+    outDir: path.resolve(String(options.outDir)),
+    fileCount: parsePositiveInteger(options.fileCount, 'fileCount'),
+    entitiesPerFile: parsePositiveInteger(options.entitiesPerFile, 'entitiesPerFile'),
+    importFanout: parseNonNegativeInteger(options.importFanout, 'importFanout'),
+    importStyleMix: parseImportStyleMix(options.importStyleMix),
+    nestedDepth: parseNonNegativeInteger(options.nestedDepth, 'nestedDepth'),
+    bodyLines: parseNonNegativeInteger(options.bodyLines, 'bodyLines'),
+    language: String(options.language),
+    gitInit: Boolean(options.gitInit),
+    force: Boolean(options.force),
+  };
+
+  if (!['ts', 'js', 'mixed'].includes(normalized.language)) {
+    throw new Error('--language must be ts, js, or mixed.');
+  }
+
+  if (normalized.importStyleMix.length === 0) {
+    throw new Error('--import-style-mix must contain at least one import style.');
+  }
+
+  return normalized;
+}
+
+async function prepareOutputDirectory(outDir, force) {
+  let entries = [];
+  try {
+    entries = await fs.readdir(outDir);
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  if (entries.length > 0 && !force) {
+    try {
+      await fs.stat(path.join(outDir, MARKER_FILE));
+    } catch {
+      throw new Error(`Refusing to replace non-empty directory without ${MARKER_FILE}: ${outDir}`);
+    }
+  }
+
+  await fs.rm(outDir, { recursive: true, force: true });
+  await fs.mkdir(outDir, { recursive: true });
+  await fs.writeFile(path.join(outDir, MARKER_FILE), 'generated by scripts/large-js-fixture.mjs\n', 'utf8');
+}
+
+async function writeProjectFiles(outDir, options) {
+  const packageJson = {
+    name: 'sem-large-js-fixture',
+    private: true,
+    type: 'module',
+  };
+  const tsconfig = {
+    compilerOptions: {
+      allowJs: true,
+      checkJs: false,
+      module: 'ESNext',
+      moduleResolution: 'Bundler',
+      target: 'ES2022',
+      strict: false,
+    },
+    include: ['src/**/*'],
+  };
+
+  await fs.writeFile(path.join(outDir, 'package.json'), `${stableJson(packageJson)}\n`, 'utf8');
+  await fs.writeFile(path.join(outDir, 'tsconfig.json'), `${stableJson(tsconfig)}\n`, 'utf8');
+  await fs.writeFile(
+    path.join(outDir, 'README.md'),
+    [
+      '# sem Large JS/TS Fixture',
+      '',
+      'This repository is generated for sem performance testing.',
+      `Files: ${options.fileCount}`,
+      `Entities per file: ${options.entitiesPerFile}`,
+      '',
+    ].join('\n'),
+    'utf8',
+  );
+}
+
+function renderSourceFile(index, ext, options) {
+  const id = fileId(index);
+  const isTs = ext === '.ts';
+  const lines = [
+    '// Generated fixture source for sem performance testing.',
+    ...renderImports(index, ext, options),
+  ];
+
+  if (lines[lines.length - 1] !== '') {
+    lines.push('');
+  }
+
+  if (isTs) {
+    lines.push(`export type T${id.slice(1)}_000 = { value: number };`);
+    lines.push('');
+  }
+
+  lines.push(renderDefaultExport(id, isTs));
+  lines.push('');
+
+  for (let entityIndex = 0; entityIndex < options.entitiesPerFile; entityIndex += 1) {
+    lines.push(renderEntity(index, entityIndex, ext, options));
+    lines.push('');
+  }
+
+  lines.push(renderClass(index, ext, options));
+  lines.push('');
+
+  return `${lines.join('\n')}`;
+}
+
+function renderImports(index, ext, options) {
+  const imports = [];
+  for (let offset = 1; offset <= options.importFanout; offset += 1) {
+    const targetIndex = (index + offset) % options.fileCount;
+    if (targetIndex === index) {
+      continue;
+    }
+
+    const targetExt = extensionFor(targetIndex, options.language);
+    const style = effectiveImportStyle(
+      options.importStyleMix[(offset - 1) % options.importStyleMix.length],
+      ext,
+      targetExt,
+    );
+    const targetId = fileId(targetIndex);
+    const importIndex = offset - 1;
+    const specifier = `./${targetId}`;
+
+    if (style === 'named') {
+      imports.push(
+        `import { ${targetId}_e000 as imported_${targetId}_${importIndex} } from '${specifier}';`,
+      );
+    } else if (style === 'default') {
+      imports.push(`import default_${targetId}_${importIndex} from '${specifier}';`);
+    } else if (style === 'namespace') {
+      imports.push(`import * as ns_${targetId}_${importIndex} from '${specifier}';`);
+    } else if (style === 'type') {
+      imports.push(`import type { T${targetId.slice(1)}_000 as Type_${targetId}_${importIndex} } from '${specifier}';`);
+    } else {
+      imports.push(`import '${specifier}';`);
+    }
+  }
+
+  if (imports.length > 0) {
+    imports.push('');
+  }
+
+  return imports;
+}
+
+function renderDefaultExport(id, isTs) {
+  if (isTs) {
+    return `export default function default_${id}(input: number): number { return input + ${Number(id.slice(1))}; }`;
+  }
+  return `export default function default_${id}(input) { return input + ${Number(id.slice(1))}; }`;
+}
+
+function renderEntity(index, entityIndex, ext, options) {
+  const id = fileId(index);
+  const entity = `${id}_e${pad(entityIndex, 3)}`;
+  const isTs = ext === '.ts';
+  const lines = [];
+
+  lines.push(
+    isTs
+      ? `export function ${entity}(input: number): number {`
+      : `export function ${entity}(input) {`,
+  );
+
+  for (let depth = 1; depth <= options.nestedDepth; depth += 1) {
+    lines.push(
+      isTs
+        ? `  function ${entity}_nested_${depth}(value: number): number {`
+        : `  function ${entity}_nested_${depth}(value) {`,
+    );
+    lines.push(`    return value + ${depth};`);
+    lines.push('  }');
+  }
+
+  if (entityIndex === 0) {
+    lines.push(`  ${incrementalMarkerLine(id, entity, ext, 0)}`);
+  }
+
+  for (let lineIndex = 0; lineIndex < options.bodyLines; lineIndex += 1) {
+    lines.push(`  const local_${entity}_${lineIndex} = input + ${index} + ${entityIndex} + ${lineIndex};`);
+  }
+
+  for (const useLine of renderImportUses(index, ext, options)) {
+    lines.push(`  ${useLine}`);
+  }
+
+  let returnExpression = 'input';
+  for (let depth = 1; depth <= options.nestedDepth; depth += 1) {
+    returnExpression = `${entity}_nested_${depth}(${returnExpression})`;
+  }
+  lines.push(`  return ${returnExpression};`);
+  lines.push('}');
+
+  return lines.join('\n');
+}
+
+function renderClass(index, ext, options) {
+  const id = fileId(index);
+  const isTs = ext === '.ts';
+  const lines = [`export class C${id} {`];
+  for (let depth = 0; depth <= options.nestedDepth; depth += 1) {
+    lines.push(isTs ? `  m${depth}(input: number): number {` : `  m${depth}(input) {`);
+    lines.push(`    return input + ${index} + ${depth};`);
+    lines.push('  }');
+  }
+  lines.push('}');
+  return lines.join('\n');
+}
+
+function renderImportUses(index, ext, options) {
+  const uses = [];
+  for (let offset = 1; offset <= options.importFanout; offset += 1) {
+    const targetIndex = (index + offset) % options.fileCount;
+    if (targetIndex === index) {
+      continue;
+    }
+
+    const targetExt = extensionFor(targetIndex, options.language);
+    const style = effectiveImportStyle(
+      options.importStyleMix[(offset - 1) % options.importStyleMix.length],
+      ext,
+      targetExt,
+    );
+    const targetId = fileId(targetIndex);
+    const importIndex = offset - 1;
+
+    if (style === 'named') {
+      uses.push(`const use_named_${targetId}_${importIndex} = imported_${targetId}_${importIndex}(input);`);
+    } else if (style === 'default') {
+      uses.push(`const use_default_${targetId}_${importIndex} = default_${targetId}_${importIndex}(input);`);
+    } else if (style === 'namespace') {
+      uses.push(`const use_namespace_${targetId}_${importIndex} = ns_${targetId}_${importIndex}.${targetId}_e000(input);`);
+    } else if (style === 'type') {
+      uses.push(`const use_type_${targetId}_${importIndex}: Type_${targetId}_${importIndex} = { value: input };`);
+    }
+  }
+  return uses;
+}
+
+function effectiveImportStyle(style, sourceExt, targetExt) {
+  if (style === 'type' && (sourceExt !== '.ts' || targetExt !== '.ts')) {
+    return 'named';
+  }
+  return style;
+}
+
+function incrementalMarkerLine(id, entity, ext, value) {
+  if (ext === '.ts') {
+    return `const incrementalMarker_${entity}: number = ${value};`;
+  }
+  return `const incrementalMarker_${entity} = ${value};`;
+}
+
+async function initializeGitRepository(outDir) {
+  await execFileAsync('git', ['init'], { cwd: outDir });
+  await execFileAsync('git', ['config', 'user.email', 'sem-fixture@example.invalid'], { cwd: outDir });
+  await execFileAsync('git', ['config', 'user.name', 'sem fixture'], { cwd: outDir });
+  await execFileAsync('git', ['add', '.'], { cwd: outDir });
+  await execFileAsync('git', ['commit', '-m', 'initial fixture'], { cwd: outDir });
+}
+
+function parseImportStyleMixPart(part) {
+  const [style, rawWeight = '1'] = part.split(':');
+  if (!IMPORT_STYLES.has(style)) {
+    throw new Error(`Unknown import style "${style}".`);
+  }
+
+  const weight = parsePositiveInteger(rawWeight, `weight for ${style}`);
+  return Array.from({ length: weight }, () => style);
+}
+
+function extensionFor(index, language) {
+  if (language === 'mixed') {
+    return index % 2 === 0 ? '.ts' : '.js';
+  }
+  return language === 'js' ? '.js' : '.ts';
+}
+
+function fileId(index) {
+  return `f${pad(index, 4)}`;
+}
+
+function pad(value, width) {
+  return String(value).padStart(width, '0');
+}
+
+function stableJson(value) {
+  return JSON.stringify(value, null, 2);
+}
+
+function readFlagValue(argv, index, flag) {
+  const value = argv[index];
+  if (value === undefined || value.startsWith('--')) {
+    throw new Error(`Missing value for ${flag}.`);
+  }
+  return value;
+}
+
+function parsePositiveInteger(value, label) {
+  const text = String(value).trim();
+  const parsed = Number.parseInt(text, 10);
+  if (!/^\d+$/.test(text) || !Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new Error(`${label} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+function parseNonNegativeInteger(value, label) {
+  const text = String(value).trim();
+  const parsed = Number.parseInt(text, 10);
+  if (!/^\d+$/.test(text) || !Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new Error(`${label} must be a non-negative integer.`);
+  }
+  return parsed;
+}
+
+const HELP = `
+Generate a deterministic JS/TS fixture for sem performance testing.
+
+Usage:
+  node scripts/large-js-fixture.mjs --out <dir> [options]
+
+Options:
+  --files <count>
+  --entities-per-file <count>
+  --fanout <count>
+  --import-style-mix <mix>
+  --nested-depth <count>
+  --body-lines <count>
+  --language <ts|js|mixed>
+  --no-git-init
+  --force
+`.trim();
+
+async function runCli() {
+  const parsed = parseLargeJsFixtureArgs(process.argv.slice(2));
+  if (parsed.help) {
+    console.log(HELP);
+    return;
+  }
+
+  const result = await generateLargeJsFixture(parsed);
+  console.log(stableJson(result.manifest));
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  runCli().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/large-js-fixture.test.mjs
+++ b/scripts/large-js-fixture.test.mjs
@@ -1,0 +1,153 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  generateLargeJsFixture,
+  parseImportStyleMix,
+  parseLargeJsFixtureArgs,
+} from './large-js-fixture.mjs';
+
+async function withTempDirectory(callback) {
+  const tempDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'sem-large-js-fixture-test-'));
+
+  try {
+    return await callback(tempDirectory);
+  } finally {
+    await fs.rm(tempDirectory, { recursive: true, force: true });
+  }
+}
+
+test('generates a deterministic TypeScript fixture with every import style', async () => {
+  await withTempDirectory(async (tempDirectory) => {
+    const outDir = path.join(tempDirectory, 'fixture');
+    const options = {
+      outDir,
+      fileCount: 5,
+      entitiesPerFile: 2,
+      importFanout: 4,
+      importStyleMix: parseImportStyleMix('named,default,namespace,type'),
+      nestedDepth: 2,
+      bodyLines: 3,
+      language: 'ts',
+      gitInit: false,
+    };
+
+    const first = await generateLargeJsFixture(options);
+    const firstSource = await fs.readFile(path.join(outDir, 'src', 'f0000.ts'), 'utf8');
+    const firstManifest = await fs.readFile(path.join(outDir, 'fixture-manifest.json'), 'utf8');
+
+    const second = await generateLargeJsFixture(options);
+    const secondSource = await fs.readFile(path.join(outDir, 'src', 'f0000.ts'), 'utf8');
+    const secondManifest = await fs.readFile(path.join(outDir, 'fixture-manifest.json'), 'utf8');
+
+    assert.equal(first.manifest.files.length, 5);
+    assert.equal(second.manifest.files.length, 5);
+    assert.equal(firstSource, secondSource);
+    assert.equal(firstManifest, secondManifest);
+
+    assert.match(firstSource, /import \{ f0001_e000 as imported_f0001_0 \}/);
+    assert.match(firstSource, /import default_f0002_1 from '\.\/f0002';/);
+    assert.match(firstSource, /import \* as ns_f0003_2 from '\.\/f0003';/);
+    assert.match(firstSource, /import type \{ T0004_000 as Type_f0004_3 \}/);
+    assert.match(firstSource, /function f0000_e000\(input: number\): number/);
+    assert.match(firstSource, /function f0000_e000_nested_1\(value: number\): number/);
+    assert.match(firstSource, /const incrementalMarker_f0000_e000: number = 0;/);
+  });
+});
+
+test('mixed fixtures avoid TypeScript-only syntax in JavaScript files', async () => {
+  await withTempDirectory(async (tempDirectory) => {
+    const outDir = path.join(tempDirectory, 'fixture');
+
+    await generateLargeJsFixture({
+      outDir,
+      fileCount: 2,
+      entitiesPerFile: 1,
+      importFanout: 1,
+      importStyleMix: parseImportStyleMix('type'),
+      nestedDepth: 1,
+      bodyLines: 1,
+      language: 'mixed',
+      gitInit: false,
+    });
+
+    const tsSource = await fs.readFile(path.join(outDir, 'src', 'f0000.ts'), 'utf8');
+    const jsSource = await fs.readFile(path.join(outDir, 'src', 'f0001.js'), 'utf8');
+
+    assert.doesNotMatch(tsSource, /import type/);
+    assert.match(tsSource, /import \{ f0001_e000 as imported_f0001_0 \}/);
+    assert.doesNotMatch(jsSource, /: number/);
+    assert.doesNotMatch(jsSource, /import type/);
+    assert.match(jsSource, /function f0001_e000\(input\)/);
+  });
+});
+
+test('parses CLI knobs and weighted import style mixes', () => {
+  const parsed = parseLargeJsFixtureArgs([
+    '--out',
+    'tmp-fixture',
+    '--files',
+    '7',
+    '--entities-per-file',
+    '3',
+    '--fanout',
+    '2',
+    '--import-style-mix',
+    'named:2,default',
+    '--nested-depth',
+    '1',
+    '--body-lines',
+    '5',
+    '--language',
+    'js',
+    '--no-git-init',
+    '--force',
+  ]);
+
+  assert.equal(parsed.outDir, path.resolve('tmp-fixture'));
+  assert.equal(parsed.fileCount, 7);
+  assert.equal(parsed.entitiesPerFile, 3);
+  assert.equal(parsed.importFanout, 2);
+  assert.deepEqual(parsed.importStyleMix, ['named', 'named', 'default']);
+  assert.equal(parsed.nestedDepth, 1);
+  assert.equal(parsed.bodyLines, 5);
+  assert.equal(parsed.language, 'js');
+  assert.equal(parsed.gitInit, false);
+  assert.equal(parsed.force, true);
+
+  assert.throws(() => parseImportStyleMix('named:0'), /positive integer/);
+  assert.throws(() => parseLargeJsFixtureArgs(['--files', '10abc']), /positive integer/);
+});
+
+test('protects non-fixture directories unless force is set', async () => {
+  await withTempDirectory(async (tempDirectory) => {
+    const outDir = path.join(tempDirectory, 'occupied');
+    await fs.mkdir(outDir, { recursive: true });
+    await fs.writeFile(path.join(outDir, 'keep.txt'), 'do not replace\n', 'utf8');
+
+    await assert.rejects(
+      () =>
+        generateLargeJsFixture({
+          outDir,
+          fileCount: 1,
+          entitiesPerFile: 1,
+          importFanout: 0,
+          gitInit: false,
+        }),
+      /Refusing to replace non-empty directory/,
+    );
+
+    await generateLargeJsFixture({
+      outDir,
+      fileCount: 1,
+      entitiesPerFile: 1,
+      importFanout: 0,
+      gitInit: false,
+      force: true,
+    });
+
+    await assert.rejects(() => fs.stat(path.join(outDir, 'keep.txt')), /ENOENT/);
+  });
+});


### PR DESCRIPTION
## Summary

- Optimizes `sem diff --patch` blob/content resolution and formatter JSON/string output to avoid per-file subprocess and allocation hot paths.
- Adds topology-only graph cache loading for `impact --deps` / `--dependents`, plus opt-in CLI phase timings via `SEM_TIMINGS`.
- Makes incremental cache edge updates granular, with safeguards for JS/TS import/re-export invalidation and MCP cache compatibility.
- Adds a public large JS/TS fixture generator and benchmark runner.

Closes #313
Closes #314
Closes #315
Closes #316
Closes #317
Closes #318

## Test plan

- `cargo test --manifest-path crates/Cargo.toml --workspace`
- `node --test scripts/large-js-fixture.test.mjs benchmarks/large-js-fixture/run.test.mjs`
- `git diff --check --no-ext-diff`
- `cargo build --manifest-path crates/Cargo.toml --release --bin sem`
- `SEM_TIMINGS=json sem graph . --json --file-exts .ts .js` smoke on generated fixture

## Benchmarks

Release binary compared against `/tmp/sem-perf-baseline/sem-before`.

- Generated graph fixture, 1,500 mixed JS/TS files:
  - cold cache: 2822.848 ms before, 3513.053 ms after
  - warm cache: 172.095 ms before, 174.801 ms after
  - one-file incremental: 433.205 ms before, 379.957 ms after
- Generated cached `impact --deps`, 2,500 mixed JS/TS files:
  - average: 220 ms before, 170 ms after
- Generated 1,000-file TS patch through `sem diff --patch --json`:
  - 61220 ms before, 410 ms after
- Detached `/tmp` worktree of a 4,415-file TS/JS repo:
  - cold graph: 5930 ms before, 5830 ms after

## Large-repo graph resolution scaling (follow-on)

A follow-on commit (`2b58693`) targets the cold entity-graph build that this PR disclosed as a regression — the path used by `sem graph` and by the first `sem impact` / `sem context` before the cache is warm. That build scaled super-linearly, making a fresh checkout's first `sem impact` run for many minutes on very large monorepos. Profiling a large real-world TypeScript/JavaScript monorepo (~71,000 files, ~2.7M entities) showed the scope resolver dominating. These changes are performance-only and output-preserving.

- **`resolve_ref` candidate-scan gating.** The global symbol-table scan for same-name entities only ever fed Swift overload disambiguation, so it is now gated behind the presence of Swift call signatures; other languages take a same-file match from a per-file name index in O(1).
- **Pass-2 import table (quadratic → linear).** Each file rescanned the entire prebuilt import table for its own entries — O(files × imports). It is grouped by file once up front, so each file does work proportional to its own imports. This is the largest contributor at high file counts.
- **Unused default-export table.** Per-symbol imports are already resolved on the graph-build path and the JS/TS default-export table is never read there, so building it is now skipped on that path.
- **Parallel default-export builders.** Both default-export table builders were single-threaded loops over every file; they now run as parallel map-reduces with identical output.
- **Per-reference lookup hoisting.** The owning-entity span/children, descendant-range, and consumed-words lookups were re-hashed on every reference; they are now fetched once per entity, removing the HashMap hashing that dominated the hottest loop.
- **Name-keyed per-file import table.** `resolve_ref` allocated a `(path, name)` tuple key per reference; since the per-file table only holds the current file's imports, it is now keyed by name alone.

Headline results, measured primarily in **instructions retired** (`/usr/bin/time -l`, resilient to CPU throttling and machine contention; wall-time is noisier):

| Workload | Instructions retired | Wall |
|---|---|---|
| 32,000-file / ~245k-entity TS/JS subset | **−9.8%** | ~1.3× |
| Second large TS/JS repo (~4,400 files, ~244k entities) | −4.3% | ~1.1× |
| ~71,000-file / ~2.7M-entity monorepo, cold `sem impact` in a fresh worktree | completes full graph build in **~452 s** (then **~6.5 s** warm/cached) | — |

The win grows with file count because it is dominated by the quadratic pass-2 fix. The ~71k-file baseline was previously impractical to run to completion — the removed O(files × imports) rescan is tens of billions of operations in a hot path at that scale — and the optimized build now finishes and warms a cache that serves subsequent calls in seconds.

Output is **byte-identical** before/after: `sem graph --json` produces identical entities and edges (sorted-output diffing) on five real repositories spanning TypeScript, JavaScript, and Rust, and `cargo test --workspace` passes (25 suites). A small **pre-existing** run-to-run nondeterminism (~5 edges out of 533k on a 32k-file repo) in ambiguous method-call resolution via HashMap ordering affects the baseline and this branch identically and is not introduced here.
