### PR TITLE
Reduce graph memory and cache overhead

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -889,6 +889,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,6 +984,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1378,6 +1396,7 @@ dependencies = [
  "colored",
  "git2",
  "ignore",
+ "mimalloc",
  "openssl-sys",
  "rusqlite",
  "sem-core",
@@ -1438,6 +1457,7 @@ dependencies = [
  "git2",
  "ignore",
  "lru",
+ "mimalloc",
  "openssl",
  "rmcp",
  "rusqlite",

--- a/crates/sem-cli/Cargo.toml
+++ b/crates/sem-cli/Cargo.toml
@@ -27,6 +27,7 @@ openssl-sys = { version = "0.9", optional = true }
 serde_json = "1"
 rusqlite = { version = "0.32", features = ["bundled"] }
 clap_complete_command = "0.6.1"
+mimalloc = "0.1"
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/sem-{ target }{ archive-suffix }"

--- a/crates/sem-cli/src/cache.rs
+++ b/crates/sem-cli/src/cache.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::io::Write;
 use std::path::Path;
 
 use rusqlite::{params, Connection};
@@ -44,15 +45,16 @@ impl DiskCache {
         tx.execute_batch("DELETE FROM files; DELETE FROM entities; DELETE FROM edges;")?;
 
         {
-            let mut stmt = tx
-                .prepare("INSERT INTO files (path, mtime_secs, mtime_nanos) VALUES (?1, ?2, ?3)")?;
+            let mut stmt = tx.prepare(
+                "INSERT INTO files (path, mtime_secs, mtime_nanos, content_hash) VALUES (?1, ?2, ?3, ?4)",
+            )?;
             for file in files {
                 if shared_cache::is_manifest_file_name(file) {
                     continue;
                 }
                 let full = root.join(file);
-                if let Some((secs, nanos)) = shared_cache::file_mtime_parts(&full) {
-                    stmt.execute(params![file, secs, nanos])?;
+                if let Some((secs, nanos, content_hash)) = shared_cache::file_fingerprint(&full) {
+                    stmt.execute(params![file, secs, nanos, content_hash])?;
                 }
             }
         }
@@ -109,46 +111,8 @@ impl DiskCache {
         root: &Path,
         files: &[String],
     ) -> Option<(EntityGraph, Vec<SemanticEntity>)> {
-        if shared_cache::is_manifest_stale(&self.conn, root) {
+        if !self.has_fresh_complete_cache(root, files) {
             return None;
-        }
-
-        let cached_count: i64 = self
-            .conn
-            .query_row("SELECT COUNT(*) FROM files", [], |row| row.get(0))
-            .ok()?;
-        if (cached_count - shared_cache::manifest_entry_count(&self.conn)) as usize
-            != shared_cache::source_file_count(files)
-        {
-            return None;
-        }
-
-        // Load all cached mtimes in one query and validate against disk
-        let mut stmt = self
-            .conn
-            .prepare("SELECT path, mtime_secs, mtime_nanos FROM files")
-            .ok()?;
-        let cached_mtimes: HashMap<String, (i64, i64)> = stmt
-            .query_map([], |row| {
-                Ok((
-                    row.get::<_, String>(0)?,
-                    (row.get::<_, i64>(1)?, row.get::<_, i64>(2)?),
-                ))
-            })
-            .ok()?
-            .filter_map(|r| r.ok())
-            .collect();
-
-        for file in files {
-            if shared_cache::is_manifest_file_name(file) {
-                continue;
-            }
-            let (secs, nanos) = cached_mtimes.get(file.as_str()).copied()?;
-            let full = root.join(file);
-            let (current_secs, current_nanos) = shared_cache::file_mtime_parts(&full)?;
-            if secs != current_secs || nanos != current_nanos {
-                return None;
-            }
         }
 
         let mut entity_stmt = self
@@ -223,45 +187,8 @@ impl DiskCache {
 
     /// Load only graph topology from a fresh cache.
     pub fn load_graph_topology(&self, root: &Path, files: &[String]) -> Option<EntityGraph> {
-        if shared_cache::is_manifest_stale(&self.conn, root) {
+        if !self.has_fresh_complete_cache(root, files) {
             return None;
-        }
-
-        let cached_count: i64 = self
-            .conn
-            .query_row("SELECT COUNT(*) FROM files", [], |row| row.get(0))
-            .ok()?;
-        if (cached_count - shared_cache::manifest_entry_count(&self.conn)) as usize
-            != shared_cache::source_file_count(files)
-        {
-            return None;
-        }
-
-        let mut stmt = self
-            .conn
-            .prepare("SELECT path, mtime_secs, mtime_nanos FROM files")
-            .ok()?;
-        let cached_mtimes: HashMap<String, (i64, i64)> = stmt
-            .query_map([], |row| {
-                Ok((
-                    row.get::<_, String>(0)?,
-                    (row.get::<_, i64>(1)?, row.get::<_, i64>(2)?),
-                ))
-            })
-            .ok()?
-            .filter_map(|r| r.ok())
-            .collect();
-
-        for file in files {
-            if shared_cache::is_manifest_file_name(file) {
-                continue;
-            }
-            let (secs, nanos) = cached_mtimes.get(file.as_str()).copied()?;
-            let full = root.join(file);
-            let (current_secs, current_nanos) = shared_cache::file_mtime_parts(&full)?;
-            if secs != current_secs || nanos != current_nanos {
-                return None;
-            }
         }
 
         let mut entity_stmt = self
@@ -292,6 +219,160 @@ impl DiskCache {
 
         let edges = self.load_edges()?;
         Some(EntityGraph::from_parts(entity_map, edges))
+    }
+
+    pub fn write_graph_json_topology<W: Write>(
+        &self,
+        root: &Path,
+        files: &[String],
+        mut writer: W,
+    ) -> std::io::Result<bool> {
+        if !self.has_fresh_complete_cache(root, files) {
+            return Ok(false);
+        }
+
+        let entity_count: i64 =
+            match self
+                .conn
+                .query_row("SELECT COUNT(*) FROM entities", [], |row| row.get(0))
+            {
+                Ok(count) => count,
+                Err(_) => return Ok(false),
+            };
+        let edge_count: i64 = match self
+            .conn
+            .query_row("SELECT COUNT(*) FROM edges", [], |row| row.get(0))
+        {
+            Ok(count) => count,
+            Err(_) => return Ok(false),
+        };
+
+        let mut entity_stmt = match self.conn.prepare(
+            "SELECT id, name, entity_type, file_path, start_line, end_line, parent_id FROM entities ORDER BY id",
+        ) {
+            Ok(stmt) => stmt,
+            Err(_) => return Ok(false),
+        };
+        let mut edge_stmt = match self.conn.prepare(
+            "SELECT from_entity, to_entity, ref_type FROM edges ORDER BY from_entity, to_entity, CASE ref_type WHEN 'calls' THEN 0 WHEN 'imports' THEN 1 ELSE 2 END",
+        ) {
+            Ok(stmt) => stmt,
+            Err(_) => return Ok(false),
+        };
+
+        writer.write_all(b"{\"entities\":[")?;
+        let mut entity_rows = entity_stmt.query([]).map_err(sql_io_error)?;
+        let mut first = true;
+        while let Some(row) = entity_rows.next().map_err(sql_io_error)? {
+            if first {
+                first = false;
+            } else {
+                writer.write_all(b",")?;
+            }
+            let entity = EntityInfo {
+                id: row.get(0).map_err(sql_io_error)?,
+                name: row.get(1).map_err(sql_io_error)?,
+                entity_type: row.get(2).map_err(sql_io_error)?,
+                file_path: row.get(3).map_err(sql_io_error)?,
+                start_line: row.get::<_, i64>(4).map_err(sql_io_error)? as usize,
+                end_line: row.get::<_, i64>(5).map_err(sql_io_error)? as usize,
+                parent_id: row.get(6).map_err(sql_io_error)?,
+            };
+            serde_json::to_writer(&mut writer, &entity).map_err(json_io_error)?;
+        }
+
+        writer.write_all(b"],\"edges\":[")?;
+        let mut edge_rows = edge_stmt.query([]).map_err(sql_io_error)?;
+        let mut first = true;
+        while let Some(row) = edge_rows.next().map_err(sql_io_error)? {
+            if first {
+                first = false;
+            } else {
+                writer.write_all(b",")?;
+            }
+            let rt: String = row.get(2).map_err(sql_io_error)?;
+            let ref_type = match rt.as_str() {
+                "calls" => RefType::Calls,
+                "imports" => RefType::Imports,
+                _ => RefType::TypeRef,
+            };
+            let edge = EntityRef {
+                from_entity: row.get(0).map_err(sql_io_error)?,
+                to_entity: row.get(1).map_err(sql_io_error)?,
+                ref_type,
+            };
+            serde_json::to_writer(&mut writer, &edge).map_err(json_io_error)?;
+        }
+
+        write!(
+            writer,
+            "],\"stats\":{{\"entityCount\":{},\"edgeCount\":{}}}}}\n",
+            entity_count, edge_count
+        )?;
+        Ok(true)
+    }
+
+    fn has_fresh_complete_cache(&self, root: &Path, files: &[String]) -> bool {
+        if shared_cache::is_manifest_stale(&self.conn, root) {
+            return false;
+        }
+
+        let cached_count: i64 = match self
+            .conn
+            .query_row("SELECT COUNT(*) FROM files", [], |row| row.get(0))
+        {
+            Ok(count) => count,
+            Err(_) => return false,
+        };
+        if (cached_count - shared_cache::manifest_entry_count(&self.conn)) as usize
+            != shared_cache::source_file_count(files)
+        {
+            return false;
+        }
+
+        let mut stmt = self
+            .conn
+            .prepare("SELECT path, mtime_secs, mtime_nanos, content_hash FROM files")
+            .ok();
+        let Some(ref mut stmt) = stmt else {
+            return false;
+        };
+        let cached_mtimes: HashMap<String, (i64, i64, Option<String>)> = match stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                (
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                ),
+            ))
+        }) {
+            Ok(rows) => rows.filter_map(|r| r.ok()).collect(),
+            Err(_) => return false,
+        };
+
+        for file in files {
+            if shared_cache::is_manifest_file_name(file) {
+                continue;
+            }
+            let Some((secs, nanos, content_hash)) = cached_mtimes.get(file.as_str()) else {
+                return false;
+            };
+            let full = root.join(file);
+            match shared_cache::file_freshness(&full, *secs, *nanos, content_hash.as_deref()) {
+                Some(shared_cache::FileFreshness::Fresh) => {}
+                Some(shared_cache::FileFreshness::FreshWithUpdatedFingerprint {
+                    secs,
+                    nanos,
+                    content_hash,
+                }) => {
+                    self.refresh_file_fingerprint(file, secs, nanos, &content_hash);
+                }
+                Some(shared_cache::FileFreshness::Stale) | None => return false,
+            }
+        }
+
+        true
     }
 
     fn load_edges(&self) -> Option<Vec<EntityRef>> {
@@ -329,13 +410,17 @@ impl DiskCache {
         // Load all cached file paths + mtimes
         let mut stmt = self
             .conn
-            .prepare("SELECT path, mtime_secs, mtime_nanos FROM files")
+            .prepare("SELECT path, mtime_secs, mtime_nanos, content_hash FROM files")
             .ok()?;
-        let cached_files: HashMap<String, (i64, i64)> = stmt
+        let cached_files: HashMap<String, (i64, i64, Option<String>)> = stmt
             .query_map([], |row| {
                 Ok((
                     row.get::<_, String>(0)?,
-                    (row.get::<_, i64>(1)?, row.get::<_, i64>(2)?),
+                    (
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, Option<String>>(3)?,
+                    ),
                 ))
             })
             .ok()?
@@ -358,16 +443,26 @@ impl DiskCache {
         let mut stale_current_file_count = 0;
         for file in source_files {
             match cached_files.get(file) {
-                Some(&(secs, nanos)) => {
+                Some((secs, nanos, content_hash)) => {
                     let full = root.join(file);
-                    let is_stale = shared_cache::file_mtime_parts(&full)
-                        .map(|(current_secs, current_nanos)| {
-                            secs != current_secs || nanos != current_nanos
-                        })
-                        .unwrap_or(true);
-                    if is_stale {
-                        stale_current_file_count += 1;
-                        stale_source_files.push(file.clone());
+                    match shared_cache::file_freshness(
+                        &full,
+                        *secs,
+                        *nanos,
+                        content_hash.as_deref(),
+                    ) {
+                        Some(shared_cache::FileFreshness::Fresh) => {}
+                        Some(shared_cache::FileFreshness::FreshWithUpdatedFingerprint {
+                            secs,
+                            nanos,
+                            content_hash,
+                        }) => {
+                            self.refresh_file_fingerprint(file, secs, nanos, &content_hash);
+                        }
+                        Some(shared_cache::FileFreshness::Stale) | None => {
+                            stale_current_file_count += 1;
+                            stale_source_files.push(file.clone());
+                        }
                     }
                 }
                 None => {
@@ -409,35 +504,28 @@ impl DiskCache {
             .conn
             .prepare("SELECT id, name, entity_type, file_path, start_line, end_line, content, content_hash, structural_hash, parent_id, metadata_json FROM entities")
             .ok()?;
-        let all_cached: Vec<SemanticEntity> = entity_stmt
-            .query_map([], |row| {
-                let metadata_json: Option<String> = row.get(10)?;
-                let metadata = metadata_json.and_then(|j| serde_json::from_str(&j).ok());
-                Ok(SemanticEntity {
-                    id: row.get(0)?,
-                    name: row.get(1)?,
-                    entity_type: row.get(2)?,
-                    file_path: row.get(3)?,
-                    start_line: row.get::<_, i64>(4)? as usize,
-                    end_line: row.get::<_, i64>(5)? as usize,
-                    content: row.get(6)?,
-                    content_hash: row.get(7)?,
-                    structural_hash: row.get(8)?,
-                    parent_id: row.get(9)?,
-                    metadata,
-                })
-            })
-            .ok()?
-            .filter_map(|r| r.ok())
-            .collect();
-
         let mut cached_entities = Vec::new();
         let mut stale_file_entities = Vec::new();
-        for e in all_cached {
-            if stale_set.contains(e.file_path.as_str()) {
-                stale_file_entities.push(e);
+        let mut entity_rows = entity_stmt.query([]).ok()?;
+        while let Some(row) = entity_rows.next().ok()? {
+            let metadata_json: Option<String> = row.get(10).ok()?;
+            let entity = SemanticEntity {
+                id: row.get(0).ok()?,
+                name: row.get(1).ok()?,
+                entity_type: row.get(2).ok()?,
+                file_path: row.get(3).ok()?,
+                start_line: row.get::<_, i64>(4).ok()? as usize,
+                end_line: row.get::<_, i64>(5).ok()? as usize,
+                content: row.get(6).ok()?,
+                content_hash: row.get(7).ok()?,
+                structural_hash: row.get(8).ok()?,
+                parent_id: row.get(9).ok()?,
+                metadata: metadata_json.and_then(|j| serde_json::from_str(&j).ok()),
+            };
+            if stale_set.contains(entity.file_path.as_str()) {
+                stale_file_entities.push(entity);
             } else {
-                cached_entities.push(e);
+                cached_entities.push(entity);
             }
         }
 
@@ -558,12 +646,12 @@ impl DiskCache {
         // Insert new mtimes for stale files
         {
             let mut ins = tx.prepare(
-                "INSERT OR REPLACE INTO files (path, mtime_secs, mtime_nanos) VALUES (?1, ?2, ?3)",
+                "INSERT OR REPLACE INTO files (path, mtime_secs, mtime_nanos, content_hash) VALUES (?1, ?2, ?3, ?4)",
             )?;
             for file in &source_stale_files {
                 let full = root.join(file);
-                if let Some((secs, nanos)) = shared_cache::file_mtime_parts(&full) {
-                    ins.execute(params![file, secs, nanos])?;
+                if let Some((secs, nanos, content_hash)) = shared_cache::file_fingerprint(&full) {
+                    ins.execute(params![file, secs, nanos, content_hash])?;
                 }
             }
         }
@@ -688,6 +776,21 @@ impl DiskCache {
         tx.commit()?;
         Ok(())
     }
+
+    fn refresh_file_fingerprint(&self, file: &str, secs: i64, nanos: i64, content_hash: &str) {
+        let _ = self.conn.execute(
+            "UPDATE files SET mtime_secs = ?2, mtime_nanos = ?3, content_hash = ?4 WHERE path = ?1",
+            params![file, secs, nanos, content_hash],
+        );
+    }
+}
+
+fn sql_io_error(error: rusqlite::Error) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::Other, error)
+}
+
+fn json_io_error(error: serde_json::Error) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::Other, error)
 }
 
 #[cfg(test)]
@@ -817,6 +920,17 @@ mod tests {
             .unwrap()
     }
 
+    fn cached_file_mtime(cache: &DiskCache, file: &str) -> (i64, i64) {
+        cache
+            .conn
+            .query_row(
+                "SELECT mtime_secs, mtime_nanos FROM files WHERE path = ?1",
+                rusqlite::params![file],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap()
+    }
+
     fn sample_files(root: &Path) -> Vec<String> {
         write_file(&root.join("sample.foo"), "export const alpha = () => 1;\n");
         vec!["sample.foo".to_string()]
@@ -834,6 +948,60 @@ mod tests {
         cache.save(root, files, &empty_graph(), &[]).unwrap();
         assert!(cache.load(root, files).is_some());
         cache
+    }
+
+    #[test]
+    fn write_graph_json_topology_streams_fresh_cache() {
+        let root = temp_repo_root("graph-json-topology");
+        write_file(&root.join("a.rs"), "fn a() {}\n");
+        write_file(&root.join("b.rs"), "fn b() { a(); }\n");
+        let files = vec!["b.rs".to_string(), "a.rs".to_string()];
+        let entities = vec![
+            entity("b-id", "b.rs", "b", "fn b() { a(); }"),
+            entity("a-id", "a.rs", "a", "fn a() {}"),
+        ];
+        let graph = graph_with_edges(&entities, vec![edge("b-id", "a-id")]);
+        let cache = DiskCache::open(&root).unwrap();
+        cache.save(&root, &files, &graph, &entities).unwrap();
+
+        let mut output = Vec::new();
+        assert!(cache
+            .write_graph_json_topology(&root, &files, &mut output)
+            .unwrap());
+        let value: serde_json::Value = serde_json::from_slice(&output).unwrap();
+
+        assert_eq!(
+            value["stats"],
+            serde_json::json!({"entityCount": 2, "edgeCount": 1})
+        );
+        assert_eq!(value["entities"][0]["id"], "a-id");
+        assert_eq!(value["entities"][1]["id"], "b-id");
+        assert_eq!(value["edges"][0]["fromEntity"], "b-id");
+        assert_eq!(value["edges"][0]["toEntity"], "a-id");
+
+        drop(cache);
+        cleanup(root);
+    }
+
+    #[test]
+    fn load_refreshes_mtime_when_file_content_is_unchanged() {
+        let root = temp_repo_root("mtime-only-refresh");
+        let file = root.join("same.rs");
+        write_file(&file, "fn same() {}\n");
+        let files = vec!["same.rs".to_string()];
+        let cache = save_empty_cache(&root, &files);
+        let before = cached_file_mtime(&cache, "same.rs");
+
+        rewrite_after_mtime_tick(&file, "fn same() {}\n");
+        let current = shared_cache::file_mtime_parts(&file).unwrap();
+        assert_ne!(before, current);
+
+        assert!(cache.load_graph_topology(&root, &files).is_some());
+        assert!(cache.load_partial(&root, &files).is_none());
+        assert_eq!(cached_file_mtime(&cache, "same.rs"), current);
+
+        drop(cache);
+        cleanup(root);
     }
 
     fn write_gitattributes(root: &Path) {

--- a/crates/sem-cli/src/commands/files.rs
+++ b/crates/sem-cli/src/commands/files.rs
@@ -1,12 +1,8 @@
-use std::fs::File;
-use std::io::Read;
 use std::path::Path;
 
 use colored::Colorize;
-use sem_core::utils::scan::{is_default_excluded, is_probably_binary_path};
 use sem_core::parser::registry::ParserRegistry;
-
-const BINARY_PROBE_BYTES: usize = 4096;
+use sem_core::utils::scan::{is_default_excluded, is_probably_binary_path};
 
 pub fn find_supported_files_in_path(
     root: &Path,
@@ -27,6 +23,21 @@ pub fn find_supported_files_in_path(
     let semignore = root.join(".semignore");
     if semignore.exists() {
         builder.add_ignore(semignore);
+    }
+
+    if !no_default_excludes {
+        let root = root.to_path_buf();
+        builder.filter_entry(move |entry| {
+            if !entry
+                .file_type()
+                .is_some_and(|file_type| file_type.is_dir())
+            {
+                return true;
+            }
+
+            let rel_path = file_path_for_entity(&root, entry.path());
+            !is_default_excluded(&rel_path)
+        });
     }
 
     let walker = builder.build();
@@ -64,10 +75,7 @@ pub fn find_supported_files_in_path(
         if is_probably_binary_path(&rel_path) {
             continue;
         }
-        if registry.get_plugin(&rel_path).is_none() {
-            continue;
-        }
-        if has_nul_byte(path).unwrap_or(false) {
+        if !has_supported_plugin(path, &rel_path, registry, ext_filter) {
             continue;
         }
         files.push(rel_path);
@@ -77,6 +85,27 @@ pub fn find_supported_files_in_path(
     files
 }
 
+fn has_supported_plugin(
+    path: &Path,
+    rel_path: &str,
+    registry: &ParserRegistry,
+    ext_filter: &[String],
+) -> bool {
+    if registry.get_explicit_plugin(rel_path).is_some() {
+        return true;
+    }
+
+    if !ext_filter.is_empty() || Path::new(rel_path).extension().is_some() {
+        return false;
+    }
+
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return false;
+    };
+
+    registry.detect_plugin_from_content(&content).is_some()
+}
+
 pub fn file_path_for_entity(root: &Path, path: &Path) -> String {
     path.strip_prefix(root)
         .ok()
@@ -84,13 +113,6 @@ pub fn file_path_for_entity(root: &Path, path: &Path) -> String {
         .unwrap_or(path)
         .to_string_lossy()
         .replace('\\', "/")
-}
-
-fn has_nul_byte(path: &Path) -> std::io::Result<bool> {
-    let mut file = File::open(path)?;
-    let mut buffer = [0; BINARY_PROBE_BYTES];
-    let len = file.read(&mut buffer)?;
-    Ok(buffer[..len].contains(&0))
 }
 
 #[cfg(test)]
@@ -120,6 +142,12 @@ mod tests {
         fs::create_dir_all(root.join("src")).unwrap();
         fs::create_dir_all(root.join("dist")).unwrap();
         fs::write(root.join("src/main.rs"), "fn main() {}\n").unwrap();
+        fs::write(
+            root.join("src/run"),
+            "#!/usr/bin/env node\nfunction main() {}\n",
+        )
+        .unwrap();
+        fs::write(root.join("src/notes.weird"), "plain text\n").unwrap();
         fs::write(root.join("src/blob.weird"), b"abc\0def").unwrap();
         fs::write(root.join("src/icon.png"), b"\x89PNG\r\n").unwrap();
         fs::write(root.join("dist/generated.js"), "function generated() {}\n").unwrap();
@@ -127,13 +155,22 @@ mod tests {
         let registry = create_default_registry();
         let files = find_supported_files_in_path(&root, &root, &registry, &[], false);
 
-        assert_eq!(files, vec!["src/main.rs".to_string()]);
+        assert_eq!(
+            files,
+            vec!["src/main.rs".to_string(), "src/run".to_string()]
+        );
 
         let files_with_generated = find_supported_files_in_path(&root, &root, &registry, &[], true);
         assert!(files_with_generated.contains(&"src/main.rs".to_string()));
+        assert!(files_with_generated.contains(&"src/run".to_string()));
         assert!(files_with_generated.contains(&"dist/generated.js".to_string()));
+        assert!(!files_with_generated.contains(&"src/notes.weird".to_string()));
         assert!(!files_with_generated.contains(&"src/blob.weird".to_string()));
         assert!(!files_with_generated.contains(&"src/icon.png".to_string()));
+
+        let rs_files =
+            find_supported_files_in_path(&root, &root, &registry, &[".rs".to_string()], true);
+        assert_eq!(rs_files, vec!["src/main.rs".to_string()]);
 
         fs::remove_dir_all(root).unwrap();
     }

--- a/crates/sem-cli/src/commands/graph.rs
+++ b/crates/sem-cli/src/commands/graph.rs
@@ -5,6 +5,7 @@ use sem_core::git::bridge::GitBridge;
 use sem_core::model::entity::SemanticEntity;
 use sem_core::parser::graph::{EntityGraph, EntityRef, RefType};
 use sem_core::parser::registry::ParserRegistry;
+use serde::ser::{SerializeMap, Serializer};
 
 use crate::cache::DiskCache;
 use crate::timings::Timings;
@@ -29,27 +30,40 @@ pub fn graph_command(opts: GraphOptions) {
     let file_paths =
         find_supported_files_inner(root, &registry, &ext_filter, opts.no_default_excludes);
     timings.mark("file_discovery");
-    let (graph, _entities) =
-        get_or_build_graph_with_timings(root, &file_paths, &registry, opts.no_cache, &mut timings);
+    if opts.json && !opts.no_cache {
+        if let Ok(disk) = DiskCache::open(root) {
+            timings.mark("cache_open");
+            let stdout = std::io::stdout();
+            match disk.write_graph_json_topology(root, &file_paths, stdout.lock()) {
+                Ok(true) => {
+                    timings.mark("cache_topology_json_stream");
+                    timings.finish();
+                    return;
+                }
+                Ok(false) => {}
+                Err(err) => {
+                    eprintln!(
+                        "{} failed to stream cached graph JSON: {}",
+                        "error:".red().bold(),
+                        err
+                    );
+                    std::process::exit(1);
+                }
+            }
+        }
+    }
+
+    let graph = get_or_build_graph_topology_with_timings(
+        root,
+        &file_paths,
+        &registry,
+        opts.no_cache,
+        &mut timings,
+    );
 
     if opts.json {
-        let mut entities = graph.entities.values().collect::<Vec<_>>();
-        entities.sort_by(|a, b| a.id.cmp(&b.id));
-
-        let mut edges = graph.edges.iter().collect::<Vec<_>>();
-        edges.sort_by(compare_entity_refs);
-
-        let output = serde_json::json!({
-            "entities": entities,
-            "edges": edges,
-            "stats": {
-                "entityCount": graph.entities.len(),
-                "edgeCount": graph.edges.len()
-            }
-        });
-        let output = serde_json::to_string(&output).unwrap();
+        write_graph_json(&graph).unwrap();
         timings.mark("cli_output_serialization");
-        println!("{}", output);
     } else {
         timings.mark("cli_output_serialization");
         println!(
@@ -60,6 +74,38 @@ pub fn graph_command(opts: GraphOptions) {
         );
     }
     timings.finish();
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct GraphStats {
+    entity_count: usize,
+    edge_count: usize,
+}
+
+fn write_graph_json(graph: &EntityGraph) -> serde_json::Result<()> {
+    let mut entities = graph.entities.values().collect::<Vec<_>>();
+    entities.sort_by(|a, b| a.id.cmp(&b.id));
+
+    let mut edges = graph.edges.iter().collect::<Vec<_>>();
+    edges.sort_by(compare_entity_refs);
+
+    let stdout = std::io::stdout();
+    let mut stdout = stdout.lock();
+    let mut serializer = serde_json::Serializer::new(&mut stdout);
+    let mut map = (&mut serializer).serialize_map(Some(3))?;
+    map.serialize_entry("entities", &entities)?;
+    map.serialize_entry("edges", &edges)?;
+    map.serialize_entry(
+        "stats",
+        &GraphStats {
+            entity_count: graph.entities.len(),
+            edge_count: graph.edges.len(),
+        },
+    )?;
+    map.end()?;
+    use std::io::Write;
+    stdout.write_all(b"\n").map_err(serde_json::Error::io)
 }
 
 fn compare_entity_refs(a: &&EntityRef, b: &&EntityRef) -> std::cmp::Ordering {

--- a/crates/sem-cli/src/main.rs
+++ b/crates/sem-cli/src/main.rs
@@ -4,6 +4,9 @@ mod formatters;
 mod stats;
 mod timings;
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use clap::CommandFactory;
 use clap::{Parser, Subcommand, ValueEnum};
 use colored::control;

--- a/crates/sem-core/src/parser/graph.rs
+++ b/crates/sem-core/src/parser/graph.rs
@@ -40,6 +40,15 @@ use crate::parser::import_resolution::{
 use crate::parser::registry::{resolve_go_method_parent_ids, ParserRegistry};
 use crate::parser::scope_resolve;
 
+#[cfg(not(test))]
+const PARSED_FILE_REUSE_LIMIT: usize = 20_000;
+#[cfg(test)]
+const PARSED_FILE_REUSE_LIMIT: usize = 8;
+#[cfg(not(test))]
+const SCOPE_RESOLVE_FILE_CHUNK_SIZE: usize = 5_000;
+#[cfg(test)]
+const SCOPE_RESOLVE_FILE_CHUNK_SIZE: usize = 3;
+
 #[derive(Clone, Copy)]
 struct ChildRange<'a> {
     file_path: &'a str,
@@ -517,34 +526,6 @@ impl LineReferenceIndex {
     }
 }
 
-fn build_reference_indexes(
-    root: &Path,
-    file_paths: &[String],
-    parsed_files: &[(String, String, tree_sitter::Tree)],
-) -> HashMap<String, FileReferenceIndex> {
-    let parsed_content: HashMap<&str, &str> = parsed_files
-        .iter()
-        .map(|(file_path, content, _)| (file_path.as_str(), content.as_str()))
-        .collect();
-
-    maybe_par_iter!(file_paths)
-        .filter_map(|file_path| {
-            let ext = file_path.rfind('.').map(|i| &file_path[i..]).unwrap_or("");
-            crate::parser::plugins::code::languages::get_language_config(ext)?;
-
-            if let Some(content) = parsed_content.get(file_path.as_str()) {
-                return Some((file_path.clone(), FileReferenceIndex::from_content(content)));
-            }
-
-            let content = std::fs::read_to_string(root.join(file_path)).ok()?;
-            Some((
-                file_path.clone(),
-                FileReferenceIndex::from_content(&content),
-            ))
-        })
-        .collect()
-}
-
 fn identifier_tokens(line: &str) -> impl Iterator<Item = (&str, usize)> {
     let mut start = None;
     let mut chars = line.char_indices();
@@ -652,6 +633,335 @@ fn direct_reference_line_ranges(
     ranges
 }
 
+struct ReferenceResolutionContext<'a> {
+    symbol_table: &'a HashMap<String, Vec<String>>,
+    entity_map: &'a HashMap<String, EntityInfo>,
+    import_table: &'a HashMap<(String, String), String>,
+    scope_consumed_words: &'a HashMap<String, HashSet<String>>,
+    child_ranges_by_parent: &'a HashMap<&'a str, Vec<ChildRange<'a>>>,
+    child_line_ranges: &'a HashMap<String, Vec<(usize, usize)>>,
+    parent_child_pairs: &'a HashSet<(&'a str, &'a str)>,
+    class_child_names: &'a HashSet<(&'a str, &'a str)>,
+    class_entity_files: &'a HashSet<(&'a str, &'a str)>,
+    enclosing_class: &'a HashMap<&'a str, &'a str>,
+    class_members: &'a HashMap<&'a str, Vec<(&'a str, &'a str)>>,
+}
+
+fn resolve_references_with_file_indexes<'a>(
+    root: &Path,
+    file_paths: &[String],
+    all_entities: &'a [SemanticEntity],
+    needs_resolution: Option<&HashSet<&'a str>>,
+    context: &ReferenceResolutionContext<'a>,
+) -> Vec<(String, String, RefType)> {
+    let mut entities_by_file: HashMap<&'a str, Vec<&'a SemanticEntity>> = HashMap::new();
+    for entity in all_entities {
+        if needs_resolution
+            .as_ref()
+            .is_some_and(|ids| !ids.contains(entity.id.as_str()))
+        {
+            continue;
+        }
+        let ext = entity
+            .file_path
+            .rfind('.')
+            .map(|i| &entity.file_path[i..])
+            .unwrap_or("");
+        if crate::parser::plugins::code::languages::get_language_config(ext).is_none() {
+            continue;
+        }
+        entities_by_file
+            .entry(entity.file_path.as_str())
+            .or_default()
+            .push(entity);
+    }
+
+    let mut sorted_file_paths = file_paths.to_vec();
+    sorted_file_paths.sort_unstable();
+    sorted_file_paths.dedup();
+
+    maybe_par_iter!(sorted_file_paths)
+        .filter_map(|file_path| {
+            let entities = entities_by_file.get(file_path.as_str())?;
+            let needs_index = entities.iter().any(|entity| {
+                !entity_requires_content_span_filter(entity, context.child_ranges_by_parent)
+            });
+            let reference_index = if needs_index {
+                build_file_reference_index(root, file_path)
+            } else {
+                None
+            };
+
+            let mut file_edges = Vec::new();
+            for entity in entities {
+                file_edges.extend(resolve_entity_references(
+                    entity,
+                    reference_index.as_ref(),
+                    context,
+                ));
+            }
+            Some(file_edges)
+        })
+        .collect::<Vec<_>>()
+        .into_iter()
+        .flatten()
+        .collect()
+}
+
+fn build_file_reference_index(root: &Path, file_path: &str) -> Option<FileReferenceIndex> {
+    let ext = file_path.rfind('.').map(|i| &file_path[i..]).unwrap_or("");
+    crate::parser::plugins::code::languages::get_language_config(ext)?;
+    let content = std::fs::read_to_string(root.join(file_path)).ok()?;
+    Some(FileReferenceIndex::from_content(&content))
+}
+
+fn resolve_scopes_in_file_chunks(
+    root: &Path,
+    file_paths: &[String],
+    all_entities: &[SemanticEntity],
+    entity_map: &HashMap<String, EntityInfo>,
+    pre_built: &scope_resolve::PreBuiltLookups,
+    import_table: &HashMap<(String, String), String>,
+) -> (
+    Vec<(String, String, RefType)>,
+    HashMap<String, HashSet<String>>,
+) {
+    let mut all_edges = Vec::new();
+    let mut all_consumed_words: HashMap<String, HashSet<String>> = HashMap::new();
+
+    for chunk in file_paths.chunks(SCOPE_RESOLVE_FILE_CHUNK_SIZE) {
+        if !chunk.iter().any(|file_path| {
+            let ext = file_path.rfind('.').map(|i| &file_path[i..]).unwrap_or("");
+            crate::parser::plugins::code::languages::get_language_config(ext)
+                .and_then(|config| config.scope_resolve)
+                .is_some()
+        }) {
+            continue;
+        }
+
+        let result = scope_resolve::resolve_with_scopes_full(
+            root,
+            chunk,
+            all_entities,
+            entity_map,
+            None,
+            Some(pre_built),
+            Some(import_table),
+            false,
+        );
+        all_edges.extend(result.edges);
+        for (entity_id, words) in result.consumed_words {
+            all_consumed_words
+                .entry(entity_id)
+                .or_default()
+                .extend(words);
+        }
+    }
+
+    (all_edges, all_consumed_words)
+}
+
+fn resolve_entity_references(
+    entity: &SemanticEntity,
+    reference_index: Option<&FileReferenceIndex>,
+    context: &ReferenceResolutionContext<'_>,
+) -> Vec<(String, String, RefType)> {
+    let ext = entity
+        .file_path
+        .rfind('.')
+        .map(|i| &entity.file_path[i..])
+        .unwrap_or("");
+    let Some(language_config) = crate::parser::plugins::code::languages::get_language_config(ext)
+    else {
+        return vec![];
+    };
+    let fallback_end_line =
+        fallback_reference_end_line(entity, language_config.scope_resolve.is_some());
+    let fallback_ranges =
+        direct_reference_line_ranges(entity, fallback_end_line, context.child_line_ranges);
+
+    let mut entity_edges = Vec::new();
+    let mut consumed_words = context
+        .scope_consumed_words
+        .get(&entity.id)
+        .cloned()
+        .unwrap_or_default();
+
+    let reference_index =
+        if entity_requires_content_span_filter(entity, context.child_ranges_by_parent) {
+            None
+        } else {
+            reference_index
+        };
+    let fallback_stripped = if reference_index.is_none() {
+        Some(strip_comments_and_strings(&entity.content))
+    } else {
+        None
+    };
+    let local_bindings =
+        local_binding_names_filtered(&entity.content, ext, |local_line, start, end| {
+            entity_owns_content_span(
+                entity.id.as_str(),
+                entity.file_path.as_str(),
+                source_line_for_entity_content(entity, local_line),
+                Some(start),
+                Some(end),
+                context.child_ranges_by_parent,
+            )
+        });
+
+    let dot_chains: Vec<(&str, &str, Option<(usize, usize, usize)>)> = match reference_index {
+        Some(index) => index
+            .dot_chains_in_ranges(&fallback_ranges)
+            .into_iter()
+            .map(|(receiver, member)| (receiver, member, None))
+            .collect(),
+        None => extract_dot_chains_with_positions(fallback_stripped.as_ref().unwrap())
+            .into_iter()
+            .map(|(receiver, member, line, start, end)| {
+                (receiver, member, Some((line, start, end)))
+            })
+            .collect(),
+    };
+
+    for (receiver, member, position) in &dot_chains {
+        if consumed_words.contains(*member) {
+            continue;
+        }
+        if let Some((local_line, local_start_byte, local_end_byte)) = *position {
+            if !entity_owns_content_span(
+                entity.id.as_str(),
+                entity.file_path.as_str(),
+                source_line_for_entity_content(entity, local_line),
+                Some(local_start_byte),
+                Some(local_end_byte),
+                context.child_ranges_by_parent,
+            ) {
+                continue;
+            }
+        }
+        let edge_count_before = entity_edges.len();
+        if *receiver == "self" || *receiver == "this" {
+            if let Some(class_name) = context.enclosing_class.get(entity.id.as_str()) {
+                if let Some(members) = context.class_members.get(class_name) {
+                    for (name, target_id) in members {
+                        if *name == *member && *target_id != entity.id.as_str() {
+                            entity_edges.push((
+                                entity.id.clone(),
+                                target_id.to_string(),
+                                RefType::Calls,
+                            ));
+                            consumed_words.insert(member.to_string());
+                            break;
+                        }
+                    }
+                }
+            }
+        } else if context
+            .class_entity_files
+            .contains(&(*receiver, entity.file_path.as_str()))
+        {
+            if let Some(members) = context.class_members.get(*receiver) {
+                for (name, target_id) in members {
+                    if *name == *member {
+                        entity_edges.push((
+                            entity.id.clone(),
+                            target_id.to_string(),
+                            RefType::Calls,
+                        ));
+                        consumed_words.insert(member.to_string());
+                        consumed_words.insert(receiver.to_string());
+                        break;
+                    }
+                }
+            }
+        }
+        if entity_edges.len() == edge_count_before {
+            consumed_words.insert(member.to_string());
+        }
+    }
+
+    let refs: Vec<(&str, RefType)> = match reference_index {
+        Some(index) => index.refs_with_types_in_ranges(&fallback_ranges, &entity.name),
+        None => {
+            let stripped = fallback_stripped.as_ref().unwrap();
+            extract_references_with_stripped_filtered(
+                &entity.content,
+                &entity.name,
+                stripped,
+                |local_line, local_start_byte, local_end_byte| {
+                    entity_owns_content_span(
+                        entity.id.as_str(),
+                        entity.file_path.as_str(),
+                        source_line_for_entity_content(entity, local_line),
+                        Some(local_start_byte),
+                        Some(local_end_byte),
+                        context.child_ranges_by_parent,
+                    )
+                },
+            )
+            .into_iter()
+            .map(|ref_name| (ref_name, infer_ref_type(&entity.content, ref_name)))
+            .collect()
+        }
+    };
+    for (ref_name, ref_type) in refs {
+        if consumed_words.contains(ref_name) {
+            continue;
+        }
+        if local_bindings.contains(ref_name) {
+            continue;
+        }
+
+        if context
+            .class_child_names
+            .contains(&(entity.id.as_str(), ref_name))
+        {
+            continue;
+        }
+
+        let import_key = (entity.file_path.clone(), ref_name.to_string());
+        if let Some(import_target_id) = context.import_table.get(&import_key) {
+            if import_target_id != &entity.id
+                && !context
+                    .parent_child_pairs
+                    .contains(&(entity.id.as_str(), import_target_id.as_str()))
+                && !context
+                    .parent_child_pairs
+                    .contains(&(import_target_id.as_str(), entity.id.as_str()))
+            {
+                entity_edges.push((entity.id.clone(), import_target_id.clone(), ref_type));
+            }
+            continue;
+        }
+
+        if let Some(target_ids) = context.symbol_table.get(ref_name) {
+            let target = target_ids.iter().find(|id| {
+                *id != &entity.id
+                    && context
+                        .entity_map
+                        .get(*id)
+                        .map_or(false, |e| e.file_path == entity.file_path)
+            });
+
+            if let Some(target_id) = target {
+                if context
+                    .parent_child_pairs
+                    .contains(&(entity.id.as_str(), target_id.as_str()))
+                    || context
+                        .parent_child_pairs
+                        .contains(&(target_id.as_str(), entity.id.as_str()))
+                {
+                    continue;
+                }
+                entity_edges.push((entity.id.clone(), target_id.clone(), ref_type));
+            }
+        }
+    }
+
+    entity_edges
+}
+
 impl EntityGraph {
     /// Reconstruct an EntityGraph from pre-loaded parts (e.g. from a cache).
     pub fn from_parts(entities: HashMap<String, EntityInfo>, edges: Vec<EntityRef>) -> Self {
@@ -685,8 +995,10 @@ impl EntityGraph {
         file_paths: &[String],
         registry: &ParserRegistry,
     ) -> (Self, Vec<SemanticEntity>) {
+        let retain_parsed_files = file_paths.len() <= PARSED_FILE_REUSE_LIMIT;
         // Pass 1: Extract all entities in parallel (file I/O + tree-sitter parsing)
-        // Also collect (file_path, content, tree) for scope_resolve reuse
+        // Small and medium repos reuse parse trees in scope resolution; large repos
+        // keep peak memory bounded by reparsing scope chunks.
         let per_file: Vec<(
             Vec<SemanticEntity>,
             Option<(String, String, tree_sitter::Tree)>,
@@ -694,9 +1006,15 @@ impl EntityGraph {
             .filter_map(|file_path| {
                 let full_path = root.join(file_path);
                 let content = std::fs::read_to_string(&full_path).ok()?;
-                let (entities, tree) = registry.extract_entities_with_tree(file_path, &content)?;
-                let parsed = tree.map(|t| (file_path.clone(), content, t));
-                Some((entities, parsed))
+                if retain_parsed_files {
+                    let (entities, tree) =
+                        registry.extract_entities_with_tree(file_path, &content)?;
+                    let parsed = tree.map(|tree| (file_path.clone(), content, tree));
+                    Some((entities, parsed))
+                } else {
+                    let entities = registry.extract_entities(file_path, &content);
+                    Some((entities, None))
+                }
             })
             .collect();
 
@@ -813,6 +1131,7 @@ impl EntityGraph {
             }
         }
         sort_symbol_table_targets_by_source(&mut symbol_table, &entity_map);
+        let symbol_table = Arc::new(symbol_table);
 
         // Build import table: (file_path, imported_name) → target entity ID
         // e.g. ("io_handler.py", "validate") → "core.py::function::validate"
@@ -821,7 +1140,7 @@ impl EntityGraph {
             file_paths,
             &symbol_table,
             &entity_map,
-            Some(&parsed_files),
+            retain_parsed_files.then_some(parsed_files.as_slice()),
         );
         // Build owned Go package index for scope resolver
         let owned_go_pkg_index: HashMap<String, Vec<(String, String)>> =
@@ -865,9 +1184,6 @@ impl EntityGraph {
                 HashMap::new()
             };
 
-        // Wrap symbol_table in Arc to avoid expensive deep clone (621K entries)
-        let symbol_table = Arc::new(symbol_table);
-
         let pre_built = scope_resolve::PreBuiltLookups {
             symbol_table: Arc::clone(&symbol_table),
             class_members: scope_class_members,
@@ -876,8 +1192,6 @@ impl EntityGraph {
             go_pkg_index: owned_go_pkg_index,
         };
 
-        let reference_indexes = build_reference_indexes(root, file_paths, &parsed_files);
-
         // Run scope-aware resolver for supported languages (reuse pre-parsed trees)
         let has_scope_lang = file_paths.iter().any(|f| {
             let ext = f.rfind('.').map(|i| &f[i..]).unwrap_or("");
@@ -885,234 +1199,51 @@ impl EntityGraph {
                 .and_then(|c| c.scope_resolve)
                 .is_some()
         });
-        let (scope_edges, scope_consumed_words) = if has_scope_lang {
+        let (scope_edges, scope_consumed_words) = if has_scope_lang && retain_parsed_files {
             let result = scope_resolve::resolve_with_scopes_full(
                 root,
                 file_paths,
                 &all_entities,
                 &entity_map,
                 Some(parsed_files),
-                Some(pre_built),
+                Some(&pre_built),
                 Some(&import_table),
                 false,
             );
             (result.edges, result.consumed_words)
+        } else if has_scope_lang {
+            resolve_scopes_in_file_chunks(
+                root,
+                file_paths,
+                &all_entities,
+                &entity_map,
+                &pre_built,
+                &import_table,
+            )
         } else {
             (vec![], HashMap::new())
         };
-        // Pass 2: Extract references in parallel, then resolve against symbol table
-        // Phase 1: Dot-chain resolution (precise self.X, this.X, ClassName.X)
-        // Phase 2: Bag-of-words resolution (existing logic, skipping consumed words)
-        // Skip entities already resolved by scope resolver (Python files)
-        // Skip entities from non-code file types (JSON, SQL, etc.) that can't produce edges
-        let resolved_refs: Vec<(String, String, RefType)> = maybe_par_iter!(all_entities)
-            .map(|entity| {
-                // Skip entities from file types that don't have language configs
-                // (JSON, SQL, YAML, etc. — they extract entities but never produce reference edges)
-                let ext = entity
-                    .file_path
-                    .rfind('.')
-                    .map(|i| &entity.file_path[i..])
-                    .unwrap_or("");
-                let Some(language_config) =
-                    crate::parser::plugins::code::languages::get_language_config(ext)
-                else {
-                    return vec![];
-                };
-                let fallback_end_line =
-                    fallback_reference_end_line(entity, language_config.scope_resolve.is_some());
-                let fallback_ranges =
-                    direct_reference_line_ranges(entity, fallback_end_line, &child_line_ranges);
 
-                let mut entity_edges = Vec::new();
-                let mut consumed_words = scope_consumed_words
-                    .get(&entity.id)
-                    .cloned()
-                    .unwrap_or_default();
-
-                let reference_index =
-                    if entity_requires_content_span_filter(entity, &child_ranges_by_parent) {
-                        None
-                    } else {
-                        reference_indexes.get(entity.file_path.as_str())
-                    };
-                let fallback_stripped = if reference_index.is_none() {
-                    Some(strip_comments_and_strings(&entity.content))
-                } else {
-                    None
-                };
-                let local_bindings =
-                    local_binding_names_filtered(&entity.content, ext, |local_line, start, end| {
-                        entity_owns_content_span(
-                            entity.id.as_str(),
-                            entity.file_path.as_str(),
-                            source_line_for_entity_content(entity, local_line),
-                            Some(start),
-                            Some(end),
-                            &child_ranges_by_parent,
-                        )
-                    });
-
-                // Phase 1: Dot-chain resolution
-                let dot_chains: Vec<(&str, &str, Option<(usize, usize, usize)>)> =
-                    match reference_index {
-                        Some(index) => index
-                            .dot_chains_in_ranges(&fallback_ranges)
-                            .into_iter()
-                            .map(|(receiver, member)| (receiver, member, None))
-                            .collect(),
-                        None => {
-                            extract_dot_chains_with_positions(fallback_stripped.as_ref().unwrap())
-                                .into_iter()
-                                .map(|(receiver, member, line, start, end)| {
-                                    (receiver, member, Some((line, start, end)))
-                                })
-                                .collect()
-                        }
-                    };
-
-                for (receiver, member, position) in &dot_chains {
-                    if consumed_words.contains(*member) {
-                        continue;
-                    }
-                    if let Some((local_line, local_start_byte, local_end_byte)) = *position {
-                        if !entity_owns_content_span(
-                            entity.id.as_str(),
-                            entity.file_path.as_str(),
-                            source_line_for_entity_content(entity, local_line),
-                            Some(local_start_byte),
-                            Some(local_end_byte),
-                            &child_ranges_by_parent,
-                        ) {
-                            continue;
-                        }
-                    }
-                    let edge_count_before = entity_edges.len();
-                    if *receiver == "self" || *receiver == "this" {
-                        // self.B / this.B: resolve to sibling method in enclosing class
-                        if let Some(class_name) = enclosing_class.get(entity.id.as_str()) {
-                            if let Some(members) = class_members.get(class_name) {
-                                for (n, tid) in members {
-                                    if *n == *member && *tid != entity.id.as_str() {
-                                        entity_edges.push((
-                                            entity.id.clone(),
-                                            tid.to_string(),
-                                            RefType::Calls,
-                                        ));
-                                        consumed_words.insert(member.to_string());
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                    } else if class_entity_files.contains(&(*receiver, entity.file_path.as_str())) {
-                        // ClassName.B: resolve to class member
-                        if let Some(members) = class_members.get(*receiver) {
-                            for (n, tid) in members {
-                                if *n == *member {
-                                    entity_edges.push((
-                                        entity.id.clone(),
-                                        tid.to_string(),
-                                        RefType::Calls,
-                                    ));
-                                    consumed_words.insert(member.to_string());
-                                    consumed_words.insert(receiver.to_string());
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    if entity_edges.len() == edge_count_before {
-                        consumed_words.insert(member.to_string());
-                    }
-                }
-
-                // Phase 2: Bag-of-words resolution (skip words consumed by dot-chains)
-                let refs: Vec<(&str, RefType)> = match reference_index {
-                    Some(index) => index.refs_with_types_in_ranges(&fallback_ranges, &entity.name),
-                    None => {
-                        let stripped = fallback_stripped.as_ref().unwrap();
-                        extract_references_with_stripped_filtered(
-                            &entity.content,
-                            &entity.name,
-                            stripped,
-                            |local_line, local_start_byte, local_end_byte| {
-                                entity_owns_content_span(
-                                    entity.id.as_str(),
-                                    entity.file_path.as_str(),
-                                    source_line_for_entity_content(entity, local_line),
-                                    Some(local_start_byte),
-                                    Some(local_end_byte),
-                                    &child_ranges_by_parent,
-                                )
-                            },
-                        )
-                        .into_iter()
-                        .map(|ref_name| (ref_name, infer_ref_type(&entity.content, ref_name)))
-                        .collect()
-                    }
-                };
-                for (ref_name, ref_type) in refs {
-                    if consumed_words.contains(ref_name) {
-                        continue;
-                    }
-                    if local_bindings.contains(ref_name) {
-                        continue;
-                    }
-
-                    // Skip references to names that are this class's own methods
-                    if class_child_names.contains(&(entity.id.as_str(), ref_name)) {
-                        continue;
-                    }
-
-                    // Check import table first: if this file imports this name,
-                    // resolve to the import target instead of global symbol table
-                    let import_key = (entity.file_path.clone(), ref_name.to_string());
-                    if let Some(import_target_id) = import_table.get(&import_key) {
-                        if import_target_id != &entity.id
-                            && !parent_child_pairs
-                                .contains(&(entity.id.as_str(), import_target_id.as_str()))
-                            && !parent_child_pairs
-                                .contains(&(import_target_id.as_str(), entity.id.as_str()))
-                        {
-                            entity_edges.push((
-                                entity.id.clone(),
-                                import_target_id.clone(),
-                                ref_type,
-                            ));
-                        }
-                        continue;
-                    }
-
-                    if let Some(target_ids) = symbol_table.get(ref_name) {
-                        // Without an import, only resolve to entities in the same file.
-                        // Cross-file resolution is handled by the import table above.
-                        let target = target_ids.iter().find(|id| {
-                            *id != &entity.id
-                                && entity_map
-                                    .get(*id)
-                                    .map_or(false, |e| e.file_path == entity.file_path)
-                        });
-
-                        if let Some(target_id) = target {
-                            // Skip parent-child edges (class -> own method)
-                            if parent_child_pairs
-                                .contains(&(entity.id.as_str(), target_id.as_str()))
-                                || parent_child_pairs
-                                    .contains(&(target_id.as_str(), entity.id.as_str()))
-                            {
-                                continue;
-                            }
-                            entity_edges.push((entity.id.clone(), target_id.clone(), ref_type));
-                        }
-                    }
-                }
-                entity_edges
-            })
-            .collect::<Vec<_>>()
-            .into_iter()
-            .flatten()
-            .collect();
+        let reference_context = ReferenceResolutionContext {
+            symbol_table: symbol_table.as_ref(),
+            entity_map: &entity_map,
+            import_table: &import_table,
+            scope_consumed_words: &scope_consumed_words,
+            child_ranges_by_parent: &child_ranges_by_parent,
+            child_line_ranges: &child_line_ranges,
+            parent_child_pairs: &parent_child_pairs,
+            class_child_names: &class_child_names,
+            class_entity_files: &class_entity_files,
+            enclosing_class: &enclosing_class,
+            class_members: &class_members,
+        };
+        let resolved_refs = resolve_references_with_file_indexes(
+            root,
+            file_paths,
+            &all_entities,
+            None,
+            &reference_context,
+        );
 
         let export_edges = build_export_alias_edges(&all_entities, &import_table);
 
@@ -1304,14 +1435,7 @@ impl EntityGraph {
             );
         }
         sort_symbol_table_targets_by_source(&mut symbol_table, &entity_map);
-
-        let import_table = build_import_table(
-            root,
-            all_file_paths,
-            &symbol_table,
-            &entity_map,
-            Some(&parsed_files),
-        );
+        let symbol_table = Arc::new(symbol_table);
 
         let entity_file_paths: HashMap<&str, &str> = all_entities
             .iter()
@@ -1328,6 +1452,11 @@ impl EntityGraph {
             HashSet::with_capacity(stale_entity_ids.len() + stale_cached_entity_ids.len());
         stale_or_cached_stale_entity_ids.extend(stale_entity_ids.iter().copied());
         stale_or_cached_stale_entity_ids.extend(stale_cached_entity_ids.iter().copied());
+
+        let has_new_or_deleted_stale_entities = all_entities.iter().any(|entity| {
+            stale_set.contains(entity.file_path.as_str())
+                && !cached_hashes.contains_key(entity.id.as_str())
+        }) || !deleted_ids.is_empty();
 
         // Find clean entities whose cached outgoing edges are invalidated by stale targets.
         let mut affected_clean_ids: HashSet<String> = HashSet::new();
@@ -1404,6 +1533,18 @@ impl EntityGraph {
             }
         }
 
+        let import_table = if has_new_or_deleted_stale_entities {
+            Some(build_import_table(
+                root,
+                all_file_paths,
+                &symbol_table,
+                &entity_map,
+                Some(&parsed_files),
+            ))
+        } else {
+            None
+        };
+
         let mut new_stale_entity_ids: HashSet<&str> = HashSet::new();
         let mut new_stale_names: HashSet<&str> = HashSet::new();
         for entity in &all_entities {
@@ -1415,6 +1556,9 @@ impl EntityGraph {
             }
         }
         if !new_stale_names.is_empty() {
+            let import_table = import_table
+                .as_ref()
+                .expect("new stale entity analysis requires a full import table");
             let new_stale_import_refs: HashSet<(&str, &str)> = import_table
                 .iter()
                 .filter(|(_, target_id)| new_stale_entity_ids.contains(target_id.as_str()))
@@ -1567,6 +1711,28 @@ impl EntityGraph {
             }
         }
 
+        let import_table = match import_table {
+            Some(import_table) => import_table,
+            None => {
+                let mut file_paths = stale_files.to_vec();
+                file_paths.extend(
+                    affected_clean_file_paths
+                        .iter()
+                        .map(|file_path| (*file_path).to_string()),
+                );
+                file_paths.sort_unstable();
+                file_paths.dedup();
+                build_import_table_with_default_export_paths(
+                    root,
+                    &file_paths,
+                    all_file_paths,
+                    &symbol_table,
+                    &entity_map,
+                    Some(&parsed_files),
+                )
+            }
+        };
+
         // Keep edges where both endpoints are in clean (non-stale) files and from_entity
         // is not affected by target changes. Drop ALL cached edges from stale-file entities
         // (even content_clean ones) because import/scope context may have changed even when
@@ -1659,9 +1825,28 @@ impl EntityGraph {
 
         let mut enclosing_class: HashMap<&str, &str> = HashMap::new();
         let mut class_members: HashMap<&str, Vec<(&str, &str)>> = HashMap::new();
+        let mut scope_class_members: HashMap<String, Vec<(String, String)>> = HashMap::new();
+        let mut scope_owner_members: HashMap<String, Vec<(String, String)>> = HashMap::new();
+        let mut scope_entity_ranges: HashMap<String, Vec<(usize, usize, String)>> = HashMap::new();
 
         for entity in &all_entities {
+            scope_entity_ranges
+                .entry(entity.file_path.clone())
+                .or_default()
+                .push((entity.start_line, entity.end_line, entity.id.clone()));
             if let Some(ref pid) = entity.parent_id {
+                scope_owner_members
+                    .entry(pid.clone())
+                    .or_default()
+                    .push((entity.name.clone(), entity.id.clone()));
+                if let Some(parent) = entity_map.get(pid.as_str()) {
+                    if let Some(owner_name) = scope_resolve::class_member_owner_name(parent) {
+                        scope_class_members
+                            .entry(owner_name.to_string())
+                            .or_default()
+                            .push((entity.name.clone(), entity.id.clone()));
+                    }
+                }
                 if let Some(&parent_name) = id_to_name.get(pid.as_str()) {
                     if class_entity_names.contains(parent_name) {
                         enclosing_class.insert(entity.id.as_str(), parent_name);
@@ -1672,6 +1857,24 @@ impl EntityGraph {
                     }
                 }
             }
+            if entity.entity_type == "method" && entity.file_path.ends_with(".go") {
+                if let Some(struct_name) = scope_resolve::extract_go_receiver_type(&entity.content)
+                {
+                    scope_class_members
+                        .entry(struct_name)
+                        .or_default()
+                        .push((entity.name.clone(), entity.id.clone()));
+                }
+            }
+        }
+        for members in scope_class_members.values_mut() {
+            members.sort_unstable();
+        }
+        for members in scope_owner_members.values_mut() {
+            members.sort_unstable();
+        }
+        for ranges in scope_entity_ranges.values_mut() {
+            ranges.sort_unstable();
         }
 
         // Run scope-aware resolver only on files that need resolution
@@ -1682,8 +1885,6 @@ impl EntityGraph {
             })
             .cloned()
             .collect();
-
-        let reference_indexes = build_reference_indexes(root, &resolve_file_paths, &parsed_files);
 
         let has_scope_lang = resolve_file_paths.iter().any(|f| {
             let ext = f.rfind('.').map(|i| &f[i..]).unwrap_or("");
@@ -1704,13 +1905,26 @@ impl EntityGraph {
             } else {
                 Some(relevant_parsed)
             };
+            let owned_go_pkg_index: HashMap<String, Vec<(String, String)>> =
+                if resolve_file_paths.iter().any(|f| f.ends_with(".go")) {
+                    scope_resolve::build_go_pkg_index(&symbol_table, &entity_map)
+                } else {
+                    HashMap::new()
+                };
+            let pre_built = scope_resolve::PreBuiltLookups {
+                symbol_table: Arc::clone(&symbol_table),
+                class_members: scope_class_members,
+                owner_members: scope_owner_members,
+                entity_ranges: scope_entity_ranges,
+                go_pkg_index: owned_go_pkg_index,
+            };
             let result = scope_resolve::resolve_with_scopes_full(
                 root,
                 &resolve_file_paths,
                 &all_entities,
                 &entity_map,
                 pre,
-                None,
+                Some(&pre_built),
                 Some(&import_table),
                 false,
             );
@@ -1718,208 +1932,27 @@ impl EntityGraph {
         } else {
             (vec![], HashMap::new())
         };
-        // Resolve references only for entities in needs_resolution
-        let resolved_refs: Vec<(String, String, RefType)> = maybe_par_iter!(all_entities)
-            .map(|entity| {
-                if !needs_resolution.contains(entity.id.as_str()) {
-                    return vec![];
-                }
-                // Skip entities from non-code file types (JSON, SQL, etc.)
-                let ext = entity
-                    .file_path
-                    .rfind('.')
-                    .map(|i| &entity.file_path[i..])
-                    .unwrap_or("");
-                let Some(language_config) =
-                    crate::parser::plugins::code::languages::get_language_config(ext)
-                else {
-                    return vec![];
-                };
-                let fallback_end_line =
-                    fallback_reference_end_line(entity, language_config.scope_resolve.is_some());
-                let fallback_ranges =
-                    direct_reference_line_ranges(entity, fallback_end_line, &child_line_ranges);
 
-                let mut entity_edges = Vec::new();
-                let mut consumed_words = scope_consumed_words
-                    .get(&entity.id)
-                    .cloned()
-                    .unwrap_or_default();
-
-                let reference_index =
-                    if entity_requires_content_span_filter(entity, &child_ranges_by_parent) {
-                        None
-                    } else {
-                        reference_indexes.get(entity.file_path.as_str())
-                    };
-                let fallback_stripped = if reference_index.is_none() {
-                    Some(strip_comments_and_strings(&entity.content))
-                } else {
-                    None
-                };
-                let local_bindings =
-                    local_binding_names_filtered(&entity.content, ext, |local_line, start, end| {
-                        entity_owns_content_span(
-                            entity.id.as_str(),
-                            entity.file_path.as_str(),
-                            source_line_for_entity_content(entity, local_line),
-                            Some(start),
-                            Some(end),
-                            &child_ranges_by_parent,
-                        )
-                    });
-
-                // Phase 1: Dot-chain resolution
-                let dot_chains: Vec<(&str, &str, Option<(usize, usize, usize)>)> =
-                    match reference_index {
-                        Some(index) => index
-                            .dot_chains_in_ranges(&fallback_ranges)
-                            .into_iter()
-                            .map(|(receiver, member)| (receiver, member, None))
-                            .collect(),
-                        None => {
-                            extract_dot_chains_with_positions(fallback_stripped.as_ref().unwrap())
-                                .into_iter()
-                                .map(|(receiver, member, line, start, end)| {
-                                    (receiver, member, Some((line, start, end)))
-                                })
-                                .collect()
-                        }
-                    };
-
-                for (receiver, member, position) in &dot_chains {
-                    if consumed_words.contains(*member) {
-                        continue;
-                    }
-                    if let Some((local_line, local_start_byte, local_end_byte)) = *position {
-                        if !entity_owns_content_span(
-                            entity.id.as_str(),
-                            entity.file_path.as_str(),
-                            source_line_for_entity_content(entity, local_line),
-                            Some(local_start_byte),
-                            Some(local_end_byte),
-                            &child_ranges_by_parent,
-                        ) {
-                            continue;
-                        }
-                    }
-                    let edge_count_before = entity_edges.len();
-                    if *receiver == "self" || *receiver == "this" {
-                        if let Some(class_name) = enclosing_class.get(entity.id.as_str()) {
-                            if let Some(members) = class_members.get(class_name) {
-                                for (n, tid) in members {
-                                    if *n == *member && *tid != entity.id.as_str() {
-                                        entity_edges.push((
-                                            entity.id.clone(),
-                                            tid.to_string(),
-                                            RefType::Calls,
-                                        ));
-                                        consumed_words.insert(member.to_string());
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                    } else if class_entity_files.contains(&(*receiver, entity.file_path.as_str())) {
-                        if let Some(members) = class_members.get(*receiver) {
-                            for (n, tid) in members {
-                                if *n == *member {
-                                    entity_edges.push((
-                                        entity.id.clone(),
-                                        tid.to_string(),
-                                        RefType::Calls,
-                                    ));
-                                    consumed_words.insert(member.to_string());
-                                    consumed_words.insert(receiver.to_string());
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    if entity_edges.len() == edge_count_before {
-                        consumed_words.insert(member.to_string());
-                    }
-                }
-
-                // Phase 2: Bag-of-words resolution
-                let refs: Vec<(&str, RefType)> = match reference_index {
-                    Some(index) => index.refs_with_types_in_ranges(&fallback_ranges, &entity.name),
-                    None => {
-                        let stripped = fallback_stripped.as_ref().unwrap();
-                        extract_references_with_stripped_filtered(
-                            &entity.content,
-                            &entity.name,
-                            stripped,
-                            |local_line, local_start_byte, local_end_byte| {
-                                entity_owns_content_span(
-                                    entity.id.as_str(),
-                                    entity.file_path.as_str(),
-                                    source_line_for_entity_content(entity, local_line),
-                                    Some(local_start_byte),
-                                    Some(local_end_byte),
-                                    &child_ranges_by_parent,
-                                )
-                            },
-                        )
-                        .into_iter()
-                        .map(|ref_name| (ref_name, infer_ref_type(&entity.content, ref_name)))
-                        .collect()
-                    }
-                };
-                for (ref_name, ref_type) in refs {
-                    if consumed_words.contains(ref_name) {
-                        continue;
-                    }
-                    if local_bindings.contains(ref_name) {
-                        continue;
-                    }
-                    if class_child_names.contains(&(entity.id.as_str(), ref_name)) {
-                        continue;
-                    }
-
-                    let import_key = (entity.file_path.clone(), ref_name.to_string());
-                    if let Some(import_target_id) = import_table.get(&import_key) {
-                        if import_target_id != &entity.id
-                            && !parent_child_pairs
-                                .contains(&(entity.id.as_str(), import_target_id.as_str()))
-                            && !parent_child_pairs
-                                .contains(&(import_target_id.as_str(), entity.id.as_str()))
-                        {
-                            entity_edges.push((
-                                entity.id.clone(),
-                                import_target_id.clone(),
-                                ref_type,
-                            ));
-                        }
-                        continue;
-                    }
-
-                    if let Some(target_ids) = symbol_table.get(ref_name) {
-                        let target = target_ids.iter().find(|id| {
-                            *id != &entity.id
-                                && entity_map
-                                    .get(*id)
-                                    .map_or(false, |e| e.file_path == entity.file_path)
-                        });
-
-                        if let Some(target_id) = target {
-                            if parent_child_pairs
-                                .contains(&(entity.id.as_str(), target_id.as_str()))
-                                || parent_child_pairs
-                                    .contains(&(target_id.as_str(), entity.id.as_str()))
-                            {
-                                continue;
-                            }
-                            entity_edges.push((entity.id.clone(), target_id.clone(), ref_type));
-                        }
-                    }
-                }
-                entity_edges
-            })
-            .collect::<Vec<_>>()
-            .into_iter()
-            .flatten()
-            .collect();
+        let reference_context = ReferenceResolutionContext {
+            symbol_table: symbol_table.as_ref(),
+            entity_map: &entity_map,
+            import_table: &import_table,
+            scope_consumed_words: &scope_consumed_words,
+            child_ranges_by_parent: &child_ranges_by_parent,
+            child_line_ranges: &child_line_ranges,
+            parent_child_pairs: &parent_child_pairs,
+            class_child_names: &class_child_names,
+            class_entity_files: &class_entity_files,
+            enclosing_class: &enclosing_class,
+            class_members: &class_members,
+        };
+        let resolved_refs = resolve_references_with_file_indexes(
+            root,
+            &resolve_file_paths,
+            &all_entities,
+            Some(&needs_resolution),
+            &reference_context,
+        );
 
         let export_edges = build_export_alias_edges(&all_entities, &import_table);
 
@@ -2813,6 +2846,24 @@ fn build_import_table(
     entity_map: &HashMap<String, EntityInfo>,
     pre_parsed_content: Option<&[(String, String, tree_sitter::Tree)]>,
 ) -> HashMap<(String, String), String> {
+    build_import_table_with_default_export_paths(
+        root,
+        file_paths,
+        file_paths,
+        symbol_table,
+        entity_map,
+        pre_parsed_content,
+    )
+}
+
+fn build_import_table_with_default_export_paths(
+    root: &Path,
+    file_paths: &[String],
+    default_export_file_paths: &[String],
+    symbol_table: &HashMap<String, Vec<String>>,
+    entity_map: &HashMap<String, EntityInfo>,
+    pre_parsed_content: Option<&[(String, String, tree_sitter::Tree)]>,
+) -> HashMap<(String, String), String> {
     // Build a content lookup from pre-parsed files to avoid re-reading from disk
     let mut content_map: HashMap<&str, &str> = HashMap::new();
     if let Some(files) = pre_parsed_content {
@@ -2823,7 +2874,11 @@ fn build_import_table(
         );
     }
     let mut owned_content: HashMap<String, String> = HashMap::new();
-    for file_path in file_paths {
+    let mut content_file_paths: Vec<&String> = file_paths.iter().collect();
+    content_file_paths.extend(default_export_file_paths.iter());
+    content_file_paths.sort_unstable();
+    content_file_paths.dedup();
+    for file_path in content_file_paths {
         if file_path.ends_with(".go") || content_map.contains_key(file_path.as_str()) {
             continue;
         }
@@ -2836,8 +2891,12 @@ fn build_import_table(
             .iter()
             .map(|(file_path, content)| (file_path.as_str(), content.as_str())),
     );
-    let ts_default_exports =
-        build_ts_default_export_table(file_paths, symbol_table, entity_map, &content_map);
+    let ts_default_exports = build_ts_default_export_table(
+        default_export_file_paths,
+        symbol_table,
+        entity_map,
+        &content_map,
+    );
     let ts_top_level_entities = OnceLock::new();
     let ts_exported_names_by_file: Mutex<HashMap<String, Arc<HashSet<String>>>> =
         Mutex::new(HashMap::new());
@@ -4311,6 +4370,42 @@ function outer() {
         assert!(graph.entities.contains_key("deep.ts::class::L0"));
         assert!(entities.iter().any(|e| e.name == "method"));
         assert_eq!(entities.len(), depth + 1);
+    }
+
+    #[test]
+    fn test_chunked_scope_resolution_keeps_cross_chunk_import_edges() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        let mut files = Vec::new();
+        for index in 0..10 {
+            let file_name = format!("file_{index}.ts");
+            let content = if index == 0 {
+                "export function target() { return 1; }\n".to_string()
+            } else if index == 9 {
+                "import { target } from './file_0';\nexport function caller() { return target(); }\n"
+                    .to_string()
+            } else {
+                format!("export function filler_{index}() {{ return {index}; }}\n")
+            };
+            write_file(root, &file_name, &content);
+            files.push(file_name);
+        }
+
+        let (graph, _) = EntityGraph::build(root, &files, &registry);
+        let caller_id = graph
+            .entities
+            .iter()
+            .find(|(_, entity)| entity.name == "caller")
+            .map(|(id, _)| id.clone())
+            .expect("caller entity should exist");
+        let deps = graph.get_dependencies(&caller_id);
+
+        assert!(
+            deps.iter().any(|dep| dep.name == "target"),
+            "caller should resolve imported target across scope chunks. Deps: {:?}",
+            deps.iter().map(|dep| &dep.name).collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/crates/sem-core/src/parser/registry.rs
+++ b/crates/sem-core/src/parser/registry.rs
@@ -48,6 +48,19 @@ impl ParserRegistry {
         self.get_plugin_by_id("fallback")
     }
 
+    pub fn get_explicit_plugin(&self, file_path: &str) -> Option<&dyn SemanticParserPlugin> {
+        for ext in get_extensions(file_path) {
+            if let Some(&idx) = self.extension_map.get(&ext) {
+                return Some(self.plugins[idx].as_ref());
+            }
+        }
+        None
+    }
+
+    pub fn detect_plugin_from_content(&self, content: &str) -> Option<&dyn SemanticParserPlugin> {
+        self.detect_from_shebang(content)
+    }
+
     /// Try to detect language from shebang line when extension-based lookup fails.
     /// Call this as a fallback when file content is available.
     pub fn get_plugin_with_content(&self, file_path: &str, content: &str) -> Option<&dyn SemanticParserPlugin> {

--- a/crates/sem-core/src/parser/scope_resolve.rs
+++ b/crates/sem-core/src/parser/scope_resolve.rs
@@ -556,7 +556,7 @@ pub(crate) fn resolve_with_scopes_full(
     all_entities: &[SemanticEntity],
     entity_map: &HashMap<String, EntityInfo>,
     pre_parsed: Option<Vec<(String, String, tree_sitter::Tree)>>,
-    pre_built: Option<PreBuiltLookups>,
+    pre_built: Option<&PreBuiltLookups>,
     pre_built_import_table: Option<&HashMap<(String, String), String>>,
     emit_local_binding_log: bool,
 ) -> ScopeResultFull {
@@ -564,79 +564,79 @@ pub(crate) fn resolve_with_scopes_full(
     let mut log: Vec<ResolutionEntry> = Vec::new();
     let mut consumed_words: HashMap<String, HashSet<String>> = HashMap::new();
 
-    // Use pre-built lookups if provided, otherwise build from scratch
-    let (symbol_table, class_members, owner_members, entity_ranges, go_pkg_index) =
-        if let Some(pb) = pre_built {
-            (
-                pb.symbol_table,
-                pb.class_members,
-                pb.owner_members,
-                pb.entity_ranges,
-                pb.go_pkg_index,
-            )
-        } else {
-            let mut symbol_table: HashMap<String, Vec<String>> = HashMap::new();
-            let mut class_members: HashMap<String, Vec<(String, String)>> = HashMap::new();
-            let mut owner_members: HashMap<String, Vec<(String, String)>> = HashMap::new();
-            let mut entity_ranges: HashMap<String, Vec<(usize, usize, String)>> = HashMap::new();
+    // Use pre-built lookups if provided, otherwise build from scratch.
+    let owned_lookups;
+    let lookups = if let Some(pb) = pre_built {
+        pb
+    } else {
+        let mut symbol_table: HashMap<String, Vec<String>> = HashMap::new();
+        let mut class_members: HashMap<String, Vec<(String, String)>> = HashMap::new();
+        let mut owner_members: HashMap<String, Vec<(String, String)>> = HashMap::new();
+        let mut entity_ranges: HashMap<String, Vec<(usize, usize, String)>> = HashMap::new();
 
-            for entity in all_entities {
-                symbol_table
-                    .entry(entity.name.clone())
+        for entity in all_entities {
+            symbol_table
+                .entry(entity.name.clone())
+                .or_default()
+                .push(entity.id.clone());
+
+            if let Some(ref pid) = entity.parent_id {
+                owner_members
+                    .entry(pid.clone())
                     .or_default()
-                    .push(entity.id.clone());
-
-                if let Some(ref pid) = entity.parent_id {
-                    owner_members
-                        .entry(pid.clone())
-                        .or_default()
-                        .push((entity.name.clone(), entity.id.clone()));
-                    if let Some(parent) = entity_map.get(pid) {
-                        if let Some(owner_name) = class_member_owner_name(parent) {
-                            class_members
-                                .entry(owner_name.to_string())
-                                .or_default()
-                                .push((entity.name.clone(), entity.id.clone()));
-                        }
-                    }
-                }
-
-                if entity.entity_type == "method" && entity.file_path.ends_with(".go") {
-                    if let Some(struct_name) = extract_go_receiver_type(&entity.content) {
+                    .push((entity.name.clone(), entity.id.clone()));
+                if let Some(parent) = entity_map.get(pid) {
+                    if let Some(owner_name) = class_member_owner_name(parent) {
                         class_members
-                            .entry(struct_name)
+                            .entry(owner_name.to_string())
                             .or_default()
                             .push((entity.name.clone(), entity.id.clone()));
                     }
                 }
-
-                entity_ranges
-                    .entry(entity.file_path.clone())
-                    .or_default()
-                    .push((entity.start_line, entity.end_line, entity.id.clone()));
-            }
-            sort_symbol_table_targets_by_source(&mut symbol_table, entity_map);
-            for members in class_members.values_mut() {
-                members.sort_unstable();
-            }
-            for members in owner_members.values_mut() {
-                members.sort_unstable();
-            }
-            for ranges in entity_ranges.values_mut() {
-                ranges.sort_unstable();
             }
 
-            // Build Go package index for O(1) import lookup
-            let go_pkg_index = build_go_pkg_index(&symbol_table, entity_map);
+            if entity.entity_type == "method" && entity.file_path.ends_with(".go") {
+                if let Some(struct_name) = extract_go_receiver_type(&entity.content) {
+                    class_members
+                        .entry(struct_name)
+                        .or_default()
+                        .push((entity.name.clone(), entity.id.clone()));
+                }
+            }
 
-            (
-                Arc::new(symbol_table),
-                class_members,
-                owner_members,
-                entity_ranges,
-                go_pkg_index,
-            )
+            entity_ranges
+                .entry(entity.file_path.clone())
+                .or_default()
+                .push((entity.start_line, entity.end_line, entity.id.clone()));
+        }
+        sort_symbol_table_targets_by_source(&mut symbol_table, entity_map);
+        for members in class_members.values_mut() {
+            members.sort_unstable();
+        }
+        for members in owner_members.values_mut() {
+            members.sort_unstable();
+        }
+        for ranges in entity_ranges.values_mut() {
+            ranges.sort_unstable();
+        }
+
+        // Build Go package index for O(1) import lookup
+        let go_pkg_index = build_go_pkg_index(&symbol_table, entity_map);
+
+        owned_lookups = PreBuiltLookups {
+            symbol_table: Arc::new(symbol_table),
+            class_members,
+            owner_members,
+            entity_ranges,
+            go_pkg_index,
         };
+        &owned_lookups
+    };
+    let symbol_table = lookups.symbol_table.as_ref();
+    let class_members = &lookups.class_members;
+    let owner_members = &lookups.owner_members;
+    let entity_ranges = &lookups.entity_ranges;
+    let go_pkg_index = &lookups.go_pkg_index;
 
     // Build file-path indexed entity lookup: file_path -> Vec<&SemanticEntity>
     let mut entities_by_file: HashMap<&str, Vec<&SemanticEntity>> = HashMap::new();
@@ -793,9 +793,16 @@ pub(crate) fn resolve_with_scopes_full(
         &symbol_table,
         &mut instance_attr_types,
     );
+    let func_name_return_types = deterministic_return_types_by_name(&return_type_map, symbol_table);
 
-    let swift_call_signatures =
-        build_swift_call_signatures(parsed_files, all_entities, &entity_ranges, entity_map);
+    let swift_call_signatures = if parsed_files
+        .iter()
+        .any(|(file_path, _, _)| file_path.ends_with(".swift"))
+    {
+        build_swift_call_signatures(parsed_files, all_entities, &entity_ranges, entity_map)
+    } else {
+        HashMap::new()
+    };
 
     // Group the prebuilt import table by importing file once. Otherwise every file
     // in Pass 2 would rescan the entire table to find its own entries — O(files ×
@@ -905,16 +912,6 @@ pub(crate) fn resolve_with_scopes_full(
                 pre_built_import_table.is_some(),
             );
 
-            // Resolve pending call types using the complete return type map
-            inject_return_type_bindings(
-                &entity_inner_scope,
-                &mut scopes,
-                &return_type_map,
-                &symbol_table,
-                &local_import_table,
-                file_path,
-            );
-
             // The per-file import table is keyed by (file_path, name) but only ever
             // holds this file's entries, so re-key it by name once. resolve_ref then
             // looks up imports without allocating a key string per reference.
@@ -922,6 +919,14 @@ pub(crate) fn resolve_with_scopes_full(
                 .iter()
                 .map(|((_, name), target_id)| (name.as_str(), target_id.as_str()))
                 .collect();
+
+            // Resolve pending call types using the complete return type map.
+            inject_return_type_bindings(
+                &mut scopes,
+                &func_name_return_types,
+                &return_type_map,
+                &local_import_by_name,
+            );
 
             let mut file_edges: Vec<(String, String, RefType)> = Vec::new();
             let mut file_log: Vec<ResolutionEntry> = Vec::new();
@@ -1295,6 +1300,29 @@ fn row_in_descendant_ranges(ranges: Option<&Vec<(usize, usize)>>, row: usize) ->
 /// Creates class scopes and maps methods to them.
 /// Uses an iterative worklist to avoid stack overflow on deeply nested ASTs.
 /// Fixes: https://github.com/Ataraxy-Labs/sem/issues/103
+fn push_named_children_rev<'a>(
+    worklist: &mut Vec<tree_sitter::Node<'a>>,
+    node: tree_sitter::Node<'a>,
+) {
+    for idx in (0..node.named_child_count()).rev() {
+        if let Some(child) = node.named_child(idx as u32) {
+            worklist.push(child);
+        }
+    }
+}
+
+fn push_scoped_named_children_rev<'a>(
+    worklist: &mut Vec<(tree_sitter::Node<'a>, usize)>,
+    node: tree_sitter::Node<'a>,
+    scope: usize,
+) {
+    for idx in (0..node.named_child_count()).rev() {
+        if let Some(child) = node.named_child(idx as u32) {
+            worklist.push((child, scope));
+        }
+    }
+}
+
 fn build_scopes_from_ast(
     root: tree_sitter::Node,
     root_scope: usize,
@@ -1398,11 +1426,7 @@ fn build_scopes_from_ast(
                     }
                 }
 
-                let mut cursor = node.walk();
-                let children: Vec<_> = node.named_children(&mut cursor).collect();
-                for child in children.into_iter().rev() {
-                    worklist.push((child, class_scope_idx));
-                }
+                push_scoped_named_children_rev(&mut worklist, node, class_scope_idx);
                 continue;
             } else if !is_impl {
                 let class_scope_idx = scopes.len();
@@ -1416,11 +1440,7 @@ fn build_scopes_from_ast(
                     owner_id: None,
                     kind: "class",
                 });
-                let mut cursor = node.walk();
-                let children: Vec<_> = node.named_children(&mut cursor).collect();
-                for child in children.into_iter().rev() {
-                    worklist.push((child, class_scope_idx));
-                }
+                push_scoped_named_children_rev(&mut worklist, node, class_scope_idx);
                 continue;
             }
         }
@@ -1467,11 +1487,7 @@ fn build_scopes_from_ast(
                 }
             }
 
-            let mut cursor = node.walk();
-            let children: Vec<_> = node.named_children(&mut cursor).collect();
-            for child in children.into_iter().rev() {
-                worklist.push((child, mod_scope_idx));
-            }
+            push_scoped_named_children_rev(&mut worklist, node, mod_scope_idx);
             continue;
         }
 
@@ -1563,19 +1579,11 @@ fn build_scopes_from_ast(
                 }
             }
 
-            let mut cursor = node.walk();
-            let children: Vec<_> = node.named_children(&mut cursor).collect();
-            for child in children.into_iter().rev() {
-                worklist.push((child, func_scope_idx));
-            }
+            push_scoped_named_children_rev(&mut worklist, node, func_scope_idx);
             continue;
         }
 
-        let mut cursor = node.walk();
-        let children: Vec<_> = node.named_children(&mut cursor).collect();
-        for child in children.into_iter().rev() {
-            worklist.push((child, current_scope));
-        }
+        push_scoped_named_children_rev(&mut worklist, node, current_scope);
     }
 }
 
@@ -2392,7 +2400,7 @@ pub fn extract_go_receiver_type(content: &str) -> Option<String> {
 
 /// Build Go package index: pkg_name → [(entity_name, entity_id)]
 /// Maps file stems and parent directory names to entities for O(1) package import lookup.
-fn build_go_pkg_index(
+pub(crate) fn build_go_pkg_index(
     symbol_table: &HashMap<String, Vec<String>>,
     entity_map: &HashMap<String, EntityInfo>,
 ) -> HashMap<String, Vec<(String, String)>> {
@@ -2481,11 +2489,7 @@ fn scan_return_types(
             }
         }
 
-        let mut cursor = node.walk();
-        let children: Vec<_> = node.named_children(&mut cursor).collect();
-        for child in children.into_iter().rev() {
-            worklist.push(child);
-        }
+        push_named_children_rev(&mut worklist, node);
     }
 }
 
@@ -2619,11 +2623,7 @@ fn scan_init_self_attrs(
             InitStrategy::None => {}
         }
 
-        let mut cursor = node.walk();
-        let children: Vec<_> = node.named_children(&mut cursor).collect();
-        for child in children.into_iter().rev() {
-            worklist.push(child);
-        }
+        push_named_children_rev(&mut worklist, node);
     }
 }
 
@@ -3565,11 +3565,7 @@ fn scan_constructor_calls(
             }
         }
 
-        let mut cursor = node.walk();
-        let children: Vec<_> = node.named_children(&mut cursor).collect();
-        for child in children.into_iter().rev() {
-            worklist.push(child);
-        }
+        push_named_children_rev(&mut worklist, node);
     }
 }
 
@@ -3607,43 +3603,21 @@ fn infer_expr_type(
 /// Resolve pending call types using the return type map.
 /// For scopes with `x = func()` where func has a known return type, bind x to that type.
 fn inject_return_type_bindings(
-    _entity_inner_scope: &HashMap<String, usize>,
     scopes: &mut Vec<Scope>,
+    func_name_return_types: &HashMap<String, String>,
     return_type_map: &HashMap<String, String>,
-    symbol_table: &HashMap<String, Vec<String>>,
-    import_table: &HashMap<(String, String), String>,
-    file_path: &str,
+    import_table_by_name: &HashMap<&str, &str>,
 ) {
-    let mut func_name_return_types =
-        deterministic_return_types_by_name(return_type_map, symbol_table);
-
-    // Also resolve through imports: if `get_connection` is imported and has a known return type
-    let mut import_entries: Vec<(&(String, String), &String)> = import_table
-        .iter()
-        .filter(|((fp, _), _)| fp == file_path)
-        .collect();
-    import_entries.sort_unstable_by(
-        |((_, left_name), left_target), ((_, right_name), right_target)| {
-            left_name
-                .cmp(right_name)
-                .then_with(|| left_target.cmp(right_target))
-        },
-    );
-
-    for ((_, local_name), target_id) in import_entries {
-        if let Some(ret_type) = return_type_map.get(target_id) {
-            func_name_return_types.insert(local_name.clone(), ret_type.clone());
-        }
-    }
-
     // Resolve pending call types in all scopes
     for scope in scopes.iter_mut() {
         let resolved: Vec<(String, String)> = scope
             .pending_call_types
             .iter()
             .filter_map(|(var_name, func_name)| {
-                func_name_return_types
-                    .get(func_name)
+                import_table_by_name
+                    .get(func_name.as_str())
+                    .and_then(|target_id| return_type_map.get(*target_id))
+                    .or_else(|| func_name_return_types.get(func_name))
                     .map(|ret_type| (var_name.clone(), ret_type.clone()))
             })
             .collect();
@@ -4774,11 +4748,7 @@ fn build_swift_call_signatures(
                 }
             }
 
-            let mut cursor = node.walk();
-            let children: Vec<_> = node.named_children(&mut cursor).collect();
-            for child in children.into_iter().rev() {
-                worklist.push(child);
-            }
+            push_named_children_rev(&mut worklist, node);
         }
     }
 
@@ -4880,11 +4850,7 @@ fn find_first_swift_callable_declaration<'a>(
             return Some(node);
         }
 
-        let mut cursor = node.walk();
-        let children: Vec<_> = node.named_children(&mut cursor).collect();
-        for child in children.into_iter().rev() {
-            worklist.push(child);
-        }
+        push_named_children_rev(&mut worklist, node);
     }
 
     None
@@ -4907,11 +4873,7 @@ fn extract_swift_declaration_argument_labels(
             continue;
         }
 
-        let mut cursor = current.walk();
-        let children: Vec<_> = current.named_children(&mut cursor).collect();
-        for child in children.into_iter().rev() {
-            worklist.push(child);
-        }
+        push_named_children_rev(&mut worklist, current);
     }
 
     labels
@@ -5130,11 +5092,7 @@ fn collect_all_file_refs(
                     }
                 }
             }
-            let mut cursor = node.walk();
-            let children: Vec<_> = node.named_children(&mut cursor).collect();
-            for child in children.into_iter().rev() {
-                worklist.push(child);
-            }
+            push_named_children_rev(&mut worklist, node);
             continue;
         }
 
@@ -5154,11 +5112,7 @@ fn collect_all_file_refs(
                     });
                 }
             }
-            let mut cursor = node.walk();
-            let children: Vec<_> = node.named_children(&mut cursor).collect();
-            for child in children.into_iter().rev() {
-                worklist.push(child);
-            }
+            push_named_children_rev(&mut worklist, node);
             continue;
         }
 
@@ -5179,11 +5133,7 @@ fn collect_all_file_refs(
                     });
                 }
             }
-            let mut cursor = node.walk();
-            let children: Vec<_> = node.named_children(&mut cursor).collect();
-            for child in children.into_iter().rev() {
-                worklist.push(child);
-            }
+            push_named_children_rev(&mut worklist, node);
             continue;
         }
 
@@ -5208,11 +5158,7 @@ fn collect_all_file_refs(
         }
 
         // Recurse into children
-        let mut cursor = node.walk();
-        let children: Vec<_> = node.named_children(&mut cursor).collect();
-        for child in children.into_iter().rev() {
-            worklist.push(child);
-        }
+        push_named_children_rev(&mut worklist, node);
     }
     refs
 }

--- a/crates/sem-core/src/utils/hash.rs
+++ b/crates/sem-core/src/utils/hash.rs
@@ -3,7 +3,11 @@ use tree_sitter::Node;
 use xxhash_rust::xxh3::Xxh3;
 
 pub fn content_hash(content: &str) -> String {
-    format!("{:016x}", xxhash_rust::xxh3::xxh3_64(content.as_bytes()))
+    content_hash_bytes(content.as_bytes())
+}
+
+pub fn content_hash_bytes(content: &[u8]) -> String {
+    format!("{:016x}", xxhash_rust::xxh3::xxh3_64(content))
 }
 
 pub fn short_hash(content: &str, length: usize) -> String {
@@ -150,6 +154,11 @@ mod tests {
         let h = content_hash("test");
         assert_eq!(h.len(), 16); // xxHash64 = 8 bytes = 16 hex chars
         assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn test_content_hash_bytes_matches_string_hash() {
+        assert_eq!(content_hash_bytes(b"test"), content_hash("test"));
     }
 
     #[test]

--- a/crates/sem-mcp/Cargo.toml
+++ b/crates/sem-mcp/Cargo.toml
@@ -28,6 +28,7 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 openssl = { version = "0.10", features = ["vendored"], optional = true }
+mimalloc = "0.1"
 
 [dev-dependencies]
 tempfile = "3.24.0"

--- a/crates/sem-mcp/src/cache.rs
+++ b/crates/sem-mcp/src/cache.rs
@@ -7,8 +7,9 @@ use std::path::{Component, Path, PathBuf};
 use rusqlite::{params, Connection, Transaction};
 use sem_core::model::entity::SemanticEntity;
 use sem_core::parser::graph::{EntityGraph, EntityInfo, EntityRef, RefType};
+use sem_core::utils::hash::content_hash_bytes;
 
-pub const CACHE_SCHEMA_VERSION: i32 = 2;
+pub const CACHE_SCHEMA_VERSION: i32 = 3;
 pub const CACHE_INDEXES: &[(&str, &str, &str)] = &[
     ("idx_entities_file_path", "entities", "file_path"),
     ("idx_entities_name", "entities", "name"),
@@ -27,7 +28,8 @@ const CACHE_SCHEMA_SQL: &str = "
 CREATE TABLE IF NOT EXISTS files (
     path TEXT PRIMARY KEY,
     mtime_secs INTEGER NOT NULL,
-    mtime_nanos INTEGER NOT NULL
+    mtime_nanos INTEGER NOT NULL,
+    content_hash TEXT
 );
 CREATE TABLE IF NOT EXISTS entities (
     id TEXT PRIMARY KEY,
@@ -325,6 +327,51 @@ pub fn file_mtime_parts(path: &Path) -> Option<(i64, i64)> {
     Some((dur.as_secs() as i64, dur.subsec_nanos() as i64))
 }
 
+pub fn file_content_hash(path: &Path) -> Option<String> {
+    let content = std::fs::read(path).ok()?;
+    Some(content_hash_bytes(&content))
+}
+
+pub fn file_fingerprint(path: &Path) -> Option<(i64, i64, String)> {
+    let (secs, nanos) = file_mtime_parts(path)?;
+    let hash = file_content_hash(path)?;
+    Some((secs, nanos, hash))
+}
+
+pub enum FileFreshness {
+    Fresh,
+    FreshWithUpdatedFingerprint {
+        secs: i64,
+        nanos: i64,
+        content_hash: String,
+    },
+    Stale,
+}
+
+pub fn file_freshness(
+    path: &Path,
+    cached_secs: i64,
+    cached_nanos: i64,
+    cached_content_hash: Option<&str>,
+) -> Option<FileFreshness> {
+    let (current_secs, current_nanos) = file_mtime_parts(path)?;
+    if cached_secs == current_secs && cached_nanos == current_nanos {
+        return Some(FileFreshness::Fresh);
+    }
+
+    let cached_content_hash = cached_content_hash?;
+    let current_content_hash = file_content_hash(path)?;
+    if current_content_hash == cached_content_hash {
+        return Some(FileFreshness::FreshWithUpdatedFingerprint {
+            secs: current_secs,
+            nanos: current_nanos,
+            content_hash: current_content_hash,
+        });
+    }
+
+    Some(FileFreshness::Stale)
+}
+
 pub fn is_cache_manifest_key(path: &str) -> bool {
     CACHE_MANIFEST_FILES
         .iter()
@@ -394,7 +441,7 @@ pub fn refresh_manifest_entries(tx: &Transaction<'_>, root: &Path) -> Result<(),
     }
 
     let mut insert = tx.prepare(
-        "INSERT OR REPLACE INTO files (path, mtime_secs, mtime_nanos) VALUES (?1, ?2, ?3)",
+        "INSERT OR REPLACE INTO files (path, mtime_secs, mtime_nanos, content_hash) VALUES (?1, ?2, ?3, NULL)",
     )?;
     for (file_name, cache_key) in CACHE_MANIFEST_FILES {
         let full = root.join(file_name);
@@ -436,15 +483,16 @@ impl DiskCache {
         tx.execute_batch("DELETE FROM files; DELETE FROM entities; DELETE FROM edges;")?;
 
         {
-            let mut stmt = tx
-                .prepare("INSERT INTO files (path, mtime_secs, mtime_nanos) VALUES (?1, ?2, ?3)")?;
+            let mut stmt = tx.prepare(
+                "INSERT INTO files (path, mtime_secs, mtime_nanos, content_hash) VALUES (?1, ?2, ?3, ?4)",
+            )?;
             for file in files {
                 if is_manifest_file_name(file) {
                     continue;
                 }
                 let full = root.join(file);
-                if let Some((secs, nanos)) = file_mtime_parts(&full) {
-                    stmt.execute(params![file, secs, nanos])?;
+                if let Some((secs, nanos, content_hash)) = file_fingerprint(&full) {
+                    stmt.execute(params![file, secs, nanos, content_hash])?;
                 }
             }
         }
@@ -516,20 +564,28 @@ impl DiskCache {
         // Verify all mtimes match
         let mut stmt = self
             .conn
-            .prepare("SELECT mtime_secs, mtime_nanos FROM files WHERE path = ?1")
+            .prepare("SELECT mtime_secs, mtime_nanos, content_hash FROM files WHERE path = ?1")
             .ok()?;
         for file in files {
             if is_manifest_file_name(file) {
                 continue;
             }
-            let full = root.join(file);
-            let (current_secs, current_nanos) = file_mtime_parts(&full)?;
-
-            let (secs, nanos): (i64, i64) = stmt
-                .query_row(params![file], |row| Ok((row.get(0)?, row.get(1)?)))
+            let (secs, nanos, content_hash): (i64, i64, Option<String>) = stmt
+                .query_row(params![file], |row| {
+                    Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+                })
                 .ok()?;
-            if secs != current_secs || nanos != current_nanos {
-                return None;
+            let full = root.join(file);
+            match file_freshness(&full, secs, nanos, content_hash.as_deref())? {
+                FileFreshness::Fresh => {}
+                FileFreshness::FreshWithUpdatedFingerprint {
+                    secs,
+                    nanos,
+                    content_hash,
+                } => {
+                    self.refresh_file_fingerprint(file, secs, nanos, &content_hash);
+                }
+                FileFreshness::Stale => return None,
             }
         }
 
@@ -622,13 +678,17 @@ impl DiskCache {
 
         let mut stmt = self
             .conn
-            .prepare("SELECT path, mtime_secs, mtime_nanos FROM files")
+            .prepare("SELECT path, mtime_secs, mtime_nanos, content_hash FROM files")
             .ok()?;
-        let cached_mtimes: HashMap<String, (i64, i64)> = stmt
+        let cached_mtimes: HashMap<String, (i64, i64, Option<String>)> = stmt
             .query_map([], |row| {
                 Ok((
                     row.get::<_, String>(0)?,
-                    (row.get::<_, i64>(1)?, row.get::<_, i64>(2)?),
+                    (
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, Option<String>>(3)?,
+                    ),
                 ))
             })
             .ok()?
@@ -639,11 +699,18 @@ impl DiskCache {
             if is_manifest_file_name(file) {
                 continue;
             }
-            let (secs, nanos) = cached_mtimes.get(file.as_str()).copied()?;
+            let (secs, nanos, content_hash) = cached_mtimes.get(file.as_str())?;
             let full = root.join(file);
-            let (current_secs, current_nanos) = file_mtime_parts(&full)?;
-            if secs != current_secs || nanos != current_nanos {
-                return None;
+            match file_freshness(&full, *secs, *nanos, content_hash.as_deref())? {
+                FileFreshness::Fresh => {}
+                FileFreshness::FreshWithUpdatedFingerprint {
+                    secs,
+                    nanos,
+                    content_hash,
+                } => {
+                    self.refresh_file_fingerprint(file, secs, nanos, &content_hash);
+                }
+                FileFreshness::Stale => return None,
             }
         }
 
@@ -675,6 +742,13 @@ impl DiskCache {
 
         let edges = self.load_edges()?;
         Some(EntityGraph::from_parts(entity_map, edges))
+    }
+
+    fn refresh_file_fingerprint(&self, file: &str, secs: i64, nanos: i64, content_hash: &str) {
+        let _ = self.conn.execute(
+            "UPDATE files SET mtime_secs = ?2, mtime_nanos = ?3, content_hash = ?4 WHERE path = ?1",
+            params![file, secs, nanos, content_hash],
+        );
     }
 
     fn load_edges(&self) -> Option<Vec<EntityRef>> {
@@ -711,13 +785,17 @@ impl DiskCache {
 
         let mut stmt = self
             .conn
-            .prepare("SELECT path, mtime_secs, mtime_nanos FROM files")
+            .prepare("SELECT path, mtime_secs, mtime_nanos, content_hash FROM files")
             .ok()?;
-        let cached_files: HashMap<String, (i64, i64)> = stmt
+        let cached_files: HashMap<String, (i64, i64, Option<String>)> = stmt
             .query_map([], |row| {
                 Ok((
                     row.get::<_, String>(0)?,
-                    (row.get::<_, i64>(1)?, row.get::<_, i64>(2)?),
+                    (
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, Option<String>>(3)?,
+                    ),
                 ))
             })
             .ok()?
@@ -739,16 +817,21 @@ impl DiskCache {
         let mut stale_current_file_count = 0;
         for file in source_files {
             match cached_files.get(file) {
-                Some(&(secs, nanos)) => {
+                Some((secs, nanos, content_hash)) => {
                     let full = root.join(file);
-                    let is_stale = file_mtime_parts(&full)
-                        .map(|(current_secs, current_nanos)| {
-                            secs != current_secs || nanos != current_nanos
-                        })
-                        .unwrap_or(true);
-                    if is_stale {
-                        stale_current_file_count += 1;
-                        stale_source_files.push(file.clone());
+                    match file_freshness(&full, *secs, *nanos, content_hash.as_deref()) {
+                        Some(FileFreshness::Fresh) => {}
+                        Some(FileFreshness::FreshWithUpdatedFingerprint {
+                            secs,
+                            nanos,
+                            content_hash,
+                        }) => {
+                            self.refresh_file_fingerprint(file, secs, nanos, &content_hash);
+                        }
+                        Some(FileFreshness::Stale) | None => {
+                            stale_current_file_count += 1;
+                            stale_source_files.push(file.clone());
+                        }
                     }
                 }
                 None => {
@@ -955,12 +1038,12 @@ impl DiskCache {
 
         {
             let mut ins = tx.prepare(
-                "INSERT OR REPLACE INTO files (path, mtime_secs, mtime_nanos) VALUES (?1, ?2, ?3)",
+                "INSERT OR REPLACE INTO files (path, mtime_secs, mtime_nanos, content_hash) VALUES (?1, ?2, ?3, ?4)",
             )?;
             for file in &source_stale_files {
                 let full = root.join(file);
-                if let Some((secs, nanos)) = file_mtime_parts(&full) {
-                    ins.execute(params![file, secs, nanos])?;
+                if let Some((secs, nanos, content_hash)) = file_fingerprint(&full) {
+                    ins.execute(params![file, secs, nanos, content_hash])?;
                 }
             }
         }
@@ -1203,6 +1286,17 @@ mod tests {
             .unwrap()
     }
 
+    fn cached_file_mtime(cache: &DiskCache, file: &str) -> (i64, i64) {
+        cache
+            .conn
+            .query_row(
+                "SELECT mtime_secs, mtime_nanos FROM files WHERE path = ?1",
+                rusqlite::params![file],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap()
+    }
+
     fn sample_files(root: &Path) -> Vec<String> {
         write_file(&root.join("sample.foo"), "export const alpha = () => 1;\n");
         vec!["sample.foo".to_string()]
@@ -1335,6 +1429,27 @@ mod tests {
         let removed_gitattributes = compute_manifest_hash(&root, &files).unwrap();
         assert_eq!(without_gitattributes, removed_gitattributes);
 
+        cleanup(root);
+    }
+
+    #[test]
+    fn load_refreshes_mtime_when_file_content_is_unchanged() {
+        let root = temp_repo_root("mtime-only-refresh");
+        let file = root.join("same.rs");
+        write_file(&file, "fn same() {}\n");
+        let files = vec!["same.rs".to_string()];
+        let cache = save_empty_cache(&root, &files);
+        let before = cached_file_mtime(&cache, "same.rs");
+
+        rewrite_after_mtime_tick(&file, "fn same() {}\n");
+        let current = file_mtime_parts(&file).unwrap();
+        assert_ne!(before, current);
+
+        assert!(cache.load_graph_topology(&root, &files).is_some());
+        assert!(cache.load_partial(&root, &files).is_none());
+        assert_eq!(cached_file_mtime(&cache, "same.rs"), current);
+
+        drop(cache);
         cleanup(root);
     }
 

--- a/crates/sem-mcp/src/main.rs
+++ b/crates/sem-mcp/src/main.rs
@@ -1,3 +1,6 @@
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     if std::env::args().any(|a| a == "--version" || a == "-V") {
         println!("sem-mcp {}", env!("CARGO_PKG_VERSION"));


### PR DESCRIPTION
## Summary

- Streams `sem graph --json` output and adds a fresh-cache SQLite streaming path so graph JSON no longer duplicates the full graph in memory.
- Avoids repo-wide fallback parsing during graph scans, prunes default-excluded directories before descent, and removes the extra NUL-byte probe for known source extensions.
- Bounds huge full-build memory by avoiding retained parse trees above 20k files, resolving scope in chunks, and building fallback reference indexes per file.
- Cuts scope-resolution CPU/allocation churn by precomputing deterministic return-type lookups once, avoiding per-node AST child vector allocations, and skipping Swift signature scans for non-Swift chunks.
- Reduces incremental-cache peak memory by streaming cached entity rows directly into clean/stale buckets.
- Stores source-file content fingerprints in the cache so mtime-only churn can refresh mtimes without rebuilding the graph.
- Adds `mimalloc` for the CLI and MCP binaries.

## Stacking note

This branch is intentionally based on #325 (`Iron-Ham/fix-deterministic-graph-output`) because this work builds on the deterministic graph output and earlier performance work in the open stack. The PR is still pointed at upstream `main` so reviewers can see the eventual merge target, but GitHub cannot hide the stacked #319/#325 commits and diff while targeting `main`. The new implementation in this PR is the single top commit: `ffa9398 perf: reduce graph memory and cache overhead`.

## Performance issues considered

This implements the best immediate wins from #322, #314, #324, #316, #317, and #321: reduce retained graph/source/parse-tree memory, compact fallback reference work, add low-effort allocator and scope-resolution wins, stream graph JSON from cache, and keep public benchmark coverage. #318 is partially addressed by targeted edge rewrites, cache streaming, and content-aware freshness checks, but remains open for full per-file import metadata and cache granularity. #320 and #315 remain deeper follow-ups for entity interning and persisted TS/JS import metadata; this PR only takes the parts that had a direct, measured win in the current graph path.

## Benchmarks

Release binary compared against a clean PR #325 baseline where noted.

- Generated 5,000-file JS/TS graph fixture, `sem graph . --json --file-exts .ts .js`:
  - cold cache: 10422.991 ms before, 7804.303 ms after
  - warm cache: 944.993 ms before, 441.568 ms after
  - one-file incremental: 2275.921 ms before, 1391.307 ms after
- Generated 5,000-file JS/TS fixture, cold no-cache graph RSS (`/usr/bin/time -l`):
  - max resident set size: ~10.02 GB before, ~7.88 GB after
  - after wall time: 6.66 s
- Large 100k+ file JS/TS monorepo, `sem graph . --file-exts .ts .tsx .js .jsx .mjs .cjs` with isolated cache:
  - before: earlier probe hit ~12.5 GB RSS and was stopped
  - cold cache after: 59.63 s wall, 6.05 GB max RSS, 660741 entities, 1647490 edges
  - warm cache after: 3.05 s wall, 1.54 GB max RSS, same graph counts
  - one-file content incremental after: 9.96 s wall, 3.91 GB max RSS, same graph counts
  - 500-file mtime-only churn after: 3.17 s wall, 1.54 GB max RSS, same graph counts, stayed on `cache_topology_load`

The largest confirmed win is peak memory/RSS. Warm cache and one-file incremental are also substantially faster because `graph --json` can avoid entity-body loads and giant JSON allocations, the full graph path no longer repeats the deterministic return-type index for every file, and mtime-only churn no longer forces expensive incremental rebuilds.

## Graph correctness validation

Compared `sem graph --no-cache --json --file-exts .ts .tsx .js .jsx .mjs .cjs` against the PR #325 binary on a 4.4k-file JS/TS repo with a similar monorepo shape. The canonical graph output matched exactly after normalizing to graph-relevant fields:

- entities: 90591 before, 90591 after
- edges: 141938 before, 141938 after
- canonical entity tuples: no mismatches
- canonical edge tuples: no mismatches

The raw JSON SHA changed only because object key order differs; the graph structure and ordered canonical entity/edge tuples match.

## Test plan

- `cargo test --manifest-path crates/Cargo.toml --workspace`
- `cargo build --manifest-path crates/Cargo.toml --release -p sem-cli -p sem-mcp`
- `node benchmarks/large-js-fixture/run.mjs --sem ./crates/target/release/sem --files 5000 --fanout 3 --timeout-ms 120000 --no-json-out`
- `/usr/bin/time -l ./crates/target/release/sem graph . --no-cache --json --file-exts .ts .js` on the generated 5k fixture
- `sem graph` cold, warm, and one-file incremental runs on a large 100k+ file JS/TS monorepo with an isolated cache
- PR #325 vs this branch canonical graph comparison on a 4.4k-file JS/TS repo
- 500-file mtime-only churn check on a large 100k+ file JS/TS monorepo
- `git diff --check --no-ext-diff`



