### PR TITLE
Narrow incremental import cache work

### DIFF
--- a/crates/sem-cli/src/cache.rs
+++ b/crates/sem-cli/src/cache.rs
@@ -12,6 +12,7 @@ pub struct PartialCache {
     pub stale_files: Vec<String>,
     pub cached_entities: Vec<SemanticEntity>,
     pub cached_edges: Vec<EntityRef>,
+    pub cached_importing_stale_files: Vec<String>,
     /// Cached entities from stale files (for entity-level content_hash comparison)
     pub stale_file_entities: Vec<SemanticEntity>,
 }
@@ -42,7 +43,9 @@ impl DiskCache {
     ) -> Result<(), rusqlite::Error> {
         let tx = self.conn.unchecked_transaction()?;
 
-        tx.execute_batch("DELETE FROM files; DELETE FROM entities; DELETE FROM edges;")?;
+        tx.execute_batch(
+            "DELETE FROM files; DELETE FROM entities; DELETE FROM edges; DELETE FROM file_imports;",
+        )?;
 
         {
             let mut stmt = tx.prepare(
@@ -60,6 +63,7 @@ impl DiskCache {
         }
 
         shared_cache::refresh_manifest_entries(&tx, root)?;
+        shared_cache::refresh_file_import_entries(&tx, root, files, files)?;
 
         // Insert entities with prepared statement (already in a transaction, so fast)
         {
@@ -337,19 +341,20 @@ impl DiskCache {
         let Some(ref mut stmt) = stmt else {
             return false;
         };
-        let cached_mtimes: HashMap<String, (i64, i64, Option<String>)> = match stmt.query_map([], |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                (
-                    row.get::<_, i64>(1)?,
-                    row.get::<_, i64>(2)?,
-                    row.get::<_, Option<String>>(3)?,
-                ),
-            ))
-        }) {
-            Ok(rows) => rows.filter_map(|r| r.ok()).collect(),
-            Err(_) => return false,
-        };
+        let cached_mtimes: HashMap<String, (i64, i64, Option<String>)> =
+            match stmt.query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    (
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, Option<String>>(3)?,
+                    ),
+                ))
+            }) {
+                Ok(rows) => rows.filter_map(|r| r.ok()).collect(),
+                Err(_) => return false,
+            };
 
         for file in files {
             if shared_cache::is_manifest_file_name(file) {
@@ -441,10 +446,10 @@ impl DiskCache {
         // Find stale source files: mtime differs or not in cache
         let mut stale_source_files: Vec<String> = Vec::new();
         let mut stale_current_file_count = 0;
-        for file in source_files {
-            match cached_files.get(file) {
+        for file in &source_files {
+            match cached_files.get(file.as_str()) {
                 Some((secs, nanos, content_hash)) => {
-                    let full = root.join(file);
+                    let full = root.join(file.as_str());
                     match shared_cache::file_freshness(
                         &full,
                         *secs,
@@ -461,13 +466,13 @@ impl DiskCache {
                         }
                         Some(shared_cache::FileFreshness::Stale) | None => {
                             stale_current_file_count += 1;
-                            stale_source_files.push(file.clone());
+                            stale_source_files.push((*file).clone());
                         }
                     }
                 }
                 None => {
                     stale_current_file_count += 1;
-                    stale_source_files.push(file.clone());
+                    stale_source_files.push((*file).clone());
                 }
             }
         }
@@ -498,6 +503,13 @@ impl DiskCache {
             .chain(deleted_cached_files.iter())
             .map(|s| s.as_str())
             .collect();
+        let mut import_stale_files = stale_source_files.clone();
+        import_stale_files.extend(deleted_cached_files.iter().cloned());
+        let cached_importing_stale_files = shared_cache::cached_importing_files_for_stale_files(
+            &self.conn,
+            &import_stale_files,
+            &source_files,
+        );
 
         // Load ALL entities, split into clean vs stale-file
         let mut entity_stmt = self
@@ -556,6 +568,7 @@ impl DiskCache {
             stale_files: stale_source_files,
             cached_entities,
             cached_edges,
+            cached_importing_stale_files,
             stale_file_entities,
         })
     }
@@ -657,6 +670,12 @@ impl DiskCache {
         }
 
         shared_cache::refresh_manifest_entries(&tx, root)?;
+        let mut import_files_to_refresh: Vec<String> = source_stale_files
+            .iter()
+            .map(|file| (*file).clone())
+            .collect();
+        import_files_to_refresh.extend(deleted_cached_files.iter().cloned());
+        shared_cache::refresh_file_import_entries(&tx, root, &import_files_to_refresh, all_files)?;
 
         if repair_changed_clean_entity_ids {
             tx.execute("DELETE FROM entities", [])?;
@@ -920,6 +939,17 @@ mod tests {
             .unwrap()
     }
 
+    fn file_import_count(cache: &DiskCache, importing_file: &str, imported_file: &str) -> i64 {
+        cache
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM file_imports WHERE importing_file = ?1 AND imported_file = ?2",
+                rusqlite::params![importing_file, imported_file],
+                |row| row.get(0),
+            )
+            .unwrap()
+    }
+
     fn cached_file_mtime(cache: &DiskCache, file: &str) -> (i64, i64) {
         cache
             .conn
@@ -999,6 +1029,58 @@ mod tests {
         assert!(cache.load_graph_topology(&root, &files).is_some());
         assert!(cache.load_partial(&root, &files).is_none());
         assert_eq!(cached_file_mtime(&cache, "same.rs"), current);
+
+        drop(cache);
+        cleanup(root);
+    }
+
+    #[test]
+    fn partial_cache_reports_clean_files_that_import_stale_js_ts_files() {
+        let root = temp_repo_root("incremental-import-metadata");
+        write_file(
+            &root.join("a.ts"),
+            "import { target } from './b';\nexport function useIt() { return target(); }\n",
+        );
+        write_file(
+            &root.join("b.ts"),
+            "export function target() { return 1; }\n",
+        );
+        write_file(
+            &root.join("c.ts"),
+            "export function other() { return 2; }\n",
+        );
+        let files = vec!["a.ts".to_string(), "b.ts".to_string(), "c.ts".to_string()];
+        let cache = DiskCache::open(&root).unwrap();
+        cache.save(&root, &files, &empty_graph(), &[]).unwrap();
+
+        assert_eq!(file_import_count(&cache, "a.ts", "b.ts"), 1);
+
+        rewrite_after_mtime_tick(
+            &root.join("b.ts"),
+            "export function target() { return 3; }\n",
+        );
+        let partial = cache.load_partial(&root, &files).unwrap();
+        assert_eq!(partial.stale_files, vec!["b.ts"]);
+        assert_eq!(partial.cached_importing_stale_files, vec!["a.ts"]);
+
+        rewrite_after_mtime_tick(
+            &root.join("a.ts"),
+            "import { other } from './c';\nexport function useIt() { return other(); }\n",
+        );
+        cache
+            .save_incremental_with_repair_metadata(
+                &root,
+                &files,
+                &["a.ts".to_string()],
+                &empty_graph(),
+                &[],
+                false,
+                &[],
+                &[],
+            )
+            .unwrap();
+        assert_eq!(file_import_count(&cache, "a.ts", "b.ts"), 0);
+        assert_eq!(file_import_count(&cache, "a.ts", "c.ts"), 1);
 
         drop(cache);
         cleanup(root);

--- a/crates/sem-cli/src/commands/graph.rs
+++ b/crates/sem-cli/src/commands/graph.rs
@@ -200,15 +200,17 @@ pub fn get_or_build_graph_with_timings(
             // Try incremental: load clean cached data, rebuild only stale files
             if let Some(partial) = disk.load_partial(root, file_paths) {
                 timings.mark("cache_partial_load");
-                let (graph, entities, metadata) = EntityGraph::build_incremental_with_metadata(
-                    root,
-                    &partial.stale_files,
-                    file_paths,
-                    partial.cached_entities,
-                    partial.cached_edges,
-                    partial.stale_file_entities,
-                    registry,
-                );
+                let (graph, entities, metadata) =
+                    EntityGraph::build_incremental_with_metadata_and_import_candidates(
+                        root,
+                        &partial.stale_files,
+                        file_paths,
+                        partial.cached_entities,
+                        partial.cached_edges,
+                        partial.stale_file_entities,
+                        Some(&partial.cached_importing_stale_files),
+                        registry,
+                    );
                 timings.mark("incremental_graph_rebuild");
                 let _ = disk.save_incremental_with_repair_metadata(
                     root,

--- a/crates/sem-core/src/parser/graph.rs
+++ b/crates/sem-core/src/parser/graph.rs
@@ -35,7 +35,8 @@ use crate::git::types::{FileChange, FileStatus};
 use crate::model::entity::SemanticEntity;
 use crate::parser::import_resolution::{
     find_import_file, find_import_target, import_source_matches_file, is_js_ts_file,
-    js_ts_named_exports_from_content, sort_import_candidate_files, JS_TS_EXTENSIONS,
+    js_ts_import_source_files_from_content, js_ts_named_exports_from_content,
+    sort_import_candidate_files, JS_TS_EXTENSIONS,
 };
 use crate::parser::registry::{resolve_go_method_parent_ids, ParserRegistry};
 use crate::parser::scope_resolve;
@@ -355,6 +356,25 @@ fn sort_symbol_table_targets_by_source(
             });
         }
     }
+}
+
+fn dedupe_resolved_edges(
+    combined: Vec<(String, String, RefType)>,
+) -> Vec<(String, String, RefType)> {
+    let mut keep = vec![false; combined.len()];
+    let mut seen_edges: HashSet<(&str, &str)> = HashSet::with_capacity(combined.len());
+    for (index, (from_entity, to_entity, _)) in combined.iter().enumerate() {
+        if seen_edges.insert((from_entity.as_str(), to_entity.as_str())) {
+            keep[index] = true;
+        }
+    }
+    drop(seen_edges);
+
+    combined
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, edge)| keep[index].then_some(edge))
+        .collect()
 }
 
 #[derive(Debug)]
@@ -1251,13 +1271,7 @@ impl EntityGraph {
         let mut combined: Vec<(String, String, RefType)> = scope_edges;
         combined.extend(export_edges);
         combined.extend(resolved_refs);
-        let mut seen_edges: HashSet<(String, String)> = HashSet::with_capacity(combined.len());
-        let mut all_resolved: Vec<(String, String, RefType)> = Vec::with_capacity(combined.len());
-        for edge in combined {
-            if seen_edges.insert((edge.0.clone(), edge.1.clone())) {
-                all_resolved.push(edge);
-            }
-        }
+        let all_resolved = dedupe_resolved_edges(combined);
 
         // Build edge indexes from resolved references
         let mut edges: Vec<EntityRef> = Vec::with_capacity(all_resolved.len());
@@ -1323,6 +1337,28 @@ impl EntityGraph {
         cached_entities: Vec<SemanticEntity>,
         cached_edges: Vec<EntityRef>,
         stale_file_cached_entities: Vec<SemanticEntity>,
+        registry: &ParserRegistry,
+    ) -> (Self, Vec<SemanticEntity>, IncrementalBuildMetadata) {
+        Self::build_incremental_with_metadata_and_import_candidates(
+            root,
+            stale_files,
+            all_file_paths,
+            cached_entities,
+            cached_edges,
+            stale_file_cached_entities,
+            None,
+            registry,
+        )
+    }
+
+    pub fn build_incremental_with_metadata_and_import_candidates(
+        root: &Path,
+        stale_files: &[String],
+        all_file_paths: &[String],
+        cached_entities: Vec<SemanticEntity>,
+        cached_edges: Vec<EntityRef>,
+        stale_file_cached_entities: Vec<SemanticEntity>,
+        cached_importing_stale_files: Option<&[String]>,
         registry: &ParserRegistry,
     ) -> (Self, Vec<SemanticEntity>, IncrementalBuildMetadata) {
         // Build set of stale file paths for quick lookup
@@ -1670,26 +1706,37 @@ impl EntityGraph {
             .filter(|file_path| is_js_ts_file(file_path))
             .collect();
         if !stale_js_ts_file_paths.is_empty() {
-            let clean_js_ts_import_tokens: HashMap<&str, Vec<String>> = all_file_paths
-                .iter()
-                .map(String::as_str)
-                .filter(|file_path| !stale_set.contains(*file_path) && is_js_ts_file(file_path))
-                .filter_map(|file_path| {
-                    let content = read_import_scan_prefix(&root.join(file_path))?;
-                    let mut tokens: Vec<String> = stale_js_ts_file_paths
-                        .iter()
-                        .flat_map(|stale_file_path| {
-                            content_import_tokens_for_file(file_path, &content, stale_file_path)
-                        })
-                        .collect();
-                    if tokens.is_empty() {
-                        return None;
-                    }
-                    tokens.sort_unstable();
-                    tokens.dedup();
-                    Some((file_path, tokens))
-                })
-                .collect();
+            let clean_import_candidate_files: Vec<&str> = match cached_importing_stale_files {
+                Some(files) => files
+                    .iter()
+                    .map(String::as_str)
+                    .filter(|file_path| !stale_set.contains(*file_path) && is_js_ts_file(file_path))
+                    .collect(),
+                None => all_file_paths
+                    .iter()
+                    .map(String::as_str)
+                    .filter(|file_path| !stale_set.contains(*file_path) && is_js_ts_file(file_path))
+                    .collect(),
+            };
+            let clean_js_ts_import_tokens: HashMap<&str, Vec<String>> =
+                clean_import_candidate_files
+                    .into_iter()
+                    .filter_map(|file_path| {
+                        let content = read_import_scan_prefix(&root.join(file_path))?;
+                        let mut tokens: Vec<String> = stale_js_ts_file_paths
+                            .iter()
+                            .flat_map(|stale_file_path| {
+                                content_import_tokens_for_file(file_path, &content, stale_file_path)
+                            })
+                            .collect();
+                        if tokens.is_empty() {
+                            return None;
+                        }
+                        tokens.sort_unstable();
+                        tokens.dedup();
+                        Some((file_path, tokens))
+                    })
+                    .collect();
 
             for entity in all_entities
                 .iter()
@@ -1960,25 +2007,29 @@ impl EntityGraph {
         let mut combined: Vec<(String, String, RefType)> = scope_edges;
         combined.extend(export_edges);
         combined.extend(resolved_refs);
-        let mut seen_edges: HashSet<(String, String)> = HashSet::with_capacity(combined.len());
-        let mut all_resolved: Vec<(String, String, RefType)> = Vec::with_capacity(combined.len());
-        for edge in combined {
-            if seen_edges.insert((edge.0.clone(), edge.1.clone())) {
-                all_resolved.push(edge);
-            }
-        }
+        let all_resolved = dedupe_resolved_edges(combined);
 
         // Build final edge list: kept edges + newly resolved edges
         let mut edges: Vec<EntityRef> = Vec::with_capacity(kept_edges.len() + all_resolved.len());
         let mut dependents: HashMap<String, Vec<String>> = HashMap::new();
         let mut dependencies: HashMap<String, Vec<String>> = HashMap::new();
 
-        // Track all edge pairs for dedup
-        let mut all_edge_pairs: HashSet<(String, String)> = HashSet::new();
+        let mut kept_edge_pairs: HashSet<(&str, &str)> = HashSet::with_capacity(kept_edges.len());
+        for edge in &kept_edges {
+            kept_edge_pairs.insert((edge.from_entity.as_str(), edge.to_entity.as_str()));
+        }
+
+        let mut new_edges: Vec<(String, String, RefType)> = Vec::with_capacity(all_resolved.len());
+        for (from_entity, to_entity, ref_type) in all_resolved {
+            if kept_edge_pairs.contains(&(from_entity.as_str(), to_entity.as_str())) {
+                continue;
+            }
+            new_edges.push((from_entity, to_entity, ref_type));
+        }
+        drop(kept_edge_pairs);
 
         // Add kept cached edges
         for edge in kept_edges {
-            all_edge_pairs.insert((edge.from_entity.clone(), edge.to_entity.clone()));
             dependents
                 .entry(edge.to_entity.clone())
                 .or_default()
@@ -1991,10 +2042,7 @@ impl EntityGraph {
         }
 
         // Add newly resolved edges, dedup against kept edges
-        for (from_entity, to_entity, ref_type) in all_resolved {
-            if !all_edge_pairs.insert((from_entity.clone(), to_entity.clone())) {
-                continue;
-            }
+        for (from_entity, to_entity, ref_type) in new_edges {
             dependents
                 .entry(to_entity.clone())
                 .or_default()
@@ -2874,16 +2922,45 @@ fn build_import_table_with_default_export_paths(
         );
     }
     let mut owned_content: HashMap<String, String> = HashMap::new();
-    let mut content_file_paths: Vec<&String> = file_paths.iter().collect();
-    content_file_paths.extend(default_export_file_paths.iter());
-    content_file_paths.sort_unstable();
-    content_file_paths.dedup();
-    for file_path in content_file_paths {
-        if file_path.ends_with(".go") || content_map.contains_key(file_path.as_str()) {
-            continue;
+    let mut content_file_set: HashSet<String> = file_paths.iter().cloned().collect();
+    if file_paths.len() == default_export_file_paths.len() {
+        content_file_set.extend(default_export_file_paths.iter().cloned());
+        for file_path in &content_file_set {
+            if file_path.ends_with(".go") || content_map.contains_key(file_path.as_str()) {
+                continue;
+            }
+            if let Ok(content) = std::fs::read_to_string(root.join(file_path)) {
+                owned_content.insert(file_path.clone(), content);
+            }
         }
-        if let Ok(content) = std::fs::read_to_string(root.join(file_path)) {
-            owned_content.insert(file_path.clone(), content);
+    } else {
+        let mut content_file_queue: Vec<String> = file_paths.to_vec();
+        while let Some(file_path) = content_file_queue.pop() {
+            if !file_path.ends_with(".go")
+                && !content_map.contains_key(file_path.as_str())
+                && !owned_content.contains_key(&file_path)
+            {
+                if let Ok(content) = std::fs::read_to_string(root.join(&file_path)) {
+                    owned_content.insert(file_path.clone(), content);
+                }
+            }
+
+            let Some(content) = content_map
+                .get(file_path.as_str())
+                .copied()
+                .or_else(|| owned_content.get(&file_path).map(String::as_str))
+            else {
+                continue;
+            };
+            for imported_file in js_ts_import_source_files_from_content(
+                &file_path,
+                content,
+                default_export_file_paths,
+            ) {
+                if content_file_set.insert(imported_file.clone()) {
+                    content_file_queue.push(imported_file);
+                }
+            }
         }
     }
     content_map.extend(
@@ -2891,12 +2968,10 @@ fn build_import_table_with_default_export_paths(
             .iter()
             .map(|(file_path, content)| (file_path.as_str(), content.as_str())),
     );
-    let ts_default_exports = build_ts_default_export_table(
-        default_export_file_paths,
-        symbol_table,
-        entity_map,
-        &content_map,
-    );
+    let mut content_file_paths: Vec<String> = content_file_set.into_iter().collect();
+    content_file_paths.sort_unstable();
+    let ts_default_exports =
+        build_ts_default_export_table(&content_file_paths, symbol_table, entity_map, &content_map);
     let ts_top_level_entities = OnceLock::new();
     let ts_exported_names_by_file: Mutex<HashMap<String, Arc<HashSet<String>>>> =
         Mutex::new(HashMap::new());
@@ -5062,6 +5137,85 @@ comment with Helper
                 .iter()
                 .any(|(file_path, name)| *file_path == "b.ts" && *name == "targetB"),
             "clean barrel export should retarget to b.ts. Deps: {:?}",
+            incremental_deps
+        );
+    }
+
+    #[test]
+    fn test_incremental_import_candidates_re_resolve_clean_barrel() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "a.ts",
+            "export default function targetA() { return 1; }\n",
+        );
+        write_file(
+            root,
+            "b.ts",
+            "export default function targetB() { return 2; }\n",
+        );
+        write_file(root, "stale.ts", "export { default } from './a';\n");
+        write_file(
+            root,
+            "barrel.ts",
+            "export { default as publicTarget } from './stale';\n",
+        );
+
+        let all_files = vec![
+            "a.ts".to_string(),
+            "b.ts".to_string(),
+            "stale.ts".to_string(),
+            "barrel.ts".to_string(),
+        ];
+        let (cached_graph, cached_entities) = EntityGraph::build(root, &all_files, &registry);
+
+        write_file(root, "stale.ts", "export { default } from './b';\n");
+
+        let cached_clean_entities = cached_entities
+            .iter()
+            .filter(|entity| entity.file_path != "stale.ts")
+            .cloned()
+            .collect();
+        let cached_stale_entities = cached_entities
+            .into_iter()
+            .filter(|entity| entity.file_path == "stale.ts")
+            .collect();
+        let cached_importing_stale_files = vec!["barrel.ts".to_string()];
+
+        let (incremental_graph, _, _) =
+            EntityGraph::build_incremental_with_metadata_and_import_candidates(
+                root,
+                &["stale.ts".into()],
+                &all_files,
+                cached_clean_entities,
+                cached_graph.edges,
+                cached_stale_entities,
+                Some(&cached_importing_stale_files),
+                &registry,
+            );
+        let (fresh_graph, _) = EntityGraph::build(root, &all_files, &registry);
+
+        let mut incremental_deps = incremental_graph
+            .get_dependencies("barrel.ts::export::publicTarget")
+            .iter()
+            .map(|entity| (entity.file_path.as_str(), entity.name.as_str()))
+            .collect::<Vec<_>>();
+        incremental_deps.sort_unstable();
+        let mut fresh_deps = fresh_graph
+            .get_dependencies("barrel.ts::export::publicTarget")
+            .iter()
+            .map(|entity| (entity.file_path.as_str(), entity.name.as_str()))
+            .collect::<Vec<_>>();
+        fresh_deps.sort_unstable();
+
+        assert_eq!(incremental_deps, fresh_deps);
+        assert!(
+            incremental_deps
+                .iter()
+                .any(|(file_path, name)| *file_path == "b.ts" && *name == "targetB"),
+            "candidate-aware incremental rebuild should retarget the clean barrel export. Deps: {:?}",
             incremental_deps
         );
     }

--- a/crates/sem-core/src/parser/import_resolution.rs
+++ b/crates/sem-core/src/parser/import_resolution.rs
@@ -14,6 +14,45 @@ pub(crate) fn is_js_ts_file(file_path: &str) -> bool {
         .any(|extension| file_path.ends_with(extension))
 }
 
+pub fn js_ts_import_source_files_from_content<P: AsRef<str>>(
+    file_path: &str,
+    content: &str,
+    candidate_file_paths: &[P],
+) -> Vec<String> {
+    if !is_js_ts_file(file_path) {
+        return Vec::new();
+    }
+
+    static FROM_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r#"\bfrom\s*['"]([^'"]+)['"]"#).unwrap());
+    static SIDE_EFFECT_IMPORT_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r#"\bimport\s*['"]([^'"]+)['"]"#).unwrap());
+
+    let mut imported_files = HashSet::new();
+    for cap in FROM_RE.captures_iter(content) {
+        if let Some(source) = cap.get(1).map(|m| m.as_str()) {
+            if let Some(imported_file) =
+                find_import_file(candidate_file_paths, source, file_path, JS_TS_EXTENSIONS)
+            {
+                imported_files.insert(imported_file.to_string());
+            }
+        }
+    }
+    for cap in SIDE_EFFECT_IMPORT_RE.captures_iter(content) {
+        if let Some(source) = cap.get(1).map(|m| m.as_str()) {
+            if let Some(imported_file) =
+                find_import_file(candidate_file_paths, source, file_path, JS_TS_EXTENSIONS)
+            {
+                imported_files.insert(imported_file.to_string());
+            }
+        }
+    }
+
+    let mut imported_files: Vec<String> = imported_files.into_iter().collect();
+    sort_import_candidate_files(&mut imported_files, JS_TS_EXTENSIONS);
+    imported_files
+}
+
 pub(crate) fn js_ts_named_exports_from_content(content: &str) -> HashSet<String> {
     static NAMED_DECL_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
@@ -350,6 +389,26 @@ mod tests {
         );
 
         assert_eq!(target, None);
+    }
+
+    #[test]
+    fn js_ts_import_source_files_resolves_relative_imports_and_re_exports() {
+        let candidates = vec![
+            "src/a.ts".to_string(),
+            "src/b.ts".to_string(),
+            "src/c/index.ts".to_string(),
+            "src/unused.ts".to_string(),
+        ];
+        let content = r#"
+import { a } from './a';
+import DefaultB from "./b";
+import './c';
+export { a as publicA } from './a';
+"#;
+
+        let imports = js_ts_import_source_files_from_content("src/main.ts", content, &candidates);
+
+        assert_eq!(imports, vec!["src/a.ts", "src/b.ts", "src/c/index.ts"]);
     }
 
     #[test]

--- a/crates/sem-core/src/parser/mod.rs
+++ b/crates/sem-core/src/parser/mod.rs
@@ -8,4 +8,5 @@ pub mod context;
 #[cfg(feature = "git")]
 pub mod hotspot;
 mod import_resolution;
+pub use import_resolution::js_ts_import_source_files_from_content;
 pub mod scope_resolve;

--- a/crates/sem-mcp/src/cache.rs
+++ b/crates/sem-mcp/src/cache.rs
@@ -7,15 +7,26 @@ use std::path::{Component, Path, PathBuf};
 use rusqlite::{params, Connection, Transaction};
 use sem_core::model::entity::SemanticEntity;
 use sem_core::parser::graph::{EntityGraph, EntityInfo, EntityRef, RefType};
+use sem_core::parser::js_ts_import_source_files_from_content;
 use sem_core::utils::hash::content_hash_bytes;
 
-pub const CACHE_SCHEMA_VERSION: i32 = 3;
+pub const CACHE_SCHEMA_VERSION: i32 = 4;
 pub const CACHE_INDEXES: &[(&str, &str, &str)] = &[
     ("idx_entities_file_path", "entities", "file_path"),
     ("idx_entities_name", "entities", "name"),
     ("idx_entities_parent_id", "entities", "parent_id"),
     ("idx_edges_from_entity", "edges", "from_entity"),
     ("idx_edges_to_entity", "edges", "to_entity"),
+    (
+        "idx_file_imports_imported_file",
+        "file_imports",
+        "imported_file",
+    ),
+    (
+        "idx_file_imports_importing_file",
+        "file_imports",
+        "importing_file",
+    ),
 ];
 
 // Cache-only keys use a NUL prefix so they cannot collide with git paths.
@@ -49,12 +60,18 @@ CREATE TABLE IF NOT EXISTS edges (
     to_entity TEXT NOT NULL,
     ref_type TEXT NOT NULL
 );
+CREATE TABLE IF NOT EXISTS file_imports (
+    importing_file TEXT NOT NULL,
+    imported_file TEXT NOT NULL,
+    PRIMARY KEY (importing_file, imported_file)
+);
 ";
 
 const CACHE_RESET_SQL: &str = "
 DROP TABLE IF EXISTS files;
 DROP TABLE IF EXISTS entities;
 DROP TABLE IF EXISTS edges;
+DROP TABLE IF EXISTS file_imports;
 ";
 
 pub fn initialize_schema(conn: &Connection) -> Result<(), rusqlite::Error> {
@@ -279,6 +296,7 @@ pub struct PartialCache {
     pub stale_files: Vec<String>,
     pub cached_entities: Vec<SemanticEntity>,
     pub cached_edges: Vec<EntityRef>,
+    pub cached_importing_stale_files: Vec<String>,
     /// Cached entities from stale files (for entity-level content_hash comparison)
     pub stale_file_entities: Vec<SemanticEntity>,
 }
@@ -453,6 +471,77 @@ pub fn refresh_manifest_entries(tx: &Transaction<'_>, root: &Path) -> Result<(),
     Ok(())
 }
 
+pub fn refresh_file_import_entries(
+    tx: &Transaction<'_>,
+    root: &Path,
+    files_to_refresh: &[String],
+    all_files: &[String],
+) -> Result<(), rusqlite::Error> {
+    let candidate_files: Vec<String> = all_files
+        .iter()
+        .filter(|file| !is_manifest_file_name(file))
+        .cloned()
+        .collect();
+
+    let mut delete = tx.prepare("DELETE FROM file_imports WHERE importing_file = ?1")?;
+    let mut insert = tx.prepare(
+        "INSERT OR IGNORE INTO file_imports (importing_file, imported_file) VALUES (?1, ?2)",
+    )?;
+
+    for file in files_to_refresh {
+        if is_manifest_file_name(file) {
+            continue;
+        }
+
+        delete.execute(params![file])?;
+        let Ok(content) = std::fs::read_to_string(root.join(file)) else {
+            continue;
+        };
+        for imported_file in
+            js_ts_import_source_files_from_content(file, &content, &candidate_files)
+        {
+            insert.execute(params![file, imported_file])?;
+        }
+    }
+
+    Ok(())
+}
+
+pub fn cached_importing_files_for_stale_files(
+    conn: &Connection,
+    stale_files: &[String],
+    current_source_files: &[&String],
+) -> Vec<String> {
+    let current_set: HashSet<&str> = current_source_files
+        .iter()
+        .map(|file| file.as_str())
+        .collect();
+    let stale_set: HashSet<&str> = stale_files.iter().map(String::as_str).collect();
+    let mut importing_files = HashSet::new();
+    let Ok(mut stmt) =
+        conn.prepare("SELECT DISTINCT importing_file FROM file_imports WHERE imported_file = ?1")
+    else {
+        return Vec::new();
+    };
+
+    for stale_file in stale_files {
+        let Ok(rows) = stmt.query_map(params![stale_file], |row| row.get::<_, String>(0)) else {
+            continue;
+        };
+        for importing_file in rows.filter_map(|row| row.ok()) {
+            if current_set.contains(importing_file.as_str())
+                && !stale_set.contains(importing_file.as_str())
+            {
+                importing_files.insert(importing_file);
+            }
+        }
+    }
+
+    let mut importing_files: Vec<String> = importing_files.into_iter().collect();
+    importing_files.sort_unstable();
+    importing_files
+}
+
 pub struct DiskCache {
     conn: Connection,
 }
@@ -480,7 +569,9 @@ impl DiskCache {
     ) -> Result<(), rusqlite::Error> {
         let tx = self.conn.unchecked_transaction()?;
 
-        tx.execute_batch("DELETE FROM files; DELETE FROM entities; DELETE FROM edges;")?;
+        tx.execute_batch(
+            "DELETE FROM files; DELETE FROM entities; DELETE FROM edges; DELETE FROM file_imports;",
+        )?;
 
         {
             let mut stmt = tx.prepare(
@@ -498,6 +589,7 @@ impl DiskCache {
         }
 
         refresh_manifest_entries(&tx, root)?;
+        refresh_file_import_entries(&tx, root, files, files)?;
 
         {
             let mut stmt = tx.prepare(
@@ -815,10 +907,10 @@ impl DiskCache {
 
         let mut stale_source_files: Vec<String> = Vec::new();
         let mut stale_current_file_count = 0;
-        for file in source_files {
-            match cached_files.get(file) {
+        for file in &source_files {
+            match cached_files.get(file.as_str()) {
                 Some((secs, nanos, content_hash)) => {
-                    let full = root.join(file);
+                    let full = root.join(file.as_str());
                     match file_freshness(&full, *secs, *nanos, content_hash.as_deref()) {
                         Some(FileFreshness::Fresh) => {}
                         Some(FileFreshness::FreshWithUpdatedFingerprint {
@@ -830,13 +922,13 @@ impl DiskCache {
                         }
                         Some(FileFreshness::Stale) | None => {
                             stale_current_file_count += 1;
-                            stale_source_files.push(file.clone());
+                            stale_source_files.push((*file).clone());
                         }
                     }
                 }
                 None => {
                     stale_current_file_count += 1;
-                    stale_source_files.push(file.clone());
+                    stale_source_files.push((*file).clone());
                 }
             }
         }
@@ -865,6 +957,10 @@ impl DiskCache {
             .chain(deleted_cached_files.iter())
             .map(|s| s.as_str())
             .collect();
+        let mut import_stale_files = stale_source_files.clone();
+        import_stale_files.extend(deleted_cached_files.iter().cloned());
+        let cached_importing_stale_files =
+            cached_importing_files_for_stale_files(&self.conn, &import_stale_files, &source_files);
 
         // Load ALL entities, split into clean vs stale-file
         let mut entity_stmt = self
@@ -930,6 +1026,7 @@ impl DiskCache {
             stale_files: stale_source_files,
             cached_entities,
             cached_edges,
+            cached_importing_stale_files,
             stale_file_entities,
         })
     }
@@ -1049,6 +1146,12 @@ impl DiskCache {
         }
 
         refresh_manifest_entries(&tx, root)?;
+        let mut import_files_to_refresh: Vec<String> = source_stale_files
+            .iter()
+            .map(|file| (*file).clone())
+            .collect();
+        import_files_to_refresh.extend(deleted_cached_files.iter().cloned());
+        refresh_file_import_entries(&tx, root, &import_files_to_refresh, all_files)?;
 
         if repair_changed_clean_entity_ids {
             tx.execute("DELETE FROM entities", [])?;
@@ -1286,6 +1389,17 @@ mod tests {
             .unwrap()
     }
 
+    fn file_import_count(cache: &DiskCache, importing_file: &str, imported_file: &str) -> i64 {
+        cache
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM file_imports WHERE importing_file = ?1 AND imported_file = ?2",
+                rusqlite::params![importing_file, imported_file],
+                |row| row.get(0),
+            )
+            .unwrap()
+    }
+
     fn cached_file_mtime(cache: &DiskCache, file: &str) -> (i64, i64) {
         cache
             .conn
@@ -1314,6 +1428,58 @@ mod tests {
         cache.save(root, files, &empty_graph(), &[]).unwrap();
         assert!(cache.load(root, files).is_some());
         cache
+    }
+
+    #[test]
+    fn partial_cache_reports_clean_files_that_import_stale_js_ts_files() {
+        let root = temp_repo_root("incremental-import-metadata");
+        write_file(
+            &root.join("a.ts"),
+            "import { target } from './b';\nexport function useIt() { return target(); }\n",
+        );
+        write_file(
+            &root.join("b.ts"),
+            "export function target() { return 1; }\n",
+        );
+        write_file(
+            &root.join("c.ts"),
+            "export function other() { return 2; }\n",
+        );
+        let files = vec!["a.ts".to_string(), "b.ts".to_string(), "c.ts".to_string()];
+        let cache = DiskCache::open(&root).unwrap();
+        cache.save(&root, &files, &empty_graph(), &[]).unwrap();
+
+        assert_eq!(file_import_count(&cache, "a.ts", "b.ts"), 1);
+
+        rewrite_after_mtime_tick(
+            &root.join("b.ts"),
+            "export function target() { return 3; }\n",
+        );
+        let partial = cache.load_partial(&root, &files).unwrap();
+        assert_eq!(partial.stale_files, vec!["b.ts"]);
+        assert_eq!(partial.cached_importing_stale_files, vec!["a.ts"]);
+
+        rewrite_after_mtime_tick(
+            &root.join("a.ts"),
+            "import { other } from './c';\nexport function useIt() { return other(); }\n",
+        );
+        cache
+            .save_incremental_with_repair_metadata(
+                &root,
+                &files,
+                &["a.ts".to_string()],
+                &empty_graph(),
+                &[],
+                false,
+                &[],
+                &[],
+            )
+            .unwrap();
+        assert_eq!(file_import_count(&cache, "a.ts", "b.ts"), 0);
+        assert_eq!(file_import_count(&cache, "a.ts", "c.ts"), 1);
+
+        drop(cache);
+        cleanup(root);
     }
 
     fn rewrite_after_mtime_tick(path: &Path, content: &str) {

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -362,15 +362,17 @@ impl SemServer {
 
             // Incremental: load clean cached data, rebuild only stale files
             if let Some(partial) = disk.load_partial(repo_root, file_paths) {
-                let (graph, entities, metadata) = EntityGraph::build_incremental_with_metadata(
-                    repo_root,
-                    &partial.stale_files,
-                    file_paths,
-                    partial.cached_entities,
-                    partial.cached_edges,
-                    partial.stale_file_entities,
-                    &self.registry,
-                );
+                let (graph, entities, metadata) =
+                    EntityGraph::build_incremental_with_metadata_and_import_candidates(
+                        repo_root,
+                        &partial.stale_files,
+                        file_paths,
+                        partial.cached_entities,
+                        partial.cached_edges,
+                        partial.stale_file_entities,
+                        Some(&partial.cached_importing_stale_files),
+                        &self.registry,
+                    );
                 let _ = disk.save_incremental_with_repair_metadata(
                     repo_root,
                     file_paths,


### PR DESCRIPTION
## Summary

This follow-up narrows incremental cache work for large JS/TS graphs:

- adds cache schema v4 `file_imports` metadata so incremental rebuilds can find clean files that import stale JS/TS files without scanning every clean JS/TS file prefix
- threads those cached import candidates through CLI and MCP incremental graph rebuilds
- limits narrow incremental import-table content reads to selected files plus discovered JS/TS import targets instead of all default-export candidates
- removes temporary cloned `(from_entity, to_entity)` edge-pair sets from cold and incremental graph edge de-duping while preserving the public string-based graph API

## Stack Note

This PR is stacked on #326 but intentionally targets `main`, matching the previous perf PR workflow. Until #326 lands, GitHub will show the parent perf/cache changes in this diff as well; the new commit here is `perf: narrow incremental import cache work`.

## Issues

Targets the next safe slices from the open perf issues:

- #318: persists per-file JS/TS import-path metadata and uses it to make one-file incremental rebuilds less proportional to total repo file count
- #320: reduces temporary edge de-dupe allocation churn without changing public `EntityGraph`, `EntityInfo`, or `EntityRef` string fields

#317 is already covered by the parent branch: deps/dependents impact modes use topology-only cache loading in CLI and MCP.

## Benchmarks

Base binary: #326 head `ffa9398`.
Current binary: this branch head.

### Targeted Import-Metadata Fixture

Throwaway fixture: 8,001 TS files, 50 clean importers of one stale `target.ts`; one body-only edit to `target.ts`; `SEM_TIMINGS=json`.

| build | total | incremental_graph_rebuild | max RSS | graph output |
| --- | ---: | ---: | ---: | --- |
| base | 379.255 ms | 252.334 ms | 67.4 MB | 8,001 entities / 50 edges |
| current | 96.904 ms | 16.914 ms | 64.6 MB | 8,001 entities / 50 edges |

Canonical entity/edge tuples matched exactly between base and current.

### Public 5k JS/TS Fixture

Command: `node benchmarks/large-js-fixture/run.mjs --files 5000 --fanout 3 --timeout-ms 120000 --no-json-out`.

| build | cold cache | warm cache | incremental one-file |
| --- | ---: | ---: | ---: |
| base | 8334.775 ms | 457.401 ms | 1387.135 ms |
| current | 7855.475 ms | 448.439 ms | 1445.220 ms |

This fixture is mostly flat for the new metadata path; the targeted fixture above isolates the all-clean-file import scan this PR removes.

### Enterprise Medium-Sized Repo Graph Correctness

Command: `sem graph . --no-cache --json --file-exts .ts .tsx .js .jsx .mjs .cjs`.

- base: 90,591 entities / 141,938 edges
- current: 90,591 entities / 141,938 edges
- canonical sorted entity tuples and edge tuples matched exactly
- current no-cache run: 3.77s real, 1.72 GB max RSS

## Test Plan

- `cargo test --manifest-path crates/Cargo.toml --workspace`
- `cargo build --manifest-path crates/Cargo.toml --release -p sem-cli -p sem-mcp`
- `git diff --check --no-ext-diff`
- Targeted import-metadata fixture before/after benchmark and canonical graph comparison
- medium representative no-cache graph before/after canonical tuple comparison

