### PR TITLE
Use direct deps path for large impact runs

### DIFF
--- a/crates/sem-cli/src/cache.rs
+++ b/crates/sem-cli/src/cache.rs
@@ -12,6 +12,7 @@ pub struct PartialCache {
     pub stale_files: Vec<String>,
     pub cached_entities: Vec<SemanticEntity>,
     pub cached_edges: Vec<EntityRef>,
+    pub cached_importing_stale_files: Vec<String>,
     /// Cached entities from stale files (for entity-level content_hash comparison)
     pub stale_file_entities: Vec<SemanticEntity>,
 }
@@ -42,7 +43,9 @@ impl DiskCache {
     ) -> Result<(), rusqlite::Error> {
         let tx = self.conn.unchecked_transaction()?;
 
-        tx.execute_batch("DELETE FROM files; DELETE FROM entities; DELETE FROM edges;")?;
+        tx.execute_batch(
+            "DELETE FROM files; DELETE FROM entities; DELETE FROM edges; DELETE FROM file_imports;",
+        )?;
 
         {
             let mut stmt = tx.prepare(
@@ -60,6 +63,7 @@ impl DiskCache {
         }
 
         shared_cache::refresh_manifest_entries(&tx, root)?;
+        shared_cache::refresh_file_import_entries(&tx, root, files, files)?;
 
         // Insert entities with prepared statement (already in a transaction, so fast)
         {
@@ -337,19 +341,20 @@ impl DiskCache {
         let Some(ref mut stmt) = stmt else {
             return false;
         };
-        let cached_mtimes: HashMap<String, (i64, i64, Option<String>)> = match stmt.query_map([], |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                (
-                    row.get::<_, i64>(1)?,
-                    row.get::<_, i64>(2)?,
-                    row.get::<_, Option<String>>(3)?,
-                ),
-            ))
-        }) {
-            Ok(rows) => rows.filter_map(|r| r.ok()).collect(),
-            Err(_) => return false,
-        };
+        let cached_mtimes: HashMap<String, (i64, i64, Option<String>)> =
+            match stmt.query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    (
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, Option<String>>(3)?,
+                    ),
+                ))
+            }) {
+                Ok(rows) => rows.filter_map(|r| r.ok()).collect(),
+                Err(_) => return false,
+            };
 
         for file in files {
             if shared_cache::is_manifest_file_name(file) {
@@ -441,10 +446,10 @@ impl DiskCache {
         // Find stale source files: mtime differs or not in cache
         let mut stale_source_files: Vec<String> = Vec::new();
         let mut stale_current_file_count = 0;
-        for file in source_files {
-            match cached_files.get(file) {
+        for file in &source_files {
+            match cached_files.get(file.as_str()) {
                 Some((secs, nanos, content_hash)) => {
-                    let full = root.join(file);
+                    let full = root.join(file.as_str());
                     match shared_cache::file_freshness(
                         &full,
                         *secs,
@@ -461,13 +466,13 @@ impl DiskCache {
                         }
                         Some(shared_cache::FileFreshness::Stale) | None => {
                             stale_current_file_count += 1;
-                            stale_source_files.push(file.clone());
+                            stale_source_files.push((*file).clone());
                         }
                     }
                 }
                 None => {
                     stale_current_file_count += 1;
-                    stale_source_files.push(file.clone());
+                    stale_source_files.push((*file).clone());
                 }
             }
         }
@@ -498,6 +503,13 @@ impl DiskCache {
             .chain(deleted_cached_files.iter())
             .map(|s| s.as_str())
             .collect();
+        let mut import_stale_files = stale_source_files.clone();
+        import_stale_files.extend(deleted_cached_files.iter().cloned());
+        let cached_importing_stale_files = shared_cache::cached_importing_files_for_stale_files(
+            &self.conn,
+            &import_stale_files,
+            &source_files,
+        );
 
         // Load ALL entities, split into clean vs stale-file
         let mut entity_stmt = self
@@ -556,6 +568,7 @@ impl DiskCache {
             stale_files: stale_source_files,
             cached_entities,
             cached_edges,
+            cached_importing_stale_files,
             stale_file_entities,
         })
     }
@@ -657,6 +670,12 @@ impl DiskCache {
         }
 
         shared_cache::refresh_manifest_entries(&tx, root)?;
+        let mut import_files_to_refresh: Vec<String> = source_stale_files
+            .iter()
+            .map(|file| (*file).clone())
+            .collect();
+        import_files_to_refresh.extend(deleted_cached_files.iter().cloned());
+        shared_cache::refresh_file_import_entries(&tx, root, &import_files_to_refresh, all_files)?;
 
         if repair_changed_clean_entity_ids {
             tx.execute("DELETE FROM entities", [])?;
@@ -920,6 +939,17 @@ mod tests {
             .unwrap()
     }
 
+    fn file_import_count(cache: &DiskCache, importing_file: &str, imported_file: &str) -> i64 {
+        cache
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM file_imports WHERE importing_file = ?1 AND imported_file = ?2",
+                rusqlite::params![importing_file, imported_file],
+                |row| row.get(0),
+            )
+            .unwrap()
+    }
+
     fn cached_file_mtime(cache: &DiskCache, file: &str) -> (i64, i64) {
         cache
             .conn
@@ -999,6 +1029,58 @@ mod tests {
         assert!(cache.load_graph_topology(&root, &files).is_some());
         assert!(cache.load_partial(&root, &files).is_none());
         assert_eq!(cached_file_mtime(&cache, "same.rs"), current);
+
+        drop(cache);
+        cleanup(root);
+    }
+
+    #[test]
+    fn partial_cache_reports_clean_files_that_import_stale_js_ts_files() {
+        let root = temp_repo_root("incremental-import-metadata");
+        write_file(
+            &root.join("a.ts"),
+            "import { target } from './b';\nexport function useIt() { return target(); }\n",
+        );
+        write_file(
+            &root.join("b.ts"),
+            "export function target() { return 1; }\n",
+        );
+        write_file(
+            &root.join("c.ts"),
+            "export function other() { return 2; }\n",
+        );
+        let files = vec!["a.ts".to_string(), "b.ts".to_string(), "c.ts".to_string()];
+        let cache = DiskCache::open(&root).unwrap();
+        cache.save(&root, &files, &empty_graph(), &[]).unwrap();
+
+        assert_eq!(file_import_count(&cache, "a.ts", "b.ts"), 1);
+
+        rewrite_after_mtime_tick(
+            &root.join("b.ts"),
+            "export function target() { return 3; }\n",
+        );
+        let partial = cache.load_partial(&root, &files).unwrap();
+        assert_eq!(partial.stale_files, vec!["b.ts"]);
+        assert_eq!(partial.cached_importing_stale_files, vec!["a.ts"]);
+
+        rewrite_after_mtime_tick(
+            &root.join("a.ts"),
+            "import { other } from './c';\nexport function useIt() { return other(); }\n",
+        );
+        cache
+            .save_incremental_with_repair_metadata(
+                &root,
+                &files,
+                &["a.ts".to_string()],
+                &empty_graph(),
+                &[],
+                false,
+                &[],
+                &[],
+            )
+            .unwrap();
+        assert_eq!(file_import_count(&cache, "a.ts", "b.ts"), 0);
+        assert_eq!(file_import_count(&cache, "a.ts", "c.ts"), 1);
 
         drop(cache);
         cleanup(root);

--- a/crates/sem-cli/src/commands/graph.rs
+++ b/crates/sem-cli/src/commands/graph.rs
@@ -263,3 +263,30 @@ pub fn get_or_build_graph_topology_with_timings(
         get_or_build_graph_with_timings(root, file_paths, registry, no_cache, timings);
     graph
 }
+
+pub fn get_or_build_direct_dependency_graph_with_timings<F>(
+    root: &Path,
+    file_paths: &[String],
+    registry: &ParserRegistry,
+    no_cache: bool,
+    timings: &mut Timings,
+    should_resolve: F,
+) -> EntityGraph
+where
+    F: FnMut(&sem_core::parser::graph::EntityInfo) -> bool,
+{
+    if !no_cache {
+        if let Ok(disk) = DiskCache::open(root) {
+            timings.mark("cache_open");
+            if let Some(graph) = disk.load_graph_topology(root, file_paths) {
+                timings.mark("cache_topology_load");
+                return graph;
+            }
+        }
+    }
+
+    let (graph, _entities) =
+        EntityGraph::build_direct_dependencies(root, file_paths, registry, should_resolve);
+    timings.mark("direct_dependency_graph_build");
+    graph
+}

--- a/crates/sem-cli/src/commands/graph.rs
+++ b/crates/sem-cli/src/commands/graph.rs
@@ -200,15 +200,17 @@ pub fn get_or_build_graph_with_timings(
             // Try incremental: load clean cached data, rebuild only stale files
             if let Some(partial) = disk.load_partial(root, file_paths) {
                 timings.mark("cache_partial_load");
-                let (graph, entities, metadata) = EntityGraph::build_incremental_with_metadata(
-                    root,
-                    &partial.stale_files,
-                    file_paths,
-                    partial.cached_entities,
-                    partial.cached_edges,
-                    partial.stale_file_entities,
-                    registry,
-                );
+                let (graph, entities, metadata) =
+                    EntityGraph::build_incremental_with_metadata_and_import_candidates(
+                        root,
+                        &partial.stale_files,
+                        file_paths,
+                        partial.cached_entities,
+                        partial.cached_edges,
+                        partial.stale_file_entities,
+                        Some(&partial.cached_importing_stale_files),
+                        registry,
+                    );
                 timings.mark("incremental_graph_rebuild");
                 let _ = disk.save_incremental_with_repair_metadata(
                     root,

--- a/crates/sem-cli/src/commands/impact.rs
+++ b/crates/sem-cli/src/commands/impact.rs
@@ -26,6 +26,8 @@ pub enum ImpactMode {
     Tests,
 }
 
+const DIRECT_DEPS_CACHE_MISS_FILE_THRESHOLD: usize = 20_000;
+
 pub fn impact_command(opts: ImpactOptions) {
     let mut timings = Timings::from_env("impact");
     let root = match GitBridge::open(Path::new(&opts.cwd)) {
@@ -50,7 +52,54 @@ pub fn impact_command(opts: ImpactOptions) {
         .map(|file| super::normalize_repo_relative_path(Path::new(&opts.cwd), root, file));
 
     match opts.mode {
-        ImpactMode::Deps | ImpactMode::Dependents => {
+        ImpactMode::Deps => {
+            let graph = if opts.no_cache || file_paths.len() > DIRECT_DEPS_CACHE_MISS_FILE_THRESHOLD
+            {
+                let entity_name = opts.entity_name.clone();
+                let entity_id = opts.entity_id.clone();
+                let file_hint_for_match = file_hint.clone();
+                super::graph::get_or_build_direct_dependency_graph_with_timings(
+                    root,
+                    &file_paths,
+                    &registry,
+                    opts.no_cache,
+                    &mut timings,
+                    move |entity| {
+                        if let Some(id) = entity_id.as_deref() {
+                            return entity.id == id;
+                        }
+                        let Some(name) = entity_name.as_deref() else {
+                            return false;
+                        };
+                        if file_hint_for_match
+                            .as_deref()
+                            .is_some_and(|file| entity.file_path != file)
+                        {
+                            return false;
+                        }
+                        super::entity_matches_query(entity, name)
+                    },
+                )
+            } else {
+                super::graph::get_or_build_graph_topology_with_timings(
+                    root,
+                    &file_paths,
+                    &registry,
+                    opts.no_cache,
+                    &mut timings,
+                )
+            };
+            let entity = find_entity(
+                &graph,
+                opts.entity_name.as_deref(),
+                opts.entity_id.as_deref(),
+                file_hint.as_deref(),
+            );
+            timings.mark("entity_lookup");
+            print_deps(&graph, entity, opts.json);
+            timings.mark("cli_output_serialization");
+        }
+        ImpactMode::Dependents => {
             let graph = super::graph::get_or_build_graph_topology_with_timings(
                 root,
                 &file_paths,
@@ -65,11 +114,7 @@ pub fn impact_command(opts: ImpactOptions) {
                 file_hint.as_deref(),
             );
             timings.mark("entity_lookup");
-            match opts.mode {
-                ImpactMode::Deps => print_deps(&graph, entity, opts.json),
-                ImpactMode::Dependents => print_dependents(&graph, entity, opts.json),
-                _ => unreachable!(),
-            }
+            print_dependents(&graph, entity, opts.json);
             timings.mark("cli_output_serialization");
         }
         ImpactMode::Tests | ImpactMode::All => {

--- a/crates/sem-cli/tests/impact_direct_deps.rs
+++ b/crates/sem-cli/tests/impact_direct_deps.rs
@@ -1,0 +1,103 @@
+use std::{
+    fs,
+    path::Path,
+    process::{Command, Output},
+};
+
+use tempfile::TempDir;
+
+fn output_text(output: &Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn assert_success(output: Output, context: &str) -> Output {
+    assert!(
+        output.status.success(),
+        "{context} failed with status {:?}\n{}",
+        output.status.code(),
+        output_text(&output)
+    );
+    output
+}
+
+fn git(repo: &Path, args: &[&str]) -> Output {
+    assert_success(
+        Command::new("git")
+            .current_dir(repo)
+            .args(args)
+            .output()
+            .unwrap(),
+        &format!("git {}", args.join(" ")),
+    )
+}
+
+fn init_repo(repo: &Path) {
+    git(repo, &["init", "-q"]);
+    git(repo, &["config", "user.email", "t@t.com"]);
+    git(repo, &["config", "user.name", "test"]);
+    git(repo, &["config", "commit.gpgsign", "false"]);
+
+    fs::write(
+        repo.join("a.ts"),
+        "export function source() { return 1; }\n",
+    )
+    .unwrap();
+    fs::write(
+        repo.join("b.ts"),
+        "import { source } from './a';\nexport function consume() { return source(); }\n",
+    )
+    .unwrap();
+    git(repo, &["add", "a.ts", "b.ts"]);
+    git(repo, &["commit", "-q", "-m", "init"]);
+}
+
+fn phase_names(output: &Output) -> Vec<String> {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let timings: serde_json::Value = serde_json::from_str(stderr.trim()).expect("timings json");
+    timings["phases"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|phase| phase["name"].as_str().unwrap().to_string())
+        .collect()
+}
+
+#[test]
+fn impact_deps_no_cache_uses_direct_dependency_graph() {
+    let repo = TempDir::new().unwrap();
+    init_repo(repo.path());
+
+    let output = assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("SEM_TIMINGS", "json")
+            .args([
+                "impact",
+                "consume",
+                "--file",
+                "b.ts",
+                "--deps",
+                "--json",
+                "--no-cache",
+                "--file-exts",
+                ".ts",
+            ])
+            .output()
+            .unwrap(),
+        "impact deps",
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["entity"]["name"], "consume");
+    assert_eq!(json["dependencies"][0]["name"], "source");
+
+    let phases = phase_names(&output);
+    assert!(phases
+        .iter()
+        .any(|phase| phase == "direct_dependency_graph_build"));
+    assert!(!phases.iter().any(|phase| phase == "full_graph_build"));
+}

--- a/crates/sem-core/src/parser/graph.rs
+++ b/crates/sem-core/src/parser/graph.rs
@@ -35,7 +35,8 @@ use crate::git::types::{FileChange, FileStatus};
 use crate::model::entity::SemanticEntity;
 use crate::parser::import_resolution::{
     find_import_file, find_import_target, import_source_matches_file, is_js_ts_file,
-    js_ts_named_exports_from_content, sort_import_candidate_files, JS_TS_EXTENSIONS,
+    js_ts_import_source_files_from_content, js_ts_named_exports_from_content,
+    sort_import_candidate_files, JS_TS_EXTENSIONS,
 };
 use crate::parser::registry::{resolve_go_method_parent_ids, ParserRegistry};
 use crate::parser::scope_resolve;
@@ -355,6 +356,25 @@ fn sort_symbol_table_targets_by_source(
             });
         }
     }
+}
+
+fn dedupe_resolved_edges(
+    combined: Vec<(String, String, RefType)>,
+) -> Vec<(String, String, RefType)> {
+    let mut keep = vec![false; combined.len()];
+    let mut seen_edges: HashSet<(&str, &str)> = HashSet::with_capacity(combined.len());
+    for (index, (from_entity, to_entity, _)) in combined.iter().enumerate() {
+        if seen_edges.insert((from_entity.as_str(), to_entity.as_str())) {
+            keep[index] = true;
+        }
+    }
+    drop(seen_edges);
+
+    combined
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, edge)| keep[index].then_some(edge))
+        .collect()
 }
 
 #[derive(Debug)]
@@ -1251,13 +1271,7 @@ impl EntityGraph {
         let mut combined: Vec<(String, String, RefType)> = scope_edges;
         combined.extend(export_edges);
         combined.extend(resolved_refs);
-        let mut seen_edges: HashSet<(String, String)> = HashSet::with_capacity(combined.len());
-        let mut all_resolved: Vec<(String, String, RefType)> = Vec::with_capacity(combined.len());
-        for edge in combined {
-            if seen_edges.insert((edge.0.clone(), edge.1.clone())) {
-                all_resolved.push(edge);
-            }
-        }
+        let all_resolved = dedupe_resolved_edges(combined);
 
         // Build edge indexes from resolved references
         let mut edges: Vec<EntityRef> = Vec::with_capacity(all_resolved.len());
@@ -1323,6 +1337,28 @@ impl EntityGraph {
         cached_entities: Vec<SemanticEntity>,
         cached_edges: Vec<EntityRef>,
         stale_file_cached_entities: Vec<SemanticEntity>,
+        registry: &ParserRegistry,
+    ) -> (Self, Vec<SemanticEntity>, IncrementalBuildMetadata) {
+        Self::build_incremental_with_metadata_and_import_candidates(
+            root,
+            stale_files,
+            all_file_paths,
+            cached_entities,
+            cached_edges,
+            stale_file_cached_entities,
+            None,
+            registry,
+        )
+    }
+
+    pub fn build_incremental_with_metadata_and_import_candidates(
+        root: &Path,
+        stale_files: &[String],
+        all_file_paths: &[String],
+        cached_entities: Vec<SemanticEntity>,
+        cached_edges: Vec<EntityRef>,
+        stale_file_cached_entities: Vec<SemanticEntity>,
+        cached_importing_stale_files: Option<&[String]>,
         registry: &ParserRegistry,
     ) -> (Self, Vec<SemanticEntity>, IncrementalBuildMetadata) {
         // Build set of stale file paths for quick lookup
@@ -1670,26 +1706,37 @@ impl EntityGraph {
             .filter(|file_path| is_js_ts_file(file_path))
             .collect();
         if !stale_js_ts_file_paths.is_empty() {
-            let clean_js_ts_import_tokens: HashMap<&str, Vec<String>> = all_file_paths
-                .iter()
-                .map(String::as_str)
-                .filter(|file_path| !stale_set.contains(*file_path) && is_js_ts_file(file_path))
-                .filter_map(|file_path| {
-                    let content = read_import_scan_prefix(&root.join(file_path))?;
-                    let mut tokens: Vec<String> = stale_js_ts_file_paths
-                        .iter()
-                        .flat_map(|stale_file_path| {
-                            content_import_tokens_for_file(file_path, &content, stale_file_path)
-                        })
-                        .collect();
-                    if tokens.is_empty() {
-                        return None;
-                    }
-                    tokens.sort_unstable();
-                    tokens.dedup();
-                    Some((file_path, tokens))
-                })
-                .collect();
+            let clean_import_candidate_files: Vec<&str> = match cached_importing_stale_files {
+                Some(files) => files
+                    .iter()
+                    .map(String::as_str)
+                    .filter(|file_path| !stale_set.contains(*file_path) && is_js_ts_file(file_path))
+                    .collect(),
+                None => all_file_paths
+                    .iter()
+                    .map(String::as_str)
+                    .filter(|file_path| !stale_set.contains(*file_path) && is_js_ts_file(file_path))
+                    .collect(),
+            };
+            let clean_js_ts_import_tokens: HashMap<&str, Vec<String>> =
+                clean_import_candidate_files
+                    .into_iter()
+                    .filter_map(|file_path| {
+                        let content = read_import_scan_prefix(&root.join(file_path))?;
+                        let mut tokens: Vec<String> = stale_js_ts_file_paths
+                            .iter()
+                            .flat_map(|stale_file_path| {
+                                content_import_tokens_for_file(file_path, &content, stale_file_path)
+                            })
+                            .collect();
+                        if tokens.is_empty() {
+                            return None;
+                        }
+                        tokens.sort_unstable();
+                        tokens.dedup();
+                        Some((file_path, tokens))
+                    })
+                    .collect();
 
             for entity in all_entities
                 .iter()
@@ -1960,25 +2007,29 @@ impl EntityGraph {
         let mut combined: Vec<(String, String, RefType)> = scope_edges;
         combined.extend(export_edges);
         combined.extend(resolved_refs);
-        let mut seen_edges: HashSet<(String, String)> = HashSet::with_capacity(combined.len());
-        let mut all_resolved: Vec<(String, String, RefType)> = Vec::with_capacity(combined.len());
-        for edge in combined {
-            if seen_edges.insert((edge.0.clone(), edge.1.clone())) {
-                all_resolved.push(edge);
-            }
-        }
+        let all_resolved = dedupe_resolved_edges(combined);
 
         // Build final edge list: kept edges + newly resolved edges
         let mut edges: Vec<EntityRef> = Vec::with_capacity(kept_edges.len() + all_resolved.len());
         let mut dependents: HashMap<String, Vec<String>> = HashMap::new();
         let mut dependencies: HashMap<String, Vec<String>> = HashMap::new();
 
-        // Track all edge pairs for dedup
-        let mut all_edge_pairs: HashSet<(String, String)> = HashSet::new();
+        let mut kept_edge_pairs: HashSet<(&str, &str)> = HashSet::with_capacity(kept_edges.len());
+        for edge in &kept_edges {
+            kept_edge_pairs.insert((edge.from_entity.as_str(), edge.to_entity.as_str()));
+        }
+
+        let mut new_edges: Vec<(String, String, RefType)> = Vec::with_capacity(all_resolved.len());
+        for (from_entity, to_entity, ref_type) in all_resolved {
+            if kept_edge_pairs.contains(&(from_entity.as_str(), to_entity.as_str())) {
+                continue;
+            }
+            new_edges.push((from_entity, to_entity, ref_type));
+        }
+        drop(kept_edge_pairs);
 
         // Add kept cached edges
         for edge in kept_edges {
-            all_edge_pairs.insert((edge.from_entity.clone(), edge.to_entity.clone()));
             dependents
                 .entry(edge.to_entity.clone())
                 .or_default()
@@ -1991,10 +2042,7 @@ impl EntityGraph {
         }
 
         // Add newly resolved edges, dedup against kept edges
-        for (from_entity, to_entity, ref_type) in all_resolved {
-            if !all_edge_pairs.insert((from_entity.clone(), to_entity.clone())) {
-                continue;
-            }
+        for (from_entity, to_entity, ref_type) in new_edges {
             dependents
                 .entry(to_entity.clone())
                 .or_default()
@@ -2874,16 +2922,45 @@ fn build_import_table_with_default_export_paths(
         );
     }
     let mut owned_content: HashMap<String, String> = HashMap::new();
-    let mut content_file_paths: Vec<&String> = file_paths.iter().collect();
-    content_file_paths.extend(default_export_file_paths.iter());
-    content_file_paths.sort_unstable();
-    content_file_paths.dedup();
-    for file_path in content_file_paths {
-        if file_path.ends_with(".go") || content_map.contains_key(file_path.as_str()) {
-            continue;
+    let mut content_file_set: HashSet<String> = file_paths.iter().cloned().collect();
+    if file_paths.len() == default_export_file_paths.len() {
+        content_file_set.extend(default_export_file_paths.iter().cloned());
+        for file_path in &content_file_set {
+            if file_path.ends_with(".go") || content_map.contains_key(file_path.as_str()) {
+                continue;
+            }
+            if let Ok(content) = std::fs::read_to_string(root.join(file_path)) {
+                owned_content.insert(file_path.clone(), content);
+            }
         }
-        if let Ok(content) = std::fs::read_to_string(root.join(file_path)) {
-            owned_content.insert(file_path.clone(), content);
+    } else {
+        let mut content_file_queue: Vec<String> = file_paths.to_vec();
+        while let Some(file_path) = content_file_queue.pop() {
+            if !file_path.ends_with(".go")
+                && !content_map.contains_key(file_path.as_str())
+                && !owned_content.contains_key(&file_path)
+            {
+                if let Ok(content) = std::fs::read_to_string(root.join(&file_path)) {
+                    owned_content.insert(file_path.clone(), content);
+                }
+            }
+
+            let Some(content) = content_map
+                .get(file_path.as_str())
+                .copied()
+                .or_else(|| owned_content.get(&file_path).map(String::as_str))
+            else {
+                continue;
+            };
+            for imported_file in js_ts_import_source_files_from_content(
+                &file_path,
+                content,
+                default_export_file_paths,
+            ) {
+                if content_file_set.insert(imported_file.clone()) {
+                    content_file_queue.push(imported_file);
+                }
+            }
         }
     }
     content_map.extend(
@@ -2891,12 +2968,10 @@ fn build_import_table_with_default_export_paths(
             .iter()
             .map(|(file_path, content)| (file_path.as_str(), content.as_str())),
     );
-    let ts_default_exports = build_ts_default_export_table(
-        default_export_file_paths,
-        symbol_table,
-        entity_map,
-        &content_map,
-    );
+    let mut content_file_paths: Vec<String> = content_file_set.into_iter().collect();
+    content_file_paths.sort_unstable();
+    let ts_default_exports =
+        build_ts_default_export_table(&content_file_paths, symbol_table, entity_map, &content_map);
     let ts_top_level_entities = OnceLock::new();
     let ts_exported_names_by_file: Mutex<HashMap<String, Arc<HashSet<String>>>> =
         Mutex::new(HashMap::new());
@@ -5062,6 +5137,85 @@ comment with Helper
                 .iter()
                 .any(|(file_path, name)| *file_path == "b.ts" && *name == "targetB"),
             "clean barrel export should retarget to b.ts. Deps: {:?}",
+            incremental_deps
+        );
+    }
+
+    #[test]
+    fn test_incremental_import_candidates_re_resolve_clean_barrel() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "a.ts",
+            "export default function targetA() { return 1; }\n",
+        );
+        write_file(
+            root,
+            "b.ts",
+            "export default function targetB() { return 2; }\n",
+        );
+        write_file(root, "stale.ts", "export { default } from './a';\n");
+        write_file(
+            root,
+            "barrel.ts",
+            "export { default as publicTarget } from './stale';\n",
+        );
+
+        let all_files = vec![
+            "a.ts".to_string(),
+            "b.ts".to_string(),
+            "stale.ts".to_string(),
+            "barrel.ts".to_string(),
+        ];
+        let (cached_graph, cached_entities) = EntityGraph::build(root, &all_files, &registry);
+
+        write_file(root, "stale.ts", "export { default } from './b';\n");
+
+        let cached_clean_entities = cached_entities
+            .iter()
+            .filter(|entity| entity.file_path != "stale.ts")
+            .cloned()
+            .collect();
+        let cached_stale_entities = cached_entities
+            .into_iter()
+            .filter(|entity| entity.file_path == "stale.ts")
+            .collect();
+        let cached_importing_stale_files = vec!["barrel.ts".to_string()];
+
+        let (incremental_graph, _, _) =
+            EntityGraph::build_incremental_with_metadata_and_import_candidates(
+                root,
+                &["stale.ts".into()],
+                &all_files,
+                cached_clean_entities,
+                cached_graph.edges,
+                cached_stale_entities,
+                Some(&cached_importing_stale_files),
+                &registry,
+            );
+        let (fresh_graph, _) = EntityGraph::build(root, &all_files, &registry);
+
+        let mut incremental_deps = incremental_graph
+            .get_dependencies("barrel.ts::export::publicTarget")
+            .iter()
+            .map(|entity| (entity.file_path.as_str(), entity.name.as_str()))
+            .collect::<Vec<_>>();
+        incremental_deps.sort_unstable();
+        let mut fresh_deps = fresh_graph
+            .get_dependencies("barrel.ts::export::publicTarget")
+            .iter()
+            .map(|entity| (entity.file_path.as_str(), entity.name.as_str()))
+            .collect::<Vec<_>>();
+        fresh_deps.sort_unstable();
+
+        assert_eq!(incremental_deps, fresh_deps);
+        assert!(
+            incremental_deps
+                .iter()
+                .any(|(file_path, name)| *file_path == "b.ts" && *name == "targetB"),
+            "candidate-aware incremental rebuild should retarget the clean barrel export. Deps: {:?}",
             incremental_deps
         );
     }

--- a/crates/sem-core/src/parser/graph.rs
+++ b/crates/sem-core/src/parser/graph.rs
@@ -1304,6 +1304,316 @@ impl EntityGraph {
         (graph, all_entities)
     }
 
+    /// Build an entity graph containing dependency edges for selected entities.
+    ///
+    /// The graph includes every entity so callers can perform the same lookup and
+    /// ambiguity checks as a full graph build. Only selected entities contribute
+    /// outgoing dependency edges.
+    pub fn build_direct_dependencies<F>(
+        root: &Path,
+        file_paths: &[String],
+        registry: &ParserRegistry,
+        mut should_resolve: F,
+    ) -> (Self, Vec<SemanticEntity>)
+    where
+        F: FnMut(&EntityInfo) -> bool,
+    {
+        let retain_parsed_files = file_paths.len() <= PARSED_FILE_REUSE_LIMIT;
+        let per_file: Vec<(
+            Vec<SemanticEntity>,
+            Option<(String, String, tree_sitter::Tree)>,
+        )> = maybe_par_iter!(file_paths)
+            .filter_map(|file_path| {
+                let content = std::fs::read_to_string(root.join(file_path)).ok()?;
+                if retain_parsed_files {
+                    let (entities, tree) =
+                        registry.extract_entities_with_tree(file_path, &content)?;
+                    let parsed = tree.map(|tree| (file_path.clone(), content, tree));
+                    Some((entities, parsed))
+                } else {
+                    Some((registry.extract_entities(file_path, &content), None))
+                }
+            })
+            .collect();
+
+        let mut all_entities: Vec<SemanticEntity> = Vec::new();
+        let mut retained_parsed_files: Vec<(String, String, tree_sitter::Tree)> = Vec::new();
+        for (entities, parsed) in per_file {
+            all_entities.extend(entities);
+            if let Some(parsed) = parsed {
+                retained_parsed_files.push(parsed);
+            }
+        }
+        resolve_go_method_parent_ids(&mut all_entities);
+
+        let mut symbol_table: HashMap<String, Vec<String>> =
+            HashMap::with_capacity(all_entities.len());
+        let mut entity_map: HashMap<String, EntityInfo> =
+            HashMap::with_capacity(all_entities.len());
+        let mut parent_child_pairs: HashSet<(&str, &str)> = HashSet::new();
+        let mut child_line_ranges: HashMap<String, Vec<(usize, usize)>> = HashMap::new();
+        let mut class_child_names: HashSet<(&str, &str)> = HashSet::new();
+        let child_ranges_by_parent = build_child_ranges_by_parent(&all_entities);
+        let mut class_entity_names: HashSet<&str> = HashSet::new();
+        let mut class_entity_files: HashSet<(&str, &str)> = HashSet::new();
+        let mut id_to_name: HashMap<&str, &str> = HashMap::with_capacity(all_entities.len());
+        let mut scope_entity_ranges: HashMap<String, Vec<(usize, usize, String)>> = HashMap::new();
+
+        for entity in &all_entities {
+            symbol_table
+                .entry(entity.name.clone())
+                .or_default()
+                .push(entity.id.clone());
+
+            entity_map.insert(
+                entity.id.clone(),
+                EntityInfo {
+                    id: entity.id.clone(),
+                    name: entity.name.clone(),
+                    entity_type: entity.entity_type.clone(),
+                    file_path: entity.file_path.clone(),
+                    parent_id: entity.parent_id.clone(),
+                    start_line: entity.start_line,
+                    end_line: entity.end_line,
+                },
+            );
+
+            if let Some(ref pid) = entity.parent_id {
+                parent_child_pairs.insert((pid.as_str(), entity.id.as_str()));
+                child_line_ranges
+                    .entry(pid.clone())
+                    .or_default()
+                    .push((entity.start_line, entity.end_line));
+                class_child_names.insert((pid.as_str(), entity.name.as_str()));
+            }
+
+            if is_nominal_member_container(entity.entity_type.as_str()) {
+                class_entity_names.insert(entity.name.as_str());
+                class_entity_files.insert((entity.name.as_str(), entity.file_path.as_str()));
+            }
+
+            id_to_name.insert(entity.id.as_str(), entity.name.as_str());
+
+            scope_entity_ranges
+                .entry(entity.file_path.clone())
+                .or_default()
+                .push((entity.start_line, entity.end_line, entity.id.clone()));
+        }
+        for ranges in child_line_ranges.values_mut() {
+            ranges.sort_unstable_by_key(|(start, end)| (*start, *end));
+        }
+
+        let mut enclosing_class: HashMap<&str, &str> = HashMap::new();
+        let mut class_members: HashMap<&str, Vec<(&str, &str)>> = HashMap::new();
+        let mut scope_class_members: HashMap<String, Vec<(String, String)>> = HashMap::new();
+        let mut scope_owner_members: HashMap<String, Vec<(String, String)>> = HashMap::new();
+
+        for entity in &all_entities {
+            if let Some(ref pid) = entity.parent_id {
+                scope_owner_members
+                    .entry(pid.clone())
+                    .or_default()
+                    .push((entity.name.clone(), entity.id.clone()));
+                if let Some(&parent_name) = id_to_name.get(pid.as_str()) {
+                    if class_entity_names.contains(parent_name) {
+                        enclosing_class.insert(entity.id.as_str(), parent_name);
+                        class_members
+                            .entry(parent_name)
+                            .or_default()
+                            .push((entity.name.as_str(), entity.id.as_str()));
+                    }
+                }
+                if let Some(parent) = entity_map.get(pid.as_str()) {
+                    if let Some(owner_name) = scope_resolve::class_member_owner_name(parent) {
+                        scope_class_members
+                            .entry(owner_name.to_string())
+                            .or_default()
+                            .push((entity.name.clone(), entity.id.clone()));
+                    }
+                }
+            }
+            if entity.entity_type == "method" && entity.file_path.ends_with(".go") {
+                if let Some(struct_name) = scope_resolve::extract_go_receiver_type(&entity.content)
+                {
+                    scope_class_members
+                        .entry(struct_name)
+                        .or_default()
+                        .push((entity.name.clone(), entity.id.clone()));
+                }
+            }
+        }
+        sort_symbol_table_targets_by_source(&mut symbol_table, &entity_map);
+        let symbol_table = Arc::new(symbol_table);
+
+        let mut needs_resolution: HashSet<String> = HashSet::new();
+        let mut resolve_file_paths: Vec<String> = Vec::new();
+        let mut resolve_file_set: HashSet<String> = HashSet::new();
+        let mut entity_ids: Vec<&String> = entity_map.keys().collect();
+        entity_ids.sort_unstable();
+        for entity_id in entity_ids {
+            let Some(entity) = entity_map.get(entity_id) else {
+                continue;
+            };
+            if should_resolve(entity) {
+                needs_resolution.insert(entity.id.clone());
+                if resolve_file_set.insert(entity.file_path.clone()) {
+                    resolve_file_paths.push(entity.file_path.clone());
+                }
+            }
+        }
+        resolve_file_paths.sort_unstable();
+
+        if needs_resolution.is_empty() {
+            return (
+                EntityGraph {
+                    entities: entity_map,
+                    edges: Vec::new(),
+                    dependents: HashMap::new(),
+                    dependencies: HashMap::new(),
+                },
+                all_entities,
+            );
+        }
+
+        let scope_file_paths = if file_paths.len() > PARSED_FILE_REUSE_LIMIT {
+            let mut scoped = Vec::new();
+            for chunk in file_paths.chunks(SCOPE_RESOLVE_FILE_CHUNK_SIZE) {
+                if chunk.iter().any(|file| resolve_file_set.contains(file)) {
+                    scoped.extend(chunk.iter().cloned());
+                }
+            }
+            scoped
+        } else {
+            file_paths.to_vec()
+        };
+        let has_scope_lang = resolve_file_paths.iter().any(|f| {
+            let ext = f.rfind('.').map(|i| &f[i..]).unwrap_or("");
+            crate::parser::plugins::code::languages::get_language_config(ext)
+                .and_then(|c| c.scope_resolve)
+                .is_some()
+        });
+        let parsed_files: Vec<(String, String, tree_sitter::Tree)> = if !has_scope_lang {
+            Vec::new()
+        } else if !retained_parsed_files.is_empty() && scope_file_paths.len() == file_paths.len() {
+            retained_parsed_files
+        } else {
+            maybe_par_iter!(&scope_file_paths)
+                .filter_map(|file_path| {
+                    let content = std::fs::read_to_string(root.join(file_path)).ok()?;
+                    let (_entities, tree) =
+                        registry.extract_entities_with_tree(file_path, &content)?;
+                    tree.map(|tree| (file_path.clone(), content, tree))
+                })
+                .collect()
+        };
+
+        let import_table = build_import_table_with_default_export_paths(
+            root,
+            &resolve_file_paths,
+            file_paths,
+            &symbol_table,
+            &entity_map,
+            Some(parsed_files.as_slice()),
+        );
+
+        let owned_go_pkg_index: HashMap<String, Vec<(String, String)>> =
+            if resolve_file_paths.iter().any(|f| f.ends_with(".go")) {
+                scope_resolve::build_go_pkg_index(&symbol_table, &entity_map)
+            } else {
+                HashMap::new()
+            };
+
+        let pre_built = scope_resolve::PreBuiltLookups {
+            symbol_table: Arc::clone(&symbol_table),
+            class_members: scope_class_members,
+            owner_members: scope_owner_members,
+            entity_ranges: scope_entity_ranges,
+            go_pkg_index: owned_go_pkg_index,
+        };
+
+        let needs_resolution_refs: HashSet<&str> =
+            needs_resolution.iter().map(String::as_str).collect();
+        let (scope_edges, scope_consumed_words) = if has_scope_lang {
+            let result = scope_resolve::resolve_with_scopes_full_for_entities(
+                root,
+                &scope_file_paths,
+                &all_entities,
+                &entity_map,
+                (!parsed_files.is_empty()).then_some(parsed_files),
+                Some(&pre_built),
+                Some(&import_table),
+                &needs_resolution_refs,
+            );
+            (result.edges, result.consumed_words)
+        } else {
+            (vec![], HashMap::new())
+        };
+
+        let reference_context = ReferenceResolutionContext {
+            symbol_table: symbol_table.as_ref(),
+            entity_map: &entity_map,
+            import_table: &import_table,
+            scope_consumed_words: &scope_consumed_words,
+            child_ranges_by_parent: &child_ranges_by_parent,
+            child_line_ranges: &child_line_ranges,
+            parent_child_pairs: &parent_child_pairs,
+            class_child_names: &class_child_names,
+            class_entity_files: &class_entity_files,
+            enclosing_class: &enclosing_class,
+            class_members: &class_members,
+        };
+        let resolved_refs = resolve_references_with_file_indexes(
+            root,
+            &resolve_file_paths,
+            &all_entities,
+            Some(&needs_resolution_refs),
+            &reference_context,
+        );
+
+        let export_edges = build_export_alias_edges(&all_entities, &import_table)
+            .into_iter()
+            .filter(|(from_entity, _, _)| needs_resolution.contains(from_entity))
+            .collect::<Vec<_>>();
+
+        let mut combined: Vec<(String, String, RefType)> = scope_edges
+            .into_iter()
+            .filter(|(from_entity, _, _)| needs_resolution.contains(from_entity))
+            .collect();
+        combined.extend(export_edges);
+        combined.extend(resolved_refs);
+        let all_resolved = dedupe_resolved_edges(combined);
+
+        let mut edges: Vec<EntityRef> = Vec::with_capacity(all_resolved.len());
+        let mut dependents: HashMap<String, Vec<String>> = HashMap::new();
+        let mut dependencies: HashMap<String, Vec<String>> = HashMap::new();
+
+        for (from_entity, to_entity, ref_type) in all_resolved {
+            dependents
+                .entry(to_entity.clone())
+                .or_default()
+                .push(from_entity.clone());
+            dependencies
+                .entry(from_entity.clone())
+                .or_default()
+                .push(to_entity.clone());
+            edges.push(EntityRef {
+                from_entity,
+                to_entity,
+                ref_type,
+            });
+        }
+
+        (
+            EntityGraph {
+                entities: entity_map,
+                edges,
+                dependents,
+                dependencies,
+            },
+            all_entities,
+        )
+    }
+
     /// Incrementally build an entity graph: reparse only stale files, reuse cached data for clean files.
     ///
     /// Uses the same full 3-phase resolution (scope + dot-chain + bag-of-words) as `build()`,
@@ -4290,6 +4600,32 @@ mod tests {
         f.write_all(content.as_bytes()).unwrap();
     }
 
+    fn dependency_ids(graph: &EntityGraph, entity_id: &str) -> Vec<String> {
+        let mut ids = graph
+            .get_dependencies(entity_id)
+            .into_iter()
+            .map(|entity| entity.id.clone())
+            .collect::<Vec<_>>();
+        ids.sort();
+        ids
+    }
+
+    fn assert_direct_dependencies_match_full(
+        root: &Path,
+        files: &[String],
+        registry: &ParserRegistry,
+        entity_id: &str,
+    ) {
+        let (full_graph, _) = EntityGraph::build(root, files, registry);
+        let expected = dependency_ids(&full_graph, entity_id);
+        let (direct_graph, _) =
+            EntityGraph::build_direct_dependencies(root, files, registry, |entity| {
+                entity.id == entity_id
+            });
+        let actual = dependency_ids(&direct_graph, entity_id);
+        assert_eq!(actual, expected);
+    }
+
     fn graph_json_payload(graph: &EntityGraph) -> serde_json::Value {
         let mut entities = graph.entities.values().collect::<Vec<_>>();
         entities.sort_by(|a, b| a.id.cmp(&b.id));
@@ -6223,6 +6559,40 @@ export function main() { return helper(); }
     }
 
     #[test]
+    fn test_direct_dependencies_match_full_graph_for_js_ts_import_forms() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "lib.ts",
+            "\
+export function namedThing() { return 1; }
+export default function defaultThing() { return 2; }
+",
+        );
+        write_file(
+            root,
+            "consumer.ts",
+            "\
+import defaultThing, { namedThing } from './lib';
+import * as lib from './lib';
+
+export function useEverything() {
+    return defaultThing() + namedThing() + lib.namedThing();
+}
+",
+        );
+        let files = vec!["lib.ts".to_string(), "consumer.ts".to_string()];
+        assert_direct_dependencies_match_full(
+            root,
+            &files,
+            &registry,
+            "consumer.ts::function::useEverything",
+        );
+    }
+
+    #[test]
     fn test_js_ts_relative_import_resolution_uses_full_path() {
         let (dir, registry) = create_test_repo();
         let root = dir.path();
@@ -6460,6 +6830,53 @@ export function usePublicCore(): string { return publicCore(); }
                 .iter()
                 .map(|d| (&d.name, &d.file_path))
                 .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_direct_dependencies_match_full_graph_for_js_ts_re_exports() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "lib.ts",
+            "\
+export function core(): string { return 'core'; }
+",
+        );
+        write_file(
+            root,
+            "barrel.ts",
+            "\
+export { core as publicCore } from './lib';
+",
+        );
+        write_file(
+            root,
+            "consumer.ts",
+            "\
+import { publicCore } from './barrel';
+export function usePublicCore(): string { return publicCore(); }
+",
+        );
+        let files = vec![
+            "lib.ts".to_string(),
+            "barrel.ts".to_string(),
+            "consumer.ts".to_string(),
+        ];
+
+        assert_direct_dependencies_match_full(
+            root,
+            &files,
+            &registry,
+            "barrel.ts::export::publicCore",
+        );
+        assert_direct_dependencies_match_full(
+            root,
+            &files,
+            &registry,
+            "consumer.ts::function::usePublicCore",
         );
     }
 

--- a/crates/sem-core/src/parser/import_resolution.rs
+++ b/crates/sem-core/src/parser/import_resolution.rs
@@ -14,6 +14,45 @@ pub(crate) fn is_js_ts_file(file_path: &str) -> bool {
         .any(|extension| file_path.ends_with(extension))
 }
 
+pub fn js_ts_import_source_files_from_content<P: AsRef<str>>(
+    file_path: &str,
+    content: &str,
+    candidate_file_paths: &[P],
+) -> Vec<String> {
+    if !is_js_ts_file(file_path) {
+        return Vec::new();
+    }
+
+    static FROM_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r#"\bfrom\s*['"]([^'"]+)['"]"#).unwrap());
+    static SIDE_EFFECT_IMPORT_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r#"\bimport\s*['"]([^'"]+)['"]"#).unwrap());
+
+    let mut imported_files = HashSet::new();
+    for cap in FROM_RE.captures_iter(content) {
+        if let Some(source) = cap.get(1).map(|m| m.as_str()) {
+            if let Some(imported_file) =
+                find_import_file(candidate_file_paths, source, file_path, JS_TS_EXTENSIONS)
+            {
+                imported_files.insert(imported_file.to_string());
+            }
+        }
+    }
+    for cap in SIDE_EFFECT_IMPORT_RE.captures_iter(content) {
+        if let Some(source) = cap.get(1).map(|m| m.as_str()) {
+            if let Some(imported_file) =
+                find_import_file(candidate_file_paths, source, file_path, JS_TS_EXTENSIONS)
+            {
+                imported_files.insert(imported_file.to_string());
+            }
+        }
+    }
+
+    let mut imported_files: Vec<String> = imported_files.into_iter().collect();
+    sort_import_candidate_files(&mut imported_files, JS_TS_EXTENSIONS);
+    imported_files
+}
+
 pub(crate) fn js_ts_named_exports_from_content(content: &str) -> HashSet<String> {
     static NAMED_DECL_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
@@ -350,6 +389,26 @@ mod tests {
         );
 
         assert_eq!(target, None);
+    }
+
+    #[test]
+    fn js_ts_import_source_files_resolves_relative_imports_and_re_exports() {
+        let candidates = vec![
+            "src/a.ts".to_string(),
+            "src/b.ts".to_string(),
+            "src/c/index.ts".to_string(),
+            "src/unused.ts".to_string(),
+        ];
+        let content = r#"
+import { a } from './a';
+import DefaultB from "./b";
+import './c';
+export { a as publicA } from './a';
+"#;
+
+        let imports = js_ts_import_source_files_from_content("src/main.ts", content, &candidates);
+
+        assert_eq!(imports, vec!["src/a.ts", "src/b.ts", "src/c/index.ts"]);
     }
 
     #[test]

--- a/crates/sem-core/src/parser/mod.rs
+++ b/crates/sem-core/src/parser/mod.rs
@@ -8,4 +8,5 @@ pub mod context;
 #[cfg(feature = "git")]
 pub mod hotspot;
 mod import_resolution;
+pub use import_resolution::js_ts_import_source_files_from_content;
 pub mod scope_resolve;

--- a/crates/sem-core/src/parser/scope_resolve.rs
+++ b/crates/sem-core/src/parser/scope_resolve.rs
@@ -560,6 +560,53 @@ pub(crate) fn resolve_with_scopes_full(
     pre_built_import_table: Option<&HashMap<(String, String), String>>,
     emit_local_binding_log: bool,
 ) -> ScopeResultFull {
+    resolve_with_scopes_full_inner(
+        root,
+        file_paths,
+        all_entities,
+        entity_map,
+        pre_parsed,
+        pre_built,
+        pre_built_import_table,
+        emit_local_binding_log,
+        None,
+    )
+}
+
+pub(crate) fn resolve_with_scopes_full_for_entities(
+    root: &Path,
+    file_paths: &[String],
+    all_entities: &[SemanticEntity],
+    entity_map: &HashMap<String, EntityInfo>,
+    pre_parsed: Option<Vec<(String, String, tree_sitter::Tree)>>,
+    pre_built: Option<&PreBuiltLookups>,
+    pre_built_import_table: Option<&HashMap<(String, String), String>>,
+    emit_entity_ids: &HashSet<&str>,
+) -> ScopeResultFull {
+    resolve_with_scopes_full_inner(
+        root,
+        file_paths,
+        all_entities,
+        entity_map,
+        pre_parsed,
+        pre_built,
+        pre_built_import_table,
+        false,
+        Some(emit_entity_ids),
+    )
+}
+
+fn resolve_with_scopes_full_inner(
+    root: &Path,
+    file_paths: &[String],
+    all_entities: &[SemanticEntity],
+    entity_map: &HashMap<String, EntityInfo>,
+    pre_parsed: Option<Vec<(String, String, tree_sitter::Tree)>>,
+    pre_built: Option<&PreBuiltLookups>,
+    pre_built_import_table: Option<&HashMap<(String, String), String>>,
+    emit_local_binding_log: bool,
+    emit_entity_ids: Option<&HashSet<&str>>,
+) -> ScopeResultFull {
     let mut all_edges: Vec<(String, String, RefType)> = Vec::new();
     let mut log: Vec<ResolutionEntry> = Vec::new();
     let mut consumed_words: HashMap<String, HashSet<String>> = HashMap::new();
@@ -940,6 +987,13 @@ pub(crate) fn resolve_with_scopes_full(
             let mut lookup_cache = ScopeLookupCache::default();
 
             for entity in &file_entities {
+                if emit_entity_ids
+                    .as_ref()
+                    .is_some_and(|ids| !ids.contains(entity.id.as_str()))
+                {
+                    continue;
+                }
+
                 let scope_idx = entity_inner_scope
                     .get(&entity.id)
                     .or_else(|| entity_scope_map.get(&entity.id))

--- a/crates/sem-mcp/src/cache.rs
+++ b/crates/sem-mcp/src/cache.rs
@@ -7,15 +7,26 @@ use std::path::{Component, Path, PathBuf};
 use rusqlite::{params, Connection, Transaction};
 use sem_core::model::entity::SemanticEntity;
 use sem_core::parser::graph::{EntityGraph, EntityInfo, EntityRef, RefType};
+use sem_core::parser::js_ts_import_source_files_from_content;
 use sem_core::utils::hash::content_hash_bytes;
 
-pub const CACHE_SCHEMA_VERSION: i32 = 3;
+pub const CACHE_SCHEMA_VERSION: i32 = 4;
 pub const CACHE_INDEXES: &[(&str, &str, &str)] = &[
     ("idx_entities_file_path", "entities", "file_path"),
     ("idx_entities_name", "entities", "name"),
     ("idx_entities_parent_id", "entities", "parent_id"),
     ("idx_edges_from_entity", "edges", "from_entity"),
     ("idx_edges_to_entity", "edges", "to_entity"),
+    (
+        "idx_file_imports_imported_file",
+        "file_imports",
+        "imported_file",
+    ),
+    (
+        "idx_file_imports_importing_file",
+        "file_imports",
+        "importing_file",
+    ),
 ];
 
 // Cache-only keys use a NUL prefix so they cannot collide with git paths.
@@ -49,12 +60,18 @@ CREATE TABLE IF NOT EXISTS edges (
     to_entity TEXT NOT NULL,
     ref_type TEXT NOT NULL
 );
+CREATE TABLE IF NOT EXISTS file_imports (
+    importing_file TEXT NOT NULL,
+    imported_file TEXT NOT NULL,
+    PRIMARY KEY (importing_file, imported_file)
+);
 ";
 
 const CACHE_RESET_SQL: &str = "
 DROP TABLE IF EXISTS files;
 DROP TABLE IF EXISTS entities;
 DROP TABLE IF EXISTS edges;
+DROP TABLE IF EXISTS file_imports;
 ";
 
 pub fn initialize_schema(conn: &Connection) -> Result<(), rusqlite::Error> {
@@ -279,6 +296,7 @@ pub struct PartialCache {
     pub stale_files: Vec<String>,
     pub cached_entities: Vec<SemanticEntity>,
     pub cached_edges: Vec<EntityRef>,
+    pub cached_importing_stale_files: Vec<String>,
     /// Cached entities from stale files (for entity-level content_hash comparison)
     pub stale_file_entities: Vec<SemanticEntity>,
 }
@@ -453,6 +471,77 @@ pub fn refresh_manifest_entries(tx: &Transaction<'_>, root: &Path) -> Result<(),
     Ok(())
 }
 
+pub fn refresh_file_import_entries(
+    tx: &Transaction<'_>,
+    root: &Path,
+    files_to_refresh: &[String],
+    all_files: &[String],
+) -> Result<(), rusqlite::Error> {
+    let candidate_files: Vec<String> = all_files
+        .iter()
+        .filter(|file| !is_manifest_file_name(file))
+        .cloned()
+        .collect();
+
+    let mut delete = tx.prepare("DELETE FROM file_imports WHERE importing_file = ?1")?;
+    let mut insert = tx.prepare(
+        "INSERT OR IGNORE INTO file_imports (importing_file, imported_file) VALUES (?1, ?2)",
+    )?;
+
+    for file in files_to_refresh {
+        if is_manifest_file_name(file) {
+            continue;
+        }
+
+        delete.execute(params![file])?;
+        let Ok(content) = std::fs::read_to_string(root.join(file)) else {
+            continue;
+        };
+        for imported_file in
+            js_ts_import_source_files_from_content(file, &content, &candidate_files)
+        {
+            insert.execute(params![file, imported_file])?;
+        }
+    }
+
+    Ok(())
+}
+
+pub fn cached_importing_files_for_stale_files(
+    conn: &Connection,
+    stale_files: &[String],
+    current_source_files: &[&String],
+) -> Vec<String> {
+    let current_set: HashSet<&str> = current_source_files
+        .iter()
+        .map(|file| file.as_str())
+        .collect();
+    let stale_set: HashSet<&str> = stale_files.iter().map(String::as_str).collect();
+    let mut importing_files = HashSet::new();
+    let Ok(mut stmt) =
+        conn.prepare("SELECT DISTINCT importing_file FROM file_imports WHERE imported_file = ?1")
+    else {
+        return Vec::new();
+    };
+
+    for stale_file in stale_files {
+        let Ok(rows) = stmt.query_map(params![stale_file], |row| row.get::<_, String>(0)) else {
+            continue;
+        };
+        for importing_file in rows.filter_map(|row| row.ok()) {
+            if current_set.contains(importing_file.as_str())
+                && !stale_set.contains(importing_file.as_str())
+            {
+                importing_files.insert(importing_file);
+            }
+        }
+    }
+
+    let mut importing_files: Vec<String> = importing_files.into_iter().collect();
+    importing_files.sort_unstable();
+    importing_files
+}
+
 pub struct DiskCache {
     conn: Connection,
 }
@@ -480,7 +569,9 @@ impl DiskCache {
     ) -> Result<(), rusqlite::Error> {
         let tx = self.conn.unchecked_transaction()?;
 
-        tx.execute_batch("DELETE FROM files; DELETE FROM entities; DELETE FROM edges;")?;
+        tx.execute_batch(
+            "DELETE FROM files; DELETE FROM entities; DELETE FROM edges; DELETE FROM file_imports;",
+        )?;
 
         {
             let mut stmt = tx.prepare(
@@ -498,6 +589,7 @@ impl DiskCache {
         }
 
         refresh_manifest_entries(&tx, root)?;
+        refresh_file_import_entries(&tx, root, files, files)?;
 
         {
             let mut stmt = tx.prepare(
@@ -815,10 +907,10 @@ impl DiskCache {
 
         let mut stale_source_files: Vec<String> = Vec::new();
         let mut stale_current_file_count = 0;
-        for file in source_files {
-            match cached_files.get(file) {
+        for file in &source_files {
+            match cached_files.get(file.as_str()) {
                 Some((secs, nanos, content_hash)) => {
-                    let full = root.join(file);
+                    let full = root.join(file.as_str());
                     match file_freshness(&full, *secs, *nanos, content_hash.as_deref()) {
                         Some(FileFreshness::Fresh) => {}
                         Some(FileFreshness::FreshWithUpdatedFingerprint {
@@ -830,13 +922,13 @@ impl DiskCache {
                         }
                         Some(FileFreshness::Stale) | None => {
                             stale_current_file_count += 1;
-                            stale_source_files.push(file.clone());
+                            stale_source_files.push((*file).clone());
                         }
                     }
                 }
                 None => {
                     stale_current_file_count += 1;
-                    stale_source_files.push(file.clone());
+                    stale_source_files.push((*file).clone());
                 }
             }
         }
@@ -865,6 +957,10 @@ impl DiskCache {
             .chain(deleted_cached_files.iter())
             .map(|s| s.as_str())
             .collect();
+        let mut import_stale_files = stale_source_files.clone();
+        import_stale_files.extend(deleted_cached_files.iter().cloned());
+        let cached_importing_stale_files =
+            cached_importing_files_for_stale_files(&self.conn, &import_stale_files, &source_files);
 
         // Load ALL entities, split into clean vs stale-file
         let mut entity_stmt = self
@@ -930,6 +1026,7 @@ impl DiskCache {
             stale_files: stale_source_files,
             cached_entities,
             cached_edges,
+            cached_importing_stale_files,
             stale_file_entities,
         })
     }
@@ -1049,6 +1146,12 @@ impl DiskCache {
         }
 
         refresh_manifest_entries(&tx, root)?;
+        let mut import_files_to_refresh: Vec<String> = source_stale_files
+            .iter()
+            .map(|file| (*file).clone())
+            .collect();
+        import_files_to_refresh.extend(deleted_cached_files.iter().cloned());
+        refresh_file_import_entries(&tx, root, &import_files_to_refresh, all_files)?;
 
         if repair_changed_clean_entity_ids {
             tx.execute("DELETE FROM entities", [])?;
@@ -1286,6 +1389,17 @@ mod tests {
             .unwrap()
     }
 
+    fn file_import_count(cache: &DiskCache, importing_file: &str, imported_file: &str) -> i64 {
+        cache
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM file_imports WHERE importing_file = ?1 AND imported_file = ?2",
+                rusqlite::params![importing_file, imported_file],
+                |row| row.get(0),
+            )
+            .unwrap()
+    }
+
     fn cached_file_mtime(cache: &DiskCache, file: &str) -> (i64, i64) {
         cache
             .conn
@@ -1314,6 +1428,58 @@ mod tests {
         cache.save(root, files, &empty_graph(), &[]).unwrap();
         assert!(cache.load(root, files).is_some());
         cache
+    }
+
+    #[test]
+    fn partial_cache_reports_clean_files_that_import_stale_js_ts_files() {
+        let root = temp_repo_root("incremental-import-metadata");
+        write_file(
+            &root.join("a.ts"),
+            "import { target } from './b';\nexport function useIt() { return target(); }\n",
+        );
+        write_file(
+            &root.join("b.ts"),
+            "export function target() { return 1; }\n",
+        );
+        write_file(
+            &root.join("c.ts"),
+            "export function other() { return 2; }\n",
+        );
+        let files = vec!["a.ts".to_string(), "b.ts".to_string(), "c.ts".to_string()];
+        let cache = DiskCache::open(&root).unwrap();
+        cache.save(&root, &files, &empty_graph(), &[]).unwrap();
+
+        assert_eq!(file_import_count(&cache, "a.ts", "b.ts"), 1);
+
+        rewrite_after_mtime_tick(
+            &root.join("b.ts"),
+            "export function target() { return 3; }\n",
+        );
+        let partial = cache.load_partial(&root, &files).unwrap();
+        assert_eq!(partial.stale_files, vec!["b.ts"]);
+        assert_eq!(partial.cached_importing_stale_files, vec!["a.ts"]);
+
+        rewrite_after_mtime_tick(
+            &root.join("a.ts"),
+            "import { other } from './c';\nexport function useIt() { return other(); }\n",
+        );
+        cache
+            .save_incremental_with_repair_metadata(
+                &root,
+                &files,
+                &["a.ts".to_string()],
+                &empty_graph(),
+                &[],
+                false,
+                &[],
+                &[],
+            )
+            .unwrap();
+        assert_eq!(file_import_count(&cache, "a.ts", "b.ts"), 0);
+        assert_eq!(file_import_count(&cache, "a.ts", "c.ts"), 1);
+
+        drop(cache);
+        cleanup(root);
     }
 
     fn rewrite_after_mtime_tick(path: &Path, content: &str) {

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -362,15 +362,17 @@ impl SemServer {
 
             // Incremental: load clean cached data, rebuild only stale files
             if let Some(partial) = disk.load_partial(repo_root, file_paths) {
-                let (graph, entities, metadata) = EntityGraph::build_incremental_with_metadata(
-                    repo_root,
-                    &partial.stale_files,
-                    file_paths,
-                    partial.cached_entities,
-                    partial.cached_edges,
-                    partial.stale_file_entities,
-                    &self.registry,
-                );
+                let (graph, entities, metadata) =
+                    EntityGraph::build_incremental_with_metadata_and_import_candidates(
+                        repo_root,
+                        &partial.stale_files,
+                        file_paths,
+                        partial.cached_entities,
+                        partial.cached_edges,
+                        partial.stale_file_entities,
+                        Some(&partial.cached_importing_stale_files),
+                        &self.registry,
+                    );
                 let _ = disk.save_incremental_with_repair_metadata(
                     repo_root,
                     file_paths,


### PR DESCRIPTION
## Summary

- Add a direct dependency graph path for `sem impact --deps`.
- Use it for explicit `--no-cache` runs and for large cache misses where building and saving a full graph is the expensive part.
- Keep `--dependents`, `--tests`, and default impact on the existing full graph path.
- Keep medium generated repo cache misses on the existing full-cache path so warm and one-file edit behavior stay fast.

## Stack note

This PR is intentionally pointed at `main`, even though it is stacked on the earlier performance PRs. Until the parent PRs land, GitHub will show their commits and diffs here as well; review should focus on the top commit for the direct `impact --deps` path.

## Benchmarks

Compared against the parent branch head for this stack.

Large generated JS/TS fixture, 25k files, 2 entities per file, 5 body lines, fanout 3:

| Run | Parent | This PR |
| --- | ---: | ---: |
| cold cache | 15967.380 ms | 5695.134 ms |
| warm same target | 313.217 ms | 5337.124 ms |
| one-file edit | 4958.516 ms | 5343.008 ms |

Medium generated JS/TS fixture, 5k files, default entity/body shape, fanout 3:

| Run | Parent | This PR |
| --- | ---: | ---: |
| cold cache | 10582.065 ms | 8351.071 ms |
| warm same target | 326.710 ms | 320.736 ms |
| one-file edit | 1607.391 ms | 1145.238 ms |

Direct no-cache same-fixture checks:

| Fixture | Parent | This PR | Output |
| --- | ---: | ---: | --- |
| 5k default shape | 7006.774 ms | 5563.944 ms | byte-identical JSON |
| 25k reduced shape | 5657.495 ms | 6074.162 ms | byte-identical JSON |

Peak RSS on the 5k direct no-cache run dropped from about 7.9 GB to about 6.7 GB.

## Tradeoff

For large repos, a cold `impact --deps` cache miss returns from the direct dependency path instead of waiting for a full graph cache save. That first run does not populate a full graph cache. If a full cache already exists, `impact --deps` still uses the existing topology cache load path.

## Test plan

- `cargo test --manifest-path crates/Cargo.toml --workspace`
- `cargo build --manifest-path crates/Cargo.toml --release -p sem-cli -p sem-mcp`
- `git diff --check --no-ext-diff`
- Generated fixture benchmark commands above with generic JS/TS fixtures
- Same-fixture JSON equality checks for direct deps output against the full graph path
