### PR TITLE
Save partial topology cache for large impact runs

### DIFF
--- a/crates/sem-cli/src/cache.rs
+++ b/crates/sem-cli/src/cache.rs
@@ -44,7 +44,7 @@ impl DiskCache {
         let tx = self.conn.unchecked_transaction()?;
 
         tx.execute_batch(
-            "DELETE FROM files; DELETE FROM entities; DELETE FROM edges; DELETE FROM file_imports;",
+            "DELETE FROM files; DELETE FROM entities; DELETE FROM edges; DELETE FROM file_imports; DELETE FROM entity_flags;",
         )?;
 
         {
@@ -106,6 +106,82 @@ impl DiskCache {
             }
         }
 
+        shared_cache::set_cache_kind(&tx, shared_cache::CACHE_KIND_FULL)?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn save_topology(
+        &self,
+        root: &Path,
+        files: &[String],
+        graph: &EntityGraph,
+        entities: &[SemanticEntity],
+    ) -> Result<(), rusqlite::Error> {
+        let tx = self.conn.unchecked_transaction()?;
+
+        tx.execute_batch(
+            "DELETE FROM files; DELETE FROM entities; DELETE FROM edges; DELETE FROM file_imports; DELETE FROM entity_flags;",
+        )?;
+
+        {
+            let mut stmt = tx.prepare(
+                "INSERT INTO files (path, mtime_secs, mtime_nanos, content_hash) VALUES (?1, ?2, ?3, ?4)",
+            )?;
+            for file in files {
+                if shared_cache::is_manifest_file_name(file) {
+                    continue;
+                }
+                let full = root.join(file);
+                if let Some((secs, nanos, content_hash)) = shared_cache::file_fingerprint(&full) {
+                    stmt.execute(params![file, secs, nanos, content_hash])?;
+                }
+            }
+        }
+
+        shared_cache::refresh_manifest_entries(&tx, root)?;
+
+        {
+            let mut stmt = tx.prepare(
+                "INSERT OR REPLACE INTO entities (id, name, entity_type, file_path, start_line, end_line, content, content_hash, structural_hash, parent_id, metadata_json) VALUES (?1, ?2, ?3, ?4, ?5, ?6, '', '', NULL, ?7, NULL)",
+            )?;
+            for e in graph.entities.values() {
+                stmt.execute(params![
+                    e.id,
+                    e.name,
+                    e.entity_type,
+                    e.file_path,
+                    e.start_line as i64,
+                    e.end_line as i64,
+                    e.parent_id,
+                ])?;
+            }
+        }
+
+        {
+            let mut stmt = tx.prepare(
+                "INSERT INTO edges (from_entity, to_entity, ref_type) VALUES (?1, ?2, ?3)",
+            )?;
+            for edge in &graph.edges {
+                let rt = match edge.ref_type {
+                    RefType::Calls => "calls",
+                    RefType::TypeRef => "typeref",
+                    RefType::Imports => "imports",
+                };
+                stmt.execute(params![edge.from_entity, edge.to_entity, rt])?;
+            }
+        }
+
+        let test_entity_ids = graph.filter_test_entities(entities);
+        {
+            let mut stmt =
+                tx.prepare("INSERT INTO entity_flags (entity_id, is_test) VALUES (?1, 1)")?;
+            for entity_id in &test_entity_ids {
+                stmt.execute(params![entity_id])?;
+            }
+        }
+
+        shared_cache::set_cache_kind(&tx, shared_cache::CACHE_KIND_TOPOLOGY)?;
         tx.commit()?;
         Ok(())
     }
@@ -191,10 +267,28 @@ impl DiskCache {
 
     /// Load only graph topology from a fresh cache.
     pub fn load_graph_topology(&self, root: &Path, files: &[String]) -> Option<EntityGraph> {
-        if !self.has_fresh_complete_cache(root, files) {
+        if !self.has_fresh_topology_cache(root, files) {
             return None;
         }
 
+        self.load_graph_topology_rows()
+    }
+
+    pub fn load_graph_topology_with_test_ids(
+        &self,
+        root: &Path,
+        files: &[String],
+    ) -> Option<(EntityGraph, HashSet<String>)> {
+        if !self.has_fresh_topology_only_cache(root, files) {
+            return None;
+        }
+
+        let graph = self.load_graph_topology_rows()?;
+        let test_entity_ids = self.load_test_entity_ids()?;
+        Some((graph, test_entity_ids))
+    }
+
+    fn load_graph_topology_rows(&self) -> Option<EntityGraph> {
         let mut entity_stmt = self
             .conn
             .prepare(
@@ -225,13 +319,26 @@ impl DiskCache {
         Some(EntityGraph::from_parts(entity_map, edges))
     }
 
+    fn load_test_entity_ids(&self) -> Option<HashSet<String>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT entity_id FROM entity_flags WHERE is_test != 0")
+            .ok()?;
+        let ids = stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .ok()?
+            .filter_map(|r| r.ok())
+            .collect();
+        Some(ids)
+    }
+
     pub fn write_graph_json_topology<W: Write>(
         &self,
         root: &Path,
         files: &[String],
         mut writer: W,
     ) -> std::io::Result<bool> {
-        if !self.has_fresh_complete_cache(root, files) {
+        if !self.has_fresh_topology_cache(root, files) {
             return Ok(false);
         }
 
@@ -317,6 +424,36 @@ impl DiskCache {
     }
 
     fn has_fresh_complete_cache(&self, root: &Path, files: &[String]) -> bool {
+        if !shared_cache::cache_has_kind(&self.conn, &[shared_cache::CACHE_KIND_FULL]) {
+            return false;
+        }
+
+        self.has_fresh_cache(root, files)
+    }
+
+    fn has_fresh_topology_cache(&self, root: &Path, files: &[String]) -> bool {
+        if !shared_cache::cache_has_kind(
+            &self.conn,
+            &[
+                shared_cache::CACHE_KIND_FULL,
+                shared_cache::CACHE_KIND_TOPOLOGY,
+            ],
+        ) {
+            return false;
+        }
+
+        self.has_fresh_cache(root, files)
+    }
+
+    fn has_fresh_topology_only_cache(&self, root: &Path, files: &[String]) -> bool {
+        if !shared_cache::cache_has_kind(&self.conn, &[shared_cache::CACHE_KIND_TOPOLOGY]) {
+            return false;
+        }
+
+        self.has_fresh_cache(root, files)
+    }
+
+    fn has_fresh_cache(&self, root: &Path, files: &[String]) -> bool {
         if shared_cache::is_manifest_stale(&self.conn, root) {
             return false;
         }
@@ -408,6 +545,10 @@ impl DiskCache {
     /// Load a partial cache: identify stale files and return clean cached data.
     /// Returns None if cache is empty or ALL files are stale (full rebuild is better).
     pub fn load_partial(&self, root: &Path, files: &[String]) -> Option<PartialCache> {
+        if !shared_cache::cache_has_kind(&self.conn, &[shared_cache::CACHE_KIND_FULL]) {
+            return None;
+        }
+
         if shared_cache::is_manifest_stale(&self.conn, root) {
             return None;
         }
@@ -792,6 +933,7 @@ impl DiskCache {
             }
         }
 
+        shared_cache::set_cache_kind(&tx, shared_cache::CACHE_KIND_FULL)?;
         tx.commit()?;
         Ok(())
     }
@@ -1008,6 +1150,63 @@ mod tests {
         assert_eq!(value["entities"][1]["id"], "b-id");
         assert_eq!(value["edges"][0]["fromEntity"], "b-id");
         assert_eq!(value["edges"][0]["toEntity"], "a-id");
+
+        drop(cache);
+        cleanup(root);
+    }
+
+    #[test]
+    fn topology_cache_loads_only_topology_readers() {
+        let root = temp_repo_root("topology-only-cache");
+        write_file(&root.join("a.rs"), "fn a() {}\n");
+        write_file(&root.join("b.rs"), "fn b() { a(); }\n");
+        write_file(&root.join("a_test.rs"), "#[test]\nfn test_a() { a(); }\n");
+        let files = vec![
+            "b.rs".to_string(),
+            "a.rs".to_string(),
+            "a_test.rs".to_string(),
+        ];
+        let entities = vec![
+            entity("b-id", "b.rs", "b", "fn b() { a(); }"),
+            entity("a-id", "a.rs", "a", "fn a() {}"),
+            entity(
+                "test-id",
+                "a_test.rs",
+                "test_a",
+                "#[test]\nfn test_a() { a(); }",
+            ),
+        ];
+        let graph = graph_with_edges(
+            &entities,
+            vec![edge("b-id", "a-id"), edge("test-id", "a-id")],
+        );
+        let cache = DiskCache::open(&root).unwrap();
+        cache
+            .save_topology(&root, &files, &graph, &entities)
+            .unwrap();
+
+        assert!(cache.load(&root, &files).is_none());
+        let topology = cache.load_graph_topology(&root, &files).unwrap();
+        assert_eq!(topology.entities.len(), 3);
+        assert_eq!(topology.edges.len(), 2);
+        let (_, test_entity_ids) = cache
+            .load_graph_topology_with_test_ids(&root, &files)
+            .unwrap();
+        assert!(test_entity_ids.contains("test-id"));
+        assert!(!test_entity_ids.contains("a-id"));
+
+        let mut output = Vec::new();
+        assert!(cache
+            .write_graph_json_topology(&root, &files, &mut output)
+            .unwrap());
+        let value: serde_json::Value = serde_json::from_slice(&output).unwrap();
+        assert_eq!(
+            value["stats"],
+            serde_json::json!({"entityCount": 3, "edgeCount": 2})
+        );
+
+        rewrite_after_mtime_tick(&root.join("a.rs"), "fn a() { let _x = 1; }\n");
+        assert!(cache.load_partial(&root, &files).is_none());
 
         drop(cache);
         cleanup(root);
@@ -1428,6 +1627,28 @@ mod tests {
         drop(cli_cache);
         drop(mcp_cache);
         cleanup(mcp_to_cli);
+
+        let cli_topology_to_mcp = temp_repo_root("cli-topology-to-mcp");
+        let cli_topology_to_mcp_files = sample_files(&cli_topology_to_mcp);
+        let cli_cache = DiskCache::open(&cli_topology_to_mcp).unwrap();
+        cli_cache
+            .save_topology(
+                &cli_topology_to_mcp,
+                &cli_topology_to_mcp_files,
+                &empty_graph(),
+                &[],
+            )
+            .unwrap();
+        let mcp_cache = shared_cache::DiskCache::open(&cli_topology_to_mcp).unwrap();
+        assert!(mcp_cache
+            .load(&cli_topology_to_mcp, &cli_topology_to_mcp_files)
+            .is_none());
+        assert!(mcp_cache
+            .load_graph_topology(&cli_topology_to_mcp, &cli_topology_to_mcp_files)
+            .is_some());
+        drop(mcp_cache);
+        drop(cli_cache);
+        cleanup(cli_topology_to_mcp);
     }
 
     #[test]

--- a/crates/sem-cli/src/commands/graph.rs
+++ b/crates/sem-cli/src/commands/graph.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{collections::HashSet, path::Path};
 
 use colored::Colorize;
 use sem_core::git::bridge::GitBridge;
@@ -188,6 +188,122 @@ pub fn get_or_build_graph_with_timings(
     no_cache: bool,
     timings: &mut Timings,
 ) -> (EntityGraph, Vec<SemanticEntity>) {
+    get_or_build_graph_with_cache_policy(
+        root,
+        file_paths,
+        registry,
+        no_cache,
+        CacheMissSavePolicy::Full,
+        timings,
+    )
+}
+
+pub fn get_or_build_graph_with_topology_save_on_miss_with_timings(
+    root: &Path,
+    file_paths: &[String],
+    registry: &ParserRegistry,
+    no_cache: bool,
+    timings: &mut Timings,
+) -> (EntityGraph, Vec<SemanticEntity>) {
+    get_or_build_graph_with_cache_policy(
+        root,
+        file_paths,
+        registry,
+        no_cache,
+        CacheMissSavePolicy::Topology,
+        timings,
+    )
+}
+
+pub enum GraphWithTestData {
+    Full(EntityGraph, Vec<SemanticEntity>),
+    Topology {
+        graph: EntityGraph,
+        test_entity_ids: HashSet<String>,
+    },
+}
+
+pub fn get_or_build_graph_with_test_data_and_topology_save_on_miss_with_timings(
+    root: &Path,
+    file_paths: &[String],
+    registry: &ParserRegistry,
+    no_cache: bool,
+    timings: &mut Timings,
+) -> GraphWithTestData {
+    if !no_cache {
+        if let Ok(disk) = DiskCache::open(root) {
+            timings.mark("cache_open");
+            if let Some((graph, entities)) = disk.load(root, file_paths) {
+                timings.mark("cache_full_load");
+                return GraphWithTestData::Full(graph, entities);
+            }
+            if let Some((graph, test_entity_ids)) =
+                disk.load_graph_topology_with_test_ids(root, file_paths)
+            {
+                timings.mark("cache_topology_load");
+                return GraphWithTestData::Topology {
+                    graph,
+                    test_entity_ids,
+                };
+            }
+
+            if let Some(partial) = disk.load_partial(root, file_paths) {
+                timings.mark("cache_partial_load");
+                let (graph, entities, metadata) =
+                    EntityGraph::build_incremental_with_metadata_and_import_candidates(
+                        root,
+                        &partial.stale_files,
+                        file_paths,
+                        partial.cached_entities,
+                        partial.cached_edges,
+                        partial.stale_file_entities,
+                        Some(&partial.cached_importing_stale_files),
+                        registry,
+                    );
+                timings.mark("incremental_graph_rebuild");
+                let _ = disk.save_incremental_with_repair_metadata(
+                    root,
+                    file_paths,
+                    &partial.stale_files,
+                    &graph,
+                    &entities,
+                    metadata.repaired_clean_entity_ids,
+                    &metadata.recomputed_edge_source_ids,
+                    &metadata.deleted_entity_ids,
+                );
+                timings.mark("cache_incremental_save");
+                return GraphWithTestData::Full(graph, entities);
+            }
+        }
+    }
+
+    let (graph, entities) = EntityGraph::build(root, file_paths, registry);
+    timings.mark("full_graph_build");
+
+    if !no_cache {
+        if let Ok(disk) = DiskCache::open(root) {
+            let _ = disk.save_topology(root, file_paths, &graph, &entities);
+            timings.mark("cache_topology_save");
+        }
+    }
+
+    GraphWithTestData::Full(graph, entities)
+}
+
+#[derive(Clone, Copy)]
+enum CacheMissSavePolicy {
+    Full,
+    Topology,
+}
+
+fn get_or_build_graph_with_cache_policy(
+    root: &Path,
+    file_paths: &[String],
+    registry: &ParserRegistry,
+    no_cache: bool,
+    save_policy: CacheMissSavePolicy,
+    timings: &mut Timings,
+) -> (EntityGraph, Vec<SemanticEntity>) {
     if !no_cache {
         if let Ok(disk) = DiskCache::open(root) {
             timings.mark("cache_open");
@@ -233,9 +349,19 @@ pub fn get_or_build_graph_with_timings(
     timings.mark("full_graph_build");
 
     if !no_cache {
-        if let Ok(disk) = DiskCache::open(root) {
-            let _ = disk.save(root, file_paths, &graph, &entities);
-            timings.mark("cache_full_save");
+        match save_policy {
+            CacheMissSavePolicy::Full => {
+                if let Ok(disk) = DiskCache::open(root) {
+                    let _ = disk.save(root, file_paths, &graph, &entities);
+                    timings.mark("cache_full_save");
+                }
+            }
+            CacheMissSavePolicy::Topology => {
+                if let Ok(disk) = DiskCache::open(root) {
+                    let _ = disk.save_topology(root, file_paths, &graph, &entities);
+                    timings.mark("cache_topology_save");
+                }
+            }
         }
     }
 
@@ -261,6 +387,29 @@ pub fn get_or_build_graph_topology_with_timings(
 
     let (graph, _entities) =
         get_or_build_graph_with_timings(root, file_paths, registry, no_cache, timings);
+    graph
+}
+
+pub fn get_or_build_graph_topology_with_topology_save_on_miss_with_timings(
+    root: &Path,
+    file_paths: &[String],
+    registry: &ParserRegistry,
+    no_cache: bool,
+    timings: &mut Timings,
+) -> EntityGraph {
+    if !no_cache {
+        if let Ok(disk) = DiskCache::open(root) {
+            timings.mark("cache_open");
+            if let Some(graph) = disk.load_graph_topology(root, file_paths) {
+                timings.mark("cache_topology_load");
+                return graph;
+            }
+        }
+    }
+
+    let (graph, _entities) = get_or_build_graph_with_topology_save_on_miss_with_timings(
+        root, file_paths, registry, no_cache, timings,
+    );
     graph
 }
 

--- a/crates/sem-cli/src/commands/impact.rs
+++ b/crates/sem-cli/src/commands/impact.rs
@@ -1,8 +1,8 @@
-use std::path::Path;
+use std::{collections::HashSet, path::Path};
 
 use colored::Colorize;
 use sem_core::git::bridge::GitBridge;
-use sem_core::parser::graph::EntityGraph;
+use sem_core::parser::graph::{EntityGraph, EntityInfo};
 
 use crate::timings::Timings;
 
@@ -26,7 +26,7 @@ pub enum ImpactMode {
     Tests,
 }
 
-const DIRECT_DEPS_CACHE_MISS_FILE_THRESHOLD: usize = 20_000;
+const LARGE_IMPACT_CACHE_MISS_FILE_THRESHOLD: usize = 20_000;
 
 pub fn impact_command(opts: ImpactOptions) {
     let mut timings = Timings::from_env("impact");
@@ -53,32 +53,60 @@ pub fn impact_command(opts: ImpactOptions) {
 
     match opts.mode {
         ImpactMode::Deps => {
-            let graph = if opts.no_cache || file_paths.len() > DIRECT_DEPS_CACHE_MISS_FILE_THRESHOLD
-            {
-                let entity_name = opts.entity_name.clone();
-                let entity_id = opts.entity_id.clone();
-                let file_hint_for_match = file_hint.clone();
-                super::graph::get_or_build_direct_dependency_graph_with_timings(
+            let graph =
+                if opts.no_cache || file_paths.len() > LARGE_IMPACT_CACHE_MISS_FILE_THRESHOLD {
+                    let entity_name = opts.entity_name.clone();
+                    let entity_id = opts.entity_id.clone();
+                    let file_hint_for_match = file_hint.clone();
+                    super::graph::get_or_build_direct_dependency_graph_with_timings(
+                        root,
+                        &file_paths,
+                        &registry,
+                        opts.no_cache,
+                        &mut timings,
+                        move |entity| {
+                            if let Some(id) = entity_id.as_deref() {
+                                return entity.id == id;
+                            }
+                            let Some(name) = entity_name.as_deref() else {
+                                return false;
+                            };
+                            if file_hint_for_match
+                                .as_deref()
+                                .is_some_and(|file| entity.file_path != file)
+                            {
+                                return false;
+                            }
+                            super::entity_matches_query(entity, name)
+                        },
+                    )
+                } else {
+                    super::graph::get_or_build_graph_topology_with_timings(
+                        root,
+                        &file_paths,
+                        &registry,
+                        opts.no_cache,
+                        &mut timings,
+                    )
+                };
+            let entity = find_entity(
+                &graph,
+                opts.entity_name.as_deref(),
+                opts.entity_id.as_deref(),
+                file_hint.as_deref(),
+            );
+            timings.mark("entity_lookup");
+            print_deps(&graph, entity, opts.json);
+            timings.mark("cli_output_serialization");
+        }
+        ImpactMode::Dependents => {
+            let graph = if file_paths.len() > LARGE_IMPACT_CACHE_MISS_FILE_THRESHOLD {
+                super::graph::get_or_build_graph_topology_with_topology_save_on_miss_with_timings(
                     root,
                     &file_paths,
                     &registry,
                     opts.no_cache,
                     &mut timings,
-                    move |entity| {
-                        if let Some(id) = entity_id.as_deref() {
-                            return entity.id == id;
-                        }
-                        let Some(name) = entity_name.as_deref() else {
-                            return false;
-                        };
-                        if file_hint_for_match
-                            .as_deref()
-                            .is_some_and(|file| entity.file_path != file)
-                        {
-                            return false;
-                        }
-                        super::entity_matches_query(entity, name)
-                    },
                 )
             } else {
                 super::graph::get_or_build_graph_topology_with_timings(
@@ -96,46 +124,86 @@ pub fn impact_command(opts: ImpactOptions) {
                 file_hint.as_deref(),
             );
             timings.mark("entity_lookup");
-            print_deps(&graph, entity, opts.json);
-            timings.mark("cli_output_serialization");
-        }
-        ImpactMode::Dependents => {
-            let graph = super::graph::get_or_build_graph_topology_with_timings(
-                root,
-                &file_paths,
-                &registry,
-                opts.no_cache,
-                &mut timings,
-            );
-            let entity = find_entity(
-                &graph,
-                opts.entity_name.as_deref(),
-                opts.entity_id.as_deref(),
-                file_hint.as_deref(),
-            );
-            timings.mark("entity_lookup");
             print_dependents(&graph, entity, opts.json);
             timings.mark("cli_output_serialization");
         }
         ImpactMode::Tests | ImpactMode::All => {
-            let (graph, all_entities) = super::graph::get_or_build_graph_with_timings(
-                root,
-                &file_paths,
-                &registry,
-                opts.no_cache,
-                &mut timings,
-            );
-            let entity = find_entity(
-                &graph,
-                opts.entity_name.as_deref(),
-                opts.entity_id.as_deref(),
-                file_hint.as_deref(),
-            );
-            timings.mark("entity_lookup");
-            match opts.mode {
-                ImpactMode::Tests => print_tests(&graph, entity, &all_entities, opts.json),
-                ImpactMode::All => print_all(&graph, entity, &all_entities, opts.json, opts.depth),
-                _ => unreachable!(),
+            if file_paths.len() > LARGE_IMPACT_CACHE_MISS_FILE_THRESHOLD {
+                let graph_data =
+                    super::graph::get_or_build_graph_with_test_data_and_topology_save_on_miss_with_timings(
+                    root,
+                    &file_paths,
+                    &registry,
+                    opts.no_cache,
+                    &mut timings,
+                );
+                match graph_data {
+                    super::graph::GraphWithTestData::Full(graph, all_entities) => {
+                        let entity = find_entity(
+                            &graph,
+                            opts.entity_name.as_deref(),
+                            opts.entity_id.as_deref(),
+                            file_hint.as_deref(),
+                        );
+                        timings.mark("entity_lookup");
+                        match opts.mode {
+                            ImpactMode::Tests => {
+                                print_tests(&graph, entity, &all_entities, opts.json)
+                            }
+                            ImpactMode::All => {
+                                print_all(&graph, entity, &all_entities, opts.json, opts.depth)
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+                    super::graph::GraphWithTestData::Topology {
+                        graph,
+                        test_entity_ids,
+                    } => {
+                        let entity = find_entity(
+                            &graph,
+                            opts.entity_name.as_deref(),
+                            opts.entity_id.as_deref(),
+                            file_hint.as_deref(),
+                        );
+                        timings.mark("entity_lookup");
+                        match opts.mode {
+                            ImpactMode::Tests => {
+                                print_tests_with_ids(&graph, entity, &test_entity_ids, opts.json)
+                            }
+                            ImpactMode::All => print_all_with_ids(
+                                &graph,
+                                entity,
+                                &test_entity_ids,
+                                opts.json,
+                                opts.depth,
+                            ),
+                            _ => unreachable!(),
+                        }
+                    }
+                }
+            } else {
+                let (graph, all_entities) = super::graph::get_or_build_graph_with_timings(
+                    root,
+                    &file_paths,
+                    &registry,
+                    opts.no_cache,
+                    &mut timings,
+                );
+                let entity = find_entity(
+                    &graph,
+                    opts.entity_name.as_deref(),
+                    opts.entity_id.as_deref(),
+                    file_hint.as_deref(),
+                );
+                timings.mark("entity_lookup");
+                match opts.mode {
+                    ImpactMode::Tests => print_tests(&graph, entity, &all_entities, opts.json),
+                    ImpactMode::All => {
+                        print_all(&graph, entity, &all_entities, opts.json, opts.depth)
+                    }
+                    _ => unreachable!(),
+                }
             }
             timings.mark("cli_output_serialization");
         }
@@ -303,16 +371,29 @@ fn print_dependents(graph: &EntityGraph, entity: &sem_core::parser::graph::Entit
 
 fn print_tests(
     graph: &EntityGraph,
-    entity: &sem_core::parser::graph::EntityInfo,
+    entity: &EntityInfo,
     all_entities: &[sem_core::model::entity::SemanticEntity],
     json: bool,
 ) {
     let tests = graph.test_impact(&entity.id, all_entities);
+    print_tests_result(entity, &tests, json);
+}
 
+fn print_tests_with_ids(
+    graph: &EntityGraph,
+    entity: &EntityInfo,
+    test_entity_ids: &HashSet<String>,
+    json: bool,
+) {
+    let tests = test_impact_from_ids(graph, &entity.id, test_entity_ids);
+    print_tests_result(entity, &tests, json);
+}
+
+fn print_tests_result(entity: &EntityInfo, tests: &[&EntityInfo], json: bool) {
     if json {
         let output = serde_json::json!({
             "entity": entity_json(entity),
-            "tests": entity_list_json(&tests),
+            "tests": entity_list_json(tests),
         });
         println!("{}", serde_json::to_string(&output).unwrap());
     } else {
@@ -327,7 +408,7 @@ fn print_tests(
             );
             let mut by_file: std::collections::HashMap<&str, Vec<_>> =
                 std::collections::HashMap::new();
-            for t in &tests {
+            for t in tests {
                 by_file.entry(t.file_path.as_str()).or_default().push(t);
             }
             let mut files: Vec<_> = by_file.keys().copied().collect();
@@ -353,15 +434,48 @@ fn print_tests(
 
 fn print_all(
     graph: &EntityGraph,
-    entity: &sem_core::parser::graph::EntityInfo,
+    entity: &EntityInfo,
     all_entities: &[sem_core::model::entity::SemanticEntity],
+    json: bool,
+    depth: usize,
+) {
+    let tests = graph.test_impact(&entity.id, all_entities);
+    print_all_with_tests(graph, entity, &tests, json, depth);
+}
+
+fn print_all_with_ids(
+    graph: &EntityGraph,
+    entity: &EntityInfo,
+    test_entity_ids: &HashSet<String>,
+    json: bool,
+    depth: usize,
+) {
+    let tests = test_impact_from_ids(graph, &entity.id, test_entity_ids);
+    print_all_with_tests(graph, entity, &tests, json, depth);
+}
+
+fn test_impact_from_ids<'a>(
+    graph: &'a EntityGraph,
+    entity_id: &str,
+    test_entity_ids: &HashSet<String>,
+) -> Vec<&'a EntityInfo> {
+    graph
+        .impact_analysis(entity_id)
+        .into_iter()
+        .filter(|info| test_entity_ids.contains(&info.id))
+        .collect()
+}
+
+fn print_all_with_tests(
+    graph: &EntityGraph,
+    entity: &EntityInfo,
+    tests: &[&EntityInfo],
     json: bool,
     depth: usize,
 ) {
     let deps = graph.get_dependencies(&entity.id);
     let dependents = graph.get_dependents(&entity.id);
     let impact_bounded = graph.impact_analysis_bounded(&entity.id, depth);
-    let tests = graph.test_impact(&entity.id, all_entities);
 
     if json {
         let impact_entities: Vec<serde_json::Value> = impact_bounded
@@ -383,7 +497,7 @@ fn print_all(
                 "total": impact_bounded.len(),
                 "entities": impact_entities,
             },
-            "tests": entity_list_json(&tests),
+            "tests": entity_list_json(tests),
         });
         println!("{}", serde_json::to_string(&output).unwrap());
     } else {
@@ -478,7 +592,7 @@ fn print_all(
                 "⚡".yellow(),
                 format!("{} tests affected:", tests.len()).bold()
             );
-            for t in &tests {
+            for t in tests {
                 println!(
                     "    {} {} ({})",
                     t.entity_type.dimmed(),

--- a/crates/sem-mcp/src/cache.rs
+++ b/crates/sem-mcp/src/cache.rs
@@ -10,7 +10,9 @@ use sem_core::parser::graph::{EntityGraph, EntityInfo, EntityRef, RefType};
 use sem_core::parser::js_ts_import_source_files_from_content;
 use sem_core::utils::hash::content_hash_bytes;
 
-pub const CACHE_SCHEMA_VERSION: i32 = 4;
+pub const CACHE_SCHEMA_VERSION: i32 = 5;
+pub const CACHE_KIND_FULL: &str = "full";
+pub const CACHE_KIND_TOPOLOGY: &str = "topology";
 pub const CACHE_INDEXES: &[(&str, &str, &str)] = &[
     ("idx_entities_file_path", "entities", "file_path"),
     ("idx_entities_name", "entities", "name"),
@@ -65,6 +67,14 @@ CREATE TABLE IF NOT EXISTS file_imports (
     imported_file TEXT NOT NULL,
     PRIMARY KEY (importing_file, imported_file)
 );
+CREATE TABLE IF NOT EXISTS cache_metadata (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS entity_flags (
+    entity_id TEXT PRIMARY KEY,
+    is_test INTEGER NOT NULL
+);
 ";
 
 const CACHE_RESET_SQL: &str = "
@@ -72,6 +82,8 @@ DROP TABLE IF EXISTS files;
 DROP TABLE IF EXISTS entities;
 DROP TABLE IF EXISTS edges;
 DROP TABLE IF EXISTS file_imports;
+DROP TABLE IF EXISTS cache_metadata;
+DROP TABLE IF EXISTS entity_flags;
 ";
 
 pub fn initialize_schema(conn: &Connection) -> Result<(), rusqlite::Error> {
@@ -97,6 +109,24 @@ pub fn initialize_schema(conn: &Connection) -> Result<(), rusqlite::Error> {
         CACHE_SCHEMA_SQL, index_sql, CACHE_SCHEMA_VERSION
     );
     conn.execute_batch(&schema_sql)
+}
+
+pub fn set_cache_kind(tx: &Transaction<'_>, kind: &str) -> Result<(), rusqlite::Error> {
+    tx.execute(
+        "INSERT OR REPLACE INTO cache_metadata (key, value) VALUES ('cache_kind', ?1)",
+        params![kind],
+    )?;
+    Ok(())
+}
+
+pub fn cache_has_kind(conn: &Connection, accepted: &[&str]) -> bool {
+    conn.query_row(
+        "SELECT value FROM cache_metadata WHERE key = 'cache_kind'",
+        [],
+        |row| row.get::<_, String>(0),
+    )
+    .ok()
+    .is_some_and(|kind| accepted.contains(&kind.as_str()))
 }
 
 pub fn cache_db_path(repo_root: &Path) -> Option<PathBuf> {
@@ -570,7 +600,7 @@ impl DiskCache {
         let tx = self.conn.unchecked_transaction()?;
 
         tx.execute_batch(
-            "DELETE FROM files; DELETE FROM entities; DELETE FROM edges; DELETE FROM file_imports;",
+            "DELETE FROM files; DELETE FROM entities; DELETE FROM edges; DELETE FROM file_imports; DELETE FROM entity_flags;",
         )?;
 
         {
@@ -630,6 +660,7 @@ impl DiskCache {
             }
         }
 
+        set_cache_kind(&tx, CACHE_KIND_FULL)?;
         tx.commit()?;
         Ok(())
     }
@@ -640,6 +671,10 @@ impl DiskCache {
         root: &Path,
         files: &[String],
     ) -> Option<(EntityGraph, Vec<SemanticEntity>)> {
+        if !cache_has_kind(&self.conn, &[CACHE_KIND_FULL]) {
+            return None;
+        }
+
         if is_manifest_stale(&self.conn, root) {
             return None;
         }
@@ -756,6 +791,10 @@ impl DiskCache {
 
     /// Load only graph topology from a fresh cache.
     pub fn load_graph_topology(&self, root: &Path, files: &[String]) -> Option<EntityGraph> {
+        if !cache_has_kind(&self.conn, &[CACHE_KIND_FULL, CACHE_KIND_TOPOLOGY]) {
+            return None;
+        }
+
         if is_manifest_stale(&self.conn, root) {
             return None;
         }
@@ -871,6 +910,10 @@ impl DiskCache {
     /// Load a partial cache: identify stale files and return clean cached data.
     /// Returns None if cache is empty or ALL files are stale (full rebuild is better).
     pub fn load_partial(&self, root: &Path, files: &[String]) -> Option<PartialCache> {
+        if !cache_has_kind(&self.conn, &[CACHE_KIND_FULL]) {
+            return None;
+        }
+
         if is_manifest_stale(&self.conn, root) {
             return None;
         }
@@ -1268,6 +1311,7 @@ impl DiskCache {
             }
         }
 
+        set_cache_kind(&tx, CACHE_KIND_FULL)?;
         tx.commit()?;
         Ok(())
     }


### PR DESCRIPTION
## Summary

- Save a topology-only SQLite cache after large cold `sem impact` cache misses instead of writing the full entity-content cache.
- Mark cache rows as `full` vs `topology` so full/incremental cache loads never consume partial entity rows.
- Persist test-entity flags alongside topology rows so repeated `impact`, `impact --tests`, `impact --dependents`, and `impact --deps` can reuse the partial cache.

## Stack note

This PR is intentionally pointed at `main`, even though it is stacked on the earlier performance PRs. Until the parent PRs land, GitHub will show their commits and diffs here as well; review should focus on the top commit for partial topology caching of large impact runs.

## Benchmarks

Compared against the parent branch head for this stack.

Generated JS/TS fixture, 100k files, 2 entities per file, 5 body lines, nested depth 1, fanout 3:

| Command | Parent | This PR cold | This PR warm | Output |
| --- | ---: | ---: | ---: | --- |
| `impact --dependents` | 89.68 s | 34.08 s | 1.07 s | cold/warm JSON byte-identical |
| `impact` | 91.30 s | 35.97 s | 1.01 s | cold/warm JSON byte-identical |
| `impact --tests` | n/a | n/a | 1.02 s | uses cached test flags |
| `impact --deps` | n/a | n/a | 0.99 s | uses cached topology |

Cold `impact --dependents` phase details:

| Phase | Parent | This PR |
| --- | ---: | ---: |
| full graph build | 21.536 s | 21.647 s |
| cache save | 67.697 s full cache | 12.036 s topology cache |
| peak RSS | 2.92 GB | 2.92 GB |
| cache DB after run | 596 MB | 352 MB |

Cold default `impact` phase details:

| Phase | Parent | This PR |
| --- | ---: | ---: |
| full graph build | 21.939 s | 22.315 s |
| cache save | 67.483 s full cache | 11.712 s topology cache |
| peak RSS | 2.88 GB | 2.92 GB |
| cache DB after run | 596 MB | 368 MB |

Warm topology-cache phase details:

| Command | topology load | total | peak RSS |
| --- | ---: | ---: | ---: |
| `impact --dependents` | 0.720 s | 1.07 s | 641 MB |
| `impact --deps` | 0.691 s | 0.99 s | 641 MB |
| `impact` | 0.693 s | 1.01 s | 642 MB |
| `impact --tests` | 0.703 s | 1.02 s | 642 MB |

## Tradeoff

The first large cold impact run still performs a full graph build and spends roughly 12 seconds writing the topology cache. That is slower than returning immediately after graph construction, but much cheaper than the previous full cache save and it makes repeated impact runs fast without storing full entity bodies. The topology cache is not a full/incremental cache; if source freshness changes, sem rebuilds and rewrites topology instead of doing an incremental entity-content repair.

## Test plan

- `cargo test --manifest-path crates/Cargo.toml --workspace`
- `cargo build --manifest-path crates/Cargo.toml --release -p sem-cli -p sem-mcp`
- `git diff --check --no-ext-diff`
- 100k generated JS/TS fixture benchmarks above
- Byte-for-byte JSON output comparison for cold vs warm `impact --dependents`
- Byte-for-byte JSON output comparison for cold vs warm default `impact`
