### PR TITLE
Add Elm language support

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1427,6 +1427,7 @@ dependencies = [
  "tree-sitter-cpp",
  "tree-sitter-dart",
  "tree-sitter-elixir",
+ "tree-sitter-elm",
  "tree-sitter-embedded-template",
  "tree-sitter-fortran",
  "tree-sitter-go",
@@ -1947,6 +1948,16 @@ name = "tree-sitter-elixir"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66dd064a762ed95bfc29857fa3cb7403bb1e5cb88112de0f6341b7e47284ba40"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-elm"
+version = "5.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23840259bfc74d3fc7638047002703bac8624f4969fd73226d7ed516a1b91e9c"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/crates/sem-core/Cargo.toml
+++ b/crates/sem-core/Cargo.toml
@@ -29,6 +29,7 @@ grammar-all = [
     "lang-scala", "lang-zig", "lang-nix",
     "lang-svelte", "lang-erb",
     "lang-haskell",
+    "lang-elm",
 ]
 
 # Individual grammar features
@@ -59,6 +60,7 @@ lang-nix = ["dep:tree-sitter-nix"]
 lang-svelte = ["dep:tree-sitter-htmlx-svelte"]
 lang-erb = ["dep:tree-sitter-embedded-template"]
 lang-haskell = ["dep:tree-sitter-haskell"]
+lang-elm = ["dep:tree-sitter-elm"]
 
 [dependencies]
 git2 = { version = "0.20", optional = true }
@@ -98,6 +100,7 @@ rayon = { version = "1.10", optional = true }
 tree-sitter-zig = { version = "1.1.2", optional = true }
 tree-sitter-nix = { version = "0.3", optional = true }
 tree-sitter-haskell = { version = "0.23", optional = true }
+tree-sitter-elm = { version = "5.9", optional = true }
 
 [dev-dependencies]
 tempfile = "3.24.0"

--- a/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
+++ b/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
@@ -1697,6 +1697,27 @@ fn extract_name(node: Node, source: &[u8]) -> Option<String> {
         }
     }
 
+    // Elm value_declaration: name is inside the function_declaration_left child
+    // e.g. "update msg model = ..." -> "update"
+    if node_type == "value_declaration" {
+        if let Some(left) = node.child_by_field_name("functionDeclarationLeft") {
+            let mut cursor = left.walk();
+            for child in left.named_children(&mut cursor) {
+                if child.kind() == "lower_case_identifier" {
+                    return Some(node_text(child, source).to_string());
+                }
+            }
+        }
+    }
+
+    // Elm infix_declaration: name is the operator field
+    // e.g. "infix right 5 (|>) = apR" -> "|>"
+    if node_type == "infix_declaration" {
+        if let Some(op) = node.child_by_field_name("operator") {
+            return Some(node_text(op, source).to_string());
+        }
+    }
+
     // Haskell instance declarations: construct name from class name + type patterns
     // e.g. "instance Eq Bool where" -> "Eq Bool"
     // Must be before the generic 'name' field lookup since instance has a 'name'

--- a/crates/sem-core/src/parser/plugins/code/languages.rs
+++ b/crates/sem-core/src/parser/plugins/code/languages.rs
@@ -329,6 +329,11 @@ fn get_haskell() -> Option<Language> {
     Some(tree_sitter_haskell::LANGUAGE.into())
 }
 
+#[cfg(feature = "lang-elm")]
+fn get_elm() -> Option<Language> {
+    Some(tree_sitter_elm::LANGUAGE.into())
+}
+
 /// Inside JS/TS function bodies, suppress variable declarations so that local
 /// variables are not extracted as nested entities. Inner function/class
 /// declarations are still extracted for diff granularity.
@@ -1042,6 +1047,25 @@ static HASKELL_CONFIG: LanguageConfig = LanguageConfig {
     suppressed_nested_entities: &[],
     scope_boundary_types: &["function"],
     get_language: get_haskell,
+    scope_resolve: None,
+};
+
+#[cfg(feature = "lang-elm")]
+static ELM_CONFIG: LanguageConfig = LanguageConfig {
+    id: "elm",
+    extensions: &[".elm"],
+    entity_node_types: &[
+        "value_declaration",
+        "type_alias_declaration",
+        "type_declaration",
+        "port_annotation",
+        "infix_declaration",
+    ],
+    container_node_types: &[],
+    call_entity_identifiers: &[],
+    suppressed_nested_entities: &[],
+    scope_boundary_types: &["value_declaration"],
+    get_language: get_elm,
     scope_resolve: None,
 };
 
@@ -2327,6 +2351,8 @@ macro_rules! all_configs {
             &NIX_CONFIG,
             #[cfg(feature = "lang-haskell")]
             &HASKELL_CONFIG,
+            #[cfg(feature = "lang-elm")]
+            &ELM_CONFIG,
         ]
     }};
 }

--- a/crates/sem-core/src/parser/registry.rs
+++ b/crates/sem-core/src/parser/registry.rs
@@ -440,6 +440,7 @@ const LANG_MAPPING: &[(&str, &str)] = &[
     ("ocaml", ".ml"),
     ("scala", ".scala"),
     ("haskell", ".hs"),
+    ("elm", ".elm"),
     ("zig", ".zig"),
     ("xml", ".xml"),
     ("json", ".json"),

--- a/crates/sem-core/tests/elm_smoke.rs
+++ b/crates/sem-core/tests/elm_smoke.rs
@@ -1,0 +1,72 @@
+#[cfg(feature = "lang-elm")]
+mod elm {
+    use sem_core::parser::plugins::create_default_registry;
+
+    #[test]
+    fn elm_extracts_all_entity_types() {
+        let registry = create_default_registry();
+        let elm_code = r#"module Main exposing (..)
+
+import Html exposing (text)
+
+type alias Model =
+    { count : Int
+    , name : String
+    }
+
+type Msg
+    = Increment
+    | Decrement
+
+port sendMessage : String -> Cmd msg
+
+update : Msg -> Model -> Model
+update msg model =
+    case msg of
+        Increment ->
+            { model | count = model.count + 1 }
+        Decrement ->
+            { model | count = model.count - 1 }
+
+view model =
+    text (String.fromInt model.count)
+
+infix right 5 (|>) = apR
+"#;
+
+        let entities = registry.extract_entities("Main.elm", elm_code);
+        assert!(!entities.is_empty(), "Should extract entities from Elm code");
+
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"Model"), "Should find type alias Model, got: {:?}", names);
+        assert!(names.contains(&"Msg"), "Should find type Msg, got: {:?}", names);
+        assert!(names.contains(&"update"), "Should find value update, got: {:?}", names);
+        assert!(names.contains(&"view"), "Should find value view, got: {:?}", names);
+        assert!(names.contains(&"sendMessage"), "Should find port sendMessage, got: {:?}", names);
+        assert!(names.contains(&"|>"), "Should find infix |>, got: {:?}", names);
+
+        // Verify file paths are correct
+        for entity in &entities {
+            assert_eq!(entity.file_path, "Main.elm");
+        }
+    }
+
+    #[test]
+    fn elm_local_let_bindings_not_extracted() {
+        let registry = create_default_registry();
+        let elm_code = r#"module Main exposing (..)
+
+greet name =
+    let
+        greeting = "Hello, "
+    in
+    greeting ++ name
+"#;
+
+        let entities = registry.extract_entities("Main.elm", elm_code);
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"greet"), "Should find top-level greet, got: {:?}", names);
+        // "greeting" is a local let binding — should NOT be a top-level entity
+        assert!(!names.contains(&"greeting"), "Should not extract local let binding, got: {:?}", names);
+    }
+}


### PR DESCRIPTION
## Summary
- Add tree-sitter-elm (v5.9) grammar with `lang-elm` feature flag
- Extract value declarations, type aliases, type declarations, port annotations, and infix declarations from `.elm` files
- Add Elm-specific name extraction for `value_declaration` and `infix_declaration` AST nodes

Closes #334

## Test plan
- [x] `cargo check -p sem-core` passes
- [x] `cargo test -p sem-core` — all 365 tests pass (363 existing + 2 new Elm tests)
- [x] Smoke test verifies all 5 entity types extracted correctly
- [x] Local let bindings are not extracted as top-level entities