### PR TITLE
feat: add Clojure/EDN language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <img src="https://img.shields.io/badge/rust-stable-orange" alt="Rust">
   <img src="https://img.shields.io/badge/tests-133_passing-brightgreen" alt="Tests">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-yellow" alt="License"></a>
-  <img src="https://img.shields.io/badge/languages-28-blue" alt="Languages">
+  <img src="https://img.shields.io/badge/languages-29-blue" alt="Languages">
 </p>
 
 sem is a semantic version control tool that works on top of Git. It parses your code with tree-sitter, extracts every function, class, and method as an entity, and diffs at the entity level instead of lines. This means you see "function `blahh` was modified" instead of "lines x-y changed."
@@ -244,7 +244,7 @@ sem unsetup
 
 ## What it parses
 
-28 programming languages with full entity extraction via tree-sitter:
+29 programming languages with full entity extraction via tree-sitter:
 
 | Language | Extensions | Entities |
 |----------|-----------|----------|
@@ -275,6 +275,7 @@ sem unsetup
 | Scala | `.scala` `.sc` `.sbt` | classes, objects, traits, enums, functions, vals, extensions |
 | Nix | `.nix` | bindings, inherit declarations |
 | Haskell | `.hs` | functions, signatures, data types, newtypes, classes, instances, type synonyms |
+| Clojure | `.clj` `.cljs` `.cljc` | vars, functions, macros, multimethods, protocols, records, types |
 | Zig | `.zig` | functions, tests, variables |
 
 Plus structured data formats:
@@ -284,6 +285,7 @@ Plus structured data formats:
 | JSON | `.json` | properties, objects (RFC 6901 paths) |
 | YAML | `.yml` `.yaml` | sections, properties (dot paths) |
 | TOML | `.toml` | sections, properties |
+| EDN | `.edn` | top-level map entries (keyword keys) |
 | CSV | `.csv` `.tsv` | rows (first column as identity) |
 | Markdown | `.md` `.mdx` | heading-based sections |
 

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1389,7 +1389,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sem-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "clap",
  "clap_complete_command",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "sem-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "git2",
  "rayon",
@@ -1424,6 +1424,7 @@ dependencies = [
  "tree-sitter-bash",
  "tree-sitter-c",
  "tree-sitter-c-sharp",
+ "tree-sitter-clojure-orchard",
  "tree-sitter-cpp",
  "tree-sitter-dart",
  "tree-sitter-elixir",
@@ -1454,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "sem-mcp"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "git2",
  "ignore",
@@ -1475,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "sem-plugin"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "sem-core",
  "serde",
@@ -1918,6 +1919,16 @@ name = "tree-sitter-c-sharp"
 version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1aac67f1ad71de1d6d39708d34811081c26dfa495658de6c14c34200849357c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-clojure-orchard"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e2db28a1ab22649790656936325bdc69e992c38006258694ea39a7620e784d"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/crates/sem-core/Cargo.toml
+++ b/crates/sem-core/Cargo.toml
@@ -30,6 +30,8 @@ grammar-all = [
     "lang-svelte", "lang-erb",
     "lang-haskell",
     "lang-elm",
+    "lang-clojure",
+    "lang-edn",
 ]
 
 # Individual grammar features
@@ -61,6 +63,8 @@ lang-svelte = ["dep:tree-sitter-htmlx-svelte"]
 lang-erb = ["dep:tree-sitter-embedded-template"]
 lang-haskell = ["dep:tree-sitter-haskell"]
 lang-elm = ["dep:tree-sitter-elm"]
+lang-clojure = ["dep:tree-sitter-clojure-orchard"]
+lang-edn = ["dep:tree-sitter-clojure-orchard"]
 
 [dependencies]
 git2 = { version = "0.20", optional = true }
@@ -101,6 +105,7 @@ tree-sitter-zig = { version = "1.1.2", optional = true }
 tree-sitter-nix = { version = "0.3", optional = true }
 tree-sitter-haskell = { version = "0.23", optional = true }
 tree-sitter-elm = { version = "5.9", optional = true }
+tree-sitter-clojure-orchard = { version = "0.2.5", optional = true }
 
 [dev-dependencies]
 tempfile = "3.24.0"

--- a/crates/sem-core/src/parser/differ.rs
+++ b/crates/sem-core/src/parser/differ.rs
@@ -1320,4 +1320,53 @@ mod tests {
         assert_eq!(changes[2].change_type, ChangeType::Added);
         assert_eq!(changes[2].after_content.as_deref(), Some("use new2;"));
     }
+
+    /// Regression: a commented-out key inside an EDN map must not displace the
+    /// key/value pairing for the entries that follow the comment.
+    ///
+    /// In tree-sitter-clojure-orchard, `comment` nodes are *named* children of
+    /// `map_lit`. The old code called `named_children()` without filtering, so a
+    /// `;` comment consumed one slot and shifted every subsequent key/value pair
+    /// by one position. Uncommenting `:published` then produced a spurious rename
+    /// (`:spinning-genai → :slug`) for a completely unchanged entry.
+    #[test]
+    #[cfg(feature = "lang-edn")]
+    fn edn_comment_inside_map_does_not_displace_key_value_pairing() {
+        let before = r#"{:body [:div]
+ ; :published #inst "2025-12-14T14:05:00Z"
+ :slug :my-post
+ :title "Hello"}"#;
+
+        let after = r#"{:body [:div]
+ :published #inst "2025-12-14T14:05:00Z"
+ :slug :my-post
+ :title "Hello"}"#;
+
+        let registry = create_default_registry();
+        let result = compute_semantic_diff(
+            &[modified_file("post.edn", before, after)],
+            &registry,
+            None,
+            None,
+        );
+
+        let non_orphan: Vec<_> = result
+            .changes
+            .iter()
+            .filter(|c| c.entity_type != "orphan")
+            .collect();
+
+        // Only :published should be added; :slug and :title are unchanged
+        assert_eq!(
+            non_orphan.len(),
+            1,
+            "expected only :published to be added, got: {:?}",
+            non_orphan
+                .iter()
+                .map(|c| (&c.entity_name, &c.change_type))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(non_orphan[0].entity_name, ":published");
+        assert_eq!(non_orphan[0].change_type, ChangeType::Added);
+    }
 }

--- a/crates/sem-core/src/parser/graph.rs
+++ b/crates/sem-core/src/parser/graph.rs
@@ -402,8 +402,13 @@ impl IndexedWordRef {
 }
 
 impl FileReferenceIndex {
-    fn from_content(content: &str) -> Self {
+    #[cfg(test)]
+    fn from_content(content: &str, extra_ident_chars: &'static [char]) -> Self {
         let stripped = strip_comments_and_strings(content);
+        Self::from_stripped(&stripped, extra_ident_chars)
+    }
+
+    fn from_stripped(stripped: &str, extra_ident_chars: &'static [char]) -> Self {
         let mut index = Self {
             tokens: Vec::new(),
             token_ids: HashMap::new(),
@@ -411,7 +416,7 @@ impl FileReferenceIndex {
         };
         let lines = stripped
             .lines()
-            .map(|line| LineReferenceIndex::from_stripped_line(line, &mut index))
+            .map(|line| LineReferenceIndex::from_stripped_line(line, &mut index, extra_ident_chars))
             .collect();
         index.lines = lines;
         index
@@ -500,7 +505,11 @@ impl FileReferenceIndex {
 }
 
 impl LineReferenceIndex {
-    fn from_stripped_line(line: &str, file_index: &mut FileReferenceIndex) -> Option<Self> {
+    fn from_stripped_line(
+        line: &str,
+        file_index: &mut FileReferenceIndex,
+        extra_ident_chars: &'static [char],
+    ) -> Option<Self> {
         let mut words = Vec::new();
         let mut seen_words: HashSet<u32> = HashSet::new();
         let import_like = {
@@ -511,7 +520,7 @@ impl LineReferenceIndex {
                 || trimmed.starts_with("require(")
         };
 
-        for (word, end_byte) in identifier_tokens(line) {
+        for (word, end_byte) in identifier_tokens(line, extra_ident_chars) {
             if !is_reference_word(word) {
                 continue;
             }
@@ -546,13 +555,16 @@ impl LineReferenceIndex {
     }
 }
 
-fn identifier_tokens(line: &str) -> impl Iterator<Item = (&str, usize)> {
+fn identifier_tokens<'a>(
+    line: &'a str,
+    extra_ident_chars: &'static [char],
+) -> impl Iterator<Item = (&'a str, usize)> {
     let mut start = None;
     let mut chars = line.char_indices();
 
     std::iter::from_fn(move || {
         for (idx, ch) in chars.by_ref() {
-            if ch.is_alphanumeric() || ch == '_' {
+            if ch.is_alphanumeric() || ch == '_' || extra_ident_chars.contains(&ch) {
                 if start.is_none() {
                     start = Some(idx);
                 }
@@ -577,7 +589,23 @@ fn is_reference_word(word: &str) -> bool {
     if word.starts_with(|c: char| c.is_lowercase()) && word.len() < 3 {
         return false;
     }
-    if !word.starts_with(|c: char| c.is_alphabetic() || c == '_') {
+    // Reject purely symbolic tokens (e.g. `*` used as arithmetic in Clojure).
+    // A valid name always contains at least one alphanumeric char or `-`/`_`.
+    // Note: extra_ident_chars like `*`, `?`, `!`, `=` are intentionally NOT added
+    // to this allowlist because bare `?` or `*` alone are never namespace references.
+    // Mixed tokens such as `my-fn?` still pass: their alphanumeric chars make
+    // `all()` return false, so we do not reject them.
+    if word
+        .chars()
+        .all(|c| !c.is_alphanumeric() && c != '_' && c != '-')
+    {
+        return false;
+    }
+    // Tokens starting with '-' or '*' only appear here for Clojure files because
+    // `extra_ident_chars_for_file` controls tokenization upstream — only Clojure
+    // has these in extra_ident_chars. '?', '!', '=' only appear as suffixes in
+    // Clojure (empty?, reset!, not=) so the start-character check below suffices.
+    if !word.starts_with(|c: char| c.is_alphabetic() || c == '_' || c == '-' || c == '*') {
         return false;
     }
     if is_common_local_name(word) {
@@ -730,9 +758,13 @@ fn resolve_references_with_file_indexes<'a>(
 
 fn build_file_reference_index(root: &Path, file_path: &str) -> Option<FileReferenceIndex> {
     let ext = file_path.rfind('.').map(|i| &file_path[i..]).unwrap_or("");
-    crate::parser::plugins::code::languages::get_language_config(ext)?;
+    let config = crate::parser::plugins::code::languages::get_language_config(ext)?;
     let content = std::fs::read_to_string(root.join(file_path)).ok()?;
-    Some(FileReferenceIndex::from_content(&content))
+    let stripped = strip_for_language(config.strip_strategy, &content);
+    Some(FileReferenceIndex::from_stripped(
+        &stripped,
+        extra_ident_chars_for_file(file_path),
+    ))
 }
 
 fn resolve_scopes_in_file_chunks(
@@ -814,7 +846,10 @@ fn resolve_entity_references(
             reference_index
         };
     let fallback_stripped = if reference_index.is_none() {
-        Some(strip_comments_and_strings(&entity.content))
+        Some(strip_for_language(
+            language_config.strip_strategy,
+            &entity.content,
+        ))
     } else {
         None
     };
@@ -909,6 +944,7 @@ fn resolve_entity_references(
                 &entity.content,
                 &entity.name,
                 stripped,
+                extra_ident_chars_for_file(&entity.file_path),
                 |local_line, local_start_byte, local_end_byte| {
                     entity_owns_content_span(
                         entity.id.as_str(),
@@ -975,6 +1011,38 @@ fn resolve_entity_references(
                     continue;
                 }
                 entity_edges.push((entity.id.clone(), target_id.clone(), ref_type));
+            }
+        }
+    }
+
+    // Resolve namespace-qualified calls (alias/name) for languages that use this pattern.
+    // The regular tokenizer splits `alias/name` at the slash, so bare `name` tokens don't
+    // match cross-file entities via the symbol table. We scan the stripped content for
+    // `alias/name` patterns and resolve them via the import table (populated by
+    // resolve_clojure_as during import table building).
+    if language_config.has_slash_qualified_refs {
+        // Always restrip via the language's own strategy: fallback_stripped may have been
+        // computed with a different strategy when reference_index was non-None above.
+        let qualified_ref_stripped =
+            strip_for_language(language_config.strip_strategy, &entity.content);
+        for cap in CLOJURE_QUALIFIED_REF_RE.captures_iter(&qualified_ref_stripped) {
+            let qualified = cap.get(1).unwrap().as_str();
+            let import_key = (entity.file_path.clone(), qualified.to_string());
+            if let Some(import_target_id) = context.import_table.get(&import_key) {
+                if import_target_id != &entity.id
+                    && !context
+                        .parent_child_pairs
+                        .contains(&(entity.id.as_str(), import_target_id.as_str()))
+                    && !context
+                        .parent_child_pairs
+                        .contains(&(import_target_id.as_str(), entity.id.as_str()))
+                {
+                    entity_edges.push((
+                        entity.id.clone(),
+                        import_target_id.clone(),
+                        RefType::Calls,
+                    ));
+                }
             }
         }
     }
@@ -1867,12 +1935,13 @@ impl EntityGraph {
                     continue;
                 }
 
-                if !text_mentions_any_name(&entity.content, &affected_target_names) {
+                let extra = extra_ident_chars_for_file(&entity.file_path);
+                if !text_mentions_any_name(&entity.content, &affected_target_names, extra) {
                     continue;
                 }
 
-                let stripped = strip_comments_and_strings(&entity.content);
-                if text_mentions_any_name(&stripped, &affected_target_names) {
+                let stripped = strip_for_language(strip_strategy_for_file(&entity.file_path), &entity.content);
+                if text_mentions_any_name(&stripped, &affected_target_names, extra) {
                     affected_clean_ids.insert(entity.id.clone());
                     affected_clean_file_paths.insert(entity.file_path.as_str());
                 }
@@ -1923,15 +1992,16 @@ impl EntityGraph {
                 .iter()
                 .filter(|entity| !stale_set.contains(entity.file_path.as_str()))
             {
+                let extra = extra_ident_chars_for_file(&entity.file_path);
                 if !new_stale_names
                     .iter()
-                    .any(|name| content_contains_identifier(&entity.content, name))
+                    .any(|name| content_contains_identifier(&entity.content, name, extra))
                 {
                     continue;
                 }
 
-                let stripped = strip_comments_and_strings(&entity.content);
-                if text_mentions_any_name(&stripped, &new_stale_names) {
+                let stripped = strip_for_language(strip_strategy_for_file(&entity.file_path), &entity.content);
+                if text_mentions_any_name(&stripped, &new_stale_names, extra) {
                     clean_entities_mentioning_new_stale_names.insert(entity.id.as_str());
                     clean_import_candidate_files.insert(entity.file_path.as_str());
                 }
@@ -1982,19 +2052,26 @@ impl EntityGraph {
 
                 let import_tokens = clean_file_import_tokens.get(entity.file_path.as_str());
                 let mentions_new_stale_name = entity_mentions_new_stale_name;
+                let extra = extra_ident_chars_for_file(&entity.file_path);
+                let strip_strategy = strip_strategy_for_file(&entity.file_path);
                 let mentions_new_stale_import_token = import_tokens.map_or(false, |tokens| {
                     tokens
                         .iter()
-                        .any(|token| content_contains_identifier(&entity.content, token))
+                        .any(|token| content_contains_identifier(&entity.content, token, extra))
                 });
                 let imported_new_stale_ref = new_stale_import_refs_by_file
                     .get(entity.file_path.as_str())
                     .map_or(false, |local_names| {
                         local_names.iter().any(|local_name| {
-                            content_contains_identifier(&entity.content, local_name)
+                            content_contains_identifier(&entity.content, local_name, extra)
                         })
                     });
-                let refs = extract_references_from_content(&entity.content, &entity.name);
+                let refs = extract_references_from_content(
+                    &entity.content,
+                    &entity.name,
+                    extra,
+                    strip_strategy,
+                );
                 if mentions_new_stale_name
                     || mentions_new_stale_import_token
                     || imported_new_stale_ref
@@ -2058,9 +2135,10 @@ impl EntityGraph {
                 let Some(tokens) = clean_js_ts_import_tokens.get(entity.file_path.as_str()) else {
                     continue;
                 };
+                let extra = extra_ident_chars_for_file(&entity.file_path);
                 if tokens
                     .iter()
-                    .any(|token| content_contains_identifier(&entity.content, token))
+                    .any(|token| content_contains_identifier(&entity.content, token, extra))
                 {
                     affected_clean_ids.insert(entity.id.clone());
                     affected_clean_file_paths.insert(entity.file_path.as_str());
@@ -2773,6 +2851,7 @@ impl EntityGraph {
             &entity.content,
             &entity.name,
             &stripped,
+            extra_ident_chars_for_file(&entity.file_path),
             |local_line, local_start_byte, local_end_byte| {
                 entity_owns_content_span(
                     entity.id.as_str(),
@@ -3289,6 +3368,8 @@ fn build_import_table_with_default_export_paths(
     // Go imports are handled entirely by the scope resolver (which uses an indexed approach).
     // We no longer need a go_pkg_index here since Go files are skipped below.
 
+    let clojure_ns_index = build_clojure_ns_index(entity_map);
+
     // Process files in parallel, each producing local import entries
     let per_file_imports: Vec<Vec<((String, String), String)>> = maybe_par_iter!(file_paths)
         .filter_map(|file_path| {
@@ -3621,6 +3702,52 @@ fn build_import_table_with_default_export_paths(
             // Go imports are handled by the scope resolver (avoids O(n²) import table explosion).
             // Skip Go files here entirely.
 
+            // Parse (:require [...]) forms for languages that use slash-qualified refs.
+            // Namespace `foo.bar-baz` maps to file `foo/bar_baz.clj` (dots→slashes, hyphens→underscores).
+            let file_ext = file_path.rfind('.').map(|i| &file_path[i..]).unwrap_or("");
+            if let Some(file_config) =
+                crate::parser::plugins::code::languages::get_language_config(file_ext)
+            {
+                if file_config.has_slash_qualified_refs {
+                    // Strip using the language's own strategy so language-specific syntax (e.g.
+                    // Clojure's `#` for reader macros/gensyms) is preserved correctly.
+                    let clojure_stripped = strip_for_language(file_config.strip_strategy, content);
+                    for cap in CLOJURE_REFER_RE.captures_iter(&clojure_stripped) {
+                        let ns_name = cap.get(1).unwrap().as_str();
+                        let symbols_str = cap.get(2).unwrap().as_str();
+                        for symbol in symbols_str.split_whitespace() {
+                            let symbol = symbol.trim_matches(|c: char| c == ',' || c == '(' || c == ')');
+                            if symbol.is_empty() {
+                                continue;
+                            }
+                            resolve_clojure_require(
+                                file_path,
+                                ns_name,
+                                symbol,
+                                symbol_table,
+                                entity_map,
+                                &mut local_imports,
+                            );
+                        }
+                    }
+                    // `:as alias` forms: add qualified `alias/name` entries for all entities in the
+                    // namespace. The tokenizer splits `alias/name` at the slash, so reference
+                    // resolution looks up the full qualified token via a separate scan (see
+                    // resolve_entity_references). We store "alias/name" as the import key.
+                    for cap in CLOJURE_AS_RE.captures_iter(&clojure_stripped) {
+                        let ns_name = cap.get(1).unwrap().as_str();
+                        let alias = cap.get(2).unwrap().as_str();
+                        resolve_clojure_as(
+                            file_path,
+                            ns_name,
+                            alias,
+                            &clojure_ns_index,
+                            &mut local_imports,
+                        );
+                    }
+                }
+            }
+
             Some(local_imports)
         })
         .collect();
@@ -3661,6 +3788,112 @@ fn resolve_rust_import(
             );
         }
     }
+}
+
+/// Pre-built index for Clojure namespace resolution.
+/// Maps file-path-without-extension → Vec<(entity_name, entity_id)>.
+/// Built once before the import-table loop to avoid O(total-entities) scans per :as alias.
+type ClojureNsIndex = HashMap<String, Vec<(String, String)>>;
+
+fn build_clojure_ns_index(entity_map: &HashMap<String, EntityInfo>) -> ClojureNsIndex {
+    let mut index: ClojureNsIndex = HashMap::new();
+    for (entity_id, entity_info) in entity_map {
+        let fp = &entity_info.file_path;
+        if !fp.ends_with(".clj") && !fp.ends_with(".cljs") && !fp.ends_with(".cljc") {
+            continue;
+        }
+        let path_no_ext = fp.rsplit_once('.').map(|(p, _)| p).unwrap_or(fp.as_str());
+        index
+            .entry(path_no_ext.to_string())
+            .or_default()
+            .push((entity_info.name.clone(), entity_id.clone()));
+    }
+    index
+}
+
+/// Resolve one symbol from a Clojure (:require [ns :refer [symbol]]) form.
+/// Converts namespace dots to slashes and hyphens to underscores to derive the file path,
+/// then matches against entity_map to find the target entity.
+fn resolve_clojure_require(
+    file_path: &str,
+    ns_name: &str,
+    symbol: &str,
+    symbol_table: &HashMap<String, Vec<String>>,
+    entity_map: &HashMap<String, EntityInfo>,
+    local_imports: &mut Vec<((String, String), String)>,
+) {
+    if ns_name.is_empty() {
+        return;
+    }
+    let Some(target_ids) = symbol_table.get(symbol) else {
+        return;
+    };
+    // www.util → www/util; my-app.core → my_app/core
+    let ns_path = ns_name.replace('.', "/").replace('-', "_");
+    // Pre-build the three suffixes once to avoid allocating inside the find loop.
+    let suffix_clj = format!("{ns_path}.clj");
+    let suffix_cljs = format!("{ns_path}.cljs");
+    let suffix_cljc = format!("{ns_path}.cljc");
+    // Match at a path-component boundary: exact or preceded by '/'.
+    // This prevents "notmyapp/core.clj" from matching namespace "myapp.core".
+    let ns_matches = |fp: &str, suffix: &str| fp == suffix || fp.ends_with(&format!("/{suffix}"));
+    let target = target_ids.iter().find(|id| {
+        entity_map.get(*id).map_or(false, |e| {
+            let fp = &e.file_path;
+            ns_matches(fp, &suffix_clj)
+                || ns_matches(fp, &suffix_cljs)
+                || ns_matches(fp, &suffix_cljc)
+        })
+    });
+    if let Some(target_id) = target {
+        local_imports.push((
+            (file_path.to_string(), symbol.to_string()),
+            target_id.clone(),
+        ));
+    }
+}
+
+/// Resolve all entities from a Clojure namespace aliased with `:as alias`.
+/// Adds `(importing_file, "alias/entity_name")` → entity_id entries so that
+/// namespace-qualified calls like `(alias/fn-name ...)` are resolved via the
+/// import table when `resolve_entity_references` scans for `alias/name` patterns.
+fn resolve_clojure_as(
+    file_path: &str,
+    ns_name: &str,
+    alias: &str,
+    ns_index: &ClojureNsIndex,
+    local_imports: &mut Vec<((String, String), String)>,
+) {
+    let ns_path = ns_name.replace('.', "/").replace('-', "_");
+    let ns_path_suffix = format!("/{}", ns_path);
+    for (path_no_ext, entities) in ns_index {
+        if path_no_ext == &ns_path || path_no_ext.ends_with(&ns_path_suffix) {
+            for (entity_name, entity_id) in entities {
+                local_imports.push((
+                    (file_path.to_string(), format!("{}/{}", alias, entity_name)),
+                    entity_id.clone(),
+                ));
+            }
+        }
+    }
+}
+
+/// Strip Clojure semicolon line comments from already-string-blanked content.
+/// `strip_comments_and_strings` blanks string literals but does not remove `;` line comments,
+/// so any remaining `;` after that call is a real comment start.
+fn strip_clojure_line_comments(s: &str) -> String {
+    // `.lines()` in Rust drops the final empty element produced by a trailing '\n',
+    // so `join("\n")` loses exactly one trailing newline — the push restores it.
+    // No double-newline: "a\nb\n" → lines=["a","b"] → join="a\nb" → push → "a\nb\n".
+    let mut result = s
+        .lines()
+        .map(|line| line.find(';').map_or(line, |pos| &line[..pos]))
+        .collect::<Vec<_>>()
+        .join("\n");
+    if s.ends_with('\n') {
+        result.push('\n');
+    }
+    result
 }
 
 /// Strip common file extensions from a filename.
@@ -3808,6 +4041,61 @@ fn strip_comments_and_strings(content: &str) -> String {
     String::from_utf8(result).expect("stripped source preserves UTF-8 boundaries")
 }
 
+/// Strip double-quoted string literals from Clojure content, preserving everything else.
+///
+/// Unlike `strip_comments_and_strings`, this does NOT treat `#` as a line comment.
+/// In Clojure, `#` is used for gensyms (`result#`), reader dispatch (`#?`, `#{}`), and
+/// other reader macros — not for comments. Treating it as a comment would blank out
+/// everything after e.g. `result#` on a line, including calls like
+/// `(rewrite/add-expected-value! ...)` that follow in the same binding form.
+///
+/// Semicolon line comments must be handled separately via `strip_clojure_line_comments`.
+fn strip_clojure_content(content: &str) -> String {
+    let bytes = content.as_bytes();
+    let len = bytes.len();
+    let mut result = vec![b' '; len];
+    let mut i = 0;
+
+    while i < len {
+        // Double-quoted strings: blank them (preserving newlines for line alignment)
+        if bytes[i] == b'"' {
+            let span_start = i;
+            i += 1;
+            while i < len {
+                if bytes[i] == b'\\' {
+                    i = (i + 2).min(len);
+                    continue;
+                }
+                if bytes[i] == b'"' {
+                    i += 1;
+                    break;
+                }
+                i += 1;
+            }
+            blank_span_preserving_newlines(&mut result, bytes, span_start, i);
+            continue;
+        }
+        // Regular code: copy through
+        result[i] = bytes[i];
+        i += 1;
+    }
+
+    String::from_utf8(result).expect("stripped source preserves UTF-8 boundaries")
+}
+
+/// Dispatch to the appropriate content stripper for the given language strategy.
+/// Add a new arm here when adding a `StripStrategy` variant for a new language.
+fn strip_for_language(
+    strategy: crate::parser::plugins::code::languages::StripStrategy,
+    content: &str,
+) -> String {
+    use crate::parser::plugins::code::languages::StripStrategy;
+    match strategy {
+        StripStrategy::Generic => strip_comments_and_strings(content),
+        StripStrategy::Clojure => strip_clojure_line_comments(&strip_clojure_content(content)),
+    }
+}
+
 /// Extract dot-chains (receiver.member) from content for precise resolution.
 /// Returns unique (receiver, member) pairs found in the content.
 fn extract_dot_chains<'a>(content: &'a str) -> Vec<(&'a str, &'a str)> {
@@ -3893,6 +4181,24 @@ static PY_LOCAL_ASSIGN_RE: LazyLock<Regex> =
 static PY_FOR_BINDING_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^\s*for\s+([A-Za-z_]\w*)\s+in\b").unwrap());
 
+// Clojure `:require [ns :refer [sym1 sym2]]` — matches inside any require form.
+// `[^\[\]]*` prevents crossing both `[` and `]` boundaries, so the regex cannot
+// span from one require form's namespace into a later form's :refer list.
+static CLOJURE_REFER_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\[([a-zA-Z][a-zA-Z0-9._-]*)\b[^\[\]]*:refer\s+\[([^\]]+)\]").unwrap());
+
+// Clojure `:require [ns :as alias]` — matches inside any require form.
+// `[^\]]*` prevents crossing bracket boundaries.
+static CLOJURE_AS_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\[([a-zA-Z][a-zA-Z0-9._-]*)\b[^\]]*:as\s+([a-zA-Z][a-zA-Z0-9_-]*)").unwrap()
+});
+
+// Clojure `alias/name` qualified references, e.g. `u/vectorize-if-not-sequential`.
+// Alias and name may contain hyphens, `?` (predicates), or `!` (bang fns).
+static CLOJURE_QUALIFIED_REF_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\b([a-zA-Z][a-zA-Z0-9_?!=*-]*/[a-zA-Z][a-zA-Z0-9_?!=*-]*)").unwrap()
+});
+
 fn collect_local_binding_captures<F>(
     line: &str,
     line_no: usize,
@@ -3971,23 +4277,73 @@ fn maybe_add_local_binding_name<F>(
     }
 }
 
+/// Returns the extra identifier characters for a given file path.
+/// Clojure uses '-' as a word character; all other languages use none.
+fn extra_ident_chars_for_file(file_path: &str) -> &'static [char] {
+    let ext = file_path.rfind('.').map(|i| &file_path[i..]).unwrap_or("");
+    crate::parser::plugins::code::languages::get_language_config(ext)
+        .map_or(&[], |c| c.extra_ident_chars)
+}
+
+fn strip_strategy_for_file(
+    file_path: &str,
+) -> crate::parser::plugins::code::languages::StripStrategy {
+    let ext = file_path.rfind('.').map(|i| &file_path[i..]).unwrap_or("");
+    crate::parser::plugins::code::languages::get_language_config(ext).map_or(
+        crate::parser::plugins::code::languages::StripStrategy::Generic,
+        |c| c.strip_strategy,
+    )
+}
+
 /// Extract identifier references from entity content using simple token analysis.
 /// Strips comments and strings first to avoid false positives from docstrings.
 /// Returns borrowed slices from the stripped content.
-fn extract_references_from_content<'a>(content: &'a str, own_name: &str) -> Vec<&'a str> {
-    let stripped = strip_comments_and_strings(content);
-    extract_references_with_stripped(content, own_name, &stripped)
+fn extract_references_from_content<'a>(
+    content: &'a str,
+    own_name: &str,
+    extra_ident_chars: &'static [char],
+    strip_strategy: crate::parser::plugins::code::languages::StripStrategy,
+) -> Vec<&'a str> {
+    let stripped = strip_for_language(strip_strategy, content);
+    extract_references_with_stripped(content, own_name, &stripped, extra_ident_chars)
 }
 
-fn text_mentions_any_name(text: &str, names: &HashSet<&str>) -> bool {
-    text.split(|c: char| !c.is_alphanumeric() && c != '_')
-        .any(|word| names.contains(word))
+/// Yields each contiguous run of identifier characters (alphanumeric, `_`, or `extra`) as a
+/// `&str` slice. Used by `text_mentions_any_name` and `content_contains_identifier` to avoid
+/// duplicating the same char-walk state machine.
+fn token_iter<'a>(text: &'a str, extra: &'static [char]) -> impl Iterator<Item = &'a str> + 'a {
+    let mut token_start: Option<usize> = None;
+    let mut char_iter = text.char_indices();
+    std::iter::from_fn(move || loop {
+        match char_iter.next() {
+            None => {
+                return token_start.take().map(|s| &text[s..]);
+            }
+            Some((idx, ch)) => {
+                if ch.is_alphanumeric() || ch == '_' || extra.contains(&ch) {
+                    token_start.get_or_insert(idx);
+                } else if let Some(s) = token_start.take() {
+                    return Some(&text[s..idx]);
+                }
+            }
+        }
+    })
 }
 
-fn content_contains_identifier(content: &str, identifier: &str) -> bool {
-    content
-        .split(|c: char| !c.is_alphanumeric() && c != '_')
-        .any(|word| word == identifier)
+fn text_mentions_any_name(
+    text: &str,
+    names: &HashSet<&str>,
+    extra_ident_chars: &'static [char],
+) -> bool {
+    token_iter(text, extra_ident_chars).any(|t| names.contains(t))
+}
+
+fn content_contains_identifier(
+    content: &str,
+    identifier: &str,
+    extra_ident_chars: &'static [char],
+) -> bool {
+    token_iter(content, extra_ident_chars).any(|t| t == identifier)
 }
 
 const IMPORT_SCAN_PREFIX_LINES: usize = 80;
@@ -4185,14 +4541,22 @@ fn extract_references_with_stripped<'a>(
     content: &'a str,
     own_name: &str,
     stripped: &str,
+    extra_ident_chars: &'static [char],
 ) -> Vec<&'a str> {
-    extract_references_with_stripped_filtered(content, own_name, stripped, |_, _, _| true)
+    extract_references_with_stripped_filtered(
+        content,
+        own_name,
+        stripped,
+        extra_ident_chars,
+        |_, _, _| true,
+    )
 }
 
 fn extract_references_with_stripped_filtered<'a, F>(
     content: &'a str,
     own_name: &str,
     stripped: &str,
+    extra_ident_chars: &'static [char],
     mut include_token: F,
 ) -> Vec<&'a str>
 where
@@ -4204,7 +4568,7 @@ where
     let mut line = 1;
 
     for (idx, ch) in content.char_indices() {
-        if ch.is_alphanumeric() || ch == '_' {
+        if ch.is_alphanumeric() || ch == '_' || extra_ident_chars.contains(&ch) {
             if token_start.is_none() {
                 token_start = Some(idx);
             }
@@ -4271,7 +4635,18 @@ fn maybe_push_reference_token<'a, F>(
     if word.starts_with(|c: char| c.is_lowercase()) && word.len() < 3 {
         return;
     }
-    if !word.starts_with(|c: char| c.is_alphabetic() || c == '_') {
+    // Reject purely symbolic tokens (e.g. `*` used as arithmetic in Clojure).
+    if word
+        .chars()
+        .all(|c| !c.is_alphanumeric() && c != '_' && c != '-')
+    {
+        return;
+    }
+    // Tokens starting with '-' or '*' only appear here for Clojure files because
+    // `extra_ident_chars_for_file` controls tokenization upstream — only Clojure
+    // has these in extra_ident_chars. '?', '!', '=' only appear as suffixes in
+    // Clojure (empty?, reset!, not=) so the start-character check below suffices.
+    if !word.starts_with(|c: char| c.is_alphabetic() || c == '_' || c == '-' || c == '*') {
         return;
     }
     // Skip common local variable names that create false graph edges
@@ -4582,6 +4957,7 @@ fn is_keyword(word: &str) -> bool {
 mod tests {
     use super::*;
     use crate::git::types::{FileChange, FileStatus};
+    use crate::parser::plugins::code::languages::StripStrategy;
     use std::io::Write;
     use tempfile::TempDir;
 
@@ -4683,7 +5059,7 @@ class Runner {
     validate(input) { return input; }
 }
 ";
-        let index = FileReferenceIndex::from_content(content);
+        let index = FileReferenceIndex::from_content(content, &[]);
         let refs = index.refs_with_types_in_ranges(&[(1, 5)], "run");
         assert!(refs.iter().any(|(word, _)| *word == "Foo"));
         assert!(refs.iter().any(|(word, _)| *word == "Runner"));
@@ -4760,7 +5136,7 @@ function outer() {
   finish();
 }
 ";
-        let index = FileReferenceIndex::from_content(content);
+        let index = FileReferenceIndex::from_content(content, &[]);
         let refs = index.refs_with_types_in_ranges(&ranges, "outer");
 
         assert!(refs.iter().any(|(word, _)| *word == "setup"));
@@ -5906,7 +6282,8 @@ func draw(widget: Widget) {
     #[test]
     fn test_extract_references() {
         let content = "function processData(input) {\n  const result = validateInput(input);\n  return transform(result);\n}";
-        let refs = extract_references_from_content(content, "processData");
+        let refs =
+            extract_references_from_content(content, "processData", &[], StripStrategy::Generic);
         assert!(refs.contains(&"validateInput"));
         assert!(refs.contains(&"transform"));
         assert!(!refs.contains(&"processData")); // self excluded
@@ -6073,7 +6450,7 @@ func draw(widget: Widget) {
     #[test]
     fn test_extract_references_skips_keywords() {
         let content = "function foo() { if (true) { return false; } }";
-        let refs = extract_references_from_content(content, "foo");
+        let refs = extract_references_from_content(content, "foo", &[], StripStrategy::Generic);
         assert!(!refs.contains(&"if"));
         assert!(!refs.contains(&"true"));
         assert!(!refs.contains(&"return"));
@@ -7898,6 +8275,368 @@ export function caller() {
         assert!(
             deps.iter().any(|d| d.name == "helper"),
             "caller should still resolve helper via bag-of-words. Deps: {:?}",
+            deps.iter().map(|d| &d.name).collect::<Vec<_>>()
+        );
+    }
+
+    #[cfg(feature = "lang-clojure")]
+    #[test]
+    fn test_clojure_namespace_alias_resolution() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        // util.cljs defines a function
+        write_file(
+            root,
+            "src/myapp/util.cljs",
+            r#"(ns myapp.util)
+
+(defn vectorize-if-not-sequential [x]
+  (if (sequential? x) x [x]))
+"#,
+        );
+
+        // elements.cljs requires util with :as u and calls u/vectorize-if-not-sequential
+        write_file(
+            root,
+            "src/myapp/elements.cljs",
+            r#"(ns myapp.elements
+  (:require [myapp.util :as u]))
+
+(defn render-items [items]
+  (u/vectorize-if-not-sequential items))
+"#,
+        );
+
+        let file_paths = vec![
+            "src/myapp/util.cljs".to_string(),
+            "src/myapp/elements.cljs".to_string(),
+        ];
+        let (graph, _) = EntityGraph::build(root, &file_paths, &registry);
+
+        let render_id = graph
+            .entities
+            .keys()
+            .find(|id| id.contains("render-items"))
+            .expect("render-items entity should exist");
+
+        let deps = graph.get_dependencies(render_id);
+        assert!(
+            deps.iter().any(|d| d.name == "vectorize-if-not-sequential"),
+            "render-items should depend on vectorize-if-not-sequential via :as alias. Deps: {:?}",
+            deps.iter().map(|d| &d.name).collect::<Vec<_>>()
+        );
+
+        let util_fn_id = graph
+            .entities
+            .keys()
+            .find(|id| id.contains("vectorize-if-not-sequential"))
+            .expect("vectorize-if-not-sequential entity should exist");
+
+        let dependents = graph.get_dependents(util_fn_id);
+        assert!(
+            dependents.iter().any(|d| d.name == "render-items"),
+            "vectorize-if-not-sequential should be depended on by render-items. Dependents: {:?}",
+            dependents.iter().map(|d| &d.name).collect::<Vec<_>>()
+        );
+    }
+
+    #[cfg(feature = "lang-clojure")]
+    #[test]
+    fn test_clojure_refer_resolution() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "src/myapp/strings.clj",
+            r#"(ns myapp.strings)
+
+(defn capitalize-first [s]
+  (str (clojure.string/upper-case (subs s 0 1)) (subs s 1)))
+"#,
+        );
+
+        write_file(
+            root,
+            "src/myapp/greeting.clj",
+            r#"(ns myapp.greeting
+  (:require [myapp.strings :refer [capitalize-first]]))
+
+(defn greet [name]
+  (str "Hello, " (capitalize-first name) "!"))
+"#,
+        );
+
+        let file_paths = vec![
+            "src/myapp/strings.clj".to_string(),
+            "src/myapp/greeting.clj".to_string(),
+        ];
+        let (graph, _) = EntityGraph::build(root, &file_paths, &registry);
+
+        let greet_id = graph
+            .entities
+            .iter()
+            .find(|(_, e)| e.name == "greet")
+            .map(|(id, _)| id)
+            .expect("greet entity should exist");
+
+        let deps = graph.get_dependencies(greet_id);
+        assert!(
+            deps.iter().any(|d| d.name == "capitalize-first"),
+            "greet should depend on capitalize-first via :refer. Deps: {:?}",
+            deps.iter().map(|d| &d.name).collect::<Vec<_>>()
+        );
+    }
+
+    #[cfg(feature = "lang-clojure")]
+    #[test]
+    fn test_clojure_kebab_reference_tracking() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "src/myapp/math.clj",
+            r#"(ns myapp.math)
+
+(defn square-root-of [n]
+  (Math/sqrt n))
+"#,
+        );
+
+        write_file(
+            root,
+            "src/myapp/stats.clj",
+            r#"(ns myapp.stats
+  (:require [myapp.math :refer [square-root-of]]))
+
+(defn std-deviation [xs]
+  (square-root-of (/ (reduce + xs) (count xs))))
+"#,
+        );
+
+        let file_paths = vec![
+            "src/myapp/math.clj".to_string(),
+            "src/myapp/stats.clj".to_string(),
+        ];
+        let (graph, _) = EntityGraph::build(root, &file_paths, &registry);
+
+        let std_dev_id = graph
+            .entities
+            .keys()
+            .find(|id| id.contains("std-deviation"))
+            .expect("std-deviation entity should exist");
+
+        let deps = graph.get_dependencies(std_dev_id);
+        assert!(
+            deps.iter().any(|d| d.name == "square-root-of"),
+            "std-deviation should depend on square-root-of (kebab name via :refer). Deps: {:?}",
+            deps.iter().map(|d| &d.name).collect::<Vec<_>>()
+        );
+    }
+
+    #[cfg(feature = "lang-clojure")]
+    #[test]
+    fn test_clojure_arithmetic_star_no_false_edge() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        // math.clj defines a function whose body uses (*) for multiplication.
+        // It does NOT import anything from another file.
+        write_file(
+            root,
+            "src/myapp/math.clj",
+            r#"(ns myapp.math)
+
+(defn hypotenuse [a b]
+  (Math/sqrt (+ (* a a) (* b b))))
+"#,
+        );
+
+        // other.clj defines a function named * — this should NOT become a dependency
+        // of hypotenuse because myapp.math never requires myapp.other.
+        write_file(
+            root,
+            "src/myapp/other.clj",
+            r#"(ns myapp.other)
+
+(defn * [x y] (* x y))
+"#,
+        );
+
+        let file_paths = vec![
+            "src/myapp/math.clj".to_string(),
+            "src/myapp/other.clj".to_string(),
+        ];
+        let (graph, _) = EntityGraph::build(root, &file_paths, &registry);
+
+        let hyp_id = graph
+            .entities
+            .keys()
+            .find(|id| id.contains("hypotenuse"))
+            .expect("hypotenuse entity should exist");
+
+        let deps = graph.get_dependencies(hyp_id);
+        assert!(
+            !deps.iter().any(|d| d.name == "*"),
+            "hypotenuse should not have a false '*' dependency from arithmetic use. Deps: {:?}",
+            deps.iter().map(|d| &d.name).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "lang-clojure")]
+    fn test_clojure_gensym_does_not_blank_qualified_call() {
+        // Regression: `strip_comments_and_strings` treated `#` as a Python/Ruby line
+        // comment, so `result# (rewrite/fn! ...)` had everything from `#` to EOL blanked.
+        // This prevented `CLOJURE_QUALIFIED_REF_RE` from finding `rewrite/fn!`.
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "src/myapp/rewrite.cljc",
+            r#"(ns myapp.rewrite)
+
+(defn add-expected-value! [path line value]
+  (str path line value))
+"#,
+        );
+
+        // The macro body contains `result#` (a gensym) followed by a qualified call
+        // `rewrite/add-expected-value!` on the same line — this is the pattern that
+        // was being incorrectly blanked.
+        write_file(
+            root,
+            "src/myapp/core.cljc",
+            r#"(ns myapp.core
+  (:require [myapp.rewrite :as rewrite]))
+
+(defmacro snap! [path line]
+  `(let [result# (rewrite/add-expected-value! ~path ~line :result)]
+     result#))
+"#,
+        );
+
+        let file_paths = vec![
+            "src/myapp/rewrite.cljc".to_string(),
+            "src/myapp/core.cljc".to_string(),
+        ];
+        let (graph, _) = EntityGraph::build(root, &file_paths, &registry);
+
+        let snap_id = graph
+            .entities
+            .iter()
+            .find(|(_, e)| e.name == "snap!")
+            .map(|(id, _)| id.clone())
+            .expect("snap! macro entity should exist");
+
+        let deps = graph.get_dependencies(&snap_id);
+        assert!(
+            deps.iter().any(|d| d.name == "add-expected-value!"),
+            "snap! should depend on add-expected-value! via rewrite/add-expected-value! alias call. Deps: {:?}",
+            deps.iter().map(|d| &d.name).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "lang-clojure")]
+    fn test_clojure_reader_conditional_require_alias_resolved() {
+        // Regression: `strip_comments_and_strings` treated `#` as a comment, so
+        // `#?(:clj [still.rewrite :as rewrite] ...)` was blanked from `#` to EOL,
+        // preventing CLOJURE_AS_RE from finding the `:as rewrite` alias.
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "src/myapp/backend.clj",
+            r#"(ns myapp.backend)
+
+(defn do-work! [x] x)
+"#,
+        );
+
+        write_file(
+            root,
+            "src/myapp/shared.cljc",
+            r#"(ns myapp.shared
+  (:require #?(:clj [myapp.backend :as backend])))
+
+(defn entry-point []
+  (backend/do-work! 42))
+"#,
+        );
+
+        let file_paths = vec![
+            "src/myapp/backend.clj".to_string(),
+            "src/myapp/shared.cljc".to_string(),
+        ];
+        let (graph, _) = EntityGraph::build(root, &file_paths, &registry);
+
+        let entry_id = graph
+            .entities
+            .iter()
+            .find(|(_, e)| e.name == "entry-point")
+            .map(|(id, _)| id.clone())
+            .expect("entry-point entity should exist");
+
+        let deps = graph.get_dependencies(&entry_id);
+        assert!(
+            deps.iter().any(|d| d.name == "do-work!"),
+            "entry-point should depend on do-work! via reader-conditional alias. Deps: {:?}",
+            deps.iter().map(|d| &d.name).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "lang-clojure")]
+    fn test_clojure_multiline_require_refer_resolution() {
+        let (dir, registry) = create_test_repo();
+        let root = dir.path();
+
+        write_file(
+            root,
+            "src/myapp/strings.clj",
+            r#"(ns myapp.strings)
+
+(defn capitalize-first [s]
+  (str (clojure.string/upper-case (subs s 0 1)) (subs s 1)))
+"#,
+        );
+
+        // :refer vector is on a separate line from the namespace vector opening bracket.
+        write_file(
+            root,
+            "src/myapp/greeting.clj",
+            r#"(ns myapp.greeting
+  (:require
+   [myapp.strings
+    :refer [capitalize-first]]))
+
+(defn greet [name]
+  (str "Hello, " (capitalize-first name) "!"))
+"#,
+        );
+
+        let file_paths = vec![
+            "src/myapp/strings.clj".to_string(),
+            "src/myapp/greeting.clj".to_string(),
+        ];
+        let (graph, _) = EntityGraph::build(root, &file_paths, &registry);
+
+        let greet_id = graph
+            .entities
+            .iter()
+            .find(|(_, e)| e.name == "greet")
+            .map(|(id, _)| id)
+            .expect("greet entity should exist");
+
+        let deps = graph.get_dependencies(greet_id);
+        assert!(
+            deps.iter().any(|d| d.name == "capitalize-first"),
+            "greet should depend on capitalize-first via multi-line :refer. Deps: {:?}",
             deps.iter().map(|d| &d.name).collect::<Vec<_>>()
         );
     }

--- a/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
+++ b/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
@@ -313,6 +313,81 @@ fn visit_node(
             }
         }
 
+        // EDN map-entry extraction: treat each keyword key–value pair in a top-level
+        // map_lit as a named "entry" entity. Values are kept as opaque content and are
+        // not recursed into, so nested maps don't leak inner entries as entities.
+        if node_type == "map_lit" && config.extract_map_entries {
+            let mut cursor = node.walk();
+            // Skip comment and dis_expr nodes: they are named children of map_lit
+            // in tree-sitter-clojure but are not actual forms. Without this filter,
+            // a comment inside a map shifts the key/value pairing by one slot,
+            // causing the entry after the comment to be misidentified as a key.
+            let children: Vec<_> = node
+                .named_children(&mut cursor)
+                .filter(|n| !matches!(n.kind(), "comment" | "dis_expr"))
+                .collect();
+            let mut i = 0;
+            while i + 1 < children.len() {
+                let key = children[i];
+                let value = children[i + 1];
+                i += 2;
+                let name = match key.kind() {
+                    "kwd_lit" | "sym_lit" => node_text(key, source).to_string(),
+                    _ => continue,
+                };
+                let content = std::str::from_utf8(
+                    &source[key.start_byte()..value.end_byte()],
+                )
+                .unwrap_or("")
+                .to_string();
+                let struct_hash = compute_structural_hash(value, source);
+                let entity = SemanticEntity {
+                    id: build_entity_id(file_path, "entry", &name, parent_id),
+                    file_path: file_path.to_string(),
+                    entity_type: "entry".to_string(),
+                    name,
+                    parent_id: parent_id.map(String::from),
+                    content_hash: content_hash(&content),
+                    structural_hash: Some(struct_hash),
+                    content,
+                    start_line: key.start_position().row + 1,
+                    end_line: value.end_position().row + 1,
+                    metadata: None,
+                };
+                entities.push(entity);
+            }
+            continue;
+        }
+
+        // Handle Clojure-style list form entities: list_lit whose first sym_lit child
+        // is a defining keyword (defn, ns, defrecord, etc.).
+        // Gated on call_entity_identifiers being non-empty, mirroring the `call` branch
+        // used for Elixir. The config's call_entity_identifiers list is the whitelist.
+        if node_type == "list_lit" && !config.call_entity_identifiers.is_empty() {
+            if let Some((name, entity_type)) = extract_list_form_entity(node, config, source) {
+                let content_str = node_text(node, source);
+                let content = content_str.to_string();
+                let struct_hash = compute_structural_hash(node, source);
+                let entity = SemanticEntity {
+                    id: build_entity_id(file_path, entity_type, &name, parent_id),
+                    file_path: file_path.to_string(),
+                    entity_type: entity_type.to_string(),
+                    name: name.clone(),
+                    parent_id: parent_id.map(String::from),
+                    content_hash: content_hash(&content),
+                    structural_hash: Some(struct_hash),
+                    content,
+                    start_line: node.start_position().row + 1,
+                    end_line: node.end_position().row + 1,
+                    metadata: None,
+                };
+                entities.push(entity);
+            }
+            // Always skip children: in practice, Clojure definitions are always top-level
+            // list forms, nesting defn would be so unidiomatic it's not worth checking for.
+            continue;
+        }
+
         // OCaml: value_definition, module_definition, class_definition, and
         // class_type_definition can each contain multiple bindings via `... and ...`.
         // Extract each binding as a separate entity.
@@ -1185,8 +1260,7 @@ fn swift_string_literal_start(source: &[u8], start: usize) -> Option<SwiftString
         return None;
     }
 
-    let is_multiline =
-        source.get(quote + 1) == Some(&b'"') && source.get(quote + 2) == Some(&b'"');
+    let is_multiline = source.get(quote + 1) == Some(&b'"') && source.get(quote + 2) == Some(&b'"');
     let body_start = quote + if is_multiline { 3 } else { 1 };
     Some(SwiftStringLiteralStart {
         body_start,
@@ -1212,7 +1286,12 @@ fn skip_swift_string_literal_with_depth(
             interpolation_depth,
         )
     } else {
-        skip_swift_string(source, start.body_start, start.hash_count, interpolation_depth)
+        skip_swift_string(
+            source,
+            start.body_start,
+            start.hash_count,
+            interpolation_depth,
+        )
     }
 }
 
@@ -2418,6 +2497,74 @@ fn map_node_type(tree_sitter_type: &str) -> &str {
         "template_declaration" => "template",
         other => other,
     }
+}
+
+/// Extract entity from a Clojure-style list form (list_lit where first sym_lit is a def keyword).
+/// Returns (name, entity_type) or None if the list head is not in config.call_entity_identifiers.
+fn extract_list_form_entity<'a>(
+    node: Node<'a>,
+    config: &LanguageConfig,
+    source: &[u8],
+) -> Option<(String, &'static str)> {
+    let mut cursor = node.walk();
+    let mut children = node.named_children(&mut cursor);
+
+    let head = children.next()?;
+    if head.kind() != "sym_lit" {
+        return None;
+    }
+    let keyword = node_text(head, source);
+    if !config.call_entity_identifiers.contains(&keyword) {
+        return None;
+    }
+    let entity_type = match keyword {
+        "defn" | "defn-" => "function",
+        "defmacro" => "macro",
+        "defmulti" => "multimethod",
+        "defmethod" => "method",
+        "defprotocol" => "protocol",
+        "defrecord" => "record",
+        "deftype" => "type",
+        "definterface" => "interface",
+        "defstruct" => "struct",
+        "def" | "defonce" => "var",
+        // Keyword is in call_entity_identifiers but has no entity-type mapping here.
+        // This is a config/code mismatch — add an arm above when adding a new keyword.
+        _ => {
+            debug_assert!(false, "unhandled call_entity_identifier: {keyword}");
+            return None;
+        }
+    };
+
+    let name_node = children.next()?;
+    // In this grammar, `^:private my-fn` is a single sym_lit whose `name` field child
+    // (sym_name) holds only the bare symbol. Use that to strip metadata annotations.
+    let base_name = clojure_sym_name(name_node, source).to_string();
+
+    // defmethod: include the dispatch value so (defmethod area :circle ...) and
+    // (defmethod area :rectangle ...) get distinct stable names instead of colliding.
+    let name = if keyword == "defmethod" {
+        if let Some(dispatch_node) = children.next() {
+            format!("{}/{}", base_name, node_text(dispatch_node, source))
+        } else {
+            base_name
+        }
+    } else {
+        base_name
+    };
+
+    Some((name, entity_type))
+}
+
+/// Extract the bare symbol text from a Clojure `sym_lit`, ignoring any metadata prefix.
+/// `^:private my-fn` is a sym_lit whose `name` field is a sym_name holding "my-fn".
+fn clojure_sym_name<'a>(node: Node<'a>, source: &'a [u8]) -> &'a str {
+    if node.kind() == "sym_lit" {
+        if let Some(name_child) = node.child_by_field_name("name") {
+            return node_text(name_child, source);
+        }
+    }
+    node_text(node, source)
 }
 
 /// Extract entity info from a call node (Elixir macros like def, defmodule, etc.)

--- a/crates/sem-core/src/parser/plugins/code/languages.rs
+++ b/crates/sem-core/src/parser/plugins/code/languages.rs
@@ -9,6 +9,18 @@ pub struct SuppressedNestedEntity {
     pub child_entity_node_type: &'static str,
 }
 
+/// Strategy for stripping comments and string literals from source content.
+/// Controls which stripping function `strip_for_language` dispatches to in graph.rs.
+/// Add a new variant here when a language requires custom comment handling.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum StripStrategy {
+    /// Standard stripper: handles `//`, `/* */`, and `#` line comments, plus string literals.
+    Generic,
+    /// Clojure: blank double-quoted strings only (preserves `#` for gensyms and reader macros),
+    /// then strip `;` line comments in a second pass.
+    Clojure,
+}
+
 #[allow(dead_code)]
 pub struct LanguageConfig {
     pub id: &'static str,
@@ -16,6 +28,21 @@ pub struct LanguageConfig {
     pub entity_node_types: &'static [&'static str],
     pub container_node_types: &'static [&'static str],
     pub call_entity_identifiers: &'static [&'static str],
+    /// Extra characters (beyond alphanumeric and `_`) that are valid identifier
+    /// constituents for this language. Used by the tokenizer and reference scanner.
+    /// E.g. Clojure uses `['-', '?', '!', '*', '=']` for kebab-case, predicates,
+    /// bang functions, dynamic vars, and equality operators.
+    pub extra_ident_chars: &'static [char],
+    /// How to strip comments and string literals from content for this language.
+    pub strip_strategy: StripStrategy,
+    /// Whether this language uses `alias/name` qualified references (e.g. Clojure).
+    /// When true, `resolve_entity_references` runs a post-processing pass to resolve
+    /// these qualified calls via the import table.
+    pub has_slash_qualified_refs: bool,
+    /// When true, a top-level `map_lit` node is broken into individual named entities,
+    /// one per keyword key–value pair. Used for EDN data files (deps.edn, etc.) where
+    /// the meaningful units are top-level map entries, not code definition forms.
+    pub extract_map_entries: bool,
     pub suppressed_nested_entities: &'static [SuppressedNestedEntity],
     /// Node types that introduce a new scope. The general (non-container) recursion
     /// in visit_node will not descend into these nodes, preventing local variables
@@ -334,6 +361,11 @@ fn get_elm() -> Option<Language> {
     Some(tree_sitter_elm::LANGUAGE.into())
 }
 
+#[cfg(any(feature = "lang-clojure", feature = "lang-edn"))]
+fn get_clojure() -> Option<Language> {
+    Some(tree_sitter_clojure_orchard::LANGUAGE.into())
+}
+
 /// Inside JS/TS function bodies, suppress variable declarations so that local
 /// variables are not extracted as nested entities. Inner function/class
 /// declarations are still extracted for diff granularity.
@@ -476,9 +508,13 @@ static TYPESCRIPT_CONFIG: LanguageConfig = LanguageConfig {
         "statement_block",
     ],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: JS_TS_SUPPRESSED_NESTED,
     scope_boundary_types: JS_TS_SCOPE_BOUNDARIES,
     get_language: get_typescript,
+    extract_map_entries: false,
     scope_resolve: Some(&TS_SCOPE_CONFIG),
 };
 
@@ -514,9 +550,13 @@ static TSX_CONFIG: LanguageConfig = LanguageConfig {
         "statement_block",
     ],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: JS_TS_SUPPRESSED_NESTED,
     scope_boundary_types: JS_TS_SCOPE_BOUNDARIES,
     get_language: get_tsx,
+    extract_map_entries: false,
     scope_resolve: Some(&TS_SCOPE_CONFIG),
 };
 
@@ -536,9 +576,13 @@ static JAVASCRIPT_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["class_body", "statement_block"],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: JS_TS_SUPPRESSED_NESTED,
     scope_boundary_types: JS_TS_SCOPE_BOUNDARIES,
     get_language: get_javascript,
+    extract_map_entries: false,
     scope_resolve: Some(&TS_SCOPE_CONFIG),
 };
 
@@ -553,9 +597,13 @@ static PYTHON_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["block"],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_python,
+    extract_map_entries: false,
     scope_resolve: Some(&PYTHON_SCOPE_CONFIG),
 };
 
@@ -572,9 +620,13 @@ static GO_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["block"],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_go,
+    extract_map_entries: false,
     scope_resolve: Some(&GO_SCOPE_CONFIG),
 };
 
@@ -596,9 +648,13 @@ static RUST_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["declaration_list", "block"],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_rust,
+    extract_map_entries: false,
     scope_resolve: Some(&RUST_SCOPE_CONFIG),
 };
 
@@ -624,9 +680,13 @@ static JAVA_CONFIG: LanguageConfig = LanguageConfig {
         "block",
     ],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_java,
+    extract_map_entries: false,
     scope_resolve: Some(&JAVA_SCOPE_CONFIG),
 };
 
@@ -644,9 +704,13 @@ static C_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["compound_statement"],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: C_SUPPRESSED_NESTED,
     scope_boundary_types: &[],
     get_language: get_c,
+    extract_map_entries: false,
     scope_resolve: None,
 };
 
@@ -670,9 +734,13 @@ static CPP_CONFIG: LanguageConfig = LanguageConfig {
         "compound_statement",
     ],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: CPP_SUPPRESSED_NESTED,
     scope_boundary_types: CPP_SCOPE_BOUNDARIES,
     get_language: get_cpp,
+    extract_map_entries: false,
     scope_resolve: Some(&CPP_SCOPE_CONFIG),
 };
 
@@ -683,9 +751,13 @@ static RUBY_CONFIG: LanguageConfig = LanguageConfig {
     entity_node_types: &["method", "singleton_method", "class", "module"],
     container_node_types: &["body_statement"],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_ruby,
+    extract_map_entries: false,
     scope_resolve: Some(&RUBY_SCOPE_CONFIG),
 };
 
@@ -708,9 +780,13 @@ static CSHARP_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["declaration_list", "record_body", "block"],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_csharp,
+    extract_map_entries: false,
     scope_resolve: Some(&CSHARP_SCOPE_CONFIG),
 };
 
@@ -733,9 +809,13 @@ static PHP_CONFIG: LanguageConfig = LanguageConfig {
         "compound_statement",
     ],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_php,
+    extract_map_entries: false,
     scope_resolve: Some(&PHP_SCOPE_CONFIG),
 };
 
@@ -753,9 +833,13 @@ static FORTRAN_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["module", "program", "internal_procedures"],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_fortran,
+    extract_map_entries: false,
     scope_resolve: None,
 };
 
@@ -786,9 +870,13 @@ static SWIFT_CONFIG: LanguageConfig = LanguageConfig {
         "computed_property",
     ],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: SWIFT_SUPPRESSED_NESTED,
     scope_boundary_types: &[],
     get_language: get_swift,
+    extract_map_entries: false,
     scope_resolve: Some(&SWIFT_SCOPE_CONFIG),
 };
 
@@ -812,9 +900,13 @@ static ELIXIR_CONFIG: LanguageConfig = LanguageConfig {
         "defexception",
         "defdelegate",
     ],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_elixir,
+    extract_map_entries: false,
     scope_resolve: None,
 };
 
@@ -825,9 +917,13 @@ static BASH_CONFIG: LanguageConfig = LanguageConfig {
     entity_node_types: &["function_definition"],
     container_node_types: &["compound_statement"],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_bash,
+    extract_map_entries: false,
     scope_resolve: Some(&BASH_SCOPE_CONFIG),
 };
 
@@ -838,12 +934,16 @@ static HCL_CONFIG: LanguageConfig = LanguageConfig {
     entity_node_types: &["block", "attribute"],
     container_node_types: &["body"],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[SuppressedNestedEntity {
         parent_entity_node_type: "block",
         child_entity_node_type: "attribute",
     }],
     scope_boundary_types: &[],
     get_language: get_hcl,
+    extract_map_entries: false,
     scope_resolve: None,
 };
 
@@ -862,9 +962,13 @@ static KOTLIN_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["class_body", "enum_class_body"],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_kotlin,
+    extract_map_entries: false,
     scope_resolve: Some(&KOTLIN_SCOPE_CONFIG),
 };
 
@@ -878,9 +982,13 @@ static XML_CONFIG: LanguageConfig = LanguageConfig {
     entity_node_types: &["element"],
     container_node_types: &["content"],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_xml,
+    extract_map_entries: false,
     scope_resolve: None,
 };
 
@@ -902,9 +1010,13 @@ static DART_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["class_body", "enum_body", "extension_body"],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_dart,
+    extract_map_entries: false,
     scope_resolve: Some(&DART_SCOPE_CONFIG),
 };
 
@@ -915,9 +1027,13 @@ static PERL_CONFIG: LanguageConfig = LanguageConfig {
     entity_node_types: &["subroutine_declaration_statement", "package_statement"],
     container_node_types: &["block"],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_perl,
+    extract_map_entries: false,
     scope_resolve: None,
 };
 
@@ -937,9 +1053,13 @@ static OCAML_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["structure", "module_binding"],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_ocaml,
+    extract_map_entries: false,
     scope_resolve: None,
 };
 
@@ -959,9 +1079,13 @@ static OCAML_INTERFACE_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["signature", "module_binding"],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_ocaml_interface,
+    extract_map_entries: false,
     scope_resolve: None,
 };
 
@@ -984,9 +1108,13 @@ static SCALA_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["template_body", "enum_body", "with_template_body"],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_scala,
+    extract_map_entries: false,
     scope_resolve: Some(&SCALA_SCOPE_CONFIG),
 };
 
@@ -1001,12 +1129,16 @@ static ZIG_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["block"],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[SuppressedNestedEntity {
         parent_entity_node_type: "function_declaration",
         child_entity_node_type: "variable_declaration",
     }],
     scope_boundary_types: &[],
     get_language: get_zig,
+    extract_map_entries: false,
     scope_resolve: Some(&ZIG_SCOPE_CONFIG),
 };
 
@@ -1017,9 +1149,13 @@ static NIX_CONFIG: LanguageConfig = LanguageConfig {
     entity_node_types: &["binding", "inherit", "inherit_from"],
     container_node_types: &["binding_set"],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_nix,
+    extract_map_entries: false,
     scope_resolve: None,
 };
 
@@ -1044,9 +1180,13 @@ static HASKELL_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["declarations", "class_body", "instance_body"],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &["function"],
     get_language: get_haskell,
+    extract_map_entries: false,
     scope_resolve: None,
 };
 
@@ -1063,9 +1203,68 @@ static ELM_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &[],
     call_entity_identifiers: &[],
+    extra_ident_chars: &[],
+    strip_strategy: StripStrategy::Generic,
+    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &["value_declaration"],
     get_language: get_elm,
+    extract_map_entries: false,
+    scope_resolve: None,
+};
+
+// EDN (Extensible Data Notation) shares Clojure's syntax and grammar.
+// Entities are top-level map entries (keyword key → value), extracted via the
+// map_lit branch in visit_node when extract_map_entries is true.
+// Non-map top-level forms (bare vecs, sets, lists) have no nameable identity
+// and are not extracted.
+#[cfg(feature = "lang-edn")]
+static EDN_CONFIG: LanguageConfig = LanguageConfig {
+    id: "edn",
+    extensions: &[".edn"],
+    entity_node_types: &[],
+    container_node_types: &[],
+    call_entity_identifiers: &[],
+    extra_ident_chars: &['-', '?', '!', '*', '='],
+    strip_strategy: StripStrategy::Clojure,
+    has_slash_qualified_refs: false,
+    suppressed_nested_entities: &[],
+    scope_boundary_types: &[],
+    get_language: get_clojure,
+    extract_map_entries: true,
+    scope_resolve: None,
+};
+
+// Clojure is a Lisp: all definition forms are `list_lit` nodes whose first named
+// child is a `sym_lit` identifying the macro (defn, ns, defrecord, etc.).
+// The entity extractor handles these via the list_lit branch in visit_node.
+#[cfg(feature = "lang-clojure")]
+static CLOJURE_CONFIG: LanguageConfig = LanguageConfig {
+    id: "clojure",
+    extensions: &[".clj", ".cljs", ".cljc"],
+    entity_node_types: &[],
+    container_node_types: &[],
+    call_entity_identifiers: &[
+        "def",
+        "defonce",
+        "defn",
+        "defn-",
+        "defmacro",
+        "defmulti",
+        "defmethod",
+        "defprotocol",
+        "defrecord",
+        "deftype",
+        "definterface",
+        "defstruct",
+    ],
+    extra_ident_chars: &['-', '?', '!', '*', '='],
+    strip_strategy: StripStrategy::Clojure,
+    has_slash_qualified_refs: true,
+    suppressed_nested_entities: &[],
+    scope_boundary_types: &[],
+    get_language: get_clojure,
+    extract_map_entries: false,
     scope_resolve: None,
 };
 
@@ -2353,6 +2552,10 @@ macro_rules! all_configs {
             &HASKELL_CONFIG,
             #[cfg(feature = "lang-elm")]
             &ELM_CONFIG,
+            #[cfg(feature = "lang-clojure")]
+            &CLOJURE_CONFIG,
+            #[cfg(feature = "lang-edn")]
+            &EDN_CONFIG,
         ]
     }};
 }

--- a/crates/sem-core/src/parser/plugins/code/mod.rs
+++ b/crates/sem-core/src/parser/plugins/code/mod.rs
@@ -893,6 +893,203 @@ end
     }
 
     #[test]
+    #[cfg(feature = "lang-clojure")]
+    fn test_clojure_entity_extraction() {
+        let code = r#"
+(ns my.app.core
+  (:require [clojure.string :as str]))
+
+(def my-var 42)
+
+(def ^:private secret "hunter2")
+
+(defonce connection (atom nil))
+
+(defn greet
+  "Returns a greeting string."
+  [name]
+  (str "Hello, " name "!"))
+
+(defmacro unless [pred & body]
+  `(when (not ~pred) ~@body))
+
+(defprotocol Greeter
+  (greet! [this name]))
+
+(defrecord Person [name age])
+
+(defmulti area :shape)
+
+(defmethod area :circle [{:keys [radius]}]
+  (* Math/PI radius radius))
+
+(defmethod area :rectangle [{:keys [width height]}]
+  (* width height))
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "core.clj");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+        eprintln!(
+            "Clojure entities: {:?}",
+            entities
+                .iter()
+                .map(|e| (&e.name, &e.entity_type))
+                .collect::<Vec<_>>()
+        );
+
+        assert!(!names.contains(&"my.app.core"), "Should not extract ns form as entity, got: {:?}", names);
+        assert!(names.contains(&"my-var"), "Should find def, got: {:?}", names);
+        assert!(names.contains(&"secret"), "Should strip ^:private metadata from name, got: {:?}", names);
+        assert!(names.contains(&"connection"), "Should find defonce, got: {:?}", names);
+        assert!(names.contains(&"greet"), "Should find defn, got: {:?}", names);
+        assert!(names.contains(&"unless"), "Should find defmacro, got: {:?}", names);
+        assert!(names.contains(&"Greeter"), "Should find defprotocol, got: {:?}", names);
+        assert!(names.contains(&"Person"), "Should find defrecord, got: {:?}", names);
+        assert!(names.contains(&"area"), "Should find defmulti, got: {:?}", names);
+        // defmethods get dispatch-qualified names so two methods on the same multimethod are distinct
+        assert!(names.contains(&"area/:circle"), "Should find defmethod area :circle, got: {:?}", names);
+        assert!(names.contains(&"area/:rectangle"), "Should find defmethod area :rectangle, got: {:?}", names);
+        let ids: Vec<&str> = entities.iter().map(|e| e.id.as_str()).collect();
+        assert!(ids.iter().collect::<std::collections::HashSet<_>>().len() == ids.len(),
+            "All entity IDs must be unique, got: {:?}", ids);
+    }
+
+    #[test]
+    #[cfg(feature = "lang-clojure")]
+    fn test_clojure_defn_private() {
+        let code = r#"
+(ns my.app)
+
+(defn- private-helper [x]
+  (* x 2))
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "app.clj");
+        let entity = entities
+            .iter()
+            .find(|e| e.name == "private-helper")
+            .expect("Should extract defn- as a function entity");
+        assert_eq!(entity.entity_type, "function");
+    }
+
+    #[test]
+    #[cfg(feature = "lang-clojure")]
+    fn test_clojure_predicate_and_bang_functions() {
+        let code = r#"
+(ns my.app.validators)
+
+(defn empty? [coll]
+  (= 0 (count coll)))
+
+(defn reset! [state new-val]
+  (compare-and-set! state @state new-val))
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "validators.clj");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"empty?"), "Should extract predicate fn empty?, got: {:?}", names);
+        assert!(names.contains(&"reset!"), "Should extract bang fn reset!, got: {:?}", names);
+        let empty_entity = entities.iter().find(|e| e.name == "empty?").unwrap();
+        let reset_entity = entities.iter().find(|e| e.name == "reset!").unwrap();
+        assert_eq!(empty_entity.entity_type, "function");
+        assert_eq!(reset_entity.entity_type, "function");
+    }
+
+    #[test]
+    #[cfg(feature = "lang-clojure")]
+    fn test_clojure_dynamic_vars_and_equality_fns() {
+        let code = r#"
+(ns my.app.core)
+
+(def *db* (atom nil))
+
+(defn not= [a b]
+  (not (= a b)))
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "core.clj");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"*db*"), "Should extract dynamic var *db*, got: {:?}", names);
+        assert!(names.contains(&"not="), "Should extract fn not=, got: {:?}", names);
+        let db_entity = entities.iter().find(|e| e.name == "*db*").unwrap();
+        let noteq_entity = entities.iter().find(|e| e.name == "not=").unwrap();
+        assert_eq!(db_entity.entity_type, "var");
+        assert_eq!(noteq_entity.entity_type, "function");
+    }
+
+    #[test]
+    #[cfg(feature = "lang-clojure")]
+    fn test_clojure_deftype_definterface_defstruct() {
+        let code = r#"
+(ns my.app)
+
+(deftype MyType [field])
+
+(definterface IFoo
+  (foo [this]))
+
+(defstruct point :x :y)
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "app.clj");
+        let by_name = |name: &str| entities.iter().find(|e| e.name == name);
+
+        assert!(by_name("MyType").is_some(), "Should extract deftype, got: {:?}", entities.iter().map(|e| &e.name).collect::<Vec<_>>());
+        assert_eq!(by_name("MyType").unwrap().entity_type, "type");
+
+        assert!(by_name("IFoo").is_some(), "Should extract definterface, got: {:?}", entities.iter().map(|e| &e.name).collect::<Vec<_>>());
+        assert_eq!(by_name("IFoo").unwrap().entity_type, "interface");
+
+        assert!(by_name("point").is_some(), "Should extract defstruct, got: {:?}", entities.iter().map(|e| &e.name).collect::<Vec<_>>());
+        assert_eq!(by_name("point").unwrap().entity_type, "struct");
+    }
+
+    #[test]
+    #[cfg(feature = "lang-clojure")]
+    fn test_clojure_cljc_extension() {
+        let code = r#"
+(ns my.app.shared)
+
+(defn platform-key [] :default)
+
+(def shared-value 99)
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "shared.cljc");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"platform-key"), "Should extract defn from .cljc, got: {:?}", names);
+        assert!(names.contains(&"shared-value"), "Should extract def from .cljc, got: {:?}", names);
+    }
+
+    #[test]
+    #[cfg(feature = "lang-clojure")]
+    fn test_clojure_defmethod_non_keyword_dispatch() {
+        let code = r#"
+(ns my.app)
+
+(defmulti process identity)
+
+(defmethod process nil [_] :nothing)
+
+(defmethod process "string" [s] s)
+
+(defmethod process 42 [n] n)
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "app.clj");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"process"), "Should extract defmulti, got: {:?}", names);
+        assert!(names.contains(&"process/nil"), "Should extract defmethod with nil dispatch, got: {:?}", names);
+        assert!(names.contains(&"process/\"string\""), "Should extract defmethod with string dispatch, got: {:?}", names);
+        assert!(names.contains(&"process/42"), "Should extract defmethod with integer dispatch, got: {:?}", names);
+        let ids: Vec<&str> = entities.iter().map(|e| e.id.as_str()).collect();
+        assert!(
+            ids.iter().collect::<std::collections::HashSet<_>>().len() == ids.len(),
+            "All entity IDs must be unique, got: {:?}", ids
+        );
+    }
+
+    #[test]
     fn test_bash_entity_extraction() {
         let code = r#"#!/bin/bash
 
@@ -2556,5 +2753,66 @@ test "basic addition" {
         assert_eq!(types["Point"], "struct");
         assert_eq!(types["Color"], "enum");
         assert_eq!(types["Person"], "struct");
+    }
+
+    #[test]
+    #[cfg(feature = "lang-edn")]
+    fn test_edn_deps_edn_map_entries() {
+        let code = r#"{:deps {org.clojure/clojure {:mvn/version "1.11.0"}}
+ :paths ["src" "resources"]
+ :aliases {:dev {:extra-deps {cider/cider-nrepl {:mvn/version "0.28.5"}}}}}"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "deps.edn");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+        let types: std::collections::HashMap<&str, &str> = entities
+            .iter()
+            .map(|e| (e.name.as_str(), e.entity_type.as_str()))
+            .collect();
+
+        assert!(names.contains(&":deps"), "Should find :deps, got: {:?}", names);
+        assert!(names.contains(&":paths"), "Should find :paths, got: {:?}", names);
+        assert!(names.contains(&":aliases"), "Should find :aliases, got: {:?}", names);
+        assert_eq!(names.len(), 3, "Should have exactly 3 entries, got: {:?}", names);
+        assert_eq!(types[":deps"], "entry");
+        assert_eq!(types[":paths"], "entry");
+        assert_eq!(types[":aliases"], "entry");
+    }
+
+    #[test]
+    #[cfg(feature = "lang-edn")]
+    fn test_edn_nested_map_values_not_extracted() {
+        // Inner map entries (inside :aliases) must not leak as top-level entities.
+        let code = r#"{:a {:b 1 :c 2} :d 3}"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "config.edn");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+
+        assert!(names.contains(&":a"), "Should find :a, got: {:?}", names);
+        assert!(names.contains(&":d"), "Should find :d, got: {:?}", names);
+        assert!(!names.contains(&":b"), "Inner :b should not be extracted");
+        assert!(!names.contains(&":c"), "Inner :c should not be extracted");
+        assert_eq!(names.len(), 2);
+    }
+
+    #[test]
+    #[cfg(feature = "lang-edn")]
+    fn test_edn_non_map_top_level_forms_not_extracted() {
+        // A bare vector at the top level has no meaningful name and yields no entities.
+        let code = r#"["alpha" "beta"]"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "data.edn");
+        assert_eq!(entities.len(), 0);
+    }
+
+    #[test]
+    #[cfg(feature = "lang-edn")]
+    fn test_edn_symbol_keys_extracted() {
+        let code = r#"{foo 1 bar 2}"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "sym.edn");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+
+        assert!(names.contains(&"foo"), "Should find foo, got: {:?}", names);
+        assert!(names.contains(&"bar"), "Should find bar, got: {:?}", names);
     }
 }


### PR DESCRIPTION
feat: add Clojure and EDN language support

Turned out quite a bit more involved and intrusive than the average language addition, but I think the implementation is pretty clean.

## Summary

### Cross-language infrastructure changes

Clojure identifier conventions (kebab-case names, predicate `?` suffixes, bang `!` suffixes, dynamic `*var*` wrappers) cannot be handled by the existing identifier tokenizer, which recognises only alphanumeric characters and `_`. Clojure’s semicolon comment syntax also conflicts with the generic stripper, which treats `#` as a line-comment character, breaking gensyms (`result#`) and reader macros (`#?`, `#{}`).

To support these without special-casing inside shared code paths, two new fields are added to `LanguageConfig`:

- `extra_ident_chars: &'static [char]` - additional characters that are valid inside an identifier token for the language. Every call site that splits on word boundaries (`identifier_tokens`, `text_mentions_any_name`, `content_contains_identifier`, `extract_references_from_content`, `extract_references_with_stripped*`, and the reference-tracking loops in `EntityGraph`) now accepts and forwards this slice. All existing configs supply `&[]`.
- `strip_strategy: StripStrategy` - selects which stripping function `strip_for_language` dispatches to. The existing `strip_comments_and_strings` becomes `StripStrategy::Generic`. `StripStrategy::Clojure` calls `strip_clojure_content` (blanks double-quoted strings, preserves `#`) followed by `strip_clojure_line_comments` (truncates at `;`). All existing configs supply `StripStrategy::Generic`.

Two further boolean flags are added:

- `has_slash_qualified_refs` - when true, `resolve_entity_references` runs a second pass with `CLOJURE_QUALIFIED_REF_RE` to resolve `alias/name` tokens that the tokenizer would otherwise split at the slash.
- `extract_map_entries` - when true, a top-level `map_lit` AST node is broken into one entity per keyword or symbol key, rather than recursing into children. Used for EDN.

`FileReferenceIndex::from_content` is split into a `#[cfg(test)]`-only variant (for tests that pass a raw string) and `from_stripped` (production path), so that `build_file_reference_index` can apply the language-specific strip strategy before indexing.

`is_reference_word` and `maybe_push_reference_token` are updated to accept tokens that start with `-` or `*`, which can only reach those functions for Clojure files (because `extra_ident_chars_for_file` gates tokenization upstream). Purely symbolic tokens (e.g. the arithmetic `*`) are rejected by a new guard that requires at least one alphanumeric, `_`, or `-` character.

### Clojure-specific

- Add `tree-sitter-clojure-orchard` (v0.2.5) with feature flags `lang-clojure` and `lang-edn` (both dialects share the same grammar).
- `CLOJURE_CONFIG` covers `.clj`, `.cljs`, `.cljc`; `call_entity_identifiers` lists `def`, `defonce`, `defn`, `defn-`, `defmacro`, `defmulti`, `defmethod`, `defprotocol`, `defrecord`, `deftype`, `definterface`, `defstruct`.
- Entity extraction uses the `list_lit` branch in `visit_node`: a list whose first named child is a `sym_lit` matching a whitelisted keyword is extracted as a named entity. `defmethod` dispatch values are appended to the base name (`area/:circle`) so multiple methods on one multimethod get distinct stable IDs. Metadata annotations (`^:private`) are stripped via `clojure_sym_name`, which reads the `name` field child of `sym_lit`.
- `ns` forms are not extracted (not in `call_entity_identifiers`); children of a matched list are not recursed into (nested `defn` is not idiomatic and would produce misleading entities).
- Namespace alias resolution: `build_import_table_with_default_export_paths` parses `(:require [ns :refer [sym]])` forms via `CLOJURE_REFER_RE` and `(:require [ns :as alias])` forms via `CLOJURE_AS_RE`. A pre-built `ClojureNsIndex` (file-path-without-extension to entity list) avoids an O(total-entities) scan per `:as` alias. Namespace dots map to path slashes and hyphens map to underscores (`myapp.string-utils` -> `myapp/string_utils`). Qualified calls (`alias/fn-name`) are resolved in `resolve_entity_references` via a post-processing pass guarded by `has_slash_qualified_refs`.

### EDN-specific

- `EDN_CONFIG` covers `.edn`; `extract_map_entries: true` triggers the `map_lit` branch in `visit_node` instead of the `list_lit` branch.
- `comment` and `dis_expr` nodes are filtered out of `named_children` before iterating key-value pairs; without this, a `;` comment inside a map shifts the pairing by one slot, producing spurious renames for unchanged entries.
- Non-map top-level forms (bare vectors, sets, lists) yield no entities.
- Inner map values are not recursed into, so nested maps do not leak inner entries as top-level entities.

## Test plan

- [x] `cargo check -p sem-core` passes
- [x] `cargo test -p sem-core` all existing tests pass plus new tests:
  - 10 Clojure entity-extraction tests (`mod.rs`): `def`/`defonce`/`defn`/`defn-`/`defmacro`/`defprotocol`/`defrecord`/`defmulti`/`defmethod`, predicate and bang functions, dynamic vars, `.cljc` extension, non-keyword dispatch values
  - 4 EDN entity-extraction tests (`mod.rs`): `deps.edn` map entries, nested map isolation, bare-vector top-level, symbol keys
  - 7 graph reference-resolution tests (`graph.rs`): `:as` alias, `:refer`, kebab-case names via `:refer`, arithmetic `*` no false edge, gensym (`result#`) does not blank qualified call, reader-conditional `#?` `:as` alias, multi-line `:refer` vector
  - 1 EDN differ regression test (`differ.rs`): comment inside map does not displace key-value pairing
- [x] Smoke test verifies all entity types extracted from representative `.clj`, `.cljs`, `.cljc`, and `.edn` files