### PR TITLE
feat: add D language support

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1389,7 +1389,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sem-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "clap",
  "clap_complete_command",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "sem-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "git2",
  "rayon",
@@ -1425,6 +1425,7 @@ dependencies = [
  "tree-sitter-c",
  "tree-sitter-c-sharp",
  "tree-sitter-cpp",
+ "tree-sitter-d",
  "tree-sitter-dart",
  "tree-sitter-elixir",
  "tree-sitter-elm",
@@ -1454,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "sem-mcp"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "git2",
  "ignore",
@@ -1475,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "sem-plugin"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "sem-core",
  "serde",
@@ -1928,6 +1929,16 @@ name = "tree-sitter-cpp"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df2196ea9d47b4ab4a31b9297eaa5a5d19a0b121dceb9f118f6790ad0ab94743"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-d"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c6fa0082e20747a92c5c863cadb7775fbe344f212837f03fc0f7187adf6fd1"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/crates/sem-core/Cargo.toml
+++ b/crates/sem-core/Cargo.toml
@@ -30,6 +30,7 @@ grammar-all = [
     "lang-svelte", "lang-erb",
     "lang-haskell",
     "lang-elm",
+    "lang-d",
 ]
 
 # Individual grammar features
@@ -61,6 +62,7 @@ lang-svelte = ["dep:tree-sitter-htmlx-svelte"]
 lang-erb = ["dep:tree-sitter-embedded-template"]
 lang-haskell = ["dep:tree-sitter-haskell"]
 lang-elm = ["dep:tree-sitter-elm"]
+lang-d = ["dep:tree-sitter-d"]
 
 [dependencies]
 git2 = { version = "0.20", optional = true }
@@ -101,6 +103,7 @@ tree-sitter-zig = { version = "1.1.2", optional = true }
 tree-sitter-nix = { version = "0.3", optional = true }
 tree-sitter-haskell = { version = "0.23", optional = true }
 tree-sitter-elm = { version = "5.9", optional = true }
+tree-sitter-d = { version = "0.8.2", optional = true }
 
 [dev-dependencies]
 tempfile = "3.24.0"

--- a/crates/sem-core/src/parser/plugins/code/languages.rs
+++ b/crates/sem-core/src/parser/plugins/code/languages.rs
@@ -334,6 +334,11 @@ fn get_elm() -> Option<Language> {
     Some(tree_sitter_elm::LANGUAGE.into())
 }
 
+#[cfg(feature = "lang-d")]
+fn get_d() -> Option<Language> {
+    Some(tree_sitter_d::LANGUAGE.into())
+}
+
 /// Inside JS/TS function bodies, suppress variable declarations so that local
 /// variables are not extracted as nested entities. Inner function/class
 /// declarations are still extracted for diff granularity.
@@ -1066,6 +1071,63 @@ static ELM_CONFIG: LanguageConfig = LanguageConfig {
     suppressed_nested_entities: &[],
     scope_boundary_types: &["value_declaration"],
     get_language: get_elm,
+    scope_resolve: None,
+};
+
+#[cfg(feature = "lang-d")]
+static D_CONFIG: LanguageConfig = LanguageConfig {
+    id: "d",
+    extensions: &[".d", ".di"],
+    entity_node_types: &[
+        "module_declaration",
+        "function_declaration",
+        "class_declaration",
+        "struct_declaration",
+        "interface_declaration",
+        "union_declaration",
+        "enum_declaration",
+        "anonymous_enum_declaration",
+        "template_declaration",
+        "mixin_template_declaration",
+        "constructor",
+        "destructor",
+        "postblit",
+        "alias_declaration",
+        "unittest_declaration",
+        "variable_declaration",
+        "manifest_constant",
+        "auto_declaration",
+    ],
+    container_node_types: &["aggregate_body"],
+    call_entity_identifiers: &[],
+    suppressed_nested_entities: &[
+        SuppressedNestedEntity {
+            parent_entity_node_type: "function_declaration",
+            child_entity_node_type: "variable_declaration",
+        },
+        SuppressedNestedEntity {
+            parent_entity_node_type: "function_declaration",
+            child_entity_node_type: "auto_declaration",
+        },
+        SuppressedNestedEntity {
+            parent_entity_node_type: "constructor",
+            child_entity_node_type: "variable_declaration",
+        },
+        SuppressedNestedEntity {
+            parent_entity_node_type: "destructor",
+            child_entity_node_type: "variable_declaration",
+        },
+        SuppressedNestedEntity {
+            parent_entity_node_type: "unittest_declaration",
+            child_entity_node_type: "variable_declaration",
+        },
+        SuppressedNestedEntity {
+            parent_entity_node_type: "unittest_declaration",
+            child_entity_node_type: "auto_declaration",
+        },
+    ],
+    scope_boundary_types: &["function_body", "block_statement"],
+    get_language: get_d,
     scope_resolve: None,
 };
 
@@ -2353,6 +2415,8 @@ macro_rules! all_configs {
             &HASKELL_CONFIG,
             #[cfg(feature = "lang-elm")]
             &ELM_CONFIG,
+            #[cfg(feature = "lang-d")]
+            &D_CONFIG,
         ]
     }};
 }

--- a/crates/sem-core/src/parser/registry.rs
+++ b/crates/sem-core/src/parser/registry.rs
@@ -441,6 +441,8 @@ const LANG_MAPPING: &[(&str, &str)] = &[
     ("scala", ".scala"),
     ("haskell", ".hs"),
     ("elm", ".elm"),
+    ("d", ".d"),
+    ("dlang", ".d"),
     ("zig", ".zig"),
     ("xml", ".xml"),
     ("json", ".json"),

--- a/crates/sem-core/tests/d_smoke.rs
+++ b/crates/sem-core/tests/d_smoke.rs
@@ -1,0 +1,116 @@
+#[cfg(feature = "lang-d")]
+mod d_lang {
+    use sem_core::parser::plugins::create_default_registry;
+
+    #[test]
+    fn d_extracts_all_entity_types() {
+        let registry = create_default_registry();
+        let d_code = r#"module mypkg.mymod;
+
+import std.stdio;
+
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+
+struct Point {
+    int x;
+    int y;
+}
+
+union Value {
+    int i;
+    float f;
+}
+
+interface Greeter {
+    string greet();
+}
+
+class HelloGreeter : Greeter {
+    string name;
+
+    this(string name) {
+        this.name = name;
+    }
+
+    ~this() {}
+
+    string greet() {
+        return "Hello, " ~ name;
+    }
+}
+
+template Repeat(T, size_t N) {
+    alias Repeat = T[N];
+}
+
+mixin template Logger() {
+    void log(string s) { writeln(s); }
+}
+
+int add(int a, int b) {
+    return a + b;
+}
+
+void main() {
+    auto g = new HelloGreeter("world");
+    writeln(g.greet());
+}
+
+unittest {
+    assert(add(1, 2) == 3);
+}
+"#;
+
+        let entities = registry.extract_entities("hello.d", d_code);
+        assert!(!entities.is_empty(), "Should extract entities from D code");
+
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+        eprintln!(
+            "D entities: {:?}",
+            entities
+                .iter()
+                .map(|e| (&e.name, &e.entity_type))
+                .collect::<Vec<_>>()
+        );
+
+        assert!(names.contains(&"Color"), "Should find enum Color, got: {:?}", names);
+        assert!(names.contains(&"Point"), "Should find struct Point, got: {:?}", names);
+        assert!(names.contains(&"Value"), "Should find union Value, got: {:?}", names);
+        assert!(names.contains(&"Greeter"), "Should find interface Greeter, got: {:?}", names);
+        assert!(names.contains(&"HelloGreeter"), "Should find class HelloGreeter, got: {:?}", names);
+        assert!(names.contains(&"greet"), "Should find method greet, got: {:?}", names);
+        assert!(names.contains(&"Repeat"), "Should find template Repeat, got: {:?}", names);
+        assert!(names.contains(&"Logger"), "Should find mixin template Logger, got: {:?}", names);
+        assert!(names.contains(&"add"), "Should find function add, got: {:?}", names);
+        assert!(names.contains(&"main"), "Should find function main, got: {:?}", names);
+
+        for entity in &entities {
+            assert_eq!(entity.file_path, "hello.d");
+        }
+    }
+
+    #[test]
+    fn d_local_variables_not_extracted_as_top_level() {
+        let registry = create_default_registry();
+        let d_code = r#"module test;
+
+int compute(int x) {
+    int local = x * 2;
+    auto another = local + 1;
+    return another;
+}
+"#;
+
+        let entities = registry.extract_entities("test.d", d_code);
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+        eprintln!("D entities (locals): {:?}", names);
+
+        assert!(names.contains(&"compute"), "Should find top-level compute, got: {:?}", names);
+        assert!(!names.contains(&"local"), "Should not extract local variable 'local', got: {:?}", names);
+        assert!(!names.contains(&"another"), "Should not extract local variable 'another', got: {:?}", names);
+    }
+}


### PR DESCRIPTION

 ## Summary
  - Adds D language support behind a new `lang-d` feature flag, wired into `grammar-all`
  - Uses `tree-sitter-d` 0.8.2 for parsing; registers `.d` and `.di` extensions and the `d` / `dlang` language aliases
  - Extracts modules, functions, classes, structs, interfaces, unions, enums, templates, mixin templates, constructors/destructors/postblits, aliases, unittests, and top-level variables/manifest constants
  - Suppresses nested entity extraction for locals inside functions, constructors, destructors, and `unittest` blocks so only top-level entities surface