### PR TITLE
Batch cache fingerprint refreshes

### DIFF
--- a/crates/sem-cli/src/cache.rs
+++ b/crates/sem-cli/src/cache.rs
@@ -471,15 +471,14 @@ impl DiskCache {
             return false;
         }
 
-        let mut stmt = self
-            .conn
-            .prepare("SELECT path, mtime_secs, mtime_nanos, content_hash FROM files")
-            .ok();
-        let Some(ref mut stmt) = stmt else {
-            return false;
-        };
-        let cached_mtimes: HashMap<String, (i64, i64, Option<String>)> =
-            match stmt.query_map([], |row| {
+        let cached_mtimes: HashMap<String, (i64, i64, Option<String>)> = {
+            let Ok(mut stmt) = self
+                .conn
+                .prepare("SELECT path, mtime_secs, mtime_nanos, content_hash FROM files")
+            else {
+                return false;
+            };
+            let cached_mtimes = match stmt.query_map([], |row| {
                 Ok((
                     row.get::<_, String>(0)?,
                     (
@@ -492,7 +491,10 @@ impl DiskCache {
                 Ok(rows) => rows.filter_map(|r| r.ok()).collect(),
                 Err(_) => return false,
             };
+            cached_mtimes
+        };
 
+        let mut fingerprint_refreshes = Vec::new();
         for file in files {
             if shared_cache::is_manifest_file_name(file) {
                 continue;
@@ -508,12 +510,18 @@ impl DiskCache {
                     nanos,
                     content_hash,
                 }) => {
-                    self.refresh_file_fingerprint(file, secs, nanos, &content_hash);
+                    fingerprint_refreshes.push(shared_cache::FileFingerprintRefresh {
+                        path: file.clone(),
+                        mtime_secs: secs,
+                        mtime_nanos: nanos,
+                        content_hash,
+                    });
                 }
                 Some(shared_cache::FileFreshness::Stale) | None => return false,
             }
         }
 
+        shared_cache::refresh_file_fingerprints_best_effort(&self.conn, &fingerprint_refreshes);
         true
     }
 
@@ -572,6 +580,7 @@ impl DiskCache {
             .ok()?
             .filter_map(|r| r.ok())
             .collect();
+        drop(stmt);
 
         if cached_files.is_empty() {
             return None;
@@ -587,6 +596,7 @@ impl DiskCache {
         // Find stale source files: mtime differs or not in cache
         let mut stale_source_files: Vec<String> = Vec::new();
         let mut stale_current_file_count = 0;
+        let mut fingerprint_refreshes = Vec::new();
         for file in &source_files {
             match cached_files.get(file.as_str()) {
                 Some((secs, nanos, content_hash)) => {
@@ -603,7 +613,12 @@ impl DiskCache {
                             nanos,
                             content_hash,
                         }) => {
-                            self.refresh_file_fingerprint(file, secs, nanos, &content_hash);
+                            fingerprint_refreshes.push(shared_cache::FileFingerprintRefresh {
+                                path: (*file).clone(),
+                                mtime_secs: secs,
+                                mtime_nanos: nanos,
+                                content_hash,
+                            });
                         }
                         Some(shared_cache::FileFreshness::Stale) | None => {
                             stale_current_file_count += 1;
@@ -628,6 +643,8 @@ impl DiskCache {
                 deleted_cached_files.push(cached_path.clone());
             }
         }
+
+        shared_cache::refresh_file_fingerprints_best_effort(&self.conn, &fingerprint_refreshes);
 
         // If nothing stale, full load would have worked
         if stale_source_files.is_empty() && deleted_cached_files.is_empty() {
@@ -937,13 +954,6 @@ impl DiskCache {
         tx.commit()?;
         Ok(())
     }
-
-    fn refresh_file_fingerprint(&self, file: &str, secs: i64, nanos: i64, content_hash: &str) {
-        let _ = self.conn.execute(
-            "UPDATE files SET mtime_secs = ?2, mtime_nanos = ?3, content_hash = ?4 WHERE path = ?1",
-            params![file, secs, nanos, content_hash],
-        );
-    }
 }
 
 fn sql_io_error(error: rusqlite::Error) -> std::io::Error {
@@ -1215,19 +1225,88 @@ mod tests {
     #[test]
     fn load_refreshes_mtime_when_file_content_is_unchanged() {
         let root = temp_repo_root("mtime-only-refresh");
-        let file = root.join("same.rs");
-        write_file(&file, "fn same() {}\n");
-        let files = vec!["same.rs".to_string()];
+        let file_contents = [
+            ("same_a.rs", "fn same_a() {}\n"),
+            ("same_b.rs", "fn same_b() {}\n"),
+            ("same_c.rs", "fn same_c() {}\n"),
+        ];
+        for (file, content) in &file_contents {
+            write_file(&root.join(*file), content);
+        }
+        let files: Vec<String> = file_contents
+            .iter()
+            .map(|(file, _)| (*file).to_string())
+            .collect();
         let cache = save_empty_cache(&root, &files);
-        let before = cached_file_mtime(&cache, "same.rs");
+        let before: Vec<(i64, i64)> = files
+            .iter()
+            .map(|file| cached_file_mtime(&cache, file))
+            .collect();
 
-        rewrite_after_mtime_tick(&file, "fn same() {}\n");
-        let current = shared_cache::file_mtime_parts(&file).unwrap();
-        assert_ne!(before, current);
+        let rewrite_all = || -> Vec<(i64, i64)> {
+            for (file, content) in &file_contents {
+                rewrite_after_mtime_tick(&root.join(*file), content);
+            }
+            file_contents
+                .iter()
+                .map(|(file, _)| shared_cache::file_mtime_parts(&root.join(*file)).unwrap())
+                .collect()
+        };
+        let assert_cached_mtimes = |expected: &[(i64, i64)]| {
+            for (file, expected) in files.iter().zip(expected) {
+                assert_eq!(cached_file_mtime(&cache, file), *expected);
+            }
+        };
 
+        let full_current = rewrite_all();
+        assert!(before
+            .iter()
+            .zip(&full_current)
+            .all(|(before, current)| before != current));
+        assert!(cache.load(&root, &files).is_some());
+        assert_cached_mtimes(&full_current);
+
+        let topology_current = rewrite_all();
         assert!(cache.load_graph_topology(&root, &files).is_some());
+        assert_cached_mtimes(&topology_current);
+
+        let partial_current = rewrite_all();
         assert!(cache.load_partial(&root, &files).is_none());
-        assert_eq!(cached_file_mtime(&cache, "same.rs"), current);
+        assert_cached_mtimes(&partial_current);
+
+        drop(cache);
+        cleanup(root);
+    }
+
+    #[test]
+    fn cache_loads_ignore_fingerprint_refresh_failure() {
+        let root = temp_repo_root("refresh-failure-cache-hit");
+        write_file(&root.join("same.rs"), "fn same() {}\n");
+        write_file(&root.join("stale.rs"), "fn stale() {}\n");
+        let files = vec!["same.rs".to_string(), "stale.rs".to_string()];
+        let cache = save_empty_cache(&root, &files);
+        let before_same = cached_file_mtime(&cache, "same.rs");
+
+        cache
+            .conn
+            .execute_batch(
+                "CREATE TRIGGER fail_fingerprint_refresh
+                 BEFORE UPDATE ON files
+                 BEGIN
+                     SELECT RAISE(FAIL, 'stop refresh');
+                 END;",
+            )
+            .unwrap();
+
+        rewrite_after_mtime_tick(&root.join("same.rs"), "fn same() {}\n");
+        assert!(cache.load(&root, &files).is_some());
+        assert!(cache.load_graph_topology(&root, &files).is_some());
+        assert_eq!(cached_file_mtime(&cache, "same.rs"), before_same);
+
+        rewrite_after_mtime_tick(&root.join("stale.rs"), "fn stale() { 1; }\n");
+        let partial = cache.load_partial(&root, &files).unwrap();
+        assert_eq!(partial.stale_files, vec!["stale.rs"]);
+        assert_eq!(cached_file_mtime(&cache, "same.rs"), before_same);
 
         drop(cache);
         cleanup(root);
@@ -1258,9 +1337,15 @@ mod tests {
             &root.join("b.ts"),
             "export function target() { return 3; }\n",
         );
+        rewrite_after_mtime_tick(
+            &root.join("c.ts"),
+            "export function other() { return 2; }\n",
+        );
+        let current_c = shared_cache::file_mtime_parts(&root.join("c.ts")).unwrap();
         let partial = cache.load_partial(&root, &files).unwrap();
         assert_eq!(partial.stale_files, vec!["b.ts"]);
         assert_eq!(partial.cached_importing_stale_files, vec!["a.ts"]);
+        assert_eq!(cached_file_mtime(&cache, "c.ts"), current_c);
 
         rewrite_after_mtime_tick(
             &root.join("a.ts"),

--- a/crates/sem-core/src/parser/graph.rs
+++ b/crates/sem-core/src/parser/graph.rs
@@ -601,10 +601,10 @@ fn is_reference_word(word: &str) -> bool {
     {
         return false;
     }
-    // Tokens starting with '-' or '*' only appear here for Clojure files because
-    // `extra_ident_chars_for_file` controls tokenization upstream — only Clojure
-    // has these in extra_ident_chars. '?', '!', '=' only appear as suffixes in
-    // Clojure (empty?, reset!, not=) so the start-character check below suffices.
+    // Tokens starting with '-' or '*' only appear here for Clojure-family files
+    // because `extra_ident_chars_for_file` controls tokenization upstream.
+    // '?', '!', '=' only appear as suffixes in symbols such as empty?, reset!,
+    // and not=, so the start-character check below suffices.
     if !word.starts_with(|c: char| c.is_alphabetic() || c == '_' || c == '-' || c == '*') {
         return false;
     }
@@ -760,7 +760,7 @@ fn build_file_reference_index(root: &Path, file_path: &str) -> Option<FileRefere
     let ext = file_path.rfind('.').map(|i| &file_path[i..]).unwrap_or("");
     let config = crate::parser::plugins::code::languages::get_language_config(ext)?;
     let content = std::fs::read_to_string(root.join(file_path)).ok()?;
-    let stripped = strip_for_language(config.strip_strategy, &content);
+    let stripped = strip_for_language(config.strip_strategy(), &content);
     Some(FileReferenceIndex::from_stripped(
         &stripped,
         extra_ident_chars_for_file(file_path),
@@ -847,7 +847,7 @@ fn resolve_entity_references(
         };
     let fallback_stripped = if reference_index.is_none() {
         Some(strip_for_language(
-            language_config.strip_strategy,
+            language_config.strip_strategy(),
             &entity.content,
         ))
     } else {
@@ -1020,11 +1020,11 @@ fn resolve_entity_references(
     // match cross-file entities via the symbol table. We scan the stripped content for
     // `alias/name` patterns and resolve them via the import table (populated by
     // resolve_clojure_as during import table building).
-    if language_config.has_slash_qualified_refs {
+    if language_config.has_slash_qualified_refs() {
         // Always restrip via the language's own strategy: fallback_stripped may have been
         // computed with a different strategy when reference_index was non-None above.
         let qualified_ref_stripped =
-            strip_for_language(language_config.strip_strategy, &entity.content);
+            strip_for_language(language_config.strip_strategy(), &entity.content);
         for cap in CLOJURE_QUALIFIED_REF_RE.captures_iter(&qualified_ref_stripped) {
             let qualified = cap.get(1).unwrap().as_str();
             let import_key = (entity.file_path.clone(), qualified.to_string());
@@ -1940,7 +1940,8 @@ impl EntityGraph {
                     continue;
                 }
 
-                let stripped = strip_for_language(strip_strategy_for_file(&entity.file_path), &entity.content);
+                let stripped =
+                    strip_for_language(strip_strategy_for_file(&entity.file_path), &entity.content);
                 if text_mentions_any_name(&stripped, &affected_target_names, extra) {
                     affected_clean_ids.insert(entity.id.clone());
                     affected_clean_file_paths.insert(entity.file_path.as_str());
@@ -2000,7 +2001,8 @@ impl EntityGraph {
                     continue;
                 }
 
-                let stripped = strip_for_language(strip_strategy_for_file(&entity.file_path), &entity.content);
+                let stripped =
+                    strip_for_language(strip_strategy_for_file(&entity.file_path), &entity.content);
                 if text_mentions_any_name(&stripped, &new_stale_names, extra) {
                     clean_entities_mentioning_new_stale_names.insert(entity.id.as_str());
                     clean_import_candidate_files.insert(entity.file_path.as_str());
@@ -3708,10 +3710,10 @@ fn build_import_table_with_default_export_paths(
             if let Some(file_config) =
                 crate::parser::plugins::code::languages::get_language_config(file_ext)
             {
-                if file_config.has_slash_qualified_refs {
+                if file_config.has_slash_qualified_refs() {
                     // Strip using the language's own strategy so language-specific syntax (e.g.
                     // Clojure's `#` for reader macros/gensyms) is preserved correctly.
-                    let clojure_stripped = strip_for_language(file_config.strip_strategy, content);
+                    let clojure_stripped = strip_for_language(file_config.strip_strategy(), content);
                     for cap in CLOJURE_REFER_RE.captures_iter(&clojure_stripped) {
                         let ns_name = cap.get(1).unwrap().as_str();
                         let symbols_str = cap.get(2).unwrap().as_str();
@@ -4084,7 +4086,7 @@ fn strip_clojure_content(content: &str) -> String {
 }
 
 /// Dispatch to the appropriate content stripper for the given language strategy.
-/// Add a new arm here when adding a `StripStrategy` variant for a new language.
+/// Each `StripStrategy` variant must be handled explicitly.
 fn strip_for_language(
     strategy: crate::parser::plugins::code::languages::StripStrategy,
     content: &str,
@@ -4184,8 +4186,9 @@ static PY_FOR_BINDING_RE: LazyLock<Regex> =
 // Clojure `:require [ns :refer [sym1 sym2]]` — matches inside any require form.
 // `[^\[\]]*` prevents crossing both `[` and `]` boundaries, so the regex cannot
 // span from one require form's namespace into a later form's :refer list.
-static CLOJURE_REFER_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"\[([a-zA-Z][a-zA-Z0-9._-]*)\b[^\[\]]*:refer\s+\[([^\]]+)\]").unwrap());
+static CLOJURE_REFER_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\[([a-zA-Z][a-zA-Z0-9._-]*)\b[^\[\]]*:refer\s+\[([^\]]+)\]").unwrap()
+});
 
 // Clojure `:require [ns :as alias]` — matches inside any require form.
 // `[^\]]*` prevents crossing bracket boundaries.
@@ -4282,7 +4285,7 @@ fn maybe_add_local_binding_name<F>(
 fn extra_ident_chars_for_file(file_path: &str) -> &'static [char] {
     let ext = file_path.rfind('.').map(|i| &file_path[i..]).unwrap_or("");
     crate::parser::plugins::code::languages::get_language_config(ext)
-        .map_or(&[], |c| c.extra_ident_chars)
+        .map_or(&[], |c| c.extra_ident_chars())
 }
 
 fn strip_strategy_for_file(
@@ -4291,7 +4294,7 @@ fn strip_strategy_for_file(
     let ext = file_path.rfind('.').map(|i| &file_path[i..]).unwrap_or("");
     crate::parser::plugins::code::languages::get_language_config(ext).map_or(
         crate::parser::plugins::code::languages::StripStrategy::Generic,
-        |c| c.strip_strategy,
+        |c| c.strip_strategy(),
     )
 }
 
@@ -4642,10 +4645,10 @@ fn maybe_push_reference_token<'a, F>(
     {
         return;
     }
-    // Tokens starting with '-' or '*' only appear here for Clojure files because
-    // `extra_ident_chars_for_file` controls tokenization upstream — only Clojure
-    // has these in extra_ident_chars. '?', '!', '=' only appear as suffixes in
-    // Clojure (empty?, reset!, not=) so the start-character check below suffices.
+    // Tokens starting with '-' or '*' only appear here for Clojure-family files
+    // because `extra_ident_chars_for_file` controls tokenization upstream.
+    // '?', '!', '=' only appear as suffixes in symbols such as empty?, reset!,
+    // and not=, so the start-character check below suffices.
     if !word.starts_with(|c: char| c.is_alphabetic() || c == '_' || c == '-' || c == '*') {
         return;
     }

--- a/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
+++ b/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
@@ -316,7 +316,7 @@ fn visit_node(
         // EDN map-entry extraction: treat each keyword key–value pair in a top-level
         // map_lit as a named "entry" entity. Values are kept as opaque content and are
         // not recursed into, so nested maps don't leak inner entries as entities.
-        if node_type == "map_lit" && config.extract_map_entries {
+        if node_type == "map_lit" && config.extract_map_entries() {
             let mut cursor = node.walk();
             // Skip comment and dis_expr nodes: they are named children of map_lit
             // in tree-sitter-clojure but are not actual forms. Without this filter,
@@ -335,11 +335,9 @@ fn visit_node(
                     "kwd_lit" | "sym_lit" => node_text(key, source).to_string(),
                     _ => continue,
                 };
-                let content = std::str::from_utf8(
-                    &source[key.start_byte()..value.end_byte()],
-                )
-                .unwrap_or("")
-                .to_string();
+                let content = std::str::from_utf8(&source[key.start_byte()..value.end_byte()])
+                    .unwrap_or("")
+                    .to_string();
                 let struct_hash = compute_structural_hash(value, source);
                 let entity = SemanticEntity {
                     id: build_entity_id(file_path, "entry", &name, parent_id),

--- a/crates/sem-core/src/parser/plugins/code/languages.rs
+++ b/crates/sem-core/src/parser/plugins/code/languages.rs
@@ -11,9 +11,8 @@ pub struct SuppressedNestedEntity {
 
 /// Strategy for stripping comments and string literals from source content.
 /// Controls which stripping function `strip_for_language` dispatches to in graph.rs.
-/// Add a new variant here when a language requires custom comment handling.
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub enum StripStrategy {
+pub(crate) enum StripStrategy {
     /// Standard stripper: handles `//`, `/* */`, and `#` line comments, plus string literals.
     Generic,
     /// Clojure: blank double-quoted strings only (preserves `#` for gensyms and reader macros),
@@ -28,21 +27,6 @@ pub struct LanguageConfig {
     pub entity_node_types: &'static [&'static str],
     pub container_node_types: &'static [&'static str],
     pub call_entity_identifiers: &'static [&'static str],
-    /// Extra characters (beyond alphanumeric and `_`) that are valid identifier
-    /// constituents for this language. Used by the tokenizer and reference scanner.
-    /// E.g. Clojure uses `['-', '?', '!', '*', '=']` for kebab-case, predicates,
-    /// bang functions, dynamic vars, and equality operators.
-    pub extra_ident_chars: &'static [char],
-    /// How to strip comments and string literals from content for this language.
-    pub strip_strategy: StripStrategy,
-    /// Whether this language uses `alias/name` qualified references (e.g. Clojure).
-    /// When true, `resolve_entity_references` runs a post-processing pass to resolve
-    /// these qualified calls via the import table.
-    pub has_slash_qualified_refs: bool,
-    /// When true, a top-level `map_lit` node is broken into individual named entities,
-    /// one per keyword key–value pair. Used for EDN data files (deps.edn, etc.) where
-    /// the meaningful units are top-level map entries, not code definition forms.
-    pub extract_map_entries: bool,
     pub suppressed_nested_entities: &'static [SuppressedNestedEntity],
     /// Node types that introduce a new scope. The general (non-container) recursion
     /// in visit_node will not descend into these nodes, preventing local variables
@@ -50,6 +34,32 @@ pub struct LanguageConfig {
     pub scope_boundary_types: &'static [&'static str],
     pub get_language: fn() -> Option<Language>,
     pub scope_resolve: Option<&'static ScopeResolveConfig>,
+}
+
+const CLOJURE_EXTRA_IDENT_CHARS: &[char] = &['-', '?', '!', '*', '='];
+
+impl LanguageConfig {
+    pub(crate) fn extra_ident_chars(&self) -> &'static [char] {
+        match self.id {
+            "clojure" | "edn" => CLOJURE_EXTRA_IDENT_CHARS,
+            _ => &[],
+        }
+    }
+
+    pub(crate) fn strip_strategy(&self) -> StripStrategy {
+        match self.id {
+            "clojure" | "edn" => StripStrategy::Clojure,
+            _ => StripStrategy::Generic,
+        }
+    }
+
+    pub(crate) fn has_slash_qualified_refs(&self) -> bool {
+        self.id == "clojure"
+    }
+
+    pub(crate) fn extract_map_entries(&self) -> bool {
+        self.id == "edn"
+    }
 }
 
 // ─── Scope Resolve Config Types ───────────────────────────────────────────────
@@ -513,13 +523,9 @@ static TYPESCRIPT_CONFIG: LanguageConfig = LanguageConfig {
         "statement_block",
     ],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: JS_TS_SUPPRESSED_NESTED,
     scope_boundary_types: JS_TS_SCOPE_BOUNDARIES,
     get_language: get_typescript,
-    extract_map_entries: false,
     scope_resolve: Some(&TS_SCOPE_CONFIG),
 };
 
@@ -555,13 +561,9 @@ static TSX_CONFIG: LanguageConfig = LanguageConfig {
         "statement_block",
     ],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: JS_TS_SUPPRESSED_NESTED,
     scope_boundary_types: JS_TS_SCOPE_BOUNDARIES,
     get_language: get_tsx,
-    extract_map_entries: false,
     scope_resolve: Some(&TS_SCOPE_CONFIG),
 };
 
@@ -581,13 +583,9 @@ static JAVASCRIPT_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["class_body", "statement_block"],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: JS_TS_SUPPRESSED_NESTED,
     scope_boundary_types: JS_TS_SCOPE_BOUNDARIES,
     get_language: get_javascript,
-    extract_map_entries: false,
     scope_resolve: Some(&TS_SCOPE_CONFIG),
 };
 
@@ -602,13 +600,9 @@ static PYTHON_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["block"],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_python,
-    extract_map_entries: false,
     scope_resolve: Some(&PYTHON_SCOPE_CONFIG),
 };
 
@@ -625,13 +619,9 @@ static GO_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["block"],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_go,
-    extract_map_entries: false,
     scope_resolve: Some(&GO_SCOPE_CONFIG),
 };
 
@@ -653,13 +643,9 @@ static RUST_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["declaration_list", "block"],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_rust,
-    extract_map_entries: false,
     scope_resolve: Some(&RUST_SCOPE_CONFIG),
 };
 
@@ -685,13 +671,9 @@ static JAVA_CONFIG: LanguageConfig = LanguageConfig {
         "block",
     ],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_java,
-    extract_map_entries: false,
     scope_resolve: Some(&JAVA_SCOPE_CONFIG),
 };
 
@@ -709,13 +691,9 @@ static C_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["compound_statement"],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: C_SUPPRESSED_NESTED,
     scope_boundary_types: &[],
     get_language: get_c,
-    extract_map_entries: false,
     scope_resolve: None,
 };
 
@@ -739,13 +717,9 @@ static CPP_CONFIG: LanguageConfig = LanguageConfig {
         "compound_statement",
     ],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: CPP_SUPPRESSED_NESTED,
     scope_boundary_types: CPP_SCOPE_BOUNDARIES,
     get_language: get_cpp,
-    extract_map_entries: false,
     scope_resolve: Some(&CPP_SCOPE_CONFIG),
 };
 
@@ -756,13 +730,9 @@ static RUBY_CONFIG: LanguageConfig = LanguageConfig {
     entity_node_types: &["method", "singleton_method", "class", "module"],
     container_node_types: &["body_statement"],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_ruby,
-    extract_map_entries: false,
     scope_resolve: Some(&RUBY_SCOPE_CONFIG),
 };
 
@@ -785,13 +755,9 @@ static CSHARP_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["declaration_list", "record_body", "block"],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_csharp,
-    extract_map_entries: false,
     scope_resolve: Some(&CSHARP_SCOPE_CONFIG),
 };
 
@@ -814,13 +780,9 @@ static PHP_CONFIG: LanguageConfig = LanguageConfig {
         "compound_statement",
     ],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_php,
-    extract_map_entries: false,
     scope_resolve: Some(&PHP_SCOPE_CONFIG),
 };
 
@@ -838,13 +800,9 @@ static FORTRAN_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["module", "program", "internal_procedures"],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_fortran,
-    extract_map_entries: false,
     scope_resolve: None,
 };
 
@@ -875,13 +833,9 @@ static SWIFT_CONFIG: LanguageConfig = LanguageConfig {
         "computed_property",
     ],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: SWIFT_SUPPRESSED_NESTED,
     scope_boundary_types: &[],
     get_language: get_swift,
-    extract_map_entries: false,
     scope_resolve: Some(&SWIFT_SCOPE_CONFIG),
 };
 
@@ -905,13 +859,9 @@ static ELIXIR_CONFIG: LanguageConfig = LanguageConfig {
         "defexception",
         "defdelegate",
     ],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_elixir,
-    extract_map_entries: false,
     scope_resolve: None,
 };
 
@@ -922,13 +872,9 @@ static BASH_CONFIG: LanguageConfig = LanguageConfig {
     entity_node_types: &["function_definition"],
     container_node_types: &["compound_statement"],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_bash,
-    extract_map_entries: false,
     scope_resolve: Some(&BASH_SCOPE_CONFIG),
 };
 
@@ -939,16 +885,12 @@ static HCL_CONFIG: LanguageConfig = LanguageConfig {
     entity_node_types: &["block", "attribute"],
     container_node_types: &["body"],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[SuppressedNestedEntity {
         parent_entity_node_type: "block",
         child_entity_node_type: "attribute",
     }],
     scope_boundary_types: &[],
     get_language: get_hcl,
-    extract_map_entries: false,
     scope_resolve: None,
 };
 
@@ -967,13 +909,9 @@ static KOTLIN_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["class_body", "enum_class_body"],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_kotlin,
-    extract_map_entries: false,
     scope_resolve: Some(&KOTLIN_SCOPE_CONFIG),
 };
 
@@ -987,13 +925,9 @@ static XML_CONFIG: LanguageConfig = LanguageConfig {
     entity_node_types: &["element"],
     container_node_types: &["content"],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_xml,
-    extract_map_entries: false,
     scope_resolve: None,
 };
 
@@ -1015,13 +949,9 @@ static DART_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["class_body", "enum_body", "extension_body"],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_dart,
-    extract_map_entries: false,
     scope_resolve: Some(&DART_SCOPE_CONFIG),
 };
 
@@ -1032,13 +962,9 @@ static PERL_CONFIG: LanguageConfig = LanguageConfig {
     entity_node_types: &["subroutine_declaration_statement", "package_statement"],
     container_node_types: &["block"],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_perl,
-    extract_map_entries: false,
     scope_resolve: None,
 };
 
@@ -1058,13 +984,9 @@ static OCAML_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["structure", "module_binding"],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_ocaml,
-    extract_map_entries: false,
     scope_resolve: None,
 };
 
@@ -1084,13 +1006,9 @@ static OCAML_INTERFACE_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["signature", "module_binding"],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_ocaml_interface,
-    extract_map_entries: false,
     scope_resolve: None,
 };
 
@@ -1113,13 +1031,9 @@ static SCALA_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["template_body", "enum_body", "with_template_body"],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_scala,
-    extract_map_entries: false,
     scope_resolve: Some(&SCALA_SCOPE_CONFIG),
 };
 
@@ -1134,16 +1048,12 @@ static ZIG_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["block"],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[SuppressedNestedEntity {
         parent_entity_node_type: "function_declaration",
         child_entity_node_type: "variable_declaration",
     }],
     scope_boundary_types: &[],
     get_language: get_zig,
-    extract_map_entries: false,
     scope_resolve: Some(&ZIG_SCOPE_CONFIG),
 };
 
@@ -1154,13 +1064,9 @@ static NIX_CONFIG: LanguageConfig = LanguageConfig {
     entity_node_types: &["binding", "inherit", "inherit_from"],
     container_node_types: &["binding_set"],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_nix,
-    extract_map_entries: false,
     scope_resolve: None,
 };
 
@@ -1185,13 +1091,9 @@ static HASKELL_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["declarations", "class_body", "instance_body"],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &["function"],
     get_language: get_haskell,
-    extract_map_entries: false,
     scope_resolve: None,
 };
 
@@ -1208,19 +1110,15 @@ static ELM_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &[],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &["value_declaration"],
     get_language: get_elm,
-    extract_map_entries: false,
     scope_resolve: None,
 };
 
 // EDN (Extensible Data Notation) shares Clojure's syntax and grammar.
 // Entities are top-level map entries (keyword key → value), extracted via the
-// map_lit branch in visit_node when extract_map_entries is true.
+// map_lit branch in visit_node when `LanguageConfig::extract_map_entries` is true.
 // Non-map top-level forms (bare vecs, sets, lists) have no nameable identity
 // and are not extracted.
 #[cfg(feature = "lang-edn")]
@@ -1230,13 +1128,9 @@ static EDN_CONFIG: LanguageConfig = LanguageConfig {
     entity_node_types: &[],
     container_node_types: &[],
     call_entity_identifiers: &[],
-    extra_ident_chars: &['-', '?', '!', '*', '='],
-    strip_strategy: StripStrategy::Clojure,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_clojure,
-    extract_map_entries: true,
     scope_resolve: None,
 };
 
@@ -1263,13 +1157,9 @@ static CLOJURE_CONFIG: LanguageConfig = LanguageConfig {
         "definterface",
         "defstruct",
     ],
-    extra_ident_chars: &['-', '?', '!', '*', '='],
-    strip_strategy: StripStrategy::Clojure,
-    has_slash_qualified_refs: true,
     suppressed_nested_entities: &[],
     scope_boundary_types: &[],
     get_language: get_clojure,
-    extract_map_entries: false,
     scope_resolve: None,
 };
 
@@ -1299,9 +1189,6 @@ static D_CONFIG: LanguageConfig = LanguageConfig {
     ],
     container_node_types: &["aggregate_body"],
     call_entity_identifiers: &[],
-    extra_ident_chars: &[],
-    strip_strategy: StripStrategy::Generic,
-    has_slash_qualified_refs: false,
     suppressed_nested_entities: &[
         SuppressedNestedEntity {
             parent_entity_node_type: "function_declaration",
@@ -1330,7 +1217,6 @@ static D_CONFIG: LanguageConfig = LanguageConfig {
     ],
     scope_boundary_types: &["function_body", "block_statement"],
     get_language: get_d,
-    extract_map_entries: false,
     scope_resolve: None,
 };
 

--- a/crates/sem-mcp/src/cache.rs
+++ b/crates/sem-mcp/src/cache.rs
@@ -396,6 +396,46 @@ pub enum FileFreshness {
     Stale,
 }
 
+pub struct FileFingerprintRefresh {
+    pub path: String,
+    pub mtime_secs: i64,
+    pub mtime_nanos: i64,
+    pub content_hash: String,
+}
+
+pub fn refresh_file_fingerprints(
+    conn: &Connection,
+    refreshes: &[FileFingerprintRefresh],
+) -> Result<(), rusqlite::Error> {
+    if refreshes.is_empty() {
+        return Ok(());
+    }
+
+    let tx = conn.unchecked_transaction()?;
+    {
+        let mut stmt = tx.prepare(
+            "UPDATE files SET mtime_secs = ?2, mtime_nanos = ?3, content_hash = ?4 WHERE path = ?1",
+        )?;
+        for refresh in refreshes {
+            stmt.execute(params![
+                &refresh.path,
+                refresh.mtime_secs,
+                refresh.mtime_nanos,
+                &refresh.content_hash
+            ])?;
+        }
+    }
+    tx.commit()
+}
+
+/// Attempts to persist refreshed file fingerprints without changing cache-hit validity.
+pub fn refresh_file_fingerprints_best_effort(
+    conn: &Connection,
+    refreshes: &[FileFingerprintRefresh],
+) {
+    let _ = refresh_file_fingerprints(conn, refreshes);
+}
+
 pub fn file_freshness(
     path: &Path,
     cached_secs: i64,
@@ -693,6 +733,7 @@ impl DiskCache {
             .conn
             .prepare("SELECT mtime_secs, mtime_nanos, content_hash FROM files WHERE path = ?1")
             .ok()?;
+        let mut fingerprint_refreshes = Vec::new();
         for file in files {
             if is_manifest_file_name(file) {
                 continue;
@@ -710,11 +751,18 @@ impl DiskCache {
                     nanos,
                     content_hash,
                 } => {
-                    self.refresh_file_fingerprint(file, secs, nanos, &content_hash);
+                    fingerprint_refreshes.push(FileFingerprintRefresh {
+                        path: file.clone(),
+                        mtime_secs: secs,
+                        mtime_nanos: nanos,
+                        content_hash,
+                    });
                 }
                 FileFreshness::Stale => return None,
             }
         }
+        drop(stmt);
+        refresh_file_fingerprints_best_effort(&self.conn, &fingerprint_refreshes);
 
         // Load entities
         let mut entity_stmt = self
@@ -825,7 +873,9 @@ impl DiskCache {
             .ok()?
             .filter_map(|r| r.ok())
             .collect();
+        drop(stmt);
 
+        let mut fingerprint_refreshes = Vec::new();
         for file in files {
             if is_manifest_file_name(file) {
                 continue;
@@ -839,11 +889,17 @@ impl DiskCache {
                     nanos,
                     content_hash,
                 } => {
-                    self.refresh_file_fingerprint(file, secs, nanos, &content_hash);
+                    fingerprint_refreshes.push(FileFingerprintRefresh {
+                        path: file.clone(),
+                        mtime_secs: secs,
+                        mtime_nanos: nanos,
+                        content_hash,
+                    });
                 }
                 FileFreshness::Stale => return None,
             }
         }
+        refresh_file_fingerprints_best_effort(&self.conn, &fingerprint_refreshes);
 
         let mut entity_stmt = self
             .conn
@@ -873,13 +929,6 @@ impl DiskCache {
 
         let edges = self.load_edges()?;
         Some(EntityGraph::from_parts(entity_map, edges))
-    }
-
-    fn refresh_file_fingerprint(&self, file: &str, secs: i64, nanos: i64, content_hash: &str) {
-        let _ = self.conn.execute(
-            "UPDATE files SET mtime_secs = ?2, mtime_nanos = ?3, content_hash = ?4 WHERE path = ?1",
-            params![file, secs, nanos, content_hash],
-        );
     }
 
     fn load_edges(&self) -> Option<Vec<EntityRef>> {
@@ -936,6 +985,7 @@ impl DiskCache {
             .ok()?
             .filter_map(|r| r.ok())
             .collect();
+        drop(stmt);
 
         if cached_files.is_empty() {
             return None;
@@ -950,6 +1000,7 @@ impl DiskCache {
 
         let mut stale_source_files: Vec<String> = Vec::new();
         let mut stale_current_file_count = 0;
+        let mut fingerprint_refreshes = Vec::new();
         for file in &source_files {
             match cached_files.get(file.as_str()) {
                 Some((secs, nanos, content_hash)) => {
@@ -961,7 +1012,12 @@ impl DiskCache {
                             nanos,
                             content_hash,
                         }) => {
-                            self.refresh_file_fingerprint(file, secs, nanos, &content_hash);
+                            fingerprint_refreshes.push(FileFingerprintRefresh {
+                                path: (*file).clone(),
+                                mtime_secs: secs,
+                                mtime_nanos: nanos,
+                                content_hash,
+                            });
                         }
                         Some(FileFreshness::Stale) | None => {
                             stale_current_file_count += 1;
@@ -986,6 +1042,8 @@ impl DiskCache {
                 deleted_cached_files.push(cached_path.clone());
             }
         }
+
+        refresh_file_fingerprints_best_effort(&self.conn, &fingerprint_refreshes);
 
         if stale_source_files.is_empty() && deleted_cached_files.is_empty() {
             return None;
@@ -1475,6 +1533,55 @@ mod tests {
     }
 
     #[test]
+    fn refresh_file_fingerprints_rolls_back_batch_on_failure() {
+        let root = temp_repo_root("mtime-refresh-rollback");
+        write_file(&root.join("a.rs"), "fn a() {}\n");
+        write_file(&root.join("b.rs"), "fn b() {}\n");
+        let files = vec!["a.rs".to_string(), "b.rs".to_string()];
+        let cache = save_empty_cache(&root, &files);
+        let before_a = cached_file_mtime(&cache, "a.rs");
+        let before_b = cached_file_mtime(&cache, "b.rs");
+
+        cache
+            .conn
+            .execute_batch(
+                "CREATE TRIGGER fail_b_refresh
+                 BEFORE UPDATE ON files
+                 WHEN OLD.path = 'b.rs'
+                 BEGIN
+                     SELECT RAISE(FAIL, 'stop refresh');
+                 END;",
+            )
+            .unwrap();
+
+        let err = refresh_file_fingerprints(
+            &cache.conn,
+            &[
+                FileFingerprintRefresh {
+                    path: "a.rs".to_string(),
+                    mtime_secs: before_a.0 + 1,
+                    mtime_nanos: before_a.1,
+                    content_hash: "updated-a".to_string(),
+                },
+                FileFingerprintRefresh {
+                    path: "b.rs".to_string(),
+                    mtime_secs: before_b.0 + 1,
+                    mtime_nanos: before_b.1,
+                    content_hash: "updated-b".to_string(),
+                },
+            ],
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("stop refresh"));
+        assert_eq!(cached_file_mtime(&cache, "a.rs"), before_a);
+        assert_eq!(cached_file_mtime(&cache, "b.rs"), before_b);
+
+        drop(cache);
+        cleanup(root);
+    }
+
+    #[test]
     fn partial_cache_reports_clean_files_that_import_stale_js_ts_files() {
         let root = temp_repo_root("incremental-import-metadata");
         write_file(
@@ -1499,9 +1606,15 @@ mod tests {
             &root.join("b.ts"),
             "export function target() { return 3; }\n",
         );
+        rewrite_after_mtime_tick(
+            &root.join("c.ts"),
+            "export function other() { return 2; }\n",
+        );
+        let current_c = file_mtime_parts(&root.join("c.ts")).unwrap();
         let partial = cache.load_partial(&root, &files).unwrap();
         assert_eq!(partial.stale_files, vec!["b.ts"]);
         assert_eq!(partial.cached_importing_stale_files, vec!["a.ts"]);
+        assert_eq!(cached_file_mtime(&cache, "c.ts"), current_c);
 
         rewrite_after_mtime_tick(
             &root.join("a.ts"),
@@ -1645,19 +1758,88 @@ mod tests {
     #[test]
     fn load_refreshes_mtime_when_file_content_is_unchanged() {
         let root = temp_repo_root("mtime-only-refresh");
-        let file = root.join("same.rs");
-        write_file(&file, "fn same() {}\n");
-        let files = vec!["same.rs".to_string()];
+        let file_contents = [
+            ("same_a.rs", "fn same_a() {}\n"),
+            ("same_b.rs", "fn same_b() {}\n"),
+            ("same_c.rs", "fn same_c() {}\n"),
+        ];
+        for (file, content) in &file_contents {
+            write_file(&root.join(*file), content);
+        }
+        let files: Vec<String> = file_contents
+            .iter()
+            .map(|(file, _)| (*file).to_string())
+            .collect();
         let cache = save_empty_cache(&root, &files);
-        let before = cached_file_mtime(&cache, "same.rs");
+        let before: Vec<(i64, i64)> = files
+            .iter()
+            .map(|file| cached_file_mtime(&cache, file))
+            .collect();
 
-        rewrite_after_mtime_tick(&file, "fn same() {}\n");
-        let current = file_mtime_parts(&file).unwrap();
-        assert_ne!(before, current);
+        let rewrite_all = || -> Vec<(i64, i64)> {
+            for (file, content) in &file_contents {
+                rewrite_after_mtime_tick(&root.join(*file), content);
+            }
+            file_contents
+                .iter()
+                .map(|(file, _)| file_mtime_parts(&root.join(*file)).unwrap())
+                .collect()
+        };
+        let assert_cached_mtimes = |expected: &[(i64, i64)]| {
+            for (file, expected) in files.iter().zip(expected) {
+                assert_eq!(cached_file_mtime(&cache, file), *expected);
+            }
+        };
 
+        let full_current = rewrite_all();
+        assert!(before
+            .iter()
+            .zip(&full_current)
+            .all(|(before, current)| before != current));
+        assert!(cache.load(&root, &files).is_some());
+        assert_cached_mtimes(&full_current);
+
+        let topology_current = rewrite_all();
         assert!(cache.load_graph_topology(&root, &files).is_some());
+        assert_cached_mtimes(&topology_current);
+
+        let partial_current = rewrite_all();
         assert!(cache.load_partial(&root, &files).is_none());
-        assert_eq!(cached_file_mtime(&cache, "same.rs"), current);
+        assert_cached_mtimes(&partial_current);
+
+        drop(cache);
+        cleanup(root);
+    }
+
+    #[test]
+    fn cache_loads_ignore_fingerprint_refresh_failure() {
+        let root = temp_repo_root("refresh-failure-cache-hit");
+        write_file(&root.join("same.rs"), "fn same() {}\n");
+        write_file(&root.join("stale.rs"), "fn stale() {}\n");
+        let files = vec!["same.rs".to_string(), "stale.rs".to_string()];
+        let cache = save_empty_cache(&root, &files);
+        let before_same = cached_file_mtime(&cache, "same.rs");
+
+        cache
+            .conn
+            .execute_batch(
+                "CREATE TRIGGER fail_fingerprint_refresh
+                 BEFORE UPDATE ON files
+                 BEGIN
+                     SELECT RAISE(FAIL, 'stop refresh');
+                 END;",
+            )
+            .unwrap();
+
+        rewrite_after_mtime_tick(&root.join("same.rs"), "fn same() {}\n");
+        assert!(cache.load(&root, &files).is_some());
+        assert!(cache.load_graph_topology(&root, &files).is_some());
+        assert_eq!(cached_file_mtime(&cache, "same.rs"), before_same);
+
+        rewrite_after_mtime_tick(&root.join("stale.rs"), "fn stale() { 1; }\n");
+        let partial = cache.load_partial(&root, &files).unwrap();
+        assert_eq!(partial.stale_files, vec!["stale.rs"]);
+        assert_eq!(cached_file_mtime(&cache, "same.rs"), before_same);
 
         drop(cache);
         cleanup(root);


### PR DESCRIPTION
## Summary
- Batch mtime-only file fingerprint refreshes through a shared SQLite transaction helper instead of writing once per file.
- Apply the batched refresh path to CLI and MCP full/topology/partial cache freshness checks.
- Expand cache tests for multi-file mtime-only refreshes, mixed stale + mtime-only partial loads, and rollback on batched refresh failure.

Fixes #342

## Metrics
Benchmark used a release `sem` binary with 5 isolated runs. Each run generated 5,000 Rust files, primed the cache with `sem graph --file-exts rs`, touched all files without changing content, then timed the cache-hit `sem graph --file-exts rs` path with `SEM_TIMINGS=json`.

| Metric | Baseline median | After median | Change |
| --- | ---: | ---: | ---: |
| `cache_topology_load` phase | 134.16 ms | 82.28 ms | -38.7% |
| total command time | 150.49 ms | 100.77 ms | -33.0% |

Raw `cache_topology_load` samples:
- Baseline: 135.09, 134.16, 131.44, 127.76, 134.95 ms
- After: 82.28, 85.51, 84.35, 77.67, 82.22 ms

## Test Plan
- `cargo test -p sem-cli cache::tests`
- `cargo test -p sem-mcp cache::tests`
- `cargo test --workspace`
- `git diff --check --no-ext-diff`