### PR TITLE
Avoid import key allocations in graph resolution

### DIFF
--- a/crates/sem-core/src/parser/graph.rs
+++ b/crates/sem-core/src/parser/graph.rs
@@ -681,10 +681,25 @@ fn direct_reference_line_ranges(
     ranges
 }
 
+type ImportsByFile<'a> = HashMap<&'a str, HashMap<&'a str, &'a str>>;
+
+fn build_imports_by_file<'a>(
+    import_table: &'a HashMap<(String, String), String>,
+) -> ImportsByFile<'a> {
+    let mut imports_by_file: ImportsByFile<'a> = HashMap::new();
+    for ((file_path, import_name), target_id) in import_table {
+        imports_by_file
+            .entry(file_path.as_str())
+            .or_default()
+            .insert(import_name.as_str(), target_id.as_str());
+    }
+    imports_by_file
+}
+
 struct ReferenceResolutionContext<'a> {
     symbol_table: &'a HashMap<String, Vec<String>>,
     entity_map: &'a HashMap<String, EntityInfo>,
-    import_table: &'a HashMap<(String, String), String>,
+    imports_by_file: &'a ImportsByFile<'a>,
     scope_consumed_words: &'a HashMap<String, HashSet<String>>,
     child_ranges_by_parent: &'a HashMap<&'a str, Vec<ChildRange<'a>>>,
     child_line_ranges: &'a HashMap<String, Vec<(usize, usize)>>,
@@ -833,11 +848,6 @@ fn resolve_entity_references(
         direct_reference_line_ranges(entity, fallback_end_line, context.child_line_ranges);
 
     let mut entity_edges = Vec::new();
-    let mut consumed_words = context
-        .scope_consumed_words
-        .get(&entity.id)
-        .cloned()
-        .unwrap_or_default();
 
     let reference_index =
         if entity_requires_content_span_filter(entity, context.child_ranges_by_parent) {
@@ -878,6 +888,11 @@ fn resolve_entity_references(
             })
             .collect(),
     };
+    let mut consumed_words: HashSet<&str> = context
+        .scope_consumed_words
+        .get(&entity.id)
+        .map(|set| set.iter().map(String::as_str).collect())
+        .unwrap_or_default();
 
     for (receiver, member, position) in &dot_chains {
         if consumed_words.contains(*member) {
@@ -906,7 +921,7 @@ fn resolve_entity_references(
                                 target_id.to_string(),
                                 RefType::Calls,
                             ));
-                            consumed_words.insert(member.to_string());
+                            consumed_words.insert(*member);
                             break;
                         }
                     }
@@ -924,15 +939,15 @@ fn resolve_entity_references(
                             target_id.to_string(),
                             RefType::Calls,
                         ));
-                        consumed_words.insert(member.to_string());
-                        consumed_words.insert(receiver.to_string());
+                        consumed_words.insert(*member);
+                        consumed_words.insert(*receiver);
                         break;
                     }
                 }
             }
         }
         if entity_edges.len() == edge_count_before {
-            consumed_words.insert(member.to_string());
+            consumed_words.insert(*member);
         }
     }
 
@@ -961,6 +976,9 @@ fn resolve_entity_references(
             .collect()
         }
     };
+    let entity_id = entity.id.as_str();
+    let imports_for_file = context.imports_by_file.get(entity.file_path.as_str());
+
     for (ref_name, ref_type) in refs {
         if consumed_words.contains(ref_name) {
             continue;
@@ -976,17 +994,18 @@ fn resolve_entity_references(
             continue;
         }
 
-        let import_key = (entity.file_path.clone(), ref_name.to_string());
-        if let Some(import_target_id) = context.import_table.get(&import_key) {
-            if import_target_id != &entity.id
+        if let Some(import_target_id) =
+            imports_for_file.and_then(|imports| imports.get(ref_name).copied())
+        {
+            if import_target_id != entity_id
                 && !context
                     .parent_child_pairs
-                    .contains(&(entity.id.as_str(), import_target_id.as_str()))
+                    .contains(&(entity_id, import_target_id))
                 && !context
                     .parent_child_pairs
-                    .contains(&(import_target_id.as_str(), entity.id.as_str()))
+                    .contains(&(import_target_id, entity_id))
             {
-                entity_edges.push((entity.id.clone(), import_target_id.clone(), ref_type));
+                entity_edges.push((entity.id.clone(), import_target_id.to_string(), ref_type));
             }
             continue;
         }
@@ -1018,8 +1037,7 @@ fn resolve_entity_references(
     // Resolve namespace-qualified calls (alias/name) for languages that use this pattern.
     // The regular tokenizer splits `alias/name` at the slash, so bare `name` tokens don't
     // match cross-file entities via the symbol table. We scan the stripped content for
-    // `alias/name` patterns and resolve them via the import table (populated by
-    // resolve_clojure_as during import table building).
+    // `alias/name` patterns and resolve them via the per-file import map.
     if language_config.has_slash_qualified_refs() {
         // Always restrip via the language's own strategy: fallback_stripped may have been
         // computed with a different strategy when reference_index was non-None above.
@@ -1027,19 +1045,20 @@ fn resolve_entity_references(
             strip_for_language(language_config.strip_strategy(), &entity.content);
         for cap in CLOJURE_QUALIFIED_REF_RE.captures_iter(&qualified_ref_stripped) {
             let qualified = cap.get(1).unwrap().as_str();
-            let import_key = (entity.file_path.clone(), qualified.to_string());
-            if let Some(import_target_id) = context.import_table.get(&import_key) {
-                if import_target_id != &entity.id
+            if let Some(import_target_id) =
+                imports_for_file.and_then(|imports| imports.get(qualified).copied())
+            {
+                if import_target_id != entity_id
                     && !context
                         .parent_child_pairs
-                        .contains(&(entity.id.as_str(), import_target_id.as_str()))
+                        .contains(&(entity_id, import_target_id))
                     && !context
                         .parent_child_pairs
-                        .contains(&(import_target_id.as_str(), entity.id.as_str()))
+                        .contains(&(import_target_id, entity_id))
                 {
                     entity_edges.push((
                         entity.id.clone(),
-                        import_target_id.clone(),
+                        import_target_id.to_string(),
                         RefType::Calls,
                     ));
                 }
@@ -1312,10 +1331,11 @@ impl EntityGraph {
             (vec![], HashMap::new())
         };
 
+        let imports_by_file = build_imports_by_file(&import_table);
         let reference_context = ReferenceResolutionContext {
             symbol_table: symbol_table.as_ref(),
             entity_map: &entity_map,
-            import_table: &import_table,
+            imports_by_file: &imports_by_file,
             scope_consumed_words: &scope_consumed_words,
             child_ranges_by_parent: &child_ranges_by_parent,
             child_line_ranges: &child_line_ranges,
@@ -1617,10 +1637,11 @@ impl EntityGraph {
             (vec![], HashMap::new())
         };
 
+        let imports_by_file = build_imports_by_file(&import_table);
         let reference_context = ReferenceResolutionContext {
             symbol_table: symbol_table.as_ref(),
             entity_map: &entity_map,
-            import_table: &import_table,
+            imports_by_file: &imports_by_file,
             scope_consumed_words: &scope_consumed_words,
             child_ranges_by_parent: &child_ranges_by_parent,
             child_line_ranges: &child_line_ranges,
@@ -2370,10 +2391,11 @@ impl EntityGraph {
             (vec![], HashMap::new())
         };
 
+        let imports_by_file = build_imports_by_file(&import_table);
         let reference_context = ReferenceResolutionContext {
             symbol_table: symbol_table.as_ref(),
             entity_map: &entity_map,
-            import_table: &import_table,
+            imports_by_file: &imports_by_file,
             scope_consumed_words: &scope_consumed_words,
             child_ranges_by_parent: &child_ranges_by_parent,
             child_line_ranges: &child_line_ranges,

--- a/crates/sem-core/tests/bow_import_lookup_bench.rs
+++ b/crates/sem-core/tests/bow_import_lookup_bench.rs
@@ -1,0 +1,93 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use sem_core::parser::graph::EntityGraph;
+use sem_core::parser::plugins::create_default_registry;
+
+struct CountingAllocator;
+
+static ALLOC_CALLS: AtomicUsize = AtomicUsize::new(0);
+static ALLOC_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
+        ALLOC_BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+        System.alloc(layout)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout)
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+fn reset_allocations() {
+    ALLOC_CALLS.store(0, Ordering::Relaxed);
+    ALLOC_BYTES.store(0, Ordering::Relaxed);
+}
+
+fn allocation_snapshot() -> (usize, usize) {
+    (
+        ALLOC_CALLS.load(Ordering::Relaxed),
+        ALLOC_BYTES.load(Ordering::Relaxed),
+    )
+}
+
+#[test]
+#[ignore]
+fn bag_of_words_import_lookup_allocation_metric() {
+    const IMPORTS: usize = 2_000;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+
+    let mut lib = String::new();
+    for i in 0..IMPORTS {
+        lib.push_str(&format!("export const value{i} = {i};\n"));
+    }
+    std::fs::write(root.join("lib.ts"), lib).unwrap();
+
+    let import_names = (0..IMPORTS)
+        .map(|i| format!("value{i}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let mut main = format!("import {{ {import_names} }} from './lib';\n\n");
+    for i in 0..IMPORTS {
+        main.push_str(&format!(
+            "export function caller{i}(other: any) {{ other.missing(); return value{i}; }}\n"
+        ));
+    }
+    std::fs::write(root.join("main.ts"), main).unwrap();
+
+    let registry = create_default_registry();
+    let files = vec!["lib.ts".to_string(), "main.ts".to_string()];
+
+    reset_allocations();
+    let start = std::time::Instant::now();
+    let (graph, _) = EntityGraph::build(root, &files, &registry);
+    let elapsed = start.elapsed();
+    let (alloc_calls, alloc_bytes) = allocation_snapshot();
+
+    let resolved_import_edges = graph
+        .edges
+        .iter()
+        .filter(|edge| {
+            let from = graph.entities.get(&edge.from_entity);
+            let to = graph.entities.get(&edge.to_entity);
+            from.is_some_and(|entity| entity.file_path == "main.ts")
+                && to.is_some_and(|entity| entity.file_path == "lib.ts")
+        })
+        .count();
+
+    assert_eq!(resolved_import_edges, IMPORTS);
+    eprintln!(
+        "bow_import_lookup_metric imports={IMPORTS} entities={} edges={} resolved_import_edges={resolved_import_edges} alloc_calls={alloc_calls} alloc_bytes={alloc_bytes} elapsed_ms={:.3}",
+        graph.entities.len(),
+        graph.edges.len(),
+        elapsed.as_secs_f64() * 1000.0,
+    );
+}


### PR DESCRIPTION
## Summary
- Build a borrowed import lookup by file before bag-of-words reference resolution.
- Replace the per-reference `(file_path.clone(), ref_name.to_string())` lookup key with borrowed name lookups.
- Borrow dot-chain consumed words in `resolve_entity_references` instead of allocating owned strings for each consumed `member`/`receiver`.
- Add an ignored allocation benchmark fixture for reproducing the import lookup metric.

Closes #343

## Metrics
Command: `RAYON_NUM_THREADS=1 cargo test --manifest-path crates/Cargo.toml -p sem-core --test bow_import_lookup_bench --release -- --ignored --nocapture`

Fixture: 2,000 TypeScript named imports and 2,000 caller references that resolve through the bag-of-words import fallback. Baseline and branch were run on the same machine/profile.

| Metric | `origin/main` | This branch | Change |
| --- | ---: | ---: | ---: |
| Allocation calls | 473,534 | 461,546 | -11,988 (-2.53%) |
| Allocated bytes | 64,353,075 | 64,484,745 | +131,670 (+0.20%) |
| Mean elapsed | 65.065 ms | 68.126 ms | noisy/no meaningful speed claim |
| Entities | 4,000 | 4,000 | unchanged |
| Edges | 2,000 | 2,000 | unchanged |
| Resolved import edges | 2,000 | 2,000 | unchanged |

Baseline elapsed samples: 64.959 ms, 64.186 ms, 66.049 ms.
Branch elapsed samples: 65.350 ms, 64.240 ms, 74.787 ms.

Relative to the prior PR metric, the borrowed `consumed_words` follow-up saves another 4,000 allocation calls and 88,000 allocated bytes in this fixture. The allocation claim is specifically reduced allocation-call churn in the hot import lookup/reference-resolution path. Total allocated bytes remain slightly higher than `origin/main` in this synthetic one-reference-per-import fixture because the borrowed per-file index allocates bucket storage once.

## Test Plan
- `sem impact --entity-id 'crates/sem-core/src/parser/graph.rs::function::resolve_entity_references' --json`
- `cargo test --manifest-path crates/Cargo.toml -p sem-core import -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p sem-core clojure -- --nocapture`
- `RAYON_NUM_THREADS=1 cargo test --manifest-path crates/Cargo.toml -p sem-core --test bow_import_lookup_bench --release -- --ignored --nocapture`
- `cargo test --manifest-path crates/Cargo.toml`

Note: `cargo test` updates stale local crate versions in `crates/Cargo.lock`; the lockfile was restored so this PR stays scoped. `cargo test --manifest-path crates/Cargo.toml --locked ...` fails for the same pre-existing stale-lockfile reason.
