### PR TITLE
Preserve LanguageConfig semver compatibility

### DIFF
--- a/crates/sem-core/src/parser/plugins/code/languages.rs
+++ b/crates/sem-core/src/parser/plugins/code/languages.rs
@@ -20,6 +20,8 @@ pub(crate) enum StripStrategy {
     Clojure,
 }
 
+const CLOJURE_EXTRA_IDENT_CHARS: &[char] = &['-', '?', '!', '*', '='];
+
 #[allow(dead_code)]
 pub struct LanguageConfig {
     pub id: &'static str,
@@ -35,8 +37,6 @@ pub struct LanguageConfig {
     pub get_language: fn() -> Option<Language>,
     pub scope_resolve: Option<&'static ScopeResolveConfig>,
 }
-
-const CLOJURE_EXTRA_IDENT_CHARS: &[char] = &['-', '?', '!', '*', '='];
 
 impl LanguageConfig {
     pub(crate) fn extra_ident_chars(&self) -> &'static [char] {


### PR DESCRIPTION
## Summary
- move unreleased LanguageConfig behavior behind crate-private methods
- keep Clojure and EDN parser behavior while restoring the v0.8.0 public struct shape
- update graph/reference extraction call sites to use the internal accessors

## Test plan
- cargo check -p sem-core
- cargo semver-checks -p sem-core --baseline-rev v0.8.0 --color never
- cargo test -p sem-core clojure -- --nocapture
- cargo test -p sem-core edn -- --nocapture
- cargo test -p sem-core