### PR TITLE
feat: universal test detection with word-boundary matching (#332)

### DIFF
--- a/crates/sem-cli/src/cache.rs
+++ b/crates/sem-cli/src/cache.rs
@@ -117,6 +117,7 @@ impl DiskCache {
         files: &[String],
         graph: &EntityGraph,
         entities: &[SemanticEntity],
+        custom_test_dirs: &[String],
     ) -> Result<(), rusqlite::Error> {
         let tx = self.conn.unchecked_transaction()?;
 
@@ -172,7 +173,7 @@ impl DiskCache {
             }
         }
 
-        let test_entity_ids = graph.filter_test_entities(entities);
+        let test_entity_ids = graph.filter_test_entities_with_custom_dirs(entities, custom_test_dirs);
         {
             let mut stmt =
                 tx.prepare("INSERT INTO entity_flags (entity_id, is_test) VALUES (?1, 1)")?;
@@ -1182,7 +1183,7 @@ mod tests {
         );
         let cache = DiskCache::open(&root).unwrap();
         cache
-            .save_topology(&root, &files, &graph, &entities)
+            .save_topology(&root, &files, &graph, &entities, &[])
             .unwrap();
 
         assert!(cache.load(&root, &files).is_none());
@@ -1636,6 +1637,7 @@ mod tests {
                 &cli_topology_to_mcp,
                 &cli_topology_to_mcp_files,
                 &empty_graph(),
+                &[],
                 &[],
             )
             .unwrap();

--- a/crates/sem-cli/src/commands/graph.rs
+++ b/crates/sem-cli/src/commands/graph.rs
@@ -282,7 +282,7 @@ pub fn get_or_build_graph_with_test_data_and_topology_save_on_miss_with_timings(
 
     if !no_cache {
         if let Ok(disk) = DiskCache::open(root) {
-            let _ = disk.save_topology(root, file_paths, &graph, &entities);
+            let _ = disk.save_topology(root, file_paths, &graph, &entities, &registry.custom_test_dirs);
             timings.mark("cache_topology_save");
         }
     }
@@ -358,7 +358,7 @@ fn get_or_build_graph_with_cache_policy(
             }
             CacheMissSavePolicy::Topology => {
                 if let Ok(disk) = DiskCache::open(root) {
-                    let _ = disk.save_topology(root, file_paths, &graph, &entities);
+                    let _ = disk.save_topology(root, file_paths, &graph, &entities, &registry.custom_test_dirs);
                     timings.mark("cache_topology_save");
                 }
             }

--- a/crates/sem-cli/src/commands/impact.rs
+++ b/crates/sem-cli/src/commands/impact.rs
@@ -148,10 +148,10 @@ pub fn impact_command(opts: ImpactOptions) {
                         timings.mark("entity_lookup");
                         match opts.mode {
                             ImpactMode::Tests => {
-                                print_tests(&graph, entity, &all_entities, opts.json)
+                                print_tests(&graph, entity, &all_entities, opts.json, &registry.custom_test_dirs)
                             }
                             ImpactMode::All => {
-                                print_all(&graph, entity, &all_entities, opts.json, opts.depth)
+                                print_all(&graph, entity, &all_entities, opts.json, opts.depth, &registry.custom_test_dirs)
                             }
                             _ => unreachable!(),
                         }
@@ -198,9 +198,9 @@ pub fn impact_command(opts: ImpactOptions) {
                 );
                 timings.mark("entity_lookup");
                 match opts.mode {
-                    ImpactMode::Tests => print_tests(&graph, entity, &all_entities, opts.json),
+                    ImpactMode::Tests => print_tests(&graph, entity, &all_entities, opts.json, &registry.custom_test_dirs),
                     ImpactMode::All => {
-                        print_all(&graph, entity, &all_entities, opts.json, opts.depth)
+                        print_all(&graph, entity, &all_entities, opts.json, opts.depth, &registry.custom_test_dirs)
                     }
                     _ => unreachable!(),
                 }
@@ -374,8 +374,9 @@ fn print_tests(
     entity: &EntityInfo,
     all_entities: &[sem_core::model::entity::SemanticEntity],
     json: bool,
+    custom_test_dirs: &[String],
 ) {
-    let tests = graph.test_impact(&entity.id, all_entities);
+    let tests = graph.test_impact_with_custom_dirs(&entity.id, all_entities, custom_test_dirs);
     print_tests_result(entity, &tests, json);
 }
 
@@ -438,8 +439,9 @@ fn print_all(
     all_entities: &[sem_core::model::entity::SemanticEntity],
     json: bool,
     depth: usize,
+    custom_test_dirs: &[String],
 ) {
-    let tests = graph.test_impact(&entity.id, all_entities);
+    let tests = graph.test_impact_with_custom_dirs(&entity.id, all_entities, custom_test_dirs);
     print_all_with_tests(graph, entity, &tests, json, depth);
 }
 

--- a/crates/sem-core/src/parser/graph.rs
+++ b/crates/sem-core/src/parser/graph.rs
@@ -2617,9 +2617,19 @@ impl EntityGraph {
         &self,
         entities: &[crate::model::entity::SemanticEntity],
     ) -> HashSet<String> {
+        self.filter_test_entities_with_custom_dirs(entities, &[])
+    }
+
+    /// Like [`filter_test_entities`], but also considers user-configured
+    /// test directories from `.semrc`.
+    pub fn filter_test_entities_with_custom_dirs(
+        &self,
+        entities: &[crate::model::entity::SemanticEntity],
+        custom_test_dirs: &[String],
+    ) -> HashSet<String> {
         let mut test_ids = HashSet::new();
         for entity in entities {
-            if is_test_entity(entity) {
+            if is_test_entity(entity, custom_test_dirs) {
                 test_ids.insert(entity.id.clone());
             }
         }
@@ -2633,7 +2643,18 @@ impl EntityGraph {
         entity_id: &str,
         all_entities: &[crate::model::entity::SemanticEntity],
     ) -> Vec<&EntityInfo> {
-        let test_ids = self.filter_test_entities(all_entities);
+        self.test_impact_with_custom_dirs(entity_id, all_entities, &[])
+    }
+
+    /// Like [`test_impact`], but also considers user-configured test
+    /// directories from `.semrc`.
+    pub fn test_impact_with_custom_dirs(
+        &self,
+        entity_id: &str,
+        all_entities: &[crate::model::entity::SemanticEntity],
+        custom_test_dirs: &[String],
+    ) -> Vec<&EntityInfo> {
+        let test_ids = self.filter_test_entities_with_custom_dirs(all_entities, custom_test_dirs);
         let impact = self.impact_analysis(entity_id);
         impact
             .into_iter()
@@ -2921,9 +2942,8 @@ fn is_scope_member_container(entity_type: &str) -> bool {
 }
 
 /// Check if an entity looks like a test based on name, file path, and content patterns.
-fn is_test_entity(entity: &crate::model::entity::SemanticEntity) -> bool {
+fn is_test_entity(entity: &crate::model::entity::SemanticEntity, custom_test_dirs: &[String]) -> bool {
     let name = &entity.name;
-    let path = &entity.file_path;
     let content = &entity.content;
 
     // Name patterns
@@ -2938,15 +2958,9 @@ fn is_test_entity(entity: &crate::model::entity::SemanticEntity) -> bool {
         return true;
     }
 
-    // File path patterns
-    let path_lower = path.to_lowercase();
-    let in_test_file = path_lower.contains("/test/")
-        || path_lower.contains("/tests/")
-        || path_lower.contains("/spec/")
-        || path_lower.contains("_test.")
-        || path_lower.contains(".test.")
-        || path_lower.contains("_spec.")
-        || path_lower.contains(".spec.");
+    // File path patterns (shared detection)
+    let in_test_file =
+        crate::parser::test_detect::is_test_path_with_custom_dirs(&entity.file_path, custom_test_dirs);
 
     // Content patterns (test annotations/decorators)
     let has_test_marker = content.contains("#[test]")
@@ -8639,5 +8653,114 @@ export function caller() {
             "greet should depend on capitalize-first via multi-line :refer. Deps: {:?}",
             deps.iter().map(|d| &d.name).collect::<Vec<_>>()
         );
+    }
+
+    // ── is_test_entity / filter_test_entities tests ─────────────────────
+
+    fn make_entity(name: &str, file_path: &str, content: &str) -> SemanticEntity {
+        SemanticEntity {
+            id: format!("{}::function::{}", file_path, name),
+            name: name.to_string(),
+            entity_type: "function".to_string(),
+            file_path: file_path.to_string(),
+            start_line: 1,
+            end_line: 5,
+            content: content.to_string(),
+            content_hash: String::new(),
+            structural_hash: None,
+            parent_id: None,
+            metadata: None,
+        }
+    }
+
+    #[test]
+    fn test_entity_detected_by_name_pattern() {
+        let entity = make_entity("test_login", "src/auth.py", "def test_login(): pass");
+        assert!(is_test_entity(&entity, &[]));
+    }
+
+    #[test]
+    fn test_entity_detected_by_path_and_content_marker() {
+        // Path match + content marker both required
+        let entity = make_entity("run", "e2e-tests/login.ts", "describe('login', () => { it('works', () => {}) })");
+        assert!(is_test_entity(&entity, &[]));
+    }
+
+    #[test]
+    fn test_entity_not_detected_in_production_code() {
+        let entity = make_entity("handle_request", "src/server.rs", "fn handle_request() {}");
+        assert!(!is_test_entity(&entity, &[]));
+    }
+
+    #[test]
+    fn test_entity_path_match_without_content_marker_not_detected() {
+        // Path says test dir, but content has no test marker → not a test
+        let entity = make_entity("helper", "tests/helpers.py", "def helper(): return 42");
+        assert!(!is_test_entity(&entity, &[]));
+    }
+
+    #[test]
+    fn test_entity_detected_in_hyphenated_test_dir() {
+        let entity = make_entity("check", "integration-tests/api.py", "@pytest.mark.slow\ndef check(): pass");
+        assert!(is_test_entity(&entity, &[]));
+    }
+
+    #[test]
+    fn test_entity_detected_in_dunder_tests_dir() {
+        let entity = make_entity("render", "__tests__/Button.test.tsx", "test('renders', () => {})");
+        assert!(is_test_entity(&entity, &[]));
+    }
+
+    #[test]
+    fn test_entity_detected_with_custom_dir() {
+        let entity = make_entity("verify", "qa/smoke.py", "@pytest.fixture\ndef verify(): pass");
+        // Without custom dirs: not detected (no name match, "qa" not a built-in)
+        assert!(!is_test_entity(&entity, &[]));
+        // With custom dirs: detected because path matches + content has @pytest
+        let custom = vec!["qa".to_string()];
+        assert!(is_test_entity(&entity, &custom));
+    }
+
+    #[test]
+    fn test_entity_contest_dir_not_false_positive() {
+        let entity = make_entity("solve", "contest/problem_a.py", "def solve(): test('input')");
+        assert!(!is_test_entity(&entity, &[]));
+    }
+
+    #[test]
+    fn filter_test_entities_with_custom_dirs_includes_custom_matches() {
+        let entities = vec![
+            make_entity("test_a", "src/lib.rs", "#[test]\nfn test_a() {}"),
+            make_entity("run", "qa/smoke.rs", "#[test]\nfn run() {}"),
+            make_entity("main", "src/main.rs", "fn main() {}"),
+        ];
+        let entity_map: std::collections::HashMap<String, EntityInfo> = entities
+            .iter()
+            .map(|e| {
+                (
+                    e.id.clone(),
+                    EntityInfo {
+                        id: e.id.clone(),
+                        name: e.name.clone(),
+                        entity_type: e.entity_type.clone(),
+                        file_path: e.file_path.clone(),
+                        parent_id: None,
+                        start_line: e.start_line,
+                        end_line: e.end_line,
+                    },
+                )
+            })
+            .collect();
+        let graph = EntityGraph::from_parts(entity_map, vec![]);
+
+        let builtin = graph.filter_test_entities(&entities);
+        assert!(builtin.contains("src/lib.rs::function::test_a"));
+        assert!(!builtin.contains("qa/smoke.rs::function::run"));
+
+        let custom = vec!["qa".to_string()];
+        let with_custom = graph.filter_test_entities_with_custom_dirs(&entities, &custom);
+        assert!(with_custom.contains("src/lib.rs::function::test_a"));
+        assert!(with_custom.contains("qa/smoke.rs::function::run"));
+        assert!(!with_custom.contains("src/main.rs::function::main"));
     }
 }

--- a/crates/sem-core/src/parser/mod.rs
+++ b/crates/sem-core/src/parser/mod.rs
@@ -4,6 +4,7 @@ pub mod differ;
 pub mod graph;
 pub mod plugins;
 pub mod verify;
+pub mod test_detect;
 pub mod context;
 #[cfg(feature = "git")]
 pub mod hotspot;

--- a/crates/sem-core/src/parser/registry.rs
+++ b/crates/sem-core/src/parser/registry.rs
@@ -19,6 +19,7 @@ pub struct ParserRegistry {
     plugins: Vec<Box<dyn SemanticParserPlugin>>,
     extension_map: HashMap<String, usize>, // ext → index into plugins
     custom_ext_canonical: HashMap<String, String>, // ".mypy" → ".py" (custom → canonical)
+    pub custom_test_dirs: Vec<String>,
 }
 
 impl ParserRegistry {
@@ -27,6 +28,7 @@ impl ParserRegistry {
             plugins: Vec::new(),
             extension_map: HashMap::new(),
             custom_ext_canonical: HashMap::new(),
+            custom_test_dirs: Vec::new(),
         }
     }
 
@@ -148,8 +150,18 @@ impl ParserRegistry {
             if line.is_empty() || line.starts_with('#') {
                 continue;
             }
-            if let Some((ext, lang)) = line.split_once('=') {
-                self.add_extension_mapping(ext.trim(), lang.trim());
+            if let Some((key, value)) = line.split_once('=') {
+                let key = key.trim();
+                let value = value.trim();
+                if key == "test-dirs" {
+                    self.custom_test_dirs = value
+                        .split(',')
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect();
+                } else {
+                    self.add_extension_mapping(key, value);
+                }
             }
         }
     }
@@ -884,6 +896,44 @@ mod tests {
             .get_plugin_with_content("script.py", content)
             .expect("should use Python parser");
         assert_eq!(plugin.id(), "code"); // Python uses code plugin, not PHP
+    }
+
+    #[test]
+    fn test_load_semrc_parses_test_dirs() {
+        let dir = TempDir::new().unwrap();
+        write_file(&dir, ".semrc", "test-dirs = e2e-tests, smoke, qa\n");
+        let mut registry = create_default_registry();
+        registry.load_semrc(dir.path());
+        assert_eq!(registry.custom_test_dirs, vec!["e2e-tests", "smoke", "qa"]);
+    }
+
+    #[test]
+    fn test_load_semrc_test_dirs_with_extension_mappings() {
+        let dir = TempDir::new().unwrap();
+        write_file(&dir, ".semrc", ".inc = php\ntest-dirs = custom-tests\n.xyz = cpp\n");
+        let mut registry = create_default_registry();
+        registry.load_semrc(dir.path());
+        assert_eq!(registry.custom_test_dirs, vec!["custom-tests"]);
+        assert!(registry.get_plugin("foo.inc").is_some());
+        assert!(registry.get_plugin("bar.xyz").is_some());
+    }
+
+    #[test]
+    fn test_load_semrc_skips_empty_test_dirs() {
+        let dir = TempDir::new().unwrap();
+        write_file(&dir, ".semrc", "test-dirs = , ,  \n");
+        let mut registry = create_default_registry();
+        registry.load_semrc(dir.path());
+        assert!(registry.custom_test_dirs.is_empty());
+    }
+
+    #[test]
+    fn test_load_semrc_no_test_dirs_leaves_empty() {
+        let dir = TempDir::new().unwrap();
+        write_file(&dir, ".semrc", ".inc = php\n");
+        let mut registry = create_default_registry();
+        registry.load_semrc(dir.path());
+        assert!(registry.custom_test_dirs.is_empty());
     }
 
     #[test]

--- a/crates/sem-core/src/parser/test_detect.rs
+++ b/crates/sem-core/src/parser/test_detect.rs
@@ -1,0 +1,177 @@
+//! Shared test-path detection logic.
+//!
+//! Single source of truth for deciding whether a file path belongs to a
+//! test/fixture/benchmark directory. Used by both `graph.rs` (test-entity
+//! filtering) and `verify.rs` (arity-check exclusions).
+
+/// Token-level matches: directory name is split on `-`, `_`, `.` and
+/// any resulting token that equals one of these triggers a match.
+const TEST_TOKENS: &[&str] = &["test", "tests", "spec", "specs"];
+
+/// Exact directory-name matches for well-known dirs that don't contain
+/// "test" or "spec" as a token.
+const EXACT_DIR_NAMES: &[&str] = &[
+    "e2e",
+    "cypress",
+    "playwright",
+    "testing",
+    "fixtures",
+    "fixture",
+    "benchmarks",
+    "benchmark",
+    "__tests__",
+    "__mocks__",
+];
+
+/// File-name patterns that indicate a test file regardless of directory.
+const TEST_FILE_PATTERNS: &[&str] = &["_test.", ".test.", "_spec.", ".spec."];
+
+/// Returns `true` if any path component (directory or file stem) matches
+/// built-in test heuristics.
+pub fn is_test_path(path: &str) -> bool {
+    is_test_path_with_custom_dirs(path, &[])
+}
+
+/// Like [`is_test_path`], but also matches if any path component equals one
+/// of the caller-supplied custom directory names.
+pub fn is_test_path_with_custom_dirs(path: &str, custom_dirs: &[String]) -> bool {
+    let path_lower = path.to_lowercase();
+
+    // File-name patterns (e.g. `foo_test.rs`, `bar.spec.ts`)
+    if let Some(file_name) = path_lower.rsplit('/').next() {
+        for pat in TEST_FILE_PATTERNS {
+            if file_name.contains(pat) {
+                return true;
+            }
+        }
+    }
+
+    // Check each path component (directory names)
+    for component in path_lower.split('/') {
+        if component.is_empty() {
+            continue;
+        }
+
+        // Exact well-known directory names
+        if EXACT_DIR_NAMES.contains(&component) {
+            return true;
+        }
+
+        // Custom directory names from .semrc
+        if custom_dirs
+            .iter()
+            .any(|d| d.eq_ignore_ascii_case(component))
+        {
+            return true;
+        }
+
+        // Token-based matching: split on `-`, `_`, `.` and check tokens
+        let has_test_token = component
+            .split(|c: char| c == '-' || c == '_' || c == '.')
+            .any(|token| TEST_TOKENS.contains(&token));
+        if has_test_token {
+            return true;
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Built-in directory patterns ──────────────────────────────────────
+
+    #[test]
+    fn classic_test_dirs() {
+        assert!(is_test_path("src/test/foo.ts"));
+        assert!(is_test_path("src/tests/foo.ts"));
+        assert!(is_test_path("src/spec/foo.ts"));
+        assert!(is_test_path("src/specs/foo.ts"));
+    }
+
+    #[test]
+    fn hyphenated_test_dirs() {
+        assert!(is_test_path("e2e-tests/foo.ts"));
+        assert!(is_test_path("integration-test/bar.py"));
+        assert!(is_test_path("unit-tests/baz.js"));
+    }
+
+    #[test]
+    fn underscored_test_dirs() {
+        assert!(is_test_path("__tests__/baz.js"));
+        assert!(is_test_path("unit_tests/foo.rs"));
+        assert!(is_test_path("integration_test/bar.go"));
+    }
+
+    #[test]
+    fn dotted_test_dirs() {
+        assert!(is_test_path("src/test.unit/foo.ts"));
+    }
+
+    #[test]
+    fn well_known_exact_dirs() {
+        assert!(is_test_path("e2e/login.spec.ts"));
+        assert!(is_test_path("cypress/e2e/login.spec.ts"));
+        assert!(is_test_path("playwright/tests/foo.ts"));
+        assert!(is_test_path("testing/helpers.py"));
+        assert!(is_test_path("fixtures/data.json"));
+        assert!(is_test_path("fixture/sample.txt"));
+        assert!(is_test_path("benchmarks/bench_main.rs"));
+        assert!(is_test_path("benchmark/perf.go"));
+        assert!(is_test_path("__mocks__/api.ts"));
+    }
+
+    // ── File-name patterns ───────────────────────────────────────────────
+
+    #[test]
+    fn test_file_name_patterns() {
+        assert!(is_test_path("src/utils_test.go"));
+        assert!(is_test_path("src/utils.test.ts"));
+        assert!(is_test_path("src/utils_spec.rb"));
+        assert!(is_test_path("src/utils.spec.js"));
+    }
+
+    // ── Negative cases ───────────────────────────────────────────────────
+
+    #[test]
+    fn no_false_positives() {
+        assert!(!is_test_path("src/main.rs"));
+        assert!(!is_test_path("src/contest/solution.py"));
+        assert!(!is_test_path("src/spectacle/viewer.ts"));
+        assert!(!is_test_path("src/attestation/verify.go"));
+        assert!(!is_test_path("src/latest/handler.js"));
+        assert!(!is_test_path("src/protest/rally.rb"));
+        assert!(!is_test_path("lib/fastest/core.ts"));
+    }
+
+    // ── Custom directories ───────────────────────────────────────────────
+
+    #[test]
+    fn custom_dir_match() {
+        let custom = vec!["qa".to_string(), "smoke".to_string()];
+        assert!(is_test_path_with_custom_dirs("qa/check.ts", &custom));
+        assert!(is_test_path_with_custom_dirs("smoke/login.py", &custom));
+    }
+
+    #[test]
+    fn custom_dir_case_insensitive() {
+        let custom = vec!["QA".to_string()];
+        assert!(is_test_path_with_custom_dirs("qa/check.ts", &custom));
+        assert!(is_test_path_with_custom_dirs("Qa/check.ts", &custom));
+    }
+
+    #[test]
+    fn custom_dir_no_false_positive() {
+        let custom = vec!["qa".to_string()];
+        assert!(!is_test_path_with_custom_dirs("src/main.rs", &custom));
+    }
+
+    #[test]
+    fn builtin_still_works_with_custom_dirs() {
+        let custom = vec!["qa".to_string()];
+        assert!(is_test_path_with_custom_dirs("src/tests/foo.ts", &custom));
+        assert!(is_test_path_with_custom_dirs("e2e-tests/bar.py", &custom));
+    }
+}

--- a/crates/sem-core/src/parser/verify.rs
+++ b/crates/sem-core/src/parser/verify.rs
@@ -505,14 +505,8 @@ const AMBIGUOUS_NAMES: &[&str] = &[
     "apply", "call", "bind", "get", "set", "run", "execute", "create",
 ];
 
-/// Path components that indicate test/fixture files (not production source).
-const TEST_PATH_MARKERS: &[&str] = &[
-    "test", "tests", "spec", "specs", "fixtures", "fixture",
-    "benchmarks", "benchmark", "__tests__", "__mocks__",
-];
-
 fn is_test_or_fixture_path(path: &str) -> bool {
-    path.split('/').any(|component| TEST_PATH_MARKERS.contains(&component))
+    crate::parser::test_detect::is_test_path(path)
 }
 
 /// Find arity mismatches across all Calls edges in the graph.

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -799,7 +799,7 @@ impl SemServer {
 
         let output = match mode {
             "tests" => {
-                let tests = graph.test_impact(entity_id, &all_entities);
+                let tests = graph.test_impact_with_custom_dirs(entity_id, &all_entities, &self.registry.custom_test_dirs);
                 let result: Vec<serde_json::Value> = tests
                     .iter()
                     .map(|d| {
@@ -823,7 +823,7 @@ impl SemServer {
                 let deps = graph.get_dependencies(entity_id);
                 let dependents = graph.get_dependents(entity_id);
                 let impact = graph.impact_analysis(entity_id);
-                let tests = graph.test_impact(entity_id, &all_entities);
+                let tests = graph.test_impact_with_custom_dirs(entity_id, &all_entities, &self.registry.custom_test_dirs);
 
                 let map_entities =
                     |list: &[&sem_core::parser::graph::EntityInfo]| -> Vec<serde_json::Value> {


### PR DESCRIPTION
Replace hardcoded path substring checks (/test/, /tests/, /spec/) with a shared test_detect module that splits directory names on separators (-, _, .) and checks tokens. This catches e2e-tests/, __tests__/, integration-test/ etc. without false positives on "contest" or "spectacle". Adds well-known exact dir matches (cypress, playwright, e2e, fixtures, __mocks__) and a .semrc `test-dirs` escape hatch for custom layouts.