### PR TITLE
Bump version to 0.10.0

### DIFF
--- a/Formula/sem.rb
+++ b/Formula/sem.rb
@@ -1,8 +1,8 @@
 class Sem < Formula
   desc "Semantic version control CLI — entity-level diffs on top of Git"
   homepage "https://github.com/Ataraxy-Labs/sem"
-  url "https://github.com/Ataraxy-Labs/sem/archive/refs/tags/v0.7.0.tar.gz"
-  # TODO: update sha256 once v0.7.0 release tarball is published
+  url "https://github.com/Ataraxy-Labs/sem/archive/refs/tags/v0.10.0.tar.gz"
+  # TODO: update sha256 once v0.10.0 release tarball is published
   sha256 ""
   license "MIT"
   head "https://github.com/Ataraxy-Labs/sem.git", branch: "main"

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ sem-core can be used as a Rust library dependency:
 
 ```toml
 [dependencies]
-sem-core = { git = "https://github.com/Ataraxy-Labs/sem", version = "0.5" }
+sem-core = { git = "https://github.com/Ataraxy-Labs/sem", version = "0.10.0" }
 ```
 
 Used by [weave](https://github.com/Ataraxy-Labs/weave) (semantic merge driver) and [inspect](https://github.com/Ataraxy-Labs/inspect) (entity-level code review).

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1449,7 +1449,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sem-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "clap",
  "clap_complete_command",
@@ -1470,7 +1470,7 @@ dependencies = [
 
 [[package]]
 name = "sem-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "git2",
  "rayon",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "sem-mcp"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "git2",
  "ignore",
@@ -1538,7 +1538,7 @@ dependencies = [
 
 [[package]]
 name = "sem-plugin"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "sem-core",
  "serde",

--- a/crates/sem-cli/Cargo.toml
+++ b/crates/sem-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-cli"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Semantic version control CLI. Shows what entities changed (functions, classes, methods) instead of lines."
@@ -15,8 +15,8 @@ name = "sem"
 path = "src/main.rs"
 
 [dependencies]
-sem-core = { path = "../sem-core", version = "0.9.0" }
-sem-mcp = { path = "../sem-mcp", version = "0.9.0" }
+sem-core = { path = "../sem-core", version = "0.10.0" }
+sem-mcp = { path = "../sem-mcp", version = "0.10.0" }
 serde = { version = "1", features = ["derive"] }
 clap = { version = "4", features = ["derive"] }
 colored = "2"

--- a/crates/sem-core/Cargo.toml
+++ b/crates/sem-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-core"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Entity-level semantic diff engine. Extracts functions, classes, and methods from 28 languages via tree-sitter and diffs at the entity level."

--- a/crates/sem-mcp/Cargo.toml
+++ b/crates/sem-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-mcp"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server for entity-level semantic code intelligence. 6 tools: sem_entities, sem_diff, sem_blame, sem_impact, sem_log, sem_context."
@@ -15,7 +15,7 @@ name = "sem-mcp"
 path = "src/main.rs"
 
 [dependencies]
-sem-core = { path = "../sem-core", version = "0.9.0" }
+sem-core = { path = "../sem-core", version = "0.10.0" }
 git2 = "0.20"
 lru = "0.16"
 rmcp = { version = "1", features = ["server", "transport-io"] }

--- a/crates/sem-plugin/Cargo.toml
+++ b/crates/sem-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-plugin"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "WASI component plugin for semantic entity-level change detection"

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -180,7 +180,7 @@ sem-core can be used as a Rust library dependency:
 
 ```toml
 [dependencies]
-sem-core = { git = "https://github.com/Ataraxy-Labs/sem", version = "0.3" }
+sem-core = { git = "https://github.com/Ataraxy-Labs/sem", version = "0.10.0" }
 ```
 
 Used by weave (semantic merge driver) and inspect (entity-level code review).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ataraxy-labs/sem",
-  "version": "0.7.0",
+  "version": "0.10.0",
   "description": "npm wrapper for the sem CLI. Downloads the matching release binary and exposes the sem command in node_modules/.bin.",
   "license": "MIT OR Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump Rust workspace crates and internal dependency constraints to 0.10.0
- Sync npm package metadata, Cargo.lock, Homebrew formula URL, and docs snippets

## Test plan
- npm test
- cargo test --workspace
