### PR TITLE
v0.10.0: cloud-backed CLI, webhook auto-sync, telemetry

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1449,7 +1449,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sem-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "clap",
  "clap_complete_command",
@@ -1470,7 +1470,7 @@ dependencies = [
 
 [[package]]
 name = "sem-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "git2",
  "rayon",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "sem-mcp"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "git2",
  "ignore",
@@ -1538,7 +1538,7 @@ dependencies = [
 
 [[package]]
 name = "sem-plugin"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "sem-core",
  "serde",

--- a/crates/sem-cli/Cargo.toml
+++ b/crates/sem-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-cli"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Semantic version control CLI. Shows what entities changed (functions, classes, methods) instead of lines."
@@ -15,8 +15,8 @@ name = "sem"
 path = "src/main.rs"
 
 [dependencies]
-sem-core = { path = "../sem-core", version = "0.9.0" }
-sem-mcp = { path = "../sem-mcp", version = "0.9.0" }
+sem-core = { path = "../sem-core", version = "0.10.0" }
+sem-mcp = { path = "../sem-mcp", version = "0.10.0" }
 serde = { version = "1", features = ["derive"] }
 clap = { version = "4", features = ["derive"] }
 colored = "2"

--- a/crates/sem-cli/src/commands/cloud.rs
+++ b/crates/sem-cli/src/commands/cloud.rs
@@ -284,7 +284,12 @@ pub fn whoami() -> Result<(), Box<dyn std::error::Error>> {
                     cached.status
                 );
             } else {
-                println!("{} {}", "Repo ID: ".bold(), "not registered".dimmed());
+                println!(
+                    "{} {} {}",
+                    "Repo ID: ".bold(),
+                    "not registered".dimmed(),
+                    "(registers automatically on first sem impact/context/log)".dimmed()
+                );
             }
         }
     }
@@ -417,9 +422,17 @@ pub struct RepoCacheEntry {
 const CLOUD_MIN_ENTITIES: usize = 20_000;
 
 /// Look up the cached entity count for a remote, if known.
+/// Only trusts counts from fully indexed repos within the cache TTL — a
+/// repo registered while still indexing reports 0 entities, and treating
+/// that as "small" would permanently route it away from the cloud.
 fn cached_entity_count(remote_url: &str) -> Option<usize> {
     let normalized = normalize_remote_url(remote_url);
-    load_repo_cache()?.get(&normalized)?.entity_count
+    let cache = load_repo_cache()?;
+    let entry = cache.get(&normalized)?;
+    if entry.status != "ready" || cache_entry_expired(entry) {
+        return None;
+    }
+    entry.entity_count
 }
 
 /// True when the repo is known to be small enough that local graph queries
@@ -551,10 +564,12 @@ impl CloudClient {
     fn resolve_repo(&self, remote_url: &str) -> Result<String, Box<dyn std::error::Error>> {
         let normalized = normalize_remote_url(remote_url);
 
-        // Check cache first
+        // Check cache first. Entries that aren't "ready" yet (still cloning
+        // or indexing) are re-fetched every time so status and entity count
+        // converge once the server finishes.
         if let Some(cache) = load_repo_cache() {
             if let Some(entry) = cache.get(&normalized) {
-                if !cache_entry_expired(entry) {
+                if entry.status == "ready" && !cache_entry_expired(entry) {
                     return Ok(entry.repo_id.clone());
                 }
             }

--- a/crates/sem-core/Cargo.toml
+++ b/crates/sem-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-core"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Entity-level semantic diff engine. Extracts functions, classes, and methods from 28 languages via tree-sitter and diffs at the entity level."

--- a/crates/sem-mcp/Cargo.toml
+++ b/crates/sem-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-mcp"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server for entity-level semantic code intelligence. 6 tools: sem_entities, sem_diff, sem_blame, sem_impact, sem_log, sem_context."
@@ -15,7 +15,7 @@ name = "sem-mcp"
 path = "src/main.rs"
 
 [dependencies]
-sem-core = { path = "../sem-core", version = "0.9.0" }
+sem-core = { path = "../sem-core", version = "0.10.0" }
 git2 = "0.20"
 lru = "0.16"
 rmcp = { version = "1", features = ["server", "transport-io"] }

--- a/crates/sem-plugin/Cargo.toml
+++ b/crates/sem-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-plugin"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "WASI component plugin for semantic entity-level change detection"


### PR DESCRIPTION
Bumps the workspace to 0.10.0. This release rolls up the cloud work already on main (cloud-backed impact/context/entities/log with size-based routing, anonymous usage telemetry with opt-out) plus one fix:

- Repos registered while still indexing reported entityCount 0, which the routing gate cached as 'small repo, stay local' permanently. Counts are now only trusted from ready repos, and pending entries re-fetch until status converges.
- sem whoami now explains how registration happens when a repo isn't registered.