### PR TITLE
Multi-path `sem entities` (closes #356) + verify install.sh checksum

### DIFF
--- a/crates/sem-cli/src/commands/cloud.rs
+++ b/crates/sem-cli/src/commands/cloud.rs
@@ -1027,8 +1027,14 @@ pub fn try_cloud_context(opts: &ContextOptions) -> Option<()> {
 
 /// Try to run `sem entities` via cloud (whole-repo directory listing only).
 pub fn try_cloud_entities(opts: &EntitiesOptions) -> Option<()> {
-    // Only use cloud for directory (whole-repo) listing, not single files
-    let path_arg = opts.path.as_deref().filter(|p| !p.is_empty()).unwrap_or(".");
+    // Only used for a single path arg (the whole-repo listing case); callers
+    // skip this fast-path entirely when multiple paths are given.
+    let path_arg = opts
+        .paths
+        .iter()
+        .map(|p| p.trim())
+        .find(|p| !p.is_empty())
+        .unwrap_or(".");
     let full_path = if Path::new(path_arg).is_absolute() {
         PathBuf::from(path_arg)
     } else {

--- a/crates/sem-cli/src/commands/entities.rs
+++ b/crates/sem-cli/src/commands/entities.rs
@@ -7,47 +7,89 @@ use sem_core::parser::registry::{resolve_go_method_parent_ids, ParserRegistry};
 
 pub struct EntitiesOptions {
     pub cwd: String,
-    pub path: Option<String>,
+    pub paths: Vec<String>,
     pub json: bool,
     pub no_default_excludes: bool,
 }
 
 pub fn entities_command(opts: EntitiesOptions) {
-    if super::cloud::try_cloud_entities(&opts).is_some() {
+    // Normalize to a non-empty list of path args, defaulting to ".".
+    let path_args: Vec<String> = {
+        let cleaned: Vec<String> = opts
+            .paths
+            .iter()
+            .map(|p| p.trim().to_string())
+            .filter(|p| !p.is_empty())
+            .collect();
+        if cleaned.is_empty() {
+            vec![".".to_string()]
+        } else {
+            cleaned
+        }
+    };
+
+    // The cloud fast-path only helps the whole-repo single listing.
+    if path_args.len() == 1 && super::cloud::try_cloud_entities(&opts).is_some() {
         return;
     }
 
     let root = Path::new(&opts.cwd);
     let registry = super::create_registry(&opts.cwd);
-    let path_arg = opts.path.as_deref().filter(|p| !p.is_empty()).unwrap_or(".");
-    let (path_label, full_path) = resolve_path(root, path_arg);
 
-    let (entities, include_file) = if full_path.is_file() {
-        (
-            extract_file_entities(&full_path, &registry, &path_label).unwrap_or_else(|e| {
-                eprintln!(
-                    "{} Cannot read '{}': {}",
-                    "error:".red().bold(),
-                    path_label,
-                    e
-                );
-                std::process::exit(1);
-            }),
-            false,
-        )
-    } else if full_path.is_dir() {
-        let file_paths = super::files::find_supported_files_in_path(
-            root,
-            &full_path,
-            &registry,
-            &[],
-            opts.no_default_excludes,
-        );
-        (extract_files_entities(root, &file_paths, &registry), true)
-    } else {
-        eprintln!("{} Path not found '{}'", "error:".red().bold(), path_arg);
-        std::process::exit(1);
+    let mut entities: Vec<SemanticEntity> = Vec::new();
+    let mut dir_count = 0usize;
+    for path_arg in &path_args {
+        let (path_label, full_path) = resolve_path(root, path_arg);
+        if full_path.is_file() {
+            let file_entities = extract_file_entities(&full_path, &registry, &path_label)
+                .unwrap_or_else(|e| {
+                    eprintln!(
+                        "{} Cannot read '{}': {}",
+                        "error:".red().bold(),
+                        path_label,
+                        e
+                    );
+                    std::process::exit(1);
+                });
+            entities.extend(file_entities);
+        } else if full_path.is_dir() {
+            dir_count += 1;
+            let file_paths = super::files::find_supported_files_in_path(
+                root,
+                &full_path,
+                &registry,
+                &[],
+                opts.no_default_excludes,
+            );
+            entities.extend(extract_files_entities(root, &file_paths, &registry));
+        } else {
+            eprintln!("{} Path not found '{}'", "error:".red().bold(), path_arg);
+            std::process::exit(1);
+        }
+    }
+
+    // Overlapping paths (e.g. a directory and a file inside it) can surface the
+    // same entity twice; sort and drop exact duplicates by id.
+    entities.sort_by(|a, b| {
+        a.file_path
+            .cmp(&b.file_path)
+            .then(a.start_line.cmp(&b.start_line))
+            .then(a.end_line.cmp(&b.end_line))
+            .then(a.entity_type.cmp(&b.entity_type))
+            .then(a.name.cmp(&b.name))
+    });
+    entities.dedup_by(|a, b| a.id == b.id);
+
+    // Show the file column whenever results span more than one file. This keeps
+    // the prior single-file vs directory behavior and covers multi-path input.
+    let distinct_files = {
+        let mut files: Vec<&str> = entities.iter().map(|e| e.file_path.as_str()).collect();
+        files.sort_unstable();
+        files.dedup();
+        files.len()
     };
+    let include_file = dir_count > 0 || distinct_files > 1;
+    let display_label = path_args.join(" ");
 
     if opts.json {
         let output: Vec<_> = entities
@@ -56,11 +98,11 @@ pub fn entities_command(opts: EntitiesOptions) {
             .collect();
         println!("{}", serde_json::to_string(&output).unwrap());
     } else if should_group_by_file(&entities) {
-        print_grouped_entities(&path_label, &entities);
+        print_grouped_entities(&display_label, &entities);
     } else if let Some(file_path) = entities.first().map(|e| e.file_path.as_str()) {
         print_file_entities(file_path, &entities);
     } else {
-        println!("{} {}\n", "entities:".green().bold(), path_label.bold());
+        println!("{} {}\n", "entities:".green().bold(), display_label.bold());
     }
 }
 

--- a/crates/sem-cli/src/main.rs
+++ b/crates/sem-cli/src/main.rs
@@ -227,11 +227,11 @@ enum Commands {
         #[arg(long, short = 'v')]
         verbose: bool,
     },
-    /// List entities under a file or directory path
+    /// List entities under one or more file or directory paths
     Entities {
-        /// File or directory path to extract entities from (defaults to .)
-        #[arg()]
-        path: Option<String>,
+        /// File or directory paths to extract entities from (defaults to .)
+        #[arg(num_args = 0..)]
+        paths: Vec<String>,
 
         /// Output format
         #[arg(long, value_parser = ["terminal", "json"])]
@@ -551,7 +551,7 @@ fn main() {
             });
         }
         Some(Commands::Entities {
-            path,
+            paths,
             format,
             json,
             no_default_excludes,
@@ -561,7 +561,7 @@ fn main() {
                     .unwrap_or_default()
                     .to_string_lossy()
                     .to_string(),
-                path,
+                paths,
                 json: resolve_json(format, json),
                 no_default_excludes,
             });

--- a/install.sh
+++ b/install.sh
@@ -42,6 +42,30 @@ get_latest_version() {
     fi
 }
 
+verify_checksum() {
+    # Verify the archive against the release checksums.txt when a sha256 tool is
+    # available. Hard-fails on mismatch; skips silently when no tool or no
+    # matching entry exists, so installs still work on minimal systems.
+    archive="$1"
+    sums=$(curl -fsSL "https://github.com/${REPO}/releases/download/${VERSION}/checksums.txt" 2>/dev/null) || return 0
+    expected=$(printf '%s\n' "$sums" | grep -F "${ARTIFACT}.tar.gz" | awk '{print $1}' | head -1)
+    [ -n "$expected" ] || return 0
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual=$(sha256sum "$archive" | awk '{print $1}')
+    elif command -v shasum >/dev/null 2>&1; then
+        actual=$(shasum -a 256 "$archive" | awk '{print $1}')
+    else
+        warn "no sha256 tool found; skipping checksum verification"
+        return 0
+    fi
+
+    if [ "$actual" != "$expected" ]; then
+        error "checksum mismatch for ${ARTIFACT}.tar.gz (expected ${expected}, got ${actual})"
+    fi
+    info "Verified" "checksum"
+}
+
 download_and_install() {
     URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARTIFACT}.tar.gz"
 
@@ -51,6 +75,8 @@ download_and_install() {
     info "Downloading" "${ARTIFACT} ${VERSION}"
     curl -fsSL "$URL" -o "${TMPDIR}/${ARTIFACT}.tar.gz" \
         || error "Download failed. Check https://github.com/${REPO}/releases for available builds."
+
+    verify_checksum "${TMPDIR}/${ARTIFACT}.tar.gz"
 
     tar xzf "${TMPDIR}/${ARTIFACT}.tar.gz" -C "$TMPDIR"
 


### PR DESCRIPTION
Two related CLI/distribution fixes in one PR.

**1. Multiple path arguments for `sem entities` (closes #356)**
`sem entities a.ts b.ts c.ts` previously errored with "unexpected argument". It now accepts any number of paths, extracts entities from each, and combines results deduped by entity id (so an overlapping directory + a file inside it does not double-count). Single-path and default-`.` behavior is unchanged, and the cloud whole-repo fast-path still applies only to the single-path case. Thanks @aleclarson for the report.

**2. Verify release checksum in install.sh**
The `curl | sh` installer downloaded and extracted the release tarball without verifying it, even though `checksums.txt` is published alongside. `sem update` already verifies; this mirrors it in the installer. Hard-fails on mismatch, skips silently when no sha256 tool or matching entry exists.

Both verified locally (multi-path/back-compat/dedup/error cases; `sh -n` plus a real temp install showing "Verified checksum").