### PR TITLE
Fix Java cross-file method-call resolution via type tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,7 @@ All notable changes to sem are documented in this file.
 
 - Cloud sync only auto-registers repos that GitHub confirms are public. Private repos run locally unless you opt in with `SEM_SYNC_PRIVATE=1`.
 - `install.sh` verifies the release archive against `checksums.txt` before installing.
+
+### Fixed
+
+- Java: resolve cross-file `receiver.method()` call edges. Local variable types were never recorded (the `Dog d = new Dog()` declaration type and `object_creation_expression` RHS were both ignored), class field types were never tracked (`init_strategy` was `None`), and `ClassName.staticMethod()` calls were dropped. As a result `sem impact`/`context` reported few or no cross-file dependents on Java code — an empty result was a false negative. Java scope-resolution recall on the test fixture rises from 27% to 100%; the common Spring field-injection pattern (`@Inject private FooService foo; ... foo.bar()`) now resolves.

--- a/crates/sem-core/src/parser/plugins/code/languages.rs
+++ b/crates/sem-core/src/parser/plugins/code/languages.rs
@@ -210,6 +210,10 @@ pub enum InitStrategy {
     StructFields {
         struct_nodes: &'static [&'static str],
     },
+    /// Java/C#: extract field types from typed field declarations in the class body
+    ClassFields {
+        class_nodes: &'static [&'static str],
+    },
     /// No instance attribute tracking
     None,
 }
@@ -1726,7 +1730,9 @@ static JAVA_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
 
     self_keywords: &["this"],
 
-    init_strategy: InitStrategy::None,
+    init_strategy: InitStrategy::ClassFields {
+        class_nodes: &["class_declaration", "interface_declaration", "enum_declaration"],
+    },
     import_extractor: None,
     external_method: false,
 

--- a/crates/sem-core/src/parser/scope_resolve.rs
+++ b/crates/sem-core/src/parser/scope_resolve.rs
@@ -1861,6 +1861,14 @@ fn scan_ts_var_declaration(
     scopes: &mut Vec<Scope>,
     source: &[u8],
 ) {
+    // Java/C#: the declared type is a `type` field on the declaration node itself
+    // (`Dog d = ...`), shared by every declarator. TS/JS put the annotation on the
+    // declarator instead, so this is None there and the per-declarator check applies.
+    let decl_type = node
+        .child_by_field_name("type")
+        .map(|n| extract_base_type(n, source))
+        .filter(|t| !t.is_empty() && t.chars().next().map_or(false, |c| c.is_uppercase()));
+
     let mut cursor = node.walk();
     for child in node.named_children(&mut cursor) {
         if child.kind() == "variable_declarator" {
@@ -1878,7 +1886,7 @@ fn scan_ts_var_declaration(
                 .unwrap_or_else(|| child.start_position().row);
             record_binding(scopes, scope_idx, &var_name, binding_row);
 
-            // Check for explicit type annotation: `const x: Foo = ...`
+            // Check for explicit type annotation: `const x: Foo = ...` (declarator-level)
             if let Some(type_ann) = child.child_by_field_name("type") {
                 let type_text = extract_base_type(type_ann, source);
                 if !type_text.is_empty()
@@ -1887,6 +1895,14 @@ fn scan_ts_var_declaration(
                     scopes[scope_idx].types.insert(var_name.clone(), type_text);
                     continue;
                 }
+            }
+
+            // Declaration-level type annotation (Java/C#): `Dog d = ...`
+            if let Some(type_text) = &decl_type {
+                scopes[scope_idx]
+                    .types
+                    .insert(var_name.clone(), type_text.clone());
+                continue;
             }
 
             // Check RHS value
@@ -2398,6 +2414,15 @@ fn record_type_from_rhs(
                 }
             }
         }
+        // Java/C#: new Foo()
+        "object_creation_expression" => {
+            if let Some(type_node) = rhs.child_by_field_name("type") {
+                let name = extract_base_type(type_node, source);
+                if !name.is_empty() && name.chars().next().map_or(false, |c| c.is_uppercase()) {
+                    scopes[scope_idx].types.insert(var_name.to_string(), name);
+                }
+            }
+        }
         // Go: Foo{} (composite_literal / struct literal)
         "composite_literal" => {
             if let Some(type_node) = rhs.child_by_field_name("type") {
@@ -2674,6 +2699,18 @@ fn scan_init_self_attrs(
                     }
                 }
             }
+            InitStrategy::ClassFields { class_nodes } => {
+                if class_nodes.contains(&kind) {
+                    let class_name = node
+                        .child_by_field_name("name")
+                        .and_then(|n| n.utf8_text(source).ok())
+                        .unwrap_or("")
+                        .to_string();
+                    if !class_name.is_empty() {
+                        scan_java_class_fields(node, &class_name, source, instance_attr_types);
+                    }
+                }
+            }
             InitStrategy::None => {}
         }
 
@@ -2715,6 +2752,50 @@ fn scan_rust_struct_fields(
                             field_type,
                         );
                     }
+                }
+            }
+        }
+    }
+}
+
+/// Java/C#: extract field types from `class Foo { private Connection conn; ... }`.
+/// A single field_declaration may declare several names (`private Foo a, b;`), all
+/// sharing the declaration's `type` field.
+fn scan_java_class_fields(
+    class_node: tree_sitter::Node,
+    class_name: &str,
+    source: &[u8],
+    instance_attr_types: &mut HashMap<(String, String), String>,
+) {
+    let Some(body) = class_node.child_by_field_name("body") else {
+        return;
+    };
+    let mut cursor = body.walk();
+    for member in body.named_children(&mut cursor) {
+        if member.kind() != "field_declaration" {
+            continue;
+        }
+        let field_type = member
+            .child_by_field_name("type")
+            .map(|n| extract_base_type(n, source))
+            .unwrap_or_default();
+        if field_type.is_empty() || !field_type.chars().next().map_or(false, |c| c.is_uppercase()) {
+            continue;
+        }
+        let mut dc = member.walk();
+        for declarator in member.named_children(&mut dc) {
+            if declarator.kind() != "variable_declarator" {
+                continue;
+            }
+            if let Some(name) = declarator
+                .child_by_field_name("name")
+                .and_then(|n| n.utf8_text(source).ok())
+            {
+                if !name.is_empty() {
+                    instance_attr_types.insert(
+                        (class_name.to_string(), name.to_string()),
+                        field_type.clone(),
+                    );
                 }
             }
         }
@@ -5725,6 +5806,25 @@ fn resolve_ref(
                         }
                         SwiftOverloadSelection::NoMatch => return None,
                         SwiftOverloadSelection::NotApplicable => {}
+                    }
+                }
+            }
+
+            // Static call: `ClassName.staticMethod()` — the receiver is a class itself,
+            // not a typed variable. Only fires for an uppercase identifier that names a
+            // known class and isn't shadowed by a local binding.
+            if is_simple_identifier_name(receiver)
+                && receiver.chars().next().map_or(false, |c| c.is_uppercase())
+                && !is_local_binding_in_scopes_cached(scope_idx, scopes, receiver, lookup_cache)
+            {
+                if let Some(members) = class_members.get(receiver) {
+                    if let SwiftOverloadSelection::Matched(mid) = select_member_candidate(
+                        members,
+                        method,
+                        argument_labels.as_deref(),
+                        swift_call_signatures,
+                    ) {
+                        return Some((mid, RefType::Calls, "static_call"));
                     }
                 }
             }


### PR DESCRIPTION
## Summary

On Java codebases, `sem impact`/`context` reported few or no **cross-file dependents** — an empty result that reads as "safe to change" was actually a false negative. The cause: `receiver.method()` call edges were almost never produced, because the receiver's *type* was never resolved. Without a known receiver type, the resolver couldn't look the method up in the target class, so the edge was dropped (and the reference was marked consumed, so the name-match fallback didn't retry it either).

On a ~3,300-file Spring codebase, a method with two known cross-file callers reported zero:

```
$ sem impact updateInBatches
⊕ method updateInBatches (.../IndexUpdateTaskService.java)
  ...
  ✓ No other entities are affected by changes to this entity.   # WRONG — 2 callers exist
```

## Root cause

Four gaps in Java scope resolution, all about never learning receiver types:

1. **Local variable types unrecorded.** `record_type_from_rhs` handled TS `new_expression` but not Java `object_creation_expression`, and the declared type in `Dog d = ...` sits on the `local_variable_declaration`'s `type` field (not on the `variable_declarator`), which `scan_ts_var_declaration` never read. So `Dog d = new Dog(); d.validate()` produced no edge.
2. **Class field types untracked.** `JAVA_SCOPE_CONFIG` had `init_strategy: InitStrategy::None`, so field declarations were never scanned into `instance_attr_types`. This is exactly what the dominant Spring pattern needs: `@Inject private FooService foo; ... foo.bar()`.
3. **Static calls dropped.** `ClassName.staticMethod()` — receiver is a class, not a variable — had no resolution path.

## Fix

- Add an `object_creation_expression` case to `record_type_from_rhs`, and read the declaration-level `type` field in `scan_ts_var_declaration` (a no-op for TS/JS, which annotate the declarator instead).
- Add an `InitStrategy::ClassFields` variant + `scan_java_class_fields`, which records `(class, field) -> type` from `field_declaration` nodes (handles multi-declarator fields). Wire it into `JAVA_SCOPE_CONFIG`.
- Add a static-call fallback in `resolve_ref`: when the receiver is an uppercase class name that isn't a local binding, resolve the method against that class's members.

Receiver-type resolution uses the global `class_members` index, so once the type is known these edges resolve **cross-file without needing an import map**.

## Tests

- `scope_resolve_java` recall **27% → 100%** (0 misses, 0 false positives). The existing Java fixture already exercised local-variable, field, static, and parameter receivers across files — it was simply failing on all of them.
- All **14** language scope-resolution tests pass — no cross-language regression (the shared `scan_ts_var_declaration` and static-call changes were verified against TS, Kotlin, Swift, Go, Rust, Ruby, C#, C++).
- All **407** `sem-core` lib tests pass.
- Verified end-to-end on the Spring codebase above: `sem impact updateInBatches` now lists both cross-file `rebuildIndex` callers.

## Notes / possible follow-ups

- No new dependencies; changes are confined to `crates/sem-core/src/parser/{plugins/code/languages.rs,scope_resolve.rs}` and the CHANGELOG.
- The same `ClassFields` strategy would likely benefit **C#** (currently `init_strategy: None`); left out of this PR to keep it Java-scoped.
- A separate, orthogonal issue remains: a Java `field_declaration` is extracted as an entity named by its *type* rather than its name (`private Svc svc;` → entity `Svc`). It doesn't affect this fix (field-type scanning reads the declarator name directly) but is worth a follow-up.