### PR TITLE
Name Java field entities by their declarator, not their type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,7 @@ All notable changes to sem are documented in this file.
 
 - Cloud sync only auto-registers repos that GitHub confirms are public. Private repos run locally unless you opt in with `SEM_SYNC_PRIVATE=1`.
 - `install.sh` verifies the release archive against `checksums.txt` before installing.
+
+### Fixed
+
+- Java: name field entities by their declarator instead of their type. `private FooService fooService;` was extracted as an entity named `FooService` (its type) rather than `fooService`, because `field_declaration` has no `name` field and the generic fallback returned the first type identifier. This collided class and field names in the symbol table. `sem entities`/`diff`/`log` now report the correct field name.

--- a/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
+++ b/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
@@ -1866,6 +1866,21 @@ fn extract_name(node: Node, source: &[u8]) -> Option<String> {
         }
     }
 
+    // Java/C#: field_declaration has its name inside the variable_declarator; the
+    // `type` is a sibling, so the bare 'name' lookup misses and the generic
+    // fallback below would otherwise return the type identifier (e.g. naming
+    // `private Svc svc;` as "Svc" instead of "svc").
+    if node_type == "field_declaration" {
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            if child.kind() == "variable_declarator" {
+                if let Some(decl_name) = child.child_by_field_name("name") {
+                    return Some(node_text(decl_name, source).to_string());
+                }
+            }
+        }
+    }
+
     // For Go var/const/type declarations, name is inside var_spec/const_spec/type_spec child.
     // Grouped forms like `var (...)` wrap specs in var_spec_list/type_spec_list.
     if node_type == "var_declaration"

--- a/crates/sem-core/src/parser/plugins/code/mod.rs
+++ b/crates/sem-core/src/parser/plugins/code/mod.rs
@@ -187,6 +187,14 @@ enum Status {
         assert!(names.contains(&"UserService"), "Should find class UserService, got: {:?}", names);
         assert!(names.contains(&"Repository"), "Should find interface Repository, got: {:?}", names);
         assert!(names.contains(&"Status"), "Should find enum Status, got: {:?}", names);
+
+        // A field is named by its declarator, not its type: `private String name;`
+        // is the field `name`, not `String`.
+        let field = entities
+            .iter()
+            .find(|e| e.entity_type == "field")
+            .expect("should extract the field entity");
+        assert_eq!(field.name, "name", "field should be named by its declarator, got: {:?}", field.name);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A Java field declaration is extracted as an entity named by its **type** rather than its **name**:

```
$ sem entities Foo.java
  class SearchIndexTaskResource
    field IndexUpdateTaskService   # WRONG — this is the field `indexUpdateTaskService`
    field ParkRepo                 # WRONG — this is the field `parkRepo`
    ...
```

## Root cause

`field_declaration` in tree-sitter-java has no `name` field — the name lives inside the `variable_declarator`, and the type is a sibling:

```
field_declaration
  modifiers
  [type] type_identifier 'IndexUpdateTaskService'
  [declarator] variable_declarator
    [name] identifier 'indexUpdateTaskService'
```

`extract_name` tries the `name` field (absent here), then falls through to its generic last-resort: "return the first `identifier`/`type_identifier` child" — which is the `type` node. So the field is named after its type.

A side effect is symbol-table pollution: a field named `IndexUpdateTaskService` collides with the *class* of the same name.

## Fix

Add a `field_declaration` case to `extract_name` that reads the name from the `variable_declarator`, mirroring the existing `lexical_declaration` / `variable_declaration` handling. Extended the Java entity-extraction unit test to assert the field is named `name` (not `String`).

After:

```
  class SearchIndexTaskResource
    field indexUpdateTaskService
    field parkRepo
    ...
```

## Tests

- All **406** `sem-core` lib tests pass, including the extended `test_java_entity_extraction`.
- Verified on a ~3,300-file Spring codebase: field entities now carry their declarator names.

## Notes

- Scope is single-declarator fields, which is effectively all real-world Java (a grep for multi-declarator private fields across the 3,300-file codebase returned zero). A multi-declarator field like `private Foo a, b;` now yields the first declarator's name (`a`) rather than the type (`Foo`); emitting one entity per declarator (as the TS path does for `const a = 1, b = 2`) would be a separate, larger change and isn't warranted by real usage.
- The change only affects `field_declaration` nodes; C# nests its declarators under a `variable_declaration`, so it is unaffected and still falls through to the generic path.