### PR TITLE
Improve impact cache freshness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to sem are documented in this file.
 
 - `sem impact` can answer direct dependency queries from a fresh SQL topology cache without rebuilding the entity graph.
 
+### Changed
+
+- `sem impact --deps` can reuse fresh caches when unrelated files change by validating the cached source set, hashes, and import metadata before falling back to a graph rebuild.
+
 ## [0.13.0] - 2026-06-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,17 @@ All notable changes to sem are documented in this file.
 ### Added
 
 - `sem impact` can answer direct dependency queries from a fresh SQL topology cache without rebuilding the entity graph.
+- `sem entities` reports phase timings and listing counters when `SEM_TIMINGS` is enabled.
 
 ### Changed
 
 - `sem impact --deps` can reuse fresh caches when unrelated files change by validating the cached source set, hashes, and import metadata before falling back to a graph rebuild.
+- `sem impact --deps` narrows cache freshness checks to the queried entity, direct dependencies, and relevant JavaScript/TypeScript imports when the query scope is explicit.
+- Source scans skip default-excluded high-volume paths such as generated source directories, fixture/vendor/benchmark trees, generated file suffixes, CSS module declarations, and asset declarations; pass `--no-default-excludes` to include them.
+- `sem entities` accepts `--file-exts` for large directory scans and avoids duplicate directory-listing post-processing.
+- `sem entities` can list entities from a fresh SQLite topology cache instead of reparsing matching directory scans.
+- `sem entities --json` streams rows to stdout instead of materializing an intermediate JSON value array.
+- `sem entities` uses listing-only extraction so local listings do not retain source text or entity hashes.
 
 ## [0.13.0] - 2026-06-16
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ sem impact authenticateUser --json
 # Disambiguate by file
 sem impact authenticateUser --file src/auth.ts
 
-# Include generated/build directories that repo-wide scans skip by default
+# Include default-excluded paths such as generated, fixture, vendor, benchmark, and build trees
 sem impact authenticateUser --no-default-excludes
 ```
 
@@ -220,7 +220,7 @@ sem entities src/auth.ts
 sem entities --json
 sem entities src/auth.ts --json
 
-# Include generated/build directories that repo-wide scans skip by default
+# Include default-excluded paths such as generated, fixture, vendor, benchmark, and build trees
 sem entities --no-default-excludes
 ```
 
@@ -238,7 +238,7 @@ sem context authenticateUser --budget 4000
 # JSON output
 sem context authenticateUser --json
 
-# Include generated/build directories that repo-wide scans skip by default
+# Include default-excluded paths such as generated, fixture, vendor, benchmark, and build trees
 sem context authenticateUser --no-default-excludes
 ```
 

--- a/crates/sem-cli/src/cache.rs
+++ b/crates/sem-cli/src/cache.rs
@@ -2,11 +2,16 @@ use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::path::Path;
 
-use rusqlite::{params, params_from_iter, Connection, OptionalExtension};
+use rusqlite::{params, params_from_iter, Connection, OpenFlags, OptionalExtension};
 use sem_core::model::entity::SemanticEntity;
 use sem_core::parser::graph::{EntityGraph, EntityInfo, EntityRef, RefType};
-use sem_core::parser::js_ts_import_source_files_from_set;
+use sem_core::parser::{
+    js_ts_has_default_re_export_from_content,
+    js_ts_import_source_files_from_filesystem_with_unscoped,
+};
+use sem_core::utils::scan::is_default_excluded;
 use sem_mcp::cache as shared_cache;
+use serde::Serialize;
 
 const CACHED_TEST_IMPACT_LIMIT: usize = 10_000;
 const SQL_PARAM_CHUNK: usize = 500;
@@ -42,6 +47,18 @@ pub struct CachedImpactResult {
     pub tests_truncated: bool,
 }
 
+#[derive(Serialize)]
+struct EntityListingJsonRow<'a> {
+    name: &'a str,
+    #[serde(rename = "type")]
+    entity_type: &'a str,
+    start_line: usize,
+    end_line: usize,
+    parent_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    file: Option<&'a str>,
+}
+
 #[derive(Debug)]
 pub enum CachedImpactError {
     CacheReadFailed,
@@ -71,12 +88,24 @@ impl DiskCache {
         Ok(Self { conn })
     }
 
+    pub fn open_existing_readonly(repo_root: &Path) -> Result<Self, rusqlite::Error> {
+        let db_path = shared_cache::cache_db_path(repo_root)
+            .ok_or_else(|| rusqlite::Error::InvalidPath(repo_root.to_path_buf()))?;
+        if !db_path.exists() {
+            return Err(rusqlite::Error::InvalidPath(db_path));
+        }
+
+        let conn = Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        Ok(Self { conn })
+    }
+
     pub fn save(
         &self,
         root: &Path,
         files: &[String],
         graph: &EntityGraph,
         entities: &[SemanticEntity],
+        source_scope: shared_cache::CacheSourceScope,
     ) -> Result<(), rusqlite::Error> {
         let tx = self.conn.unchecked_transaction()?;
 
@@ -144,6 +173,7 @@ impl DiskCache {
         }
 
         shared_cache::set_cache_kind(&tx, shared_cache::CACHE_KIND_FULL)?;
+        shared_cache::set_cache_source_scope(&tx, source_scope)?;
         tx.commit()?;
         Ok(())
     }
@@ -155,6 +185,7 @@ impl DiskCache {
         graph: &EntityGraph,
         entities: &[SemanticEntity],
         custom_test_dirs: &[String],
+        source_scope: shared_cache::CacheSourceScope,
     ) -> Result<(), rusqlite::Error> {
         let tx = self.conn.unchecked_transaction()?;
 
@@ -222,16 +253,27 @@ impl DiskCache {
         }
 
         shared_cache::set_cache_kind(&tx, shared_cache::CACHE_KIND_TOPOLOGY)?;
+        shared_cache::set_cache_source_scope(&tx, source_scope)?;
         tx.commit()?;
         Ok(())
     }
 
+    #[cfg(test)]
     pub fn load(
         &self,
         root: &Path,
         files: &[String],
     ) -> Option<(EntityGraph, Vec<SemanticEntity>)> {
-        if !self.has_fresh_complete_cache(root, files) {
+        self.load_with_source_scope(root, files, shared_cache::CacheSourceScope::Default)
+    }
+
+    pub fn load_with_source_scope(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+    ) -> Option<(EntityGraph, Vec<SemanticEntity>)> {
+        if !self.has_fresh_complete_cache(root, files, source_scope) {
             return None;
         }
 
@@ -306,20 +348,48 @@ impl DiskCache {
     }
 
     /// Load only graph topology from a fresh cache.
+    #[cfg(test)]
     pub fn load_graph_topology(&self, root: &Path, files: &[String]) -> Option<EntityGraph> {
-        if !self.has_fresh_topology_cache(root, files) {
+        self.load_graph_topology_with_source_scope(
+            root,
+            files,
+            shared_cache::CacheSourceScope::Default,
+        )
+    }
+
+    pub fn load_graph_topology_with_source_scope(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+    ) -> Option<EntityGraph> {
+        if !self.has_fresh_topology_cache(root, files, source_scope) {
             return None;
         }
 
         self.load_graph_topology_rows()
     }
 
+    #[cfg(test)]
     pub fn load_graph_topology_with_test_ids(
         &self,
         root: &Path,
         files: &[String],
     ) -> Option<(EntityGraph, HashSet<String>)> {
-        if !self.has_fresh_topology_only_cache(root, files) {
+        self.load_graph_topology_with_test_ids_and_source_scope(
+            root,
+            files,
+            shared_cache::CacheSourceScope::Default,
+        )
+    }
+
+    pub fn load_graph_topology_with_test_ids_and_source_scope(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+    ) -> Option<(EntityGraph, HashSet<String>)> {
+        if !self.has_fresh_topology_only_cache(root, files, source_scope) {
             return None;
         }
 
@@ -334,6 +404,8 @@ impl DiskCache {
         &self,
         root: &Path,
         files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+        cache_first: bool,
         entity_name: Option<&str>,
         entity_id: Option<&str>,
         file_hint: Option<&str>,
@@ -360,13 +432,15 @@ impl DiskCache {
             return self.query_dependency_impact_topology(
                 root,
                 files,
+                source_scope,
+                cache_first,
                 entity_name,
                 entity_id,
                 file_hint,
             );
         }
 
-        if !self.has_fresh_cache(root, files) {
+        if !self.has_fresh_cache(root, files, source_scope) {
             return Ok(None);
         }
 
@@ -436,11 +510,21 @@ impl DiskCache {
         &self,
         root: &Path,
         files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+        cache_first: bool,
         entity_name: Option<&str>,
         entity_id: Option<&str>,
         file_hint: Option<&str>,
     ) -> Result<Option<CachedImpactResult>, CachedImpactError> {
-        if !self.has_fresh_dependency_impact_scope(root, files)? {
+        if shared_cache::is_manifest_stale(&self.conn, root) {
+            return Ok(None);
+        }
+
+        if cache_first {
+            if !shared_cache::cache_has_default_source_scope(&self.conn) {
+                return Ok(None);
+            }
+        } else if !self.has_fresh_cache(root, files, source_scope) {
             return Ok(None);
         }
 
@@ -455,7 +539,7 @@ impl DiskCache {
             .direct_dependencies(&entity.id)
             .map_err(|_| CachedImpactError::CacheReadFailed)?;
 
-        if !self.has_fresh_dependency_impact_files(root, files, &entity, &dependencies)? {
+        if cache_first && !self.has_fresh_dependency_impact_files(root, &entity, &dependencies)? {
             return Ok(None);
         }
 
@@ -465,24 +549,13 @@ impl DiskCache {
             dependents: Vec::new(),
             impact: Vec::new(),
             tests: Vec::new(),
+            tests_truncated: false,
         }))
-    }
-
-    fn has_fresh_dependency_impact_scope(
-        &self,
-        root: &Path,
-        files: &[String],
-    ) -> Result<bool, CachedImpactError> {
-        if shared_cache::is_manifest_stale(&self.conn, root) {
-            return Ok(false);
-        }
-        self.cached_source_file_set_matches(files)
     }
 
     fn has_fresh_dependency_impact_files(
         &self,
         root: &Path,
-        files: &[String],
         entity: &EntityInfo,
         dependencies: &[EntityInfo],
     ) -> Result<bool, CachedImpactError> {
@@ -500,52 +573,27 @@ impl DiskCache {
         let cached_imported_files = self
             .cached_imported_files(&entity.file_path)
             .map_err(|_| CachedImpactError::CacheReadFailed)?;
-        let should_scan_current_imports = cached_imported_files.is_empty()
-            && !self
-                .has_file_import_entries()
-                .map_err(|_| CachedImpactError::CacheReadFailed)?;
-        for imported_file in cached_imported_files {
-            required_files.insert(imported_file);
+        let Some(current_imports) = current_imported_files(root, &entity.file_path)? else {
+            return Ok(false);
+        };
+        if cached_imported_files != current_imports.files {
+            return Ok(false);
         }
-        if should_scan_current_imports {
-            for imported_file in current_imported_files(root, files, &entity.file_path)? {
-                required_files.insert(imported_file);
+        if current_imports.has_default_re_export {
+            return Ok(false);
+        }
+        for imported_file in &cached_imported_files {
+            if file_has_default_re_export(root, imported_file)? {
+                return Ok(false);
             }
+            required_files.insert(imported_file.clone());
         }
 
         self.cached_files_are_fresh(root, required_files)
             .map_err(|_| CachedImpactError::CacheReadFailed)
     }
 
-    fn cached_source_file_set_matches(&self, files: &[String]) -> Result<bool, CachedImpactError> {
-        let current_files: HashSet<&str> = files
-            .iter()
-            .map(String::as_str)
-            .filter(|file| !shared_cache::is_manifest_file_name(file))
-            .collect();
-
-        let mut stmt = self
-            .conn
-            .prepare("SELECT path FROM files")
-            .map_err(|_| CachedImpactError::CacheReadFailed)?;
-        let rows = stmt
-            .query_map([], |row| row.get::<_, String>(0))
-            .map_err(|_| CachedImpactError::CacheReadFailed)?;
-        let cached_files: HashSet<String> = rows
-            .filter_map(|row| row.ok())
-            .filter(|path| {
-                !shared_cache::is_cache_manifest_key(path)
-                    && !shared_cache::is_manifest_file_name(path)
-            })
-            .collect();
-
-        Ok(cached_files.len() == current_files.len()
-            && current_files
-                .iter()
-                .all(|file| cached_files.contains(*file)))
-    }
-
-    fn cached_imported_files(&self, file_path: &str) -> Result<Vec<String>, rusqlite::Error> {
+    fn cached_imported_files(&self, file_path: &str) -> Result<HashSet<String>, rusqlite::Error> {
         let mut stmt = self.conn.prepare(
             "SELECT imported_file FROM file_imports
              WHERE importing_file = ?1
@@ -553,13 +601,6 @@ impl DiskCache {
         )?;
         let rows = stmt.query_map(params![file_path], |row| row.get::<_, String>(0))?;
         rows.collect()
-    }
-
-    fn has_file_import_entries(&self) -> Result<bool, rusqlite::Error> {
-        self.conn
-            .query_row("SELECT 1 FROM file_imports LIMIT 1", [], |_| Ok(()))
-            .optional()
-            .map(|row| row.is_some())
     }
 
     fn cached_files_are_fresh(
@@ -990,9 +1031,10 @@ impl DiskCache {
         &self,
         root: &Path,
         files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
         mut writer: W,
     ) -> std::io::Result<bool> {
-        if !self.has_fresh_topology_cache(root, files) {
+        if !self.has_fresh_topology_cache(root, files, source_scope) {
             return Ok(false);
         }
 
@@ -1077,15 +1119,46 @@ impl DiskCache {
         Ok(true)
     }
 
-    fn has_fresh_complete_cache(&self, root: &Path, files: &[String]) -> bool {
-        if !shared_cache::cache_has_kind(&self.conn, &[shared_cache::CACHE_KIND_FULL]) {
-            return false;
+    pub fn query_entities_listing(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+    ) -> Result<Option<Vec<EntityInfo>>, rusqlite::Error> {
+        if !self.has_fresh_topology_cache_for_files(root, files, source_scope) {
+            return Ok(None);
         }
 
-        self.has_fresh_cache(root, files)
+        if files.is_empty() {
+            return Ok(Some(Vec::new()));
+        }
+
+        let mut entities = Vec::new();
+        for chunk in files.chunks(SQL_PARAM_CHUNK) {
+            let placeholders = repeat_vars(chunk.len());
+            let sql = format!(
+                "SELECT id, name, entity_type, file_path, start_line, end_line, parent_id
+                 FROM entities
+                 WHERE file_path IN ({placeholders})
+                 ORDER BY file_path, start_line, end_line, entity_type, name"
+            );
+            let mut stmt = self.conn.prepare(&sql)?;
+            let rows = stmt.query_map(
+                params_from_iter(chunk.iter().map(String::as_str)),
+                entity_info_from_row,
+            )?;
+            entities.extend(rows.collect::<Result<Vec<_>, _>>()?);
+        }
+        sort_entity_infos(&mut entities);
+        Ok(Some(entities))
     }
 
-    fn has_fresh_topology_cache(&self, root: &Path, files: &[String]) -> bool {
+    fn has_fresh_topology_cache_for_files(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+    ) -> bool {
         if !shared_cache::cache_has_kind(
             &self.conn,
             &[
@@ -1096,18 +1169,140 @@ impl DiskCache {
             return false;
         }
 
-        self.has_fresh_cache(root, files)
+        if !shared_cache::cache_has_source_scope(&self.conn, source_scope) {
+            return false;
+        }
+
+        if shared_cache::is_manifest_stale(&self.conn, root) {
+            return false;
+        }
+
+        self.cached_files_are_fresh(
+            root,
+            files
+                .iter()
+                .filter(|file| !shared_cache::is_manifest_file_name(file))
+                .cloned()
+                .collect(),
+        )
+        .unwrap_or(false)
     }
 
-    fn has_fresh_topology_only_cache(&self, root: &Path, files: &[String]) -> bool {
+    pub fn write_entities_listing_json<W: Write>(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+        include_file: bool,
+        writer: &mut W,
+    ) -> std::io::Result<Option<u64>> {
+        if !self.has_fresh_topology_cache_for_files(root, files, source_scope) {
+            return Ok(None);
+        }
+
+        writer.write_all(b"[")?;
+        let mut first = true;
+        let mut count = 0u64;
+        for chunk in files.chunks(SQL_PARAM_CHUNK) {
+            if chunk.is_empty() {
+                continue;
+            }
+            let placeholders = repeat_vars(chunk.len());
+            let sql = format!(
+                "SELECT name, entity_type, file_path, start_line, end_line, parent_id
+                 FROM entities
+                 WHERE file_path IN ({placeholders})
+                 ORDER BY file_path, start_line, end_line, entity_type, name"
+            );
+            let mut stmt = self.conn.prepare(&sql).map_err(sql_io_error)?;
+            let mut rows = stmt
+                .query(params_from_iter(chunk.iter().map(String::as_str)))
+                .map_err(sql_io_error)?;
+            while let Some(row) = rows.next().map_err(sql_io_error)? {
+                if first {
+                    first = false;
+                } else {
+                    writer.write_all(b",")?;
+                }
+
+                let name: String = row.get(0).map_err(sql_io_error)?;
+                let entity_type: String = row.get(1).map_err(sql_io_error)?;
+                let file_path: String = row.get(2).map_err(sql_io_error)?;
+                let start_line = row.get::<_, i64>(3).map_err(sql_io_error)? as usize;
+                let end_line = row.get::<_, i64>(4).map_err(sql_io_error)? as usize;
+                let parent_id: Option<String> = row.get(5).map_err(sql_io_error)?;
+                let listing = EntityListingJsonRow {
+                    name: &name,
+                    entity_type: &entity_type,
+                    start_line,
+                    end_line,
+                    parent_id: parent_id.as_deref(),
+                    file: include_file.then_some(file_path.as_str()),
+                };
+                serde_json::to_writer(&mut *writer, &listing).map_err(json_io_error)?;
+                count += 1;
+            }
+        }
+        writer.write_all(b"]\n")?;
+
+        Ok(Some(count))
+    }
+
+    fn has_fresh_complete_cache(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+    ) -> bool {
+        if !shared_cache::cache_has_kind(&self.conn, &[shared_cache::CACHE_KIND_FULL]) {
+            return false;
+        }
+
+        self.has_fresh_cache(root, files, source_scope)
+    }
+
+    fn has_fresh_topology_cache(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+    ) -> bool {
+        if !shared_cache::cache_has_kind(
+            &self.conn,
+            &[
+                shared_cache::CACHE_KIND_FULL,
+                shared_cache::CACHE_KIND_TOPOLOGY,
+            ],
+        ) {
+            return false;
+        }
+
+        self.has_fresh_cache(root, files, source_scope)
+    }
+
+    fn has_fresh_topology_only_cache(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+    ) -> bool {
         if !shared_cache::cache_has_kind(&self.conn, &[shared_cache::CACHE_KIND_TOPOLOGY]) {
             return false;
         }
 
-        self.has_fresh_cache(root, files)
+        self.has_fresh_cache(root, files, source_scope)
     }
 
-    fn has_fresh_cache(&self, root: &Path, files: &[String]) -> bool {
+    fn has_fresh_cache(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+    ) -> bool {
+        if !shared_cache::cache_has_source_scope(&self.conn, source_scope) {
+            return false;
+        }
+
         if shared_cache::is_manifest_stale(&self.conn, root) {
             return false;
         }
@@ -1206,8 +1401,22 @@ impl DiskCache {
 
     /// Load a partial cache: identify stale files and return clean cached data.
     /// Returns None if cache is empty or ALL files are stale (full rebuild is better).
+    #[cfg(test)]
     pub fn load_partial(&self, root: &Path, files: &[String]) -> Option<PartialCache> {
+        self.load_partial_with_source_scope(root, files, shared_cache::CacheSourceScope::Default)
+    }
+
+    pub fn load_partial_with_source_scope(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+    ) -> Option<PartialCache> {
         if !shared_cache::cache_has_kind(&self.conn, &[shared_cache::CACHE_KIND_FULL]) {
+            return None;
+        }
+
+        if !shared_cache::cache_has_source_scope(&self.conn, source_scope) {
             return None;
         }
 
@@ -1396,6 +1605,7 @@ impl DiskCache {
         repair_changed_clean_entity_ids: bool,
         recomputed_edge_source_ids: &[String],
         deleted_entity_ids: &[String],
+        source_scope: shared_cache::CacheSourceScope,
     ) -> Result<(), rusqlite::Error> {
         let source_stale_files: Vec<&String> = stale_files
             .iter()
@@ -1605,6 +1815,7 @@ impl DiskCache {
         }
 
         shared_cache::set_cache_kind(&tx, shared_cache::CACHE_KIND_FULL)?;
+        shared_cache::set_cache_source_scope(&tx, source_scope)?;
         tx.commit()?;
         Ok(())
     }
@@ -1622,6 +1833,17 @@ fn entity_info_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<EntityInfo>
     })
 }
 
+fn sort_entity_infos(entities: &mut [EntityInfo]) {
+    entities.sort_by(|a, b| {
+        a.file_path
+            .cmp(&b.file_path)
+            .then(a.start_line.cmp(&b.start_line))
+            .then(a.end_line.cmp(&b.end_line))
+            .then(a.entity_type.cmp(&b.entity_type))
+            .then(a.name.cmp(&b.name))
+    });
+}
+
 fn repeat_vars(len: usize) -> String {
     std::iter::repeat("?")
         .take(len)
@@ -1637,23 +1859,42 @@ fn split_type_qualified_query(query: &str) -> Option<(&str, &str)> {
     Some((entity_type, name))
 }
 
+struct CurrentImports {
+    files: HashSet<String>,
+    has_default_re_export: bool,
+}
+
 fn current_imported_files(
     root: &Path,
-    files: &[String],
     file_path: &str,
-) -> Result<Vec<String>, CachedImpactError> {
+) -> Result<Option<CurrentImports>, CachedImpactError> {
     let content = std::fs::read_to_string(root.join(file_path))
         .map_err(|_| CachedImpactError::CacheReadFailed)?;
-    let candidate_files: HashSet<&str> = files
-        .iter()
-        .map(String::as_str)
-        .filter(|file| !shared_cache::is_manifest_file_name(file))
+    let (files, has_unscoped_imports) =
+        js_ts_import_source_files_from_filesystem_with_unscoped(root, file_path, &content);
+    if has_unscoped_imports || !is_js_ts_cache_freshness_supported(file_path) {
+        return Ok(None);
+    }
+    let files = files
+        .into_iter()
+        .filter(|file| !is_default_excluded(file))
         .collect();
-    Ok(js_ts_import_source_files_from_set(
-        file_path,
-        &content,
-        &candidate_files,
-    ))
+    Ok(Some(CurrentImports {
+        files,
+        has_default_re_export: js_ts_has_default_re_export_from_content(&content),
+    }))
+}
+
+fn file_has_default_re_export(root: &Path, file_path: &str) -> Result<bool, CachedImpactError> {
+    let content = std::fs::read_to_string(root.join(file_path))
+        .map_err(|_| CachedImpactError::CacheReadFailed)?;
+    Ok(js_ts_has_default_re_export_from_content(&content))
+}
+
+fn is_js_ts_cache_freshness_supported(file_path: &str) -> bool {
+    [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"]
+        .iter()
+        .any(|extension| file_path.ends_with(extension))
 }
 
 fn sql_io_error(error: rusqlite::Error) -> std::io::Error {
@@ -1827,7 +2068,15 @@ mod tests {
 
     fn save_empty_cache(root: &Path, files: &[String]) -> DiskCache {
         let cache = DiskCache::open(root).unwrap();
-        cache.save(root, files, &empty_graph(), &[]).unwrap();
+        cache
+            .save(
+                root,
+                files,
+                &empty_graph(),
+                &[],
+                shared_cache::CacheSourceScope::Default,
+            )
+            .unwrap();
         assert!(cache.load(root, files).is_some());
         cache
     }
@@ -1844,11 +2093,24 @@ mod tests {
         ];
         let graph = graph_with_edges(&entities, vec![edge("b-id", "a-id")]);
         let cache = DiskCache::open(&root).unwrap();
-        cache.save(&root, &files, &graph, &entities).unwrap();
+        cache
+            .save(
+                &root,
+                &files,
+                &graph,
+                &entities,
+                shared_cache::CacheSourceScope::Default,
+            )
+            .unwrap();
 
         let mut output = Vec::new();
         assert!(cache
-            .write_graph_json_topology(&root, &files, &mut output)
+            .write_graph_json_topology(
+                &root,
+                &files,
+                shared_cache::CacheSourceScope::Default,
+                &mut output
+            )
             .unwrap());
         let value: serde_json::Value = serde_json::from_slice(&output).unwrap();
 
@@ -1892,7 +2154,14 @@ mod tests {
         );
         let cache = DiskCache::open(&root).unwrap();
         cache
-            .save_topology(&root, &files, &graph, &entities, &[])
+            .save_topology(
+                &root,
+                &files,
+                &graph,
+                &entities,
+                &[],
+                shared_cache::CacheSourceScope::Default,
+            )
             .unwrap();
 
         assert!(cache.load(&root, &files).is_none());
@@ -1907,7 +2176,12 @@ mod tests {
 
         let mut output = Vec::new();
         assert!(cache
-            .write_graph_json_topology(&root, &files, &mut output)
+            .write_graph_json_topology(
+                &root,
+                &files,
+                shared_cache::CacheSourceScope::Default,
+                &mut output
+            )
             .unwrap());
         let value: serde_json::Value = serde_json::from_slice(&output).unwrap();
         assert_eq!(
@@ -1952,10 +2226,142 @@ mod tests {
         let cache = DiskCache::open(&root).unwrap();
 
         cache
-            .save_topology(&root, &files, &graph, &entities, &[])
+            .save_topology(
+                &root,
+                &files,
+                &graph,
+                &entities,
+                &[],
+                shared_cache::CacheSourceScope::Default,
+            )
             .unwrap();
 
         assert_eq!(file_import_count(&cache, "b.ts", "a.ts"), 1);
+
+        drop(cache);
+        cleanup(root);
+    }
+
+    #[test]
+    fn cache_reuse_requires_matching_source_scope_and_incremental_preserves_it() {
+        let root = temp_repo_root("source-scope-cache-reuse");
+        write_file(&root.join("a.ts"), "export function a() { return 1; }\n");
+        write_file(&root.join("b.ts"), "export function b() { return a(); }\n");
+        let files = vec!["a.ts".to_string(), "b.ts".to_string()];
+        let entities = vec![
+            entity("a-id", "a.ts", "a", "export function a() { return 1; }"),
+            entity("b-id", "b.ts", "b", "export function b() { return a(); }"),
+        ];
+        let graph = graph_with_edges(&entities, vec![edge("b-id", "a-id")]);
+        let cache = DiskCache::open(&root).unwrap();
+
+        cache
+            .save(
+                &root,
+                &files,
+                &graph,
+                &entities,
+                shared_cache::CacheSourceScope::Custom,
+            )
+            .unwrap();
+
+        assert!(cache
+            .load_with_source_scope(&root, &files, shared_cache::CacheSourceScope::Default)
+            .is_none());
+        assert!(cache
+            .load_with_source_scope(&root, &files, shared_cache::CacheSourceScope::Custom)
+            .is_some());
+        assert!(cache
+            .load_partial_with_source_scope(&root, &files, shared_cache::CacheSourceScope::Default)
+            .is_none());
+
+        rewrite_after_mtime_tick(&root.join("b.ts"), "export function b() { return 2; }\n");
+        let partial = cache
+            .load_partial_with_source_scope(&root, &files, shared_cache::CacheSourceScope::Custom)
+            .unwrap();
+        assert_eq!(partial.stale_files, vec!["b.ts"]);
+
+        let updated_entities = vec![
+            entity("a-id", "a.ts", "a", "export function a() { return 1; }"),
+            entity("b-id", "b.ts", "b", "export function b() { return 2; }"),
+        ];
+        let updated_graph = graph_with_edges(&updated_entities, vec![]);
+        cache
+            .save_incremental_with_repair_metadata(
+                &root,
+                &files,
+                &partial.stale_files,
+                &updated_graph,
+                &updated_entities,
+                false,
+                &["b-id".to_string()],
+                &[],
+                shared_cache::CacheSourceScope::Custom,
+            )
+            .unwrap();
+
+        assert!(cache
+            .load_with_source_scope(&root, &files, shared_cache::CacheSourceScope::Default)
+            .is_none());
+        assert!(cache
+            .load_with_source_scope(&root, &files, shared_cache::CacheSourceScope::Custom)
+            .is_some());
+
+        drop(cache);
+        cleanup(root);
+    }
+
+    #[test]
+    fn cache_first_dependency_impact_ignores_default_excluded_imports() {
+        let root = temp_repo_root("impact-ignores-excluded-imports");
+        std::fs::create_dir_all(root.join("src/generated")).unwrap();
+        write_file(
+            &root.join("src/a.ts"),
+            "import { generated } from './generated/client';\nexport function target() { return generated(); }\n",
+        );
+        write_file(
+            &root.join("src/generated/client.ts"),
+            "export function generated() { return 1; }\n",
+        );
+        let files = vec!["src/a.ts".to_string()];
+        let entities = vec![entity(
+            "a-id",
+            "src/a.ts",
+            "target",
+            "export function target() { return generated(); }",
+        )];
+        let graph = graph_with_edges(&entities, vec![]);
+        let cache = DiskCache::open(&root).unwrap();
+
+        cache
+            .save_topology(
+                &root,
+                &files,
+                &graph,
+                &entities,
+                &[],
+                shared_cache::CacheSourceScope::Default,
+            )
+            .unwrap();
+
+        let result = cache
+            .query_impact_topology(
+                &root,
+                &[],
+                shared_cache::CacheSourceScope::Default,
+                true,
+                Some("target"),
+                None,
+                Some("src/a.ts"),
+                CachedImpactMode::Deps,
+                2,
+            )
+            .unwrap();
+
+        assert!(
+            result.is_some(),
+            "default-scoped cache-first deps should ignore imports outside the default source set"
+        );
 
         drop(cache);
         cleanup(root);
@@ -2003,13 +2409,22 @@ mod tests {
         );
         let cache = DiskCache::open(&root).unwrap();
         cache
-            .save_topology(&root, &files, &graph, &entities, &[])
+            .save_topology(
+                &root,
+                &files,
+                &graph,
+                &entities,
+                &[],
+                shared_cache::CacheSourceScope::Default,
+            )
             .unwrap();
 
         let result = cache
             .query_impact_topology(
                 &root,
                 &files,
+                shared_cache::CacheSourceScope::Default,
+                false,
                 Some("target"),
                 None,
                 Some("a.rs"),
@@ -2175,13 +2590,22 @@ mod tests {
         );
         let cache = DiskCache::open(&root).unwrap();
         cache
-            .save_topology(&root, &files, &graph, &entities, &[])
+            .save_topology(
+                &root,
+                &files,
+                &graph,
+                &entities,
+                &[],
+                shared_cache::CacheSourceScope::Default,
+            )
             .unwrap();
 
         let result = cache
             .query_impact_topology(
                 &root,
                 &files,
+                shared_cache::CacheSourceScope::Default,
+                false,
                 Some("root"),
                 None,
                 Some("root.rs"),
@@ -2318,7 +2742,15 @@ mod tests {
         );
         let files = vec!["a.ts".to_string(), "b.ts".to_string(), "c.ts".to_string()];
         let cache = DiskCache::open(&root).unwrap();
-        cache.save(&root, &files, &empty_graph(), &[]).unwrap();
+        cache
+            .save(
+                &root,
+                &files,
+                &empty_graph(),
+                &[],
+                shared_cache::CacheSourceScope::Default,
+            )
+            .unwrap();
 
         assert_eq!(file_import_count(&cache, "a.ts", "b.ts"), 1);
 
@@ -2350,6 +2782,7 @@ mod tests {
                 false,
                 &[],
                 &[],
+                shared_cache::CacheSourceScope::Default,
             )
             .unwrap();
         assert_eq!(file_import_count(&cache, "a.ts", "b.ts"), 0);
@@ -2554,6 +2987,7 @@ mod tests {
                     entity("stale-id", "stale.rs", "stale", "stale old"),
                     entity("clean-id", "clean.rs", "clean", "clean old"),
                 ],
+                shared_cache::CacheSourceScope::Default,
             )
             .unwrap();
 
@@ -2571,6 +3005,7 @@ mod tests {
                 false,
                 &["stale-id".to_string()],
                 &[],
+                shared_cache::CacheSourceScope::Default,
             )
             .unwrap();
 
@@ -2603,6 +3038,7 @@ mod tests {
                     entity("stale-id", "stale.rs", "stale", "stale old"),
                     entity("clean-old-id", "clean.rs", "clean", "clean old"),
                 ],
+                shared_cache::CacheSourceScope::Default,
             )
             .unwrap();
 
@@ -2620,6 +3056,7 @@ mod tests {
                 true,
                 &[],
                 &[],
+                shared_cache::CacheSourceScope::Default,
             )
             .unwrap();
 
@@ -2666,7 +3103,13 @@ mod tests {
             ],
         );
         cache
-            .save(&root, &files, &initial_graph, &entities)
+            .save(
+                &root,
+                &files,
+                &initial_graph,
+                &entities,
+                shared_cache::CacheSourceScope::Default,
+            )
             .unwrap();
         let clean_edge_rowid = edge_rowid(&cache, "clean-id", "other-id").unwrap();
 
@@ -2687,6 +3130,7 @@ mod tests {
                 false,
                 &["stale-id".to_string()],
                 &["old-target-id".to_string()],
+                shared_cache::CacheSourceScope::Default,
             )
             .unwrap();
 
@@ -2708,7 +3152,13 @@ mod tests {
         write_gitattributes(&cli_to_mcp);
         let cli_cache = DiskCache::open(&cli_to_mcp).unwrap();
         cli_cache
-            .save(&cli_to_mcp, &cli_to_mcp_files, &empty_graph(), &[])
+            .save(
+                &cli_to_mcp,
+                &cli_to_mcp_files,
+                &empty_graph(),
+                &[],
+                shared_cache::CacheSourceScope::Default,
+            )
             .unwrap();
         let mcp_cache = shared_cache::DiskCache::open(&cli_to_mcp).unwrap();
         assert!(mcp_cache.load(&cli_to_mcp, &cli_to_mcp_files).is_some());
@@ -2721,7 +3171,13 @@ mod tests {
         write_gitattributes(&mcp_to_cli);
         let mcp_cache = shared_cache::DiskCache::open(&mcp_to_cli).unwrap();
         mcp_cache
-            .save(&mcp_to_cli, &mcp_to_cli_files, &empty_graph(), &[])
+            .save(
+                &mcp_to_cli,
+                &mcp_to_cli_files,
+                &empty_graph(),
+                &[],
+                shared_cache::CacheSourceScope::Default,
+            )
             .unwrap();
         let cli_cache = DiskCache::open(&mcp_to_cli).unwrap();
         assert!(cli_cache.load(&mcp_to_cli, &mcp_to_cli_files).is_some());
@@ -2739,6 +3195,7 @@ mod tests {
                 &empty_graph(),
                 &[],
                 &[],
+                shared_cache::CacheSourceScope::Default,
             )
             .unwrap();
         let mcp_cache = shared_cache::DiskCache::open(&cli_topology_to_mcp).unwrap();
@@ -2779,6 +3236,18 @@ mod tests {
         assert!(!root.join(".sem").exists());
 
         drop(cache);
+        cleanup(root);
+    }
+
+    #[test]
+    fn open_existing_readonly_does_not_create_missing_cache() {
+        let root = temp_repo_root("readonly-missing");
+        let db_path = shared_cache::cache_db_path(&root).unwrap();
+
+        assert!(!db_path.exists());
+        assert!(DiskCache::open_existing_readonly(&root).is_err());
+        assert!(!db_path.exists());
+
         cleanup(root);
     }
 

--- a/crates/sem-cli/src/cache.rs
+++ b/crates/sem-cli/src/cache.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use rusqlite::{params, params_from_iter, Connection, OptionalExtension};
 use sem_core::model::entity::SemanticEntity;
 use sem_core::parser::graph::{EntityGraph, EntityInfo, EntityRef, RefType};
+use sem_core::parser::js_ts_import_source_files_from_set;
 use sem_mcp::cache as shared_cache;
 
 const CACHED_TEST_IMPACT_LIMIT: usize = 10_000;
@@ -177,6 +178,7 @@ impl DiskCache {
         }
 
         shared_cache::refresh_manifest_entries(&tx, root)?;
+        shared_cache::refresh_file_import_entries(&tx, root, files, files)?;
 
         {
             let mut stmt = tx.prepare(
@@ -338,7 +340,13 @@ impl DiskCache {
         mode: CachedImpactMode,
         depth: usize,
     ) -> Result<Option<CachedImpactResult>, CachedImpactError> {
-        if !self.has_fresh_topology_cache(root, files) {
+        if !shared_cache::cache_has_kind(
+            &self.conn,
+            &[
+                shared_cache::CACHE_KIND_FULL,
+                shared_cache::CACHE_KIND_TOPOLOGY,
+            ],
+        ) {
             return Ok(None);
         }
 
@@ -348,6 +356,31 @@ impl DiskCache {
             return Ok(None);
         }
 
+        if matches!(mode, CachedImpactMode::Deps) {
+            return self.query_dependency_impact_topology(
+                root,
+                files,
+                entity_name,
+                entity_id,
+                file_hint,
+            );
+        }
+
+        if !self.has_fresh_cache(root, files) {
+            return Ok(None);
+        }
+
+        self.query_fresh_impact_topology(entity_name, entity_id, file_hint, mode, depth)
+    }
+
+    fn query_fresh_impact_topology(
+        &self,
+        entity_name: Option<&str>,
+        entity_id: Option<&str>,
+        file_hint: Option<&str>,
+        mode: CachedImpactMode,
+        depth: usize,
+    ) -> Result<Option<CachedImpactResult>, CachedImpactError> {
         let entity = self.find_cached_impact_entity(entity_name, entity_id, file_hint)?;
         let dependencies = if matches!(mode, CachedImpactMode::All | CachedImpactMode::Deps) {
             match self.direct_dependencies(&entity.id) {
@@ -397,6 +430,183 @@ impl DiskCache {
             tests,
             tests_truncated,
         }))
+    }
+
+    fn query_dependency_impact_topology(
+        &self,
+        root: &Path,
+        files: &[String],
+        entity_name: Option<&str>,
+        entity_id: Option<&str>,
+        file_hint: Option<&str>,
+    ) -> Result<Option<CachedImpactResult>, CachedImpactError> {
+        if !self.has_fresh_dependency_impact_scope(root, files)? {
+            return Ok(None);
+        }
+
+        let entity = match self.find_cached_impact_entity(entity_name, entity_id, file_hint) {
+            Ok(entity) => entity,
+            Err(CachedImpactError::CacheReadFailed) => {
+                return Err(CachedImpactError::CacheReadFailed);
+            }
+            Err(_) => return Ok(None),
+        };
+        let dependencies = self
+            .direct_dependencies(&entity.id)
+            .map_err(|_| CachedImpactError::CacheReadFailed)?;
+
+        if !self.has_fresh_dependency_impact_files(root, files, &entity, &dependencies)? {
+            return Ok(None);
+        }
+
+        Ok(Some(CachedImpactResult {
+            entity,
+            dependencies,
+            dependents: Vec::new(),
+            impact: Vec::new(),
+            tests: Vec::new(),
+        }))
+    }
+
+    fn has_fresh_dependency_impact_scope(
+        &self,
+        root: &Path,
+        files: &[String],
+    ) -> Result<bool, CachedImpactError> {
+        if shared_cache::is_manifest_stale(&self.conn, root) {
+            return Ok(false);
+        }
+        self.cached_source_file_set_matches(files)
+    }
+
+    fn has_fresh_dependency_impact_files(
+        &self,
+        root: &Path,
+        files: &[String],
+        entity: &EntityInfo,
+        dependencies: &[EntityInfo],
+    ) -> Result<bool, CachedImpactError> {
+        if !self
+            .cached_files_are_fresh(root, HashSet::from([entity.file_path.clone()]))
+            .map_err(|_| CachedImpactError::CacheReadFailed)?
+        {
+            return Ok(false);
+        }
+
+        let mut required_files = HashSet::new();
+        for dependency in dependencies {
+            required_files.insert(dependency.file_path.clone());
+        }
+        let cached_imported_files = self
+            .cached_imported_files(&entity.file_path)
+            .map_err(|_| CachedImpactError::CacheReadFailed)?;
+        let should_scan_current_imports = cached_imported_files.is_empty()
+            && !self
+                .has_file_import_entries()
+                .map_err(|_| CachedImpactError::CacheReadFailed)?;
+        for imported_file in cached_imported_files {
+            required_files.insert(imported_file);
+        }
+        if should_scan_current_imports {
+            for imported_file in current_imported_files(root, files, &entity.file_path)? {
+                required_files.insert(imported_file);
+            }
+        }
+
+        self.cached_files_are_fresh(root, required_files)
+            .map_err(|_| CachedImpactError::CacheReadFailed)
+    }
+
+    fn cached_source_file_set_matches(&self, files: &[String]) -> Result<bool, CachedImpactError> {
+        let current_files: HashSet<&str> = files
+            .iter()
+            .map(String::as_str)
+            .filter(|file| !shared_cache::is_manifest_file_name(file))
+            .collect();
+
+        let mut stmt = self
+            .conn
+            .prepare("SELECT path FROM files")
+            .map_err(|_| CachedImpactError::CacheReadFailed)?;
+        let rows = stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(|_| CachedImpactError::CacheReadFailed)?;
+        let cached_files: HashSet<String> = rows
+            .filter_map(|row| row.ok())
+            .filter(|path| {
+                !shared_cache::is_cache_manifest_key(path)
+                    && !shared_cache::is_manifest_file_name(path)
+            })
+            .collect();
+
+        Ok(cached_files.len() == current_files.len()
+            && current_files
+                .iter()
+                .all(|file| cached_files.contains(*file)))
+    }
+
+    fn cached_imported_files(&self, file_path: &str) -> Result<Vec<String>, rusqlite::Error> {
+        let mut stmt = self.conn.prepare(
+            "SELECT imported_file FROM file_imports
+             WHERE importing_file = ?1
+             ORDER BY imported_file",
+        )?;
+        let rows = stmt.query_map(params![file_path], |row| row.get::<_, String>(0))?;
+        rows.collect()
+    }
+
+    fn has_file_import_entries(&self) -> Result<bool, rusqlite::Error> {
+        self.conn
+            .query_row("SELECT 1 FROM file_imports LIMIT 1", [], |_| Ok(()))
+            .optional()
+            .map(|row| row.is_some())
+    }
+
+    fn cached_files_are_fresh(
+        &self,
+        root: &Path,
+        files: HashSet<String>,
+    ) -> Result<bool, rusqlite::Error> {
+        let mut stmt = self.conn.prepare(
+            "SELECT mtime_secs, mtime_nanos, content_hash
+             FROM files WHERE path = ?1",
+        )?;
+        let mut fingerprint_refreshes = Vec::new();
+
+        for file in files {
+            let cached: Option<(i64, i64, Option<String>)> = stmt
+                .query_row(params![file], |row| {
+                    Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+                })
+                .optional()?;
+            let Some((secs, nanos, content_hash)) = cached else {
+                return Ok(false);
+            };
+            match shared_cache::file_freshness(
+                &root.join(&file),
+                secs,
+                nanos,
+                content_hash.as_deref(),
+            ) {
+                Some(shared_cache::FileFreshness::Fresh) => {}
+                Some(shared_cache::FileFreshness::FreshWithUpdatedFingerprint {
+                    secs,
+                    nanos,
+                    content_hash,
+                }) => {
+                    fingerprint_refreshes.push(shared_cache::FileFingerprintRefresh {
+                        path: file,
+                        mtime_secs: secs,
+                        mtime_nanos: nanos,
+                        content_hash,
+                    });
+                }
+                Some(shared_cache::FileFreshness::Stale) | None => return Ok(false),
+            }
+        }
+
+        shared_cache::refresh_file_fingerprints_best_effort(&self.conn, &fingerprint_refreshes);
+        Ok(true)
     }
 
     fn load_graph_topology_rows(&self) -> Option<EntityGraph> {
@@ -1427,6 +1637,25 @@ fn split_type_qualified_query(query: &str) -> Option<(&str, &str)> {
     Some((entity_type, name))
 }
 
+fn current_imported_files(
+    root: &Path,
+    files: &[String],
+    file_path: &str,
+) -> Result<Vec<String>, CachedImpactError> {
+    let content = std::fs::read_to_string(root.join(file_path))
+        .map_err(|_| CachedImpactError::CacheReadFailed)?;
+    let candidate_files: HashSet<&str> = files
+        .iter()
+        .map(String::as_str)
+        .filter(|file| !shared_cache::is_manifest_file_name(file))
+        .collect();
+    Ok(js_ts_import_source_files_from_set(
+        file_path,
+        &content,
+        &candidate_files,
+    ))
+}
+
 fn sql_io_error(error: rusqlite::Error) -> std::io::Error {
     std::io::Error::new(std::io::ErrorKind::Other, error)
 }
@@ -1688,6 +1917,45 @@ mod tests {
 
         rewrite_after_mtime_tick(&root.join("a.rs"), "fn a() { let _x = 1; }\n");
         assert!(cache.load_partial(&root, &files).is_none());
+
+        drop(cache);
+        cleanup(root);
+    }
+
+    #[test]
+    fn save_topology_records_file_imports() {
+        let root = temp_repo_root("topology-file-imports");
+        write_file(
+            &root.join("a.ts"),
+            "export function target() { return 1; }\n",
+        );
+        write_file(
+            &root.join("b.ts"),
+            "import { target } from './a';\nexport function useIt() { return target(); }\n",
+        );
+        let files = vec!["a.ts".to_string(), "b.ts".to_string()];
+        let entities = vec![
+            entity(
+                "a-id",
+                "a.ts",
+                "target",
+                "export function target() { return 1; }",
+            ),
+            entity(
+                "b-id",
+                "b.ts",
+                "useIt",
+                "export function useIt() { return target(); }",
+            ),
+        ];
+        let graph = graph_with_edges(&entities, vec![edge("b-id", "a-id")]);
+        let cache = DiskCache::open(&root).unwrap();
+
+        cache
+            .save_topology(&root, &files, &graph, &entities, &[])
+            .unwrap();
+
+        assert_eq!(file_import_count(&cache, "b.ts", "a.ts"), 1);
 
         drop(cache);
         cleanup(root);
@@ -2221,6 +2489,33 @@ mod tests {
 
         assert!(cache.load(&root, &files).is_none());
         assert!(cache.load_partial(&root, &files).is_none());
+
+        drop(cache);
+        cleanup(root);
+    }
+
+    #[test]
+    fn load_refreshes_gitattributes_mtime_when_content_is_unchanged() {
+        let root = temp_repo_root("gitattributes-mtime-only-refresh");
+        let files = sample_files(&root);
+        let gitattributes = root.join(".gitattributes");
+        let content = "*.foo linguist-language=javascript\n";
+        write_file(&gitattributes, content);
+        let cache = save_empty_cache(&root, &files);
+        let cache_key = shared_cache::CACHE_MANIFEST_FILES
+            .iter()
+            .find_map(|(file_name, cache_key)| {
+                (*file_name == ".gitattributes").then_some(*cache_key)
+            })
+            .unwrap();
+        let before = cached_file_mtime(&cache, cache_key);
+
+        rewrite_after_mtime_tick(&gitattributes, content);
+        let current = shared_cache::file_mtime_parts(&gitattributes).unwrap();
+
+        assert_ne!(before, current);
+        assert!(cache.load(&root, &files).is_some());
+        assert_eq!(cached_file_mtime(&cache, cache_key), current);
 
         drop(cache);
         cleanup(root);

--- a/crates/sem-cli/src/commands/context.rs
+++ b/crates/sem-cli/src/commands/context.rs
@@ -29,6 +29,8 @@ pub fn context_command(opts: ContextOptions) {
     let root = root.as_path();
     let registry = super::create_registry(&root.to_string_lossy());
     let ext_filter = super::graph::normalize_exts(&opts.file_exts);
+    let source_scope =
+        super::graph::cache_source_scope(root, &ext_filter, opts.no_default_excludes);
 
     let file_paths = super::graph::find_supported_files_with_options(
         root,
@@ -37,7 +39,8 @@ pub fn context_command(opts: ContextOptions) {
         opts.no_default_excludes,
     );
     let prog = crate::progress::Progress::start("Building entity graph");
-    let (graph, all_entities) = super::graph::get_or_build_graph(root, &file_paths, &registry, opts.no_cache);
+    let (graph, all_entities) =
+        super::graph::get_or_build_graph(root, &file_paths, &registry, opts.no_cache, source_scope);
     prog.done(&format!(
         "{} entities, {} files",
         super::graph::fmt_count(graph.entities.len()),
@@ -86,7 +89,10 @@ pub fn context_command(opts: ContextOptions) {
         );
 
         if context_result.target_omitted {
-            println!("  {}", "target omitted: signature exceeds token budget".dimmed());
+            println!(
+                "  {}",
+                "target omitted: signature exceeds token budget".dimmed()
+            );
         }
 
         let mut current_role = String::new();
@@ -143,7 +149,10 @@ fn find_entity<'a>(
     }
 
     let name = name.unwrap_or_else(|| {
-        eprintln!("{} Either entity name or --entity-id is required", "error:".red().bold());
+        eprintln!(
+            "{} Either entity name or --entity-id is required",
+            "error:".red().bold()
+        );
         std::process::exit(1);
     });
 
@@ -159,12 +168,21 @@ fn find_entity<'a>(
     }
 
     if let Some(file) = file_hint {
-        let filtered: Vec<_> = matching.iter().filter(|e| e.file_path == file).copied().collect();
+        let filtered: Vec<_> = matching
+            .iter()
+            .filter(|e| e.file_path == file)
+            .copied()
+            .collect();
         if filtered.len() == 1 {
             return filtered[0];
         }
         if filtered.is_empty() {
-            eprintln!("{} Entity '{}' not found in file '{}'", "error:".red().bold(), name, file);
+            eprintln!(
+                "{} Entity '{}' not found in file '{}'",
+                "error:".red().bold(),
+                name,
+                file
+            );
             std::process::exit(1);
         }
         matching = filtered;
@@ -175,7 +193,12 @@ fn find_entity<'a>(
     }
 
     matching.sort_by_key(|e| (&e.file_path, e.start_line));
-    eprintln!("{} Entity name '{}' is ambiguous ({} matches). Specify --file or --entity-id:", "error:".red().bold(), name, matching.len());
+    eprintln!(
+        "{} Entity name '{}' is ambiguous ({} matches). Specify --file or --entity-id:",
+        "error:".red().bold(),
+        name,
+        matching.len()
+    );
     for m in &matching {
         eprintln!(
             "  {} {} ({}:L{})",

--- a/crates/sem-cli/src/commands/entities.rs
+++ b/crates/sem-cli/src/commands/entities.rs
@@ -1,18 +1,25 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
+use crate::{cache::DiskCache, timings::Timings};
 use colored::Colorize;
 use sem_core::model::entity::SemanticEntity;
-use sem_core::parser::registry::{resolve_go_method_parent_ids, ParserRegistry};
+use sem_core::parser::graph::EntityInfo;
+use sem_core::parser::registry::ParserRegistry;
+use serde::Serialize;
 
 pub struct EntitiesOptions {
     pub cwd: String,
     pub paths: Vec<String>,
     pub json: bool,
     pub no_default_excludes: bool,
+    pub file_exts: Vec<String>,
 }
 
 pub fn entities_command(opts: EntitiesOptions) {
+    let mut timings = Timings::from_env("entities");
+
     // Normalize to a non-empty list of path args, defaulting to ".".
     let path_args: Vec<String> = {
         let cleaned: Vec<String> = opts
@@ -27,9 +34,18 @@ pub fn entities_command(opts: EntitiesOptions) {
             cleaned
         }
     };
+    timings.counter("input_paths", path_args.len() as u64);
+    timings.mark("path_args");
+
+    let ext_filter = super::graph::normalize_exts(&opts.file_exts);
 
     // The cloud fast-path only helps the whole-repo single listing.
-    if path_args.len() == 1 && super::cloud::try_cloud_entities(&opts).is_some() {
+    if ext_filter.is_empty()
+        && path_args.len() == 1
+        && super::cloud::try_cloud_entities(&opts).is_some()
+    {
+        timings.mark("cloud_entities");
+        timings.finish();
         return;
     }
 
@@ -38,9 +54,15 @@ pub fn entities_command(opts: EntitiesOptions) {
 
     let mut entities: Vec<SemanticEntity> = Vec::new();
     let mut dir_count = 0usize;
+    let mut file_arg_count = 0usize;
+    let mut processed_file_count = 0usize;
+    let mut discovered_file_count = 0usize;
+    let mut extracted_entities = false;
     for path_arg in &path_args {
         let (path_label, full_path) = resolve_path(root, path_arg);
         if full_path.is_file() {
+            file_arg_count += 1;
+            processed_file_count += 1;
             let file_entities = extract_file_entities(&full_path, &registry, &path_label)
                 .unwrap_or_else(|e| {
                     eprintln!(
@@ -52,20 +74,57 @@ pub fn entities_command(opts: EntitiesOptions) {
                     std::process::exit(1);
                 });
             entities.extend(file_entities);
+            extracted_entities = true;
         } else if full_path.is_dir() {
             dir_count += 1;
             let file_paths = super::files::find_supported_files_in_path(
                 root,
                 &full_path,
                 &registry,
-                &[],
+                &ext_filter,
                 opts.no_default_excludes,
             );
-            entities.extend(extract_files_entities(root, &file_paths, &registry));
+            discovered_file_count += file_paths.len();
+            processed_file_count += file_paths.len();
+            timings.mark("file_discovery");
+            if opts.json
+                && path_args.len() == 1
+                && try_write_cached_entities_json(
+                    root,
+                    &file_paths,
+                    &ext_filter,
+                    opts.no_default_excludes,
+                    &mut timings,
+                )
+            {
+                timings.counter("input_files", processed_file_count as u64);
+                timings.counter("input_file_args", file_arg_count as u64);
+                timings.counter("input_dirs", dir_count as u64);
+                timings.counter("processed_files", processed_file_count as u64);
+                timings.counter("discovered_files", discovered_file_count as u64);
+                timings.mark("output_serialization");
+                timings.finish();
+                return;
+            }
+            if let Some(cached_entities) = try_cached_entities(
+                root,
+                &file_paths,
+                &ext_filter,
+                opts.no_default_excludes,
+                &mut timings,
+            ) {
+                entities.extend(cached_entities);
+            } else {
+                entities.extend(extract_files_entities(root, &file_paths, &registry));
+                extracted_entities = true;
+            }
         } else {
             eprintln!("{} Path not found '{}'", "error:".red().bold(), path_arg);
             std::process::exit(1);
         }
+    }
+    if extracted_entities {
+        timings.mark("extract_entities");
     }
 
     // Overlapping paths (e.g. a directory and a file inside it) can surface the
@@ -79,6 +138,7 @@ pub fn entities_command(opts: EntitiesOptions) {
             .then(a.name.cmp(&b.name))
     });
     entities.dedup_by(|a, b| a.id == b.id);
+    timings.mark("sort_dedup");
 
     // Show the file column whenever results span more than one file. This keeps
     // the prior single-file vs directory behavior and covers multi-path input.
@@ -90,13 +150,20 @@ pub fn entities_command(opts: EntitiesOptions) {
     };
     let include_file = dir_count > 0 || distinct_files > 1;
     let display_label = path_args.join(" ");
+    timings.counter("input_files", processed_file_count as u64);
+    timings.counter("input_file_args", file_arg_count as u64);
+    timings.counter("input_dirs", dir_count as u64);
+    timings.counter("processed_files", processed_file_count as u64);
+    timings.counter("discovered_files", discovered_file_count as u64);
+    timings.counter("distinct_files", distinct_files as u64);
+    timings.counter("entities", entities.len() as u64);
 
     if opts.json {
-        let output: Vec<_> = entities
-            .iter()
-            .map(|e| entity_json(e, include_file))
-            .collect();
-        println!("{}", serde_json::to_string(&output).unwrap());
+        let json_bytes = write_entities_json(&entities, include_file).unwrap_or_else(|e| {
+            eprintln!("{} Cannot write JSON output: {}", "error:".red().bold(), e);
+            std::process::exit(1);
+        });
+        timings.counter("json_bytes", json_bytes);
     } else if should_group_by_file(&entities) {
         print_grouped_entities(&display_label, &entities);
     } else if let Some(file_path) = entities.first().map(|e| e.file_path.as_str()) {
@@ -104,6 +171,8 @@ pub fn entities_command(opts: EntitiesOptions) {
     } else {
         println!("{} {}\n", "entities:".green().bold(), display_label.bold());
     }
+    timings.mark("output_serialization");
+    timings.finish();
 }
 
 fn resolve_path(root: &Path, path_arg: &str) -> (String, PathBuf) {
@@ -128,17 +197,103 @@ fn extract_files_entities(
     file_paths: &[String],
     registry: &ParserRegistry,
 ) -> Vec<SemanticEntity> {
-    let mut entities = registry.extract_all_entities(root, file_paths);
-    resolve_go_method_parent_ids(&mut entities);
-    entities.sort_by(|a, b| {
-        a.file_path
-            .cmp(&b.file_path)
-            .then(a.start_line.cmp(&b.start_line))
-            .then(a.end_line.cmp(&b.end_line))
-            .then(a.entity_type.cmp(&b.entity_type))
-            .then(a.name.cmp(&b.name))
-    });
-    entities
+    registry.extract_all_entities_brief(root, file_paths)
+}
+
+fn try_cached_entities(
+    root: &Path,
+    file_paths: &[String],
+    ext_filter: &[String],
+    no_default_excludes: bool,
+    timings: &mut Timings,
+) -> Option<Vec<SemanticEntity>> {
+    let source_scope = super::graph::cache_source_scope(root, ext_filter, no_default_excludes);
+    let cache = match DiskCache::open_existing_readonly(root) {
+        Ok(cache) => {
+            timings.mark("cache_open");
+            cache
+        }
+        Err(_) => {
+            timings.mark("cache_open_failed");
+            return None;
+        }
+    };
+
+    match cache.query_entities_listing(root, file_paths, source_scope) {
+        Ok(Some(entities)) => {
+            timings.counter("cached_entities", entities.len() as u64);
+            timings.mark("cache_entities_query");
+            Some(entities.into_iter().map(entity_info_to_entity).collect())
+        }
+        Ok(None) => {
+            timings.mark("cache_entities_miss");
+            None
+        }
+        Err(_) => {
+            timings.mark("cache_entities_query_failed");
+            None
+        }
+    }
+}
+
+fn try_write_cached_entities_json(
+    root: &Path,
+    file_paths: &[String],
+    ext_filter: &[String],
+    no_default_excludes: bool,
+    timings: &mut Timings,
+) -> bool {
+    let source_scope = super::graph::cache_source_scope(root, ext_filter, no_default_excludes);
+    let cache = match DiskCache::open_existing_readonly(root) {
+        Ok(cache) => {
+            timings.mark("cache_open");
+            cache
+        }
+        Err(_) => {
+            timings.mark("cache_open_failed");
+            return false;
+        }
+    };
+
+    let stdout = io::stdout();
+    let mut writer = CountingWriter::new(stdout.lock());
+    match cache.write_entities_listing_json(root, file_paths, source_scope, true, &mut writer) {
+        Ok(Some(entity_count)) => {
+            timings.counter("cached_entities", entity_count);
+            timings.counter("entities", entity_count);
+            timings.counter("json_bytes", writer.bytes());
+            timings.mark("cache_entities_query");
+            true
+        }
+        Ok(None) => {
+            timings.mark("cache_entities_miss");
+            false
+        }
+        Err(error) => {
+            eprintln!(
+                "{} Cannot write cached JSON output: {}",
+                "error:".red().bold(),
+                error
+            );
+            std::process::exit(1);
+        }
+    }
+}
+
+fn entity_info_to_entity(entity: EntityInfo) -> SemanticEntity {
+    SemanticEntity {
+        id: entity.id,
+        file_path: entity.file_path,
+        entity_type: entity.entity_type,
+        name: entity.name,
+        parent_id: entity.parent_id,
+        content: String::new(),
+        content_hash: String::new(),
+        structural_hash: None,
+        start_line: entity.start_line,
+        end_line: entity.end_line,
+        metadata: None,
+    }
 }
 
 fn file_path_for_entity(root: &Path, path: &Path) -> String {
@@ -151,23 +306,69 @@ fn extract_file_entities(
     file_path: &str,
 ) -> Result<Vec<SemanticEntity>, std::io::Error> {
     let content = std::fs::read_to_string(&full_path)?;
-    Ok(registry.extract_entities(file_path, &content))
+    Ok(registry.extract_entities_brief(file_path, &content))
 }
 
-fn entity_json(entity: &SemanticEntity, include_file: bool) -> serde_json::Value {
-    let mut value = serde_json::json!({
-        "name": entity.name,
-        "type": entity.entity_type,
-        "start_line": entity.start_line,
-        "end_line": entity.end_line,
-        "parent_id": entity.parent_id,
-    });
+#[derive(Serialize)]
+struct EntityJsonRow<'a> {
+    name: &'a str,
+    #[serde(rename = "type")]
+    entity_type: &'a str,
+    start_line: usize,
+    end_line: usize,
+    parent_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    file: Option<&'a str>,
+}
 
-    if include_file {
-        value["file"] = serde_json::json!(entity.file_path);
+fn write_entities_json(entities: &[SemanticEntity], include_file: bool) -> io::Result<u64> {
+    let stdout = io::stdout();
+    let mut writer = CountingWriter::new(stdout.lock());
+    writer.write_all(b"[")?;
+    for (index, entity) in entities.iter().enumerate() {
+        if index > 0 {
+            writer.write_all(b",")?;
+        }
+        let row = EntityJsonRow {
+            name: &entity.name,
+            entity_type: &entity.entity_type,
+            start_line: entity.start_line,
+            end_line: entity.end_line,
+            parent_id: entity.parent_id.as_deref(),
+            file: include_file.then_some(entity.file_path.as_str()),
+        };
+        serde_json::to_writer(&mut writer, &row)
+            .map_err(|error| io::Error::new(io::ErrorKind::Other, error))?;
+    }
+    writer.write_all(b"]\n")?;
+    Ok(writer.bytes())
+}
+
+struct CountingWriter<W> {
+    inner: W,
+    bytes: u64,
+}
+
+impl<W> CountingWriter<W> {
+    fn new(inner: W) -> Self {
+        Self { inner, bytes: 0 }
     }
 
-    value
+    fn bytes(&self) -> u64 {
+        self.bytes
+    }
+}
+
+impl<W: Write> Write for CountingWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let written = self.inner.write(buf)?;
+        self.bytes += written as u64;
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
 }
 
 fn print_file_entities(file_path: &str, entities: &[SemanticEntity]) {
@@ -205,7 +406,10 @@ fn print_entity_rows(entities: &[SemanticEntity], base_indent: &str) {
 }
 
 fn entities_by_id(entities: &[SemanticEntity]) -> HashMap<&str, &SemanticEntity> {
-    entities.iter().map(|entity| (entity.id.as_str(), entity)).collect()
+    entities
+        .iter()
+        .map(|entity| (entity.id.as_str(), entity))
+        .collect()
 }
 
 fn entity_indent(
@@ -213,7 +417,10 @@ fn entity_indent(
     entities_by_id: &HashMap<&str, &SemanticEntity>,
     base_indent: &str,
 ) -> String {
-    format!("{base_indent}{}", "  ".repeat(entity_depth(entity, entities_by_id)))
+    format!(
+        "{base_indent}{}",
+        "  ".repeat(entity_depth(entity, entities_by_id))
+    )
 }
 
 fn entity_depth(entity: &SemanticEntity, entities_by_id: &HashMap<&str, &SemanticEntity>) -> usize {

--- a/crates/sem-cli/src/commands/files.rs
+++ b/crates/sem-cli/src/commands/files.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, io::Write, path::Path, process::Command};
+use std::path::Path;
 
 use colored::Colorize;
 use sem_core::parser::registry::ParserRegistry;
@@ -88,181 +88,6 @@ pub fn find_supported_files_in_path(
     files
 }
 
-pub fn find_supported_files_from_git_index(
-    root: &Path,
-    registry: &ParserRegistry,
-    ext_filter: &[String],
-    no_default_excludes: bool,
-) -> Option<Vec<String>> {
-    if root.join(".semignore").exists() {
-        return None;
-    }
-
-    let output = Command::new("git")
-        .current_dir(root)
-        .args([
-            "ls-files",
-            "-z",
-            "--cached",
-            "--others",
-            "--exclude-standard",
-        ])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-
-    let missing_from_worktree = git_missing_from_worktree_paths(root)?;
-    let mut candidates = Vec::new();
-    for raw_path in output.stdout.split(|byte| *byte == 0) {
-        if raw_path.is_empty() {
-            continue;
-        }
-        let rel_path = String::from_utf8_lossy(raw_path).replace('\\', "/");
-        if missing_from_worktree.contains(rel_path.as_str()) {
-            continue;
-        }
-        if rel_path.is_empty() || rel_path.ends_with('/') {
-            continue;
-        }
-        if Path::new(&rel_path).is_absolute() {
-            return None;
-        }
-        if !no_default_excludes && is_default_excluded(&rel_path) {
-            continue;
-        }
-        if is_hidden_path(&rel_path) {
-            continue;
-        }
-        candidates.push(rel_path);
-    }
-
-    let ignored = git_ignored_paths(root, &candidates)?;
-    let mut files = Vec::new();
-    for rel_path in candidates {
-        if ignored.contains(rel_path.as_str()) {
-            continue;
-        }
-        if !ext_filter.is_empty()
-            && !ext_filter
-                .iter()
-                .any(|ext| rel_path.ends_with(ext.as_str()))
-        {
-            continue;
-        }
-        if is_probably_binary_path(&rel_path) {
-            continue;
-        }
-        if !has_supported_plugin(&root.join(&rel_path), &rel_path, registry, ext_filter) {
-            continue;
-        }
-        files.push(rel_path);
-    }
-
-    files.sort();
-    files.dedup();
-    Some(files)
-}
-
-fn git_missing_from_worktree_paths(root: &Path) -> Option<HashSet<String>> {
-    let output = Command::new("git")
-        .current_dir(root)
-        .args(["ls-files", "-z", "--deleted"])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-
-    let mut missing: HashSet<String> = output
-        .stdout
-        .split(|byte| *byte == 0)
-        .filter(|path| !path.is_empty())
-        .map(|path| String::from_utf8_lossy(path).replace('\\', "/"))
-        .collect();
-
-    let output = Command::new("git")
-        .current_dir(root)
-        .args(["ls-files", "-z", "-v"])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    for raw_entry in output.stdout.split(|byte| *byte == 0) {
-        if raw_entry.len() < 3 || raw_entry[0] != b'S' || raw_entry[1] != b' ' {
-            continue;
-        }
-        missing.insert(String::from_utf8_lossy(&raw_entry[2..]).replace('\\', "/"));
-    }
-    for path in git_non_file_symlink_paths(root)? {
-        missing.insert(path);
-    }
-
-    Some(missing)
-}
-
-fn git_non_file_symlink_paths(root: &Path) -> Option<Vec<String>> {
-    let output = Command::new("git")
-        .current_dir(root)
-        .args(["ls-files", "-z", "-s"])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-
-    let mut paths = Vec::new();
-    for raw_entry in output.stdout.split(|byte| *byte == 0) {
-        if !raw_entry.starts_with(b"120000 ") {
-            continue;
-        }
-        let Some(tab_pos) = raw_entry.iter().position(|byte| *byte == b'\t') else {
-            return None;
-        };
-        let path = String::from_utf8_lossy(&raw_entry[tab_pos + 1..]).replace('\\', "/");
-        if !root.join(&path).is_file() {
-            paths.push(path);
-        }
-    }
-    Some(paths)
-}
-
-fn git_ignored_paths(root: &Path, paths: &[String]) -> Option<HashSet<String>> {
-    if paths.is_empty() {
-        return Some(HashSet::new());
-    }
-
-    let mut child = Command::new("git")
-        .current_dir(root)
-        .args(["check-ignore", "--no-index", "-z", "--stdin"])
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
-        .spawn()
-        .ok()?;
-    {
-        let stdin = child.stdin.as_mut()?;
-        for path in paths {
-            stdin.write_all(path.as_bytes()).ok()?;
-            stdin.write_all(b"\0").ok()?;
-        }
-    }
-    let output = child.wait_with_output().ok()?;
-    if !matches!(output.status.code(), Some(0) | Some(1)) {
-        return None;
-    }
-
-    Some(
-        output
-            .stdout
-            .split(|byte| *byte == 0)
-            .filter(|path| !path.is_empty())
-            .map(|path| String::from_utf8_lossy(path).replace('\\', "/"))
-            .collect(),
-    )
-}
-
 fn is_hidden_path(rel_path: &str) -> bool {
     rel_path
         .split('/')
@@ -324,6 +149,7 @@ mod tests {
     fn scan_skips_binary_files_and_default_excludes() {
         let root = temp_dir();
         fs::create_dir_all(root.join("src")).unwrap();
+        fs::create_dir_all(root.join("src/generated")).unwrap();
         fs::create_dir_all(root.join("dist")).unwrap();
         fs::write(root.join("src/main.rs"), "fn main() {}\n").unwrap();
         fs::write(
@@ -334,6 +160,26 @@ mod tests {
         fs::write(root.join("src/notes.weird"), "plain text\n").unwrap();
         fs::write(root.join("src/blob.weird"), b"abc\0def").unwrap();
         fs::write(root.join("src/icon.png"), b"\x89PNG\r\n").unwrap();
+        fs::write(
+            root.join("src/generated/schema.ts"),
+            "export function generatedSchema() {}\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("src/api.generated.ts"),
+            "export function generatedApi() {}\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("src/styles.module.scss.d.ts"),
+            "declare const styles: Record<string, string>;\nexport default styles;\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("src/logo.svg.d.ts"),
+            "declare const src: string;\nexport default src;\n",
+        )
+        .unwrap();
         fs::write(root.join("dist/generated.js"), "function generated() {}\n").unwrap();
 
         let registry = create_default_registry();
@@ -347,6 +193,10 @@ mod tests {
         let files_with_generated = find_supported_files_in_path(&root, &root, &registry, &[], true);
         assert!(files_with_generated.contains(&"src/main.rs".to_string()));
         assert!(files_with_generated.contains(&"src/run".to_string()));
+        assert!(files_with_generated.contains(&"src/generated/schema.ts".to_string()));
+        assert!(files_with_generated.contains(&"src/api.generated.ts".to_string()));
+        assert!(files_with_generated.contains(&"src/styles.module.scss.d.ts".to_string()));
+        assert!(files_with_generated.contains(&"src/logo.svg.d.ts".to_string()));
         assert!(files_with_generated.contains(&"dist/generated.js".to_string()));
         assert!(!files_with_generated.contains(&"src/notes.weird".to_string()));
         assert!(!files_with_generated.contains(&"src/blob.weird".to_string()));

--- a/crates/sem-cli/src/commands/files.rs
+++ b/crates/sem-cli/src/commands/files.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{collections::HashSet, io::Write, path::Path, process::Command};
 
 use colored::Colorize;
 use sem_core::parser::registry::ParserRegistry;
@@ -65,6 +65,9 @@ pub fn find_supported_files_in_path(
         if !no_default_excludes && is_default_excluded(&rel_path) {
             continue;
         }
+        if is_hidden_path(&rel_path) {
+            continue;
+        }
         if !ext_filter.is_empty()
             && !ext_filter
                 .iter()
@@ -83,6 +86,187 @@ pub fn find_supported_files_in_path(
 
     files.sort();
     files
+}
+
+pub fn find_supported_files_from_git_index(
+    root: &Path,
+    registry: &ParserRegistry,
+    ext_filter: &[String],
+    no_default_excludes: bool,
+) -> Option<Vec<String>> {
+    if root.join(".semignore").exists() {
+        return None;
+    }
+
+    let output = Command::new("git")
+        .current_dir(root)
+        .args([
+            "ls-files",
+            "-z",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let missing_from_worktree = git_missing_from_worktree_paths(root)?;
+    let mut candidates = Vec::new();
+    for raw_path in output.stdout.split(|byte| *byte == 0) {
+        if raw_path.is_empty() {
+            continue;
+        }
+        let rel_path = String::from_utf8_lossy(raw_path).replace('\\', "/");
+        if missing_from_worktree.contains(rel_path.as_str()) {
+            continue;
+        }
+        if rel_path.is_empty() || rel_path.ends_with('/') {
+            continue;
+        }
+        if Path::new(&rel_path).is_absolute() {
+            return None;
+        }
+        if !no_default_excludes && is_default_excluded(&rel_path) {
+            continue;
+        }
+        if is_hidden_path(&rel_path) {
+            continue;
+        }
+        candidates.push(rel_path);
+    }
+
+    let ignored = git_ignored_paths(root, &candidates)?;
+    let mut files = Vec::new();
+    for rel_path in candidates {
+        if ignored.contains(rel_path.as_str()) {
+            continue;
+        }
+        if !ext_filter.is_empty()
+            && !ext_filter
+                .iter()
+                .any(|ext| rel_path.ends_with(ext.as_str()))
+        {
+            continue;
+        }
+        if is_probably_binary_path(&rel_path) {
+            continue;
+        }
+        if !has_supported_plugin(&root.join(&rel_path), &rel_path, registry, ext_filter) {
+            continue;
+        }
+        files.push(rel_path);
+    }
+
+    files.sort();
+    files.dedup();
+    Some(files)
+}
+
+fn git_missing_from_worktree_paths(root: &Path) -> Option<HashSet<String>> {
+    let output = Command::new("git")
+        .current_dir(root)
+        .args(["ls-files", "-z", "--deleted"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let mut missing: HashSet<String> = output
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|path| !path.is_empty())
+        .map(|path| String::from_utf8_lossy(path).replace('\\', "/"))
+        .collect();
+
+    let output = Command::new("git")
+        .current_dir(root)
+        .args(["ls-files", "-z", "-v"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    for raw_entry in output.stdout.split(|byte| *byte == 0) {
+        if raw_entry.len() < 3 || raw_entry[0] != b'S' || raw_entry[1] != b' ' {
+            continue;
+        }
+        missing.insert(String::from_utf8_lossy(&raw_entry[2..]).replace('\\', "/"));
+    }
+    for path in git_non_file_symlink_paths(root)? {
+        missing.insert(path);
+    }
+
+    Some(missing)
+}
+
+fn git_non_file_symlink_paths(root: &Path) -> Option<Vec<String>> {
+    let output = Command::new("git")
+        .current_dir(root)
+        .args(["ls-files", "-z", "-s"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let mut paths = Vec::new();
+    for raw_entry in output.stdout.split(|byte| *byte == 0) {
+        if !raw_entry.starts_with(b"120000 ") {
+            continue;
+        }
+        let Some(tab_pos) = raw_entry.iter().position(|byte| *byte == b'\t') else {
+            return None;
+        };
+        let path = String::from_utf8_lossy(&raw_entry[tab_pos + 1..]).replace('\\', "/");
+        if !root.join(&path).is_file() {
+            paths.push(path);
+        }
+    }
+    Some(paths)
+}
+
+fn git_ignored_paths(root: &Path, paths: &[String]) -> Option<HashSet<String>> {
+    if paths.is_empty() {
+        return Some(HashSet::new());
+    }
+
+    let mut child = Command::new("git")
+        .current_dir(root)
+        .args(["check-ignore", "--no-index", "-z", "--stdin"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .ok()?;
+    {
+        let stdin = child.stdin.as_mut()?;
+        for path in paths {
+            stdin.write_all(path.as_bytes()).ok()?;
+            stdin.write_all(b"\0").ok()?;
+        }
+    }
+    let output = child.wait_with_output().ok()?;
+    if !matches!(output.status.code(), Some(0) | Some(1)) {
+        return None;
+    }
+
+    Some(
+        output
+            .stdout
+            .split(|byte| *byte == 0)
+            .filter(|path| !path.is_empty())
+            .map(|path| String::from_utf8_lossy(path).replace('\\', "/"))
+            .collect(),
+    )
+}
+
+fn is_hidden_path(rel_path: &str) -> bool {
+    rel_path
+        .split('/')
+        .any(|component| component.starts_with('.') && component.len() > 1)
 }
 
 fn has_supported_plugin(

--- a/crates/sem-cli/src/commands/graph.rs
+++ b/crates/sem-cli/src/commands/graph.rs
@@ -9,6 +9,7 @@ use serde::ser::{SerializeMap, Serializer};
 
 use crate::cache::DiskCache;
 use crate::timings::Timings;
+use sem_mcp::cache::CacheSourceScope;
 
 pub struct GraphOptions {
     pub cwd: String,
@@ -29,12 +30,13 @@ pub fn graph_command(opts: GraphOptions) {
     let ext_filter = normalize_exts(&opts.file_exts);
     let file_paths =
         find_supported_files_inner(root, &registry, &ext_filter, opts.no_default_excludes);
+    let source_scope = cache_source_scope(root, &ext_filter, opts.no_default_excludes);
     timings.mark("file_discovery");
     if opts.json && !opts.no_cache {
         if let Ok(disk) = DiskCache::open(root) {
             timings.mark("cache_open");
             let stdout = std::io::stdout();
-            match disk.write_graph_json_topology(root, &file_paths, stdout.lock()) {
+            match disk.write_graph_json_topology(root, &file_paths, source_scope, stdout.lock()) {
                 Ok(true) => {
                     timings.mark("cache_topology_json_stream");
                     timings.finish();
@@ -59,6 +61,7 @@ pub fn graph_command(opts: GraphOptions) {
         &file_paths,
         &registry,
         opts.no_cache,
+        source_scope,
         &mut timings,
     );
     prog.done(&format!(
@@ -180,6 +183,18 @@ pub fn find_supported_files_with_options(
     )
 }
 
+pub fn cache_source_scope(
+    root: &Path,
+    ext_filter: &[String],
+    no_default_excludes: bool,
+) -> CacheSourceScope {
+    if ext_filter.is_empty() && !no_default_excludes && !root.join(".semignore").exists() {
+        CacheSourceScope::Default
+    } else {
+        CacheSourceScope::Custom
+    }
+}
+
 fn find_supported_files_inner(
     root: &Path,
     registry: &ParserRegistry,
@@ -196,9 +211,17 @@ pub fn get_or_build_graph(
     file_paths: &[String],
     registry: &ParserRegistry,
     no_cache: bool,
+    source_scope: CacheSourceScope,
 ) -> (EntityGraph, Vec<SemanticEntity>) {
     let mut timings = Timings::disabled("graph");
-    get_or_build_graph_with_timings(root, file_paths, registry, no_cache, &mut timings)
+    get_or_build_graph_with_timings(
+        root,
+        file_paths,
+        registry,
+        no_cache,
+        source_scope,
+        &mut timings,
+    )
 }
 
 pub fn get_or_build_graph_with_timings(
@@ -206,6 +229,7 @@ pub fn get_or_build_graph_with_timings(
     file_paths: &[String],
     registry: &ParserRegistry,
     no_cache: bool,
+    source_scope: CacheSourceScope,
     timings: &mut Timings,
 ) -> (EntityGraph, Vec<SemanticEntity>) {
     get_or_build_graph_with_cache_policy(
@@ -214,6 +238,7 @@ pub fn get_or_build_graph_with_timings(
         registry,
         no_cache,
         CacheMissSavePolicy::Full,
+        source_scope,
         timings,
     )
 }
@@ -223,6 +248,7 @@ pub fn get_or_build_graph_with_topology_save_on_miss_with_timings(
     file_paths: &[String],
     registry: &ParserRegistry,
     no_cache: bool,
+    source_scope: CacheSourceScope,
     timings: &mut Timings,
 ) -> (EntityGraph, Vec<SemanticEntity>) {
     get_or_build_graph_with_cache_policy(
@@ -231,6 +257,7 @@ pub fn get_or_build_graph_with_topology_save_on_miss_with_timings(
         registry,
         no_cache,
         CacheMissSavePolicy::Topology,
+        source_scope,
         timings,
     )
 }
@@ -248,17 +275,20 @@ pub fn get_or_build_graph_with_test_data_and_topology_save_on_miss_with_timings(
     file_paths: &[String],
     registry: &ParserRegistry,
     no_cache: bool,
+    source_scope: CacheSourceScope,
     timings: &mut Timings,
 ) -> GraphWithTestData {
     if !no_cache {
         if let Ok(disk) = DiskCache::open(root) {
             timings.mark("cache_open");
-            if let Some((graph, entities)) = disk.load(root, file_paths) {
+            if let Some((graph, entities)) =
+                disk.load_with_source_scope(root, file_paths, source_scope)
+            {
                 timings.mark("cache_full_load");
                 return GraphWithTestData::Full(graph, entities);
             }
-            if let Some((graph, test_entity_ids)) =
-                disk.load_graph_topology_with_test_ids(root, file_paths)
+            if let Some((graph, test_entity_ids)) = disk
+                .load_graph_topology_with_test_ids_and_source_scope(root, file_paths, source_scope)
             {
                 timings.mark("cache_topology_load");
                 return GraphWithTestData::Topology {
@@ -267,7 +297,9 @@ pub fn get_or_build_graph_with_test_data_and_topology_save_on_miss_with_timings(
                 };
             }
 
-            if let Some(partial) = disk.load_partial(root, file_paths) {
+            if let Some(partial) =
+                disk.load_partial_with_source_scope(root, file_paths, source_scope)
+            {
                 timings.mark("cache_partial_load");
                 let (graph, entities, metadata) =
                     EntityGraph::build_incremental_with_metadata_and_import_candidates(
@@ -290,6 +322,7 @@ pub fn get_or_build_graph_with_test_data_and_topology_save_on_miss_with_timings(
                     metadata.repaired_clean_entity_ids,
                     &metadata.recomputed_edge_source_ids,
                     &metadata.deleted_entity_ids,
+                    source_scope,
                 );
                 timings.mark("cache_incremental_save");
                 return GraphWithTestData::Full(graph, entities);
@@ -302,7 +335,14 @@ pub fn get_or_build_graph_with_test_data_and_topology_save_on_miss_with_timings(
 
     if !no_cache {
         if let Ok(disk) = DiskCache::open(root) {
-            let _ = disk.save_topology(root, file_paths, &graph, &entities, &registry.custom_test_dirs);
+            let _ = disk.save_topology(
+                root,
+                file_paths,
+                &graph,
+                &entities,
+                &registry.custom_test_dirs,
+                source_scope,
+            );
             timings.mark("cache_topology_save");
         }
     }
@@ -322,19 +362,22 @@ fn get_or_build_graph_with_cache_policy(
     registry: &ParserRegistry,
     no_cache: bool,
     save_policy: CacheMissSavePolicy,
+    source_scope: CacheSourceScope,
     timings: &mut Timings,
 ) -> (EntityGraph, Vec<SemanticEntity>) {
     if !no_cache {
         if let Ok(disk) = DiskCache::open(root) {
             timings.mark("cache_open");
             // Try full cache hit
-            if let Some(cached) = disk.load(root, file_paths) {
+            if let Some(cached) = disk.load_with_source_scope(root, file_paths, source_scope) {
                 timings.mark("cache_full_load");
                 return cached;
             }
 
             // Try incremental: load clean cached data, rebuild only stale files
-            if let Some(partial) = disk.load_partial(root, file_paths) {
+            if let Some(partial) =
+                disk.load_partial_with_source_scope(root, file_paths, source_scope)
+            {
                 timings.mark("cache_partial_load");
                 let (graph, entities, metadata) =
                     EntityGraph::build_incremental_with_metadata_and_import_candidates(
@@ -357,6 +400,7 @@ fn get_or_build_graph_with_cache_policy(
                     metadata.repaired_clean_entity_ids,
                     &metadata.recomputed_edge_source_ids,
                     &metadata.deleted_entity_ids,
+                    source_scope,
                 );
                 timings.mark("cache_incremental_save");
                 return (graph, entities);
@@ -372,13 +416,20 @@ fn get_or_build_graph_with_cache_policy(
         match save_policy {
             CacheMissSavePolicy::Full => {
                 if let Ok(disk) = DiskCache::open(root) {
-                    let _ = disk.save(root, file_paths, &graph, &entities);
+                    let _ = disk.save(root, file_paths, &graph, &entities, source_scope);
                     timings.mark("cache_full_save");
                 }
             }
             CacheMissSavePolicy::Topology => {
                 if let Ok(disk) = DiskCache::open(root) {
-                    let _ = disk.save_topology(root, file_paths, &graph, &entities, &registry.custom_test_dirs);
+                    let _ = disk.save_topology(
+                        root,
+                        file_paths,
+                        &graph,
+                        &entities,
+                        &registry.custom_test_dirs,
+                        source_scope,
+                    );
                     timings.mark("cache_topology_save");
                 }
             }
@@ -393,20 +444,29 @@ pub fn get_or_build_graph_topology_with_timings(
     file_paths: &[String],
     registry: &ParserRegistry,
     no_cache: bool,
+    source_scope: CacheSourceScope,
     timings: &mut Timings,
 ) -> EntityGraph {
     if !no_cache {
         if let Ok(disk) = DiskCache::open(root) {
             timings.mark("cache_open");
-            if let Some(graph) = disk.load_graph_topology(root, file_paths) {
+            if let Some(graph) =
+                disk.load_graph_topology_with_source_scope(root, file_paths, source_scope)
+            {
                 timings.mark("cache_topology_load");
                 return graph;
             }
         }
     }
 
-    let (graph, _entities) =
-        get_or_build_graph_with_timings(root, file_paths, registry, no_cache, timings);
+    let (graph, _entities) = get_or_build_graph_with_timings(
+        root,
+        file_paths,
+        registry,
+        no_cache,
+        source_scope,
+        timings,
+    );
     graph
 }
 
@@ -415,12 +475,15 @@ pub fn get_or_build_graph_topology_with_topology_save_on_miss_with_timings(
     file_paths: &[String],
     registry: &ParserRegistry,
     no_cache: bool,
+    source_scope: CacheSourceScope,
     timings: &mut Timings,
 ) -> EntityGraph {
     if !no_cache {
         if let Ok(disk) = DiskCache::open(root) {
             timings.mark("cache_open");
-            if let Some(graph) = disk.load_graph_topology(root, file_paths) {
+            if let Some(graph) =
+                disk.load_graph_topology_with_source_scope(root, file_paths, source_scope)
+            {
                 timings.mark("cache_topology_load");
                 return graph;
             }
@@ -428,7 +491,12 @@ pub fn get_or_build_graph_topology_with_topology_save_on_miss_with_timings(
     }
 
     let (graph, _entities) = get_or_build_graph_with_topology_save_on_miss_with_timings(
-        root, file_paths, registry, no_cache, timings,
+        root,
+        file_paths,
+        registry,
+        no_cache,
+        source_scope,
+        timings,
     );
     graph
 }
@@ -438,6 +506,7 @@ pub fn get_or_build_direct_dependency_graph_with_timings<F>(
     file_paths: &[String],
     registry: &ParserRegistry,
     no_cache: bool,
+    source_scope: CacheSourceScope,
     timings: &mut Timings,
     should_resolve: F,
 ) -> EntityGraph
@@ -447,7 +516,9 @@ where
     if !no_cache {
         if let Ok(disk) = DiskCache::open(root) {
             timings.mark("cache_open");
-            if let Some(graph) = disk.load_graph_topology(root, file_paths) {
+            if let Some(graph) =
+                disk.load_graph_topology_with_source_scope(root, file_paths, source_scope)
+            {
                 timings.mark("cache_topology_load");
                 return graph;
             }

--- a/crates/sem-cli/src/commands/impact.rs
+++ b/crates/sem-cli/src/commands/impact.rs
@@ -62,6 +62,42 @@ pub fn impact_command(opts: ImpactOptions) {
     let registry = super::create_registry(&root.to_string_lossy());
 
     let ext_filter = super::graph::normalize_exts(&opts.file_exts);
+    let file_hint = opts
+        .file_hint
+        .as_deref()
+        .map(|file| super::normalize_repo_relative_path(Path::new(&opts.cwd), root, file));
+
+    if !opts.no_cache && matches!(opts.mode, ImpactMode::Deps) {
+        match DiskCache::open(root) {
+            Ok(disk) => {
+                timings.mark("cache_open");
+                if let Some(git_file_paths) = super::files::find_supported_files_from_git_index(
+                    root,
+                    &registry,
+                    &ext_filter,
+                    opts.no_default_excludes,
+                ) {
+                    timings.mark("git_file_discovery");
+                    if try_cached_impact_query(
+                        &disk,
+                        root,
+                        &git_file_paths,
+                        &opts,
+                        file_hint.as_deref(),
+                        &mut timings,
+                    ) {
+                        return;
+                    }
+                } else {
+                    timings.mark("git_file_discovery_unavailable");
+                }
+            }
+            Err(_) => {
+                timings.mark("cache_open_failed");
+            }
+        }
+    }
+
     let file_paths = super::graph::find_supported_files_with_options(
         root,
         &registry,
@@ -70,38 +106,19 @@ pub fn impact_command(opts: ImpactOptions) {
     );
     timings.mark("file_discovery");
 
-    let file_hint = opts
-        .file_hint
-        .as_deref()
-        .map(|file| super::normalize_repo_relative_path(Path::new(&opts.cwd), root, file));
-
     if !opts.no_cache {
         match DiskCache::open(root) {
             Ok(disk) => {
                 timings.mark("cache_open");
-                match disk.query_impact_topology(
+                if try_cached_impact_query(
+                    &disk,
                     root,
                     &file_paths,
-                    opts.entity_name.as_deref(),
-                    opts.entity_id.as_deref(),
+                    &opts,
                     file_hint.as_deref(),
-                    cached_mode_for(opts.mode),
-                    opts.depth,
+                    &mut timings,
                 ) {
-                    Ok(Some(result)) => {
-                        timings.mark("cache_topology_impact_query");
-                        print_cached_result(&result, opts.mode, opts.json, opts.depth);
-                        timings.mark("cli_output_serialization");
-                        timings.finish();
-                        return;
-                    }
-                    Ok(None) => {
-                        timings.mark("cache_topology_impact_miss");
-                    }
-                    Err(CachedImpactError::CacheReadFailed) => {
-                        timings.mark("cache_topology_impact_query_failed");
-                    }
-                    Err(err) => print_cached_error(err),
+                    return;
                 }
             }
             Err(_) => {
@@ -315,6 +332,42 @@ pub fn impact_command(opts: ImpactOptions) {
         }
     }
     timings.finish();
+}
+
+fn try_cached_impact_query(
+    disk: &DiskCache,
+    root: &Path,
+    file_paths: &[String],
+    opts: &ImpactOptions,
+    file_hint: Option<&str>,
+    timings: &mut Timings,
+) -> bool {
+    match disk.query_impact_topology(
+        root,
+        file_paths,
+        opts.entity_name.as_deref(),
+        opts.entity_id.as_deref(),
+        file_hint,
+        cached_mode_for(opts.mode),
+        opts.depth,
+    ) {
+        Ok(Some(result)) => {
+            timings.mark("cache_topology_impact_query");
+            print_cached_result(&result, opts.mode, opts.json, opts.depth);
+            timings.mark("cli_output_serialization");
+            timings.finish();
+            true
+        }
+        Ok(None) => {
+            timings.mark("cache_topology_impact_miss");
+            false
+        }
+        Err(CachedImpactError::CacheReadFailed) => {
+            timings.mark("cache_topology_impact_query_failed");
+            false
+        }
+        Err(err) => print_cached_error(err),
+    }
 }
 
 fn cached_mode_for(mode: ImpactMode) -> CachedImpactMode {

--- a/crates/sem-cli/src/commands/impact.rs
+++ b/crates/sem-cli/src/commands/impact.rs
@@ -3,6 +3,7 @@ use std::{collections::HashSet, path::Path};
 use colored::Colorize;
 use sem_core::git::bridge::GitBridge;
 use sem_core::parser::graph::{EntityGraph, EntityInfo};
+use sem_mcp::cache::CacheSourceScope;
 
 use crate::cache::{CachedImpactError, CachedImpactMode, CachedImpactResult, DiskCache};
 use crate::timings::Timings;
@@ -62,34 +63,33 @@ pub fn impact_command(opts: ImpactOptions) {
     let registry = super::create_registry(&root.to_string_lossy());
 
     let ext_filter = super::graph::normalize_exts(&opts.file_exts);
+    let source_scope =
+        super::graph::cache_source_scope(root, &ext_filter, opts.no_default_excludes);
     let file_hint = opts
         .file_hint
         .as_deref()
         .map(|file| super::normalize_repo_relative_path(Path::new(&opts.cwd), root, file));
+    let cache_first_entity_scope = opts.entity_id.is_some() || file_hint.is_some();
 
-    if !opts.no_cache && matches!(opts.mode, ImpactMode::Deps) {
+    if !opts.no_cache
+        && matches!(opts.mode, ImpactMode::Deps)
+        && matches!(source_scope, CacheSourceScope::Default)
+        && cache_first_entity_scope
+    {
         match DiskCache::open(root) {
             Ok(disk) => {
                 timings.mark("cache_open");
-                if let Some(git_file_paths) = super::files::find_supported_files_from_git_index(
+                if try_cached_impact_query(
+                    &disk,
                     root,
-                    &registry,
-                    &ext_filter,
-                    opts.no_default_excludes,
+                    &[],
+                    &opts,
+                    file_hint.as_deref(),
+                    source_scope,
+                    true,
+                    &mut timings,
                 ) {
-                    timings.mark("git_file_discovery");
-                    if try_cached_impact_query(
-                        &disk,
-                        root,
-                        &git_file_paths,
-                        &opts,
-                        file_hint.as_deref(),
-                        &mut timings,
-                    ) {
-                        return;
-                    }
-                } else {
-                    timings.mark("git_file_discovery_unavailable");
+                    return;
                 }
             }
             Err(_) => {
@@ -116,6 +116,8 @@ pub fn impact_command(opts: ImpactOptions) {
                     &file_paths,
                     &opts,
                     file_hint.as_deref(),
+                    source_scope,
+                    false,
                     &mut timings,
                 ) {
                     return;
@@ -141,6 +143,7 @@ pub fn impact_command(opts: ImpactOptions) {
                             &file_paths,
                             &registry,
                             opts.no_cache,
+                            source_scope,
                             &mut timings,
                             move |entity| {
                                 if let Some(id) = entity_id.as_deref() {
@@ -164,6 +167,7 @@ pub fn impact_command(opts: ImpactOptions) {
                             &file_paths,
                             &registry,
                             opts.no_cache,
+                            source_scope,
                             &mut timings,
                         )
                     }
@@ -190,6 +194,7 @@ pub fn impact_command(opts: ImpactOptions) {
                             &file_paths,
                             &registry,
                             opts.no_cache,
+                            source_scope,
                             &mut timings,
                         )
                     } else {
@@ -198,6 +203,7 @@ pub fn impact_command(opts: ImpactOptions) {
                             &file_paths,
                             &registry,
                             opts.no_cache,
+                            source_scope,
                             &mut timings,
                         )
                     }
@@ -224,6 +230,7 @@ pub fn impact_command(opts: ImpactOptions) {
                             &file_paths,
                             &registry,
                             opts.no_cache,
+                            source_scope,
                             &mut timings,
                         )
                     },
@@ -297,6 +304,7 @@ pub fn impact_command(opts: ImpactOptions) {
                             &file_paths,
                             &registry,
                             opts.no_cache,
+                            source_scope,
                             &mut timings,
                         )
                     },
@@ -340,11 +348,15 @@ fn try_cached_impact_query(
     file_paths: &[String],
     opts: &ImpactOptions,
     file_hint: Option<&str>,
+    source_scope: CacheSourceScope,
+    cache_first: bool,
     timings: &mut Timings,
 ) -> bool {
     match disk.query_impact_topology(
         root,
         file_paths,
+        source_scope,
+        cache_first,
         opts.entity_name.as_deref(),
         opts.entity_id.as_deref(),
         file_hint,

--- a/crates/sem-cli/src/main.rs
+++ b/crates/sem-cli/src/main.rs
@@ -157,7 +157,7 @@ enum Commands {
         #[arg(long)]
         no_cache: bool,
 
-        /// Include directories and generated files that are excluded by default
+        /// Include files and directories excluded by default (generated, fixtures, vendor, benchmarks)
         #[arg(long)]
         no_default_excludes: bool,
     },
@@ -183,7 +183,7 @@ enum Commands {
         #[arg(long)]
         no_cache: bool,
 
-        /// Include directories and generated files that are excluded by default
+        /// Include files and directories excluded by default (generated, fixtures, vendor, benchmarks)
         #[arg(long)]
         no_default_excludes: bool,
     },
@@ -241,9 +241,13 @@ enum Commands {
         #[arg(long)]
         json: bool,
 
-        /// Include directories and generated files that are excluded by default
+        /// Include files and directories excluded by default (generated, fixtures, vendor, benchmarks)
         #[arg(long)]
         no_default_excludes: bool,
+
+        /// Only include files with these extensions (e.g. --file-exts .ts .tsx)
+        #[arg(long, num_args = 1..)]
+        file_exts: Vec<String>,
     },
     /// Show token-budgeted context for an entity
     Context {
@@ -279,7 +283,7 @@ enum Commands {
         #[arg(long)]
         no_cache: bool,
 
-        /// Include directories and generated files that are excluded by default
+        /// Include files and directories excluded by default (generated, fixtures, vendor, benchmarks)
         #[arg(long)]
         no_default_excludes: bool,
     },
@@ -528,6 +532,7 @@ fn main() {
             format,
             json,
             no_default_excludes,
+            file_exts,
         }) => {
             entities_command(EntitiesOptions {
                 cwd: std::env::current_dir()
@@ -537,6 +542,7 @@ fn main() {
                 paths,
                 json: resolve_json(format, json),
                 no_default_excludes,
+                file_exts,
             });
         }
         Some(Commands::Context {

--- a/crates/sem-cli/src/timings.rs
+++ b/crates/sem-cli/src/timings.rs
@@ -7,11 +7,17 @@ pub struct Timings {
     start: Instant,
     last: Instant,
     entries: Vec<TimingEntry>,
+    counters: Vec<TimingCounter>,
 }
 
 struct TimingEntry {
     name: &'static str,
     duration_ms: f64,
+}
+
+struct TimingCounter {
+    name: &'static str,
+    value: u64,
 }
 
 impl Timings {
@@ -26,6 +32,7 @@ impl Timings {
             start: now,
             last: now,
             entries: Vec::new(),
+            counters: Vec::new(),
         }
     }
 
@@ -38,6 +45,7 @@ impl Timings {
             start: now,
             last: now,
             entries: Vec::new(),
+            counters: Vec::new(),
         }
     }
 
@@ -51,6 +59,13 @@ impl Timings {
             duration_ms: elapsed_ms(now.duration_since(self.last)),
         });
         self.last = now;
+    }
+
+    pub fn counter(&mut self, name: &'static str, value: u64) {
+        if !self.enabled {
+            return;
+        }
+        self.counters.push(TimingCounter { name, value });
     }
 
     pub fn finish(&self) {
@@ -69,16 +84,31 @@ impl Timings {
                     })
                 })
                 .collect::<Vec<_>>();
-            let output = serde_json::json!({
+            let mut output = serde_json::json!({
                 "command": self.command,
                 "phases": phases,
                 "totalMs": total_ms,
             });
+            if !self.counters.is_empty() {
+                output["counters"] = serde_json::json!(self
+                    .counters
+                    .iter()
+                    .map(|counter| {
+                        serde_json::json!({
+                            "name": counter.name,
+                            "value": counter.value,
+                        })
+                    })
+                    .collect::<Vec<_>>());
+            }
             eprintln!("{}", serde_json::to_string(&output).unwrap());
         } else {
             eprintln!("sem timings ({})", self.command);
             for entry in &self.entries {
                 eprintln!("  {:<32} {:>8.3} ms", entry.name, entry.duration_ms);
+            }
+            for counter in &self.counters {
+                eprintln!("  {:<32} {:>8}", counter.name, counter.value);
             }
             eprintln!("  {:<32} {:>8.3} ms", "total", total_ms);
         }

--- a/crates/sem-cli/tests/entities_cli.rs
+++ b/crates/sem-cli/tests/entities_cli.rs
@@ -1,0 +1,341 @@
+use std::{collections::HashMap, fs, process::Command};
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn run_sem_entities_json(repo: &TempDir) -> (Value, Value) {
+    run_sem_entities_json_with_args(repo, &["entities", ".", "--json"])
+}
+
+fn run_sem_entities_json_with_args(repo: &TempDir, args: &[&str]) -> (Value, Value) {
+    let output = Command::new(env!("CARGO_BIN_EXE_sem"))
+        .current_dir(repo.path())
+        .env("DO_NOT_TRACK", "1")
+        .env("SEM_LOCAL", "1")
+        .env("SEM_TIMINGS", "json")
+        .args(args)
+        .output()
+        .expect("run sem entities");
+
+    assert!(
+        output.status.success(),
+        "sem entities failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = serde_json::from_slice(&output.stdout).expect("entities stdout json");
+    let stderr = String::from_utf8(output.stderr).expect("timings stderr utf8");
+    let timings = serde_json::from_str(stderr.trim()).expect("timings stderr json");
+    (stdout, timings)
+}
+
+fn run_sem_entities_json_value_with_args(repo: &TempDir, args: &[&str]) -> Value {
+    let output = Command::new(env!("CARGO_BIN_EXE_sem"))
+        .current_dir(repo.path())
+        .env("DO_NOT_TRACK", "1")
+        .env("SEM_LOCAL", "1")
+        .args(args)
+        .output()
+        .expect("run sem entities");
+
+    assert!(
+        output.status.success(),
+        "sem entities failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stderr), "");
+
+    serde_json::from_slice(&output.stdout).expect("entities stdout json")
+}
+
+fn run_sem_graph_json(repo: &TempDir, cache: &TempDir) {
+    let output = Command::new(env!("CARGO_BIN_EXE_sem"))
+        .current_dir(repo.path())
+        .env("DO_NOT_TRACK", "1")
+        .env("SEM_LOCAL", "1")
+        .env("SEM_CACHE_DIR", cache.path())
+        .args(["graph", ".", "--json"])
+        .output()
+        .expect("run sem graph");
+
+    assert!(
+        output.status.success(),
+        "sem graph failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn run_cached_sem_entities_json(repo: &TempDir, cache: &TempDir) -> (Value, Value) {
+    run_cached_sem_entities_json_with_args(repo, cache, &["entities", ".", "--json"])
+}
+
+fn run_cached_sem_entities_json_with_args(
+    repo: &TempDir,
+    cache: &TempDir,
+    args: &[&str],
+) -> (Value, Value) {
+    let output = Command::new(env!("CARGO_BIN_EXE_sem"))
+        .current_dir(repo.path())
+        .env("DO_NOT_TRACK", "1")
+        .env("SEM_LOCAL", "1")
+        .env("SEM_CACHE_DIR", cache.path())
+        .env("SEM_TIMINGS", "json")
+        .args(args)
+        .output()
+        .expect("run sem entities");
+
+    assert!(
+        output.status.success(),
+        "sem entities failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = serde_json::from_slice(&output.stdout).expect("entities stdout json");
+    let stderr = String::from_utf8(output.stderr).expect("timings stderr utf8");
+    let timings = serde_json::from_str(stderr.trim()).expect("timings stderr json");
+    (stdout, timings)
+}
+
+#[test]
+fn entities_json_emits_timings_and_counters() {
+    let repo = TempDir::new().expect("temp repo");
+    fs::write(
+        repo.path().join("a.ts"),
+        "export function alpha() { return 1; }\n",
+    )
+    .unwrap();
+    fs::write(
+        repo.path().join("b.ts"),
+        "export const beta = () => alpha();\n",
+    )
+    .unwrap();
+
+    let (entities, timings) = run_sem_entities_json(&repo);
+    let entities = entities.as_array().expect("entities array");
+    assert!(entities.iter().any(|entity| entity["name"] == "alpha"));
+    assert!(entities.iter().any(|entity| entity["name"] == "beta"));
+
+    assert_eq!(timings["command"], "entities");
+    let phase_names = timings["phases"]
+        .as_array()
+        .expect("phases array")
+        .iter()
+        .map(|phase| phase["name"].as_str().expect("phase name"))
+        .collect::<Vec<_>>();
+    for expected in [
+        "path_args",
+        "file_discovery",
+        "extract_entities",
+        "sort_dedup",
+        "output_serialization",
+    ] {
+        assert!(
+            phase_names.contains(&expected),
+            "missing phase {expected}; got {phase_names:?}"
+        );
+    }
+
+    let counters = timings["counters"]
+        .as_array()
+        .expect("counters array")
+        .iter()
+        .map(|counter| {
+            (
+                counter["name"].as_str().expect("counter name"),
+                counter["value"].as_u64().expect("counter value"),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    assert_eq!(counters["input_paths"], 1);
+    assert_eq!(counters["input_dirs"], 1);
+    assert_eq!(counters["input_files"], 2);
+    assert_eq!(counters["input_file_args"], 0);
+    assert_eq!(counters["processed_files"], 2);
+    assert_eq!(counters["discovered_files"], 2);
+    assert_eq!(counters["entities"], entities.len() as u64);
+    assert!(counters["json_bytes"] > 0);
+}
+
+#[test]
+fn entities_json_counts_explicit_file_inputs_separately() {
+    let repo = TempDir::new().expect("temp repo");
+    fs::write(
+        repo.path().join("a.ts"),
+        "export function alpha() { return 1; }\n",
+    )
+    .unwrap();
+
+    let (entities, timings) =
+        run_sem_entities_json_with_args(&repo, &["entities", "a.ts", "--json"]);
+    let entities = entities.as_array().expect("entities array");
+    assert!(entities.iter().any(|entity| entity["name"] == "alpha"));
+
+    let counters = timings["counters"]
+        .as_array()
+        .expect("counters array")
+        .iter()
+        .map(|counter| {
+            (
+                counter["name"].as_str().expect("counter name"),
+                counter["value"].as_u64().expect("counter value"),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    assert_eq!(counters["input_paths"], 1);
+    assert_eq!(counters["input_dirs"], 0);
+    assert_eq!(counters["input_files"], 1);
+    assert_eq!(counters["input_file_args"], 1);
+    assert_eq!(counters["processed_files"], 1);
+    assert_eq!(counters["discovered_files"], 0);
+    assert_eq!(counters["entities"], entities.len() as u64);
+}
+
+#[test]
+fn entities_file_exts_filter_directory_scans() {
+    let repo = TempDir::new().expect("temp repo");
+    fs::write(
+        repo.path().join("a.ts"),
+        "export function alpha() { return 1; }\n",
+    )
+    .unwrap();
+    fs::write(repo.path().join("config.json"), r#"{"ignored": true}"#).unwrap();
+
+    let entities = run_sem_entities_json_value_with_args(
+        &repo,
+        &["entities", ".", "--json", "--file-exts", ".ts"],
+    );
+    let entities = entities.as_array().expect("entities array");
+
+    assert!(entities.iter().any(|entity| entity["name"] == "alpha"));
+    assert!(
+        entities.iter().all(|entity| entity["file"]
+            .as_str()
+            .is_some_and(|file| file.ends_with(".ts"))),
+        "expected only .ts entities, got {entities:?}"
+    );
+
+    let bare_ext_entities = run_sem_entities_json_value_with_args(
+        &repo,
+        &["entities", ".", "--json", "--file-exts", "ts"],
+    );
+    assert_eq!(bare_ext_entities, Value::Array(entities.clone()));
+}
+
+#[test]
+fn entities_uses_fresh_topology_cache() {
+    let repo = TempDir::new().expect("temp repo");
+    let cache = TempDir::new().expect("temp cache");
+    fs::write(
+        repo.path().join("a.ts"),
+        "export function alpha() { return 1; }\n",
+    )
+    .unwrap();
+    fs::write(
+        repo.path().join("b.ts"),
+        "export function beta() { return alpha(); }\n",
+    )
+    .unwrap();
+
+    run_sem_graph_json(&repo, &cache);
+    let (entities, timings) = run_cached_sem_entities_json(&repo, &cache);
+    let entities = entities.as_array().expect("entities array");
+    assert!(entities.iter().any(|entity| entity["name"] == "alpha"));
+    assert!(entities.iter().any(|entity| entity["name"] == "beta"));
+
+    let phase_names = timings["phases"]
+        .as_array()
+        .expect("phases array")
+        .iter()
+        .map(|phase| phase["name"].as_str().expect("phase name"))
+        .collect::<Vec<_>>();
+    assert!(
+        phase_names.contains(&"cache_entities_query"),
+        "expected cache hit phase, got {phase_names:?}"
+    );
+    assert!(
+        !phase_names.contains(&"extract_entities"),
+        "cache hit should not parse files; got {phase_names:?}"
+    );
+    assert!(
+        !phase_names.contains(&"sort_dedup"),
+        "streamed cache hit should not materialize and sort entities; got {phase_names:?}"
+    );
+
+    let counters = timings["counters"]
+        .as_array()
+        .expect("counters array")
+        .iter()
+        .map(|counter| {
+            (
+                counter["name"].as_str().expect("counter name"),
+                counter["value"].as_u64().expect("counter value"),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    assert_eq!(counters["cached_entities"], entities.len() as u64);
+}
+
+#[test]
+fn entities_uses_whole_repo_cache_for_subdirectory_listing() {
+    let repo = TempDir::new().expect("temp repo");
+    let cache = TempDir::new().expect("temp cache");
+    fs::create_dir_all(repo.path().join("src")).unwrap();
+    fs::create_dir_all(repo.path().join("tests")).unwrap();
+    fs::write(
+        repo.path().join("src").join("a.ts"),
+        "export function alpha() { return 1; }\n",
+    )
+    .unwrap();
+    fs::write(
+        repo.path().join("tests").join("b.ts"),
+        "export function beta() { return 2; }\n",
+    )
+    .unwrap();
+
+    run_sem_graph_json(&repo, &cache);
+    let (entities, timings) =
+        run_cached_sem_entities_json_with_args(&repo, &cache, &["entities", "src", "--json"]);
+    let entities = entities.as_array().expect("entities array");
+    assert!(entities.iter().any(|entity| entity["name"] == "alpha"));
+    assert!(!entities.iter().any(|entity| entity["name"] == "beta"));
+    assert!(
+        entities.iter().all(|entity| entity["file"]
+            .as_str()
+            .is_some_and(|file| file.starts_with("src/"))),
+        "expected only src entities, got {entities:?}"
+    );
+
+    let phase_names = timings["phases"]
+        .as_array()
+        .expect("phases array")
+        .iter()
+        .map(|phase| phase["name"].as_str().expect("phase name"))
+        .collect::<Vec<_>>();
+    assert!(
+        phase_names.contains(&"cache_entities_query"),
+        "expected cache hit phase, got {phase_names:?}"
+    );
+    assert!(
+        !phase_names.contains(&"extract_entities"),
+        "cache hit should not parse files; got {phase_names:?}"
+    );
+
+    let counters = timings["counters"]
+        .as_array()
+        .expect("counters array")
+        .iter()
+        .map(|counter| {
+            (
+                counter["name"].as_str().expect("counter name"),
+                counter["value"].as_u64().expect("counter value"),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    assert_eq!(counters["cached_entities"], entities.len() as u64);
+    assert_eq!(counters["input_files"], 1);
+    assert_eq!(counters["discovered_files"], 1);
+}

--- a/crates/sem-cli/tests/impact_direct_deps.rs
+++ b/crates/sem-cli/tests/impact_direct_deps.rs
@@ -106,6 +106,71 @@ fn init_side_effect_import_repo(repo: &Path) {
     git(repo, &["commit", "-q", "-m", "init"]);
 }
 
+fn init_missing_import_target_repo(repo: &Path) {
+    git(repo, &["init", "-q"]);
+    git(repo, &["config", "user.email", "t@t.com"]);
+    git(repo, &["config", "user.name", "test"]);
+    git(repo, &["config", "commit.gpgsign", "false"]);
+
+    fs::write(
+        repo.join("b.ts"),
+        "import './optional';\nexport function consume() { return 1; }\n",
+    )
+    .unwrap();
+    git(repo, &["add", "b.ts"]);
+    git(repo, &["commit", "-q", "-m", "init"]);
+}
+
+fn init_default_reexport_missing_target_repo(repo: &Path) {
+    git(repo, &["init", "-q"]);
+    git(repo, &["config", "user.email", "t@t.com"]);
+    git(repo, &["config", "user.name", "test"]);
+    git(repo, &["config", "commit.gpgsign", "false"]);
+
+    fs::write(
+        repo.join("barrel.ts"),
+        "export { default } from './target';\n",
+    )
+    .unwrap();
+    fs::write(
+        repo.join("consumer.ts"),
+        "import publicTarget from './barrel';\nexport function usePublicTarget() { return publicTarget(); }\n",
+    )
+    .unwrap();
+    git(repo, &["add", "barrel.ts", "consumer.ts"]);
+    git(repo, &["commit", "-q", "-m", "init"]);
+}
+
+fn init_bare_import_target_repo(repo: &Path) {
+    git(repo, &["init", "-q"]);
+    git(repo, &["config", "user.email", "t@t.com"]);
+    git(repo, &["config", "user.name", "test"]);
+    git(repo, &["config", "commit.gpgsign", "false"]);
+
+    fs::write(
+        repo.join("b.ts"),
+        "import { source } from 'source';\nexport function consume() { return source(); }\n",
+    )
+    .unwrap();
+    git(repo, &["add", "b.ts"]);
+    git(repo, &["commit", "-q", "-m", "init"]);
+}
+
+fn init_python_missing_import_target_repo(repo: &Path) {
+    git(repo, &["init", "-q"]);
+    git(repo, &["config", "user.email", "t@t.com"]);
+    git(repo, &["config", "user.name", "test"]);
+    git(repo, &["config", "commit.gpgsign", "false"]);
+
+    fs::write(
+        repo.join("b.py"),
+        "from optional import source\n\ndef consume():\n    return source()\n",
+    )
+    .unwrap();
+    git(repo, &["add", "b.py"]);
+    git(repo, &["commit", "-q", "-m", "init"]);
+}
+
 #[cfg(unix)]
 fn init_symlink_source_repo(repo: &Path, symlink_target: &Path) {
     git(repo, &["init", "-q"]);
@@ -228,8 +293,6 @@ fn impact_deps_no_cache_uses_direct_dependency_graph() {
                 "--deps",
                 "--json",
                 "--no-cache",
-                "--file-exts",
-                ".ts",
             ])
             .output()
             .unwrap(),
@@ -257,16 +320,7 @@ fn impact_deps_uses_cached_sql_topology_query_on_second_run() {
         Command::new(env!("CARGO_BIN_EXE_sem"))
             .current_dir(repo.path())
             .env("SEM_CACHE_DIR", cache.path())
-            .args([
-                "impact",
-                "consume",
-                "--file",
-                "b.ts",
-                "--deps",
-                "--json",
-                "--file-exts",
-                ".ts",
-            ])
+            .args(["impact", "consume", "--file", "b.ts", "--deps", "--json"])
             .output()
             .unwrap(),
         "warm impact cache",
@@ -277,16 +331,7 @@ fn impact_deps_uses_cached_sql_topology_query_on_second_run() {
             .current_dir(repo.path())
             .env("SEM_CACHE_DIR", cache.path())
             .env("SEM_TIMINGS", "json")
-            .args([
-                "impact",
-                "consume",
-                "--file",
-                "b.ts",
-                "--deps",
-                "--json",
-                "--file-exts",
-                ".ts",
-            ])
+            .args(["impact", "consume", "--file", "b.ts", "--deps", "--json"])
             .output()
             .unwrap(),
         "cached impact deps",
@@ -300,7 +345,9 @@ fn impact_deps_uses_cached_sql_topology_query_on_second_run() {
     assert!(phases
         .iter()
         .any(|phase| phase == "cache_topology_impact_query"));
-    assert!(phases.iter().any(|phase| phase == "git_file_discovery"));
+    assert!(!phases
+        .iter()
+        .any(|phase| phase == "cache_source_files_load"));
     assert!(!phases.iter().any(|phase| phase == "file_discovery"));
     assert!(!phases.iter().any(|phase| phase == "cache_topology_load"));
     assert!(!phases.iter().any(|phase| phase == "full_graph_build"));
@@ -316,16 +363,7 @@ fn impact_deps_uses_cached_sql_when_unrelated_file_changes() {
         Command::new(env!("CARGO_BIN_EXE_sem"))
             .current_dir(repo.path())
             .env("SEM_CACHE_DIR", cache.path())
-            .args([
-                "impact",
-                "consume",
-                "--file",
-                "b.ts",
-                "--deps",
-                "--json",
-                "--file-exts",
-                ".ts",
-            ])
+            .args(["impact", "consume", "--file", "b.ts", "--deps", "--json"])
             .output()
             .unwrap(),
         "warm impact cache",
@@ -341,16 +379,7 @@ fn impact_deps_uses_cached_sql_when_unrelated_file_changes() {
             .current_dir(repo.path())
             .env("SEM_CACHE_DIR", cache.path())
             .env("SEM_TIMINGS", "json")
-            .args([
-                "impact",
-                "consume",
-                "--file",
-                "b.ts",
-                "--deps",
-                "--json",
-                "--file-exts",
-                ".ts",
-            ])
+            .args(["impact", "consume", "--file", "b.ts", "--deps", "--json"])
             .output()
             .unwrap(),
         "cached impact deps after unrelated edit",
@@ -364,7 +393,9 @@ fn impact_deps_uses_cached_sql_when_unrelated_file_changes() {
     assert!(phases
         .iter()
         .any(|phase| phase == "cache_topology_impact_query"));
-    assert!(phases.iter().any(|phase| phase == "git_file_discovery"));
+    assert!(!phases
+        .iter()
+        .any(|phase| phase == "cache_source_files_load"));
     assert!(!phases.iter().any(|phase| phase == "file_discovery"));
     assert!(!phases.iter().any(|phase| phase == "full_graph_build"));
 }
@@ -379,16 +410,7 @@ fn impact_deps_misses_cached_sql_when_imported_file_changes() {
         Command::new(env!("CARGO_BIN_EXE_sem"))
             .current_dir(repo.path())
             .env("SEM_CACHE_DIR", cache.path())
-            .args([
-                "impact",
-                "consume",
-                "--file",
-                "b.ts",
-                "--deps",
-                "--json",
-                "--file-exts",
-                ".ts",
-            ])
+            .args(["impact", "consume", "--file", "b.ts", "--deps", "--json"])
             .output()
             .unwrap(),
         "warm impact cache",
@@ -404,16 +426,7 @@ fn impact_deps_misses_cached_sql_when_imported_file_changes() {
             .current_dir(repo.path())
             .env("SEM_CACHE_DIR", cache.path())
             .env("SEM_TIMINGS", "json")
-            .args([
-                "impact",
-                "consume",
-                "--file",
-                "b.ts",
-                "--deps",
-                "--json",
-                "--file-exts",
-                ".ts",
-            ])
+            .args(["impact", "consume", "--file", "b.ts", "--deps", "--json"])
             .output()
             .unwrap(),
         "impact deps after imported edit",
@@ -429,50 +442,36 @@ fn impact_deps_misses_cached_sql_when_imported_file_changes() {
 }
 
 #[test]
-fn impact_deps_misses_cached_sql_when_source_file_is_deleted() {
+fn impact_deps_misses_cached_sql_when_new_import_target_appears() {
     let repo = TempDir::new().unwrap();
     let cache = TempDir::new().unwrap();
-    init_repo(repo.path());
+    init_missing_import_target_repo(repo.path());
 
     assert_success(
         Command::new(env!("CARGO_BIN_EXE_sem"))
             .current_dir(repo.path())
             .env("SEM_CACHE_DIR", cache.path())
-            .args([
-                "impact",
-                "consume",
-                "--file",
-                "b.ts",
-                "--deps",
-                "--json",
-                "--file-exts",
-                ".ts",
-            ])
+            .args(["impact", "consume", "--file", "b.ts", "--deps", "--json"])
             .output()
             .unwrap(),
         "warm impact cache",
     );
 
-    fs::remove_file(repo.path().join("c.ts")).unwrap();
+    fs::write(
+        repo.path().join("optional.ts"),
+        "export function optional() { return 1; }\n",
+    )
+    .unwrap();
 
     let output = assert_success(
         Command::new(env!("CARGO_BIN_EXE_sem"))
             .current_dir(repo.path())
             .env("SEM_CACHE_DIR", cache.path())
             .env("SEM_TIMINGS", "json")
-            .args([
-                "impact",
-                "consume",
-                "--file",
-                "b.ts",
-                "--deps",
-                "--json",
-                "--file-exts",
-                ".ts",
-            ])
+            .args(["impact", "consume", "--file", "b.ts", "--deps", "--json"])
             .output()
             .unwrap(),
-        "impact deps after source file deletion",
+        "impact deps after import target appears",
     );
 
     let phases = phase_names(&output);
@@ -485,7 +484,153 @@ fn impact_deps_misses_cached_sql_when_source_file_is_deleted() {
 }
 
 #[test]
-fn impact_deps_misses_cached_sql_when_skip_worktree_source_file_is_missing() {
+fn impact_deps_misses_cached_sql_when_default_reexport_target_appears() {
+    let repo = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+    init_default_reexport_missing_target_repo(repo.path());
+
+    assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("SEM_CACHE_DIR", cache.path())
+            .args([
+                "impact",
+                "usePublicTarget",
+                "--file",
+                "consumer.ts",
+                "--deps",
+                "--json",
+            ])
+            .output()
+            .unwrap(),
+        "warm impact cache",
+    );
+
+    fs::write(
+        repo.path().join("target.ts"),
+        "export default function publicTarget() { return 1; }\n",
+    )
+    .unwrap();
+
+    let output = assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("SEM_CACHE_DIR", cache.path())
+            .env("SEM_TIMINGS", "json")
+            .args([
+                "impact",
+                "usePublicTarget",
+                "--file",
+                "consumer.ts",
+                "--deps",
+                "--json",
+            ])
+            .output()
+            .unwrap(),
+        "impact deps after default re-export target appears",
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["dependencies"][0]["name"], "publicTarget");
+    assert_eq!(json["dependencies"][0]["file"], "target.ts");
+
+    let phases = phase_names(&output);
+    assert!(phases
+        .iter()
+        .any(|phase| phase == "cache_topology_impact_miss"));
+    assert!(!phases
+        .iter()
+        .any(|phase| phase == "cache_topology_impact_query"));
+}
+
+#[test]
+fn impact_deps_misses_cached_sql_when_new_bare_import_target_appears() {
+    let repo = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+    init_bare_import_target_repo(repo.path());
+
+    assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("SEM_CACHE_DIR", cache.path())
+            .args(["impact", "consume", "--file", "b.ts", "--deps", "--json"])
+            .output()
+            .unwrap(),
+        "warm impact cache",
+    );
+
+    fs::write(
+        repo.path().join("source.ts"),
+        "export function source() { return 1; }\n",
+    )
+    .unwrap();
+
+    let output = assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("SEM_CACHE_DIR", cache.path())
+            .env("SEM_TIMINGS", "json")
+            .args(["impact", "consume", "--file", "b.ts", "--deps", "--json"])
+            .output()
+            .unwrap(),
+        "impact deps after bare import target appears",
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["dependencies"][0]["name"], "source");
+
+    let phases = phase_names(&output);
+    assert!(phases
+        .iter()
+        .any(|phase| phase == "cache_topology_impact_miss"));
+    assert!(phases.iter().any(|phase| phase == "file_discovery"));
+}
+
+#[test]
+fn impact_deps_misses_cached_sql_when_new_python_import_target_appears() {
+    let repo = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+    init_python_missing_import_target_repo(repo.path());
+
+    assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("SEM_CACHE_DIR", cache.path())
+            .args(["impact", "consume", "--file", "b.py", "--deps", "--json"])
+            .output()
+            .unwrap(),
+        "warm impact cache",
+    );
+
+    fs::write(
+        repo.path().join("optional.py"),
+        "def source():\n    return 1\n",
+    )
+    .unwrap();
+
+    let output = assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("SEM_CACHE_DIR", cache.path())
+            .env("SEM_TIMINGS", "json")
+            .args(["impact", "consume", "--file", "b.py", "--deps", "--json"])
+            .output()
+            .unwrap(),
+        "impact deps after python import target appears",
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["dependencies"][0]["name"], "source");
+
+    let phases = phase_names(&output);
+    assert!(phases
+        .iter()
+        .any(|phase| phase == "cache_topology_impact_miss"));
+    assert!(phases.iter().any(|phase| phase == "file_discovery"));
+}
+
+#[test]
+fn impact_deps_does_not_use_cached_sql_outside_file_ext_scope() {
     let repo = TempDir::new().unwrap();
     let cache = TempDir::new().unwrap();
     init_repo(repo.path());
@@ -494,16 +639,144 @@ fn impact_deps_misses_cached_sql_when_skip_worktree_source_file_is_missing() {
         Command::new(env!("CARGO_BIN_EXE_sem"))
             .current_dir(repo.path())
             .env("SEM_CACHE_DIR", cache.path())
-            .args([
-                "impact",
-                "consume",
-                "--file",
-                "b.ts",
-                "--deps",
-                "--json",
-                "--file-exts",
-                ".ts",
-            ])
+            .args(["impact", "consume", "--file", "b.ts", "--deps", "--json"])
+            .output()
+            .unwrap(),
+        "warm impact cache",
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_sem"))
+        .current_dir(repo.path())
+        .env("SEM_CACHE_DIR", cache.path())
+        .env("SEM_TIMINGS", "json")
+        .args([
+            "impact",
+            "consume",
+            "--file",
+            "b.ts",
+            "--deps",
+            "--json",
+            "--file-exts",
+            ".tsx",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "{}", output_text(&output));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("Entity 'consume' not found"));
+}
+
+#[test]
+fn impact_deps_does_not_use_cached_sql_after_semignore_excludes_target() {
+    let repo = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+    init_repo(repo.path());
+
+    assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("SEM_CACHE_DIR", cache.path())
+            .args(["impact", "consume", "--file", "b.ts", "--deps", "--json"])
+            .output()
+            .unwrap(),
+        "warm impact cache",
+    );
+
+    fs::write(repo.path().join(".semignore"), "*.ts\n").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_sem"))
+        .current_dir(repo.path())
+        .env("SEM_CACHE_DIR", cache.path())
+        .env("SEM_TIMINGS", "json")
+        .args(["impact", "consume", "--file", "b.ts", "--deps", "--json"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "{}", output_text(&output));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("Entity 'consume' not found"));
+}
+
+#[test]
+fn impact_deps_does_not_use_cache_first_for_unscoped_name_query() {
+    let repo = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+    init_repo(repo.path());
+
+    assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("SEM_CACHE_DIR", cache.path())
+            .args(["impact", "consume", "--deps", "--json"])
+            .output()
+            .unwrap(),
+        "warm impact cache",
+    );
+
+    fs::write(
+        repo.path().join("d.ts"),
+        "export function consume() { return 4; }\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_sem"))
+        .current_dir(repo.path())
+        .env("SEM_CACHE_DIR", cache.path())
+        .env("SEM_TIMINGS", "json")
+        .args(["impact", "consume", "--deps", "--json"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "{}", output_text(&output));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("ambiguous"));
+}
+
+#[test]
+fn impact_deps_uses_cached_sql_when_unrelated_source_file_is_deleted() {
+    let repo = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+    init_repo(repo.path());
+
+    assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("SEM_CACHE_DIR", cache.path())
+            .args(["impact", "consume", "--file", "b.ts", "--deps", "--json"])
+            .output()
+            .unwrap(),
+        "warm impact cache",
+    );
+
+    fs::remove_file(repo.path().join("c.ts")).unwrap();
+
+    let output = assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("SEM_CACHE_DIR", cache.path())
+            .env("SEM_TIMINGS", "json")
+            .args(["impact", "consume", "--file", "b.ts", "--deps", "--json"])
+            .output()
+            .unwrap(),
+        "impact deps after source file deletion",
+    );
+
+    let phases = phase_names(&output);
+    assert!(phases
+        .iter()
+        .any(|phase| phase == "cache_topology_impact_query"));
+    assert!(!phases.iter().any(|phase| phase == "file_discovery"));
+}
+
+#[test]
+fn impact_deps_uses_cached_sql_when_unrelated_skip_worktree_source_file_is_missing() {
+    let repo = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+    init_repo(repo.path());
+
+    assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("SEM_CACHE_DIR", cache.path())
+            .args(["impact", "consume", "--file", "b.ts", "--deps", "--json"])
             .output()
             .unwrap(),
         "warm impact cache",
@@ -517,16 +790,7 @@ fn impact_deps_misses_cached_sql_when_skip_worktree_source_file_is_missing() {
             .current_dir(repo.path())
             .env("SEM_CACHE_DIR", cache.path())
             .env("SEM_TIMINGS", "json")
-            .args([
-                "impact",
-                "consume",
-                "--file",
-                "b.ts",
-                "--deps",
-                "--json",
-                "--file-exts",
-                ".ts",
-            ])
+            .args(["impact", "consume", "--file", "b.ts", "--deps", "--json"])
             .output()
             .unwrap(),
         "impact deps after missing skip-worktree source file",
@@ -535,15 +799,13 @@ fn impact_deps_misses_cached_sql_when_skip_worktree_source_file_is_missing() {
     let phases = phase_names(&output);
     assert!(phases
         .iter()
-        .any(|phase| phase == "cache_topology_impact_miss"));
-    assert!(!phases
-        .iter()
         .any(|phase| phase == "cache_topology_impact_query"));
+    assert!(!phases.iter().any(|phase| phase == "file_discovery"));
 }
 
 #[cfg(unix)]
 #[test]
-fn impact_deps_misses_cached_sql_when_symlink_source_target_is_missing() {
+fn impact_deps_uses_cached_sql_when_unrelated_symlink_source_target_is_missing() {
     let repo = TempDir::new().unwrap();
     let external = TempDir::new().unwrap();
     let cache = TempDir::new().unwrap();
@@ -554,16 +816,7 @@ fn impact_deps_misses_cached_sql_when_symlink_source_target_is_missing() {
         Command::new(env!("CARGO_BIN_EXE_sem"))
             .current_dir(repo.path())
             .env("SEM_CACHE_DIR", cache.path())
-            .args([
-                "impact",
-                "consume",
-                "--file",
-                "b.ts",
-                "--deps",
-                "--json",
-                "--file-exts",
-                ".ts",
-            ])
+            .args(["impact", "consume", "--file", "b.ts", "--deps", "--json"])
             .output()
             .unwrap(),
         "warm impact cache",
@@ -576,16 +829,7 @@ fn impact_deps_misses_cached_sql_when_symlink_source_target_is_missing() {
             .current_dir(repo.path())
             .env("SEM_CACHE_DIR", cache.path())
             .env("SEM_TIMINGS", "json")
-            .args([
-                "impact",
-                "consume",
-                "--file",
-                "b.ts",
-                "--deps",
-                "--json",
-                "--file-exts",
-                ".ts",
-            ])
+            .args(["impact", "consume", "--file", "b.ts", "--deps", "--json"])
             .output()
             .unwrap(),
         "impact deps after missing symlink source target",
@@ -594,10 +838,8 @@ fn impact_deps_misses_cached_sql_when_symlink_source_target_is_missing() {
     let phases = phase_names(&output);
     assert!(phases
         .iter()
-        .any(|phase| phase == "cache_topology_impact_miss"));
-    assert!(!phases
-        .iter()
         .any(|phase| phase == "cache_topology_impact_query"));
+    assert!(!phases.iter().any(|phase| phase == "file_discovery"));
 }
 
 #[test]
@@ -610,16 +852,7 @@ fn impact_deps_misses_topology_cache_when_side_effect_import_changes() {
         Command::new(env!("CARGO_BIN_EXE_sem"))
             .current_dir(repo.path())
             .env("SEM_CACHE_DIR", cache.path())
-            .args([
-                "impact",
-                "consume",
-                "--file",
-                "b.ts",
-                "--deps",
-                "--json",
-                "--file-exts",
-                ".ts",
-            ])
+            .args(["impact", "consume", "--file", "b.ts", "--deps", "--json"])
             .output()
             .unwrap(),
         "warm impact cache",
@@ -633,16 +866,7 @@ fn impact_deps_misses_topology_cache_when_side_effect_import_changes() {
             .current_dir(repo.path())
             .env("SEM_CACHE_DIR", cache.path())
             .env("SEM_TIMINGS", "json")
-            .args([
-                "impact",
-                "consume",
-                "--file",
-                "b.ts",
-                "--deps",
-                "--json",
-                "--file-exts",
-                ".ts",
-            ])
+            .args(["impact", "consume", "--file", "b.ts", "--deps", "--json"])
             .output()
             .unwrap(),
         "impact deps after side-effect import edit",
@@ -667,16 +891,7 @@ fn cached_impact_file_hint_errors_match_graph_path() {
         Command::new(env!("CARGO_BIN_EXE_sem"))
             .current_dir(repo.path())
             .env("SEM_CACHE_DIR", cache.path())
-            .args([
-                "impact",
-                "consume",
-                "--file",
-                "b.ts",
-                "--deps",
-                "--json",
-                "--file-exts",
-                ".ts",
-            ])
+            .args(["impact", "consume", "--file", "b.ts", "--deps", "--json"])
             .output()
             .unwrap(),
         "warm impact cache",
@@ -685,16 +900,7 @@ fn cached_impact_file_hint_errors_match_graph_path() {
     let missing = Command::new(env!("CARGO_BIN_EXE_sem"))
         .current_dir(repo.path())
         .env("SEM_CACHE_DIR", cache.path())
-        .args([
-            "impact",
-            "missing",
-            "--file",
-            "b.ts",
-            "--deps",
-            "--json",
-            "--file-exts",
-            ".ts",
-        ])
+        .args(["impact", "missing", "--file", "b.ts", "--deps", "--json"])
         .output()
         .unwrap();
     assert!(!missing.status.success());
@@ -705,16 +911,7 @@ fn cached_impact_file_hint_errors_match_graph_path() {
     let wrong_file = Command::new(env!("CARGO_BIN_EXE_sem"))
         .current_dir(repo.path())
         .env("SEM_CACHE_DIR", cache.path())
-        .args([
-            "impact",
-            "source",
-            "--file",
-            "b.ts",
-            "--deps",
-            "--json",
-            "--file-exts",
-            ".ts",
-        ])
+        .args(["impact", "source", "--file", "b.ts", "--deps", "--json"])
         .output()
         .unwrap();
     assert!(!wrong_file.status.success());
@@ -732,15 +929,7 @@ fn impact_all_and_tests_match_no_cache_from_topology_cache() {
         Command::new(env!("CARGO_BIN_EXE_sem"))
             .current_dir(repo.path())
             .env("SEM_CACHE_DIR", cache.path())
-            .args([
-                "impact",
-                "source",
-                "--file",
-                "a.ts",
-                "--json",
-                "--file-exts",
-                ".ts",
-            ])
+            .args(["impact", "source", "--file", "a.ts", "--json"])
             .output()
             .unwrap(),
         "warm impact cache",
@@ -748,15 +937,7 @@ fn impact_all_and_tests_match_no_cache_from_topology_cache() {
     mark_cache_as_topology_with_test_flags(cache.path());
 
     for extra_arg in [None, Some("--tests")] {
-        let mut cached_args = vec![
-            "impact",
-            "source",
-            "--file",
-            "a.ts",
-            "--json",
-            "--file-exts",
-            ".ts",
-        ];
+        let mut cached_args = vec!["impact", "source", "--file", "a.ts", "--json"];
         let mut no_cache_args = cached_args.clone();
         if let Some(extra_arg) = extra_arg {
             cached_args.push(extra_arg);

--- a/crates/sem-cli/tests/impact_direct_deps.rs
+++ b/crates/sem-cli/tests/impact_direct_deps.rs
@@ -51,7 +51,12 @@ fn init_repo(repo: &Path) {
         "import { source } from './a';\nexport function consume() { return source(); }\n",
     )
     .unwrap();
-    git(repo, &["add", "a.ts", "b.ts"]);
+    fs::write(
+        repo.join("c.ts"),
+        "export function unrelated() { return 2; }\n",
+    )
+    .unwrap();
+    git(repo, &["add", "a.ts", "b.ts", "c.ts"]);
     git(repo, &["commit", "-q", "-m", "init"]);
 }
 
@@ -82,6 +87,49 @@ fn init_topology_repo(repo: &Path) {
     )
     .unwrap();
     git(repo, &["add", "a.ts", "b.ts", "c.ts", "a.test.ts"]);
+    git(repo, &["commit", "-q", "-m", "init"]);
+}
+
+fn init_side_effect_import_repo(repo: &Path) {
+    git(repo, &["init", "-q"]);
+    git(repo, &["config", "user.email", "t@t.com"]);
+    git(repo, &["config", "user.name", "test"]);
+    git(repo, &["config", "commit.gpgsign", "false"]);
+
+    fs::write(repo.join("a.ts"), "console.log('side effect');\n").unwrap();
+    fs::write(
+        repo.join("b.ts"),
+        "import './a';\nexport function consume() { return 1; }\n",
+    )
+    .unwrap();
+    git(repo, &["add", "a.ts", "b.ts"]);
+    git(repo, &["commit", "-q", "-m", "init"]);
+}
+
+#[cfg(unix)]
+fn init_symlink_source_repo(repo: &Path, symlink_target: &Path) {
+    git(repo, &["init", "-q"]);
+    git(repo, &["config", "user.email", "t@t.com"]);
+    git(repo, &["config", "user.name", "test"]);
+    git(repo, &["config", "commit.gpgsign", "false"]);
+
+    fs::write(
+        repo.join("a.ts"),
+        "export function source() { return 1; }\n",
+    )
+    .unwrap();
+    fs::write(
+        repo.join("b.ts"),
+        "import { source } from './a';\nexport function consume() { return source(); }\n",
+    )
+    .unwrap();
+    fs::write(
+        symlink_target,
+        "export function linkedUnrelated() { return 2; }\n",
+    )
+    .unwrap();
+    std::os::unix::fs::symlink(symlink_target, repo.join("c.ts")).unwrap();
+    git(repo, &["add", "a.ts", "b.ts", "c.ts"]);
     git(repo, &["commit", "-q", "-m", "init"]);
 }
 
@@ -126,6 +174,18 @@ fn mark_cache_as_topology_with_test_flags(cache_root: &Path) {
     .unwrap();
 }
 
+fn mark_cache_as_topology_without_file_imports(cache_root: &Path) {
+    let db_path = find_cache_db(cache_root);
+    assert!(db_path.exists(), "cache db not found under {cache_root:?}");
+    let conn = rusqlite::Connection::open(db_path).unwrap();
+    conn.execute("DELETE FROM file_imports", []).unwrap();
+    conn.execute(
+        "INSERT OR REPLACE INTO cache_metadata (key, value) VALUES ('cache_kind', 'topology')",
+        [],
+    )
+    .unwrap();
+}
+
 fn phase_names(output: &Output) -> Vec<String> {
     let stderr = String::from_utf8_lossy(&output.stderr);
     let timings: serde_json::Value = serde_json::from_str(stderr.trim()).expect("timings json");
@@ -135,6 +195,20 @@ fn phase_names(output: &Output) -> Vec<String> {
         .iter()
         .map(|phase| phase["name"].as_str().unwrap().to_string())
         .collect()
+}
+
+fn rewrite_after_mtime_tick(path: &Path, content: &str) {
+    let before = fs::metadata(path).unwrap().modified().unwrap();
+
+    for _ in 0..200 {
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        fs::write(path, content).unwrap();
+        if fs::metadata(path).unwrap().modified().unwrap() != before {
+            return;
+        }
+    }
+
+    panic!("mtime did not change for {}", path.display());
 }
 
 #[test]
@@ -226,8 +300,361 @@ fn impact_deps_uses_cached_sql_topology_query_on_second_run() {
     assert!(phases
         .iter()
         .any(|phase| phase == "cache_topology_impact_query"));
+    assert!(phases.iter().any(|phase| phase == "git_file_discovery"));
+    assert!(!phases.iter().any(|phase| phase == "file_discovery"));
     assert!(!phases.iter().any(|phase| phase == "cache_topology_load"));
     assert!(!phases.iter().any(|phase| phase == "full_graph_build"));
+}
+
+#[test]
+fn impact_deps_uses_cached_sql_when_unrelated_file_changes() {
+    let repo = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+    init_repo(repo.path());
+
+    assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("SEM_CACHE_DIR", cache.path())
+            .args([
+                "impact",
+                "consume",
+                "--file",
+                "b.ts",
+                "--deps",
+                "--json",
+                "--file-exts",
+                ".ts",
+            ])
+            .output()
+            .unwrap(),
+        "warm impact cache",
+    );
+
+    rewrite_after_mtime_tick(
+        &repo.path().join("c.ts"),
+        "export function unrelated() { return 3; }\n",
+    );
+
+    let output = assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("SEM_CACHE_DIR", cache.path())
+            .env("SEM_TIMINGS", "json")
+            .args([
+                "impact",
+                "consume",
+                "--file",
+                "b.ts",
+                "--deps",
+                "--json",
+                "--file-exts",
+                ".ts",
+            ])
+            .output()
+            .unwrap(),
+        "cached impact deps after unrelated edit",
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["entity"]["name"], "consume");
+    assert_eq!(json["dependencies"][0]["name"], "source");
+
+    let phases = phase_names(&output);
+    assert!(phases
+        .iter()
+        .any(|phase| phase == "cache_topology_impact_query"));
+    assert!(phases.iter().any(|phase| phase == "git_file_discovery"));
+    assert!(!phases.iter().any(|phase| phase == "file_discovery"));
+    assert!(!phases.iter().any(|phase| phase == "full_graph_build"));
+}
+
+#[test]
+fn impact_deps_misses_cached_sql_when_imported_file_changes() {
+    let repo = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+    init_repo(repo.path());
+
+    assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("SEM_CACHE_DIR", cache.path())
+            .args([
+                "impact",
+                "consume",
+                "--file",
+                "b.ts",
+                "--deps",
+                "--json",
+                "--file-exts",
+                ".ts",
+            ])
+            .output()
+            .unwrap(),
+        "warm impact cache",
+    );
+
+    rewrite_after_mtime_tick(
+        &repo.path().join("a.ts"),
+        "export function source() { return 3; }\n",
+    );
+
+    let output = assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("SEM_CACHE_DIR", cache.path())
+            .env("SEM_TIMINGS", "json")
+            .args([
+                "impact",
+                "consume",
+                "--file",
+                "b.ts",
+                "--deps",
+                "--json",
+                "--file-exts",
+                ".ts",
+            ])
+            .output()
+            .unwrap(),
+        "impact deps after imported edit",
+    );
+
+    let phases = phase_names(&output);
+    assert!(phases
+        .iter()
+        .any(|phase| phase == "cache_topology_impact_miss"));
+    assert!(!phases
+        .iter()
+        .any(|phase| phase == "cache_topology_impact_query"));
+}
+
+#[test]
+fn impact_deps_misses_cached_sql_when_source_file_is_deleted() {
+    let repo = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+    init_repo(repo.path());
+
+    assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("SEM_CACHE_DIR", cache.path())
+            .args([
+                "impact",
+                "consume",
+                "--file",
+                "b.ts",
+                "--deps",
+                "--json",
+                "--file-exts",
+                ".ts",
+            ])
+            .output()
+            .unwrap(),
+        "warm impact cache",
+    );
+
+    fs::remove_file(repo.path().join("c.ts")).unwrap();
+
+    let output = assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("SEM_CACHE_DIR", cache.path())
+            .env("SEM_TIMINGS", "json")
+            .args([
+                "impact",
+                "consume",
+                "--file",
+                "b.ts",
+                "--deps",
+                "--json",
+                "--file-exts",
+                ".ts",
+            ])
+            .output()
+            .unwrap(),
+        "impact deps after source file deletion",
+    );
+
+    let phases = phase_names(&output);
+    assert!(phases
+        .iter()
+        .any(|phase| phase == "cache_topology_impact_miss"));
+    assert!(!phases
+        .iter()
+        .any(|phase| phase == "cache_topology_impact_query"));
+}
+
+#[test]
+fn impact_deps_misses_cached_sql_when_skip_worktree_source_file_is_missing() {
+    let repo = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+    init_repo(repo.path());
+
+    assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("SEM_CACHE_DIR", cache.path())
+            .args([
+                "impact",
+                "consume",
+                "--file",
+                "b.ts",
+                "--deps",
+                "--json",
+                "--file-exts",
+                ".ts",
+            ])
+            .output()
+            .unwrap(),
+        "warm impact cache",
+    );
+
+    git(repo.path(), &["update-index", "--skip-worktree", "c.ts"]);
+    fs::remove_file(repo.path().join("c.ts")).unwrap();
+
+    let output = assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("SEM_CACHE_DIR", cache.path())
+            .env("SEM_TIMINGS", "json")
+            .args([
+                "impact",
+                "consume",
+                "--file",
+                "b.ts",
+                "--deps",
+                "--json",
+                "--file-exts",
+                ".ts",
+            ])
+            .output()
+            .unwrap(),
+        "impact deps after missing skip-worktree source file",
+    );
+
+    let phases = phase_names(&output);
+    assert!(phases
+        .iter()
+        .any(|phase| phase == "cache_topology_impact_miss"));
+    assert!(!phases
+        .iter()
+        .any(|phase| phase == "cache_topology_impact_query"));
+}
+
+#[cfg(unix)]
+#[test]
+fn impact_deps_misses_cached_sql_when_symlink_source_target_is_missing() {
+    let repo = TempDir::new().unwrap();
+    let external = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+    let symlink_target = external.path().join("linked.ts");
+    init_symlink_source_repo(repo.path(), &symlink_target);
+
+    assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("SEM_CACHE_DIR", cache.path())
+            .args([
+                "impact",
+                "consume",
+                "--file",
+                "b.ts",
+                "--deps",
+                "--json",
+                "--file-exts",
+                ".ts",
+            ])
+            .output()
+            .unwrap(),
+        "warm impact cache",
+    );
+
+    fs::remove_file(&symlink_target).unwrap();
+
+    let output = assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("SEM_CACHE_DIR", cache.path())
+            .env("SEM_TIMINGS", "json")
+            .args([
+                "impact",
+                "consume",
+                "--file",
+                "b.ts",
+                "--deps",
+                "--json",
+                "--file-exts",
+                ".ts",
+            ])
+            .output()
+            .unwrap(),
+        "impact deps after missing symlink source target",
+    );
+
+    let phases = phase_names(&output);
+    assert!(phases
+        .iter()
+        .any(|phase| phase == "cache_topology_impact_miss"));
+    assert!(!phases
+        .iter()
+        .any(|phase| phase == "cache_topology_impact_query"));
+}
+
+#[test]
+fn impact_deps_misses_topology_cache_when_side_effect_import_changes() {
+    let repo = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+    init_side_effect_import_repo(repo.path());
+
+    assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("SEM_CACHE_DIR", cache.path())
+            .args([
+                "impact",
+                "consume",
+                "--file",
+                "b.ts",
+                "--deps",
+                "--json",
+                "--file-exts",
+                ".ts",
+            ])
+            .output()
+            .unwrap(),
+        "warm impact cache",
+    );
+    mark_cache_as_topology_without_file_imports(cache.path());
+
+    rewrite_after_mtime_tick(&repo.path().join("a.ts"), "console.log('changed');\n");
+
+    let output = assert_success(
+        Command::new(env!("CARGO_BIN_EXE_sem"))
+            .current_dir(repo.path())
+            .env("SEM_CACHE_DIR", cache.path())
+            .env("SEM_TIMINGS", "json")
+            .args([
+                "impact",
+                "consume",
+                "--file",
+                "b.ts",
+                "--deps",
+                "--json",
+                "--file-exts",
+                ".ts",
+            ])
+            .output()
+            .unwrap(),
+        "impact deps after side-effect import edit",
+    );
+
+    let phases = phase_names(&output);
+    assert!(phases
+        .iter()
+        .any(|phase| phase == "cache_topology_impact_miss"));
+    assert!(!phases
+        .iter()
+        .any(|phase| phase == "cache_topology_impact_query"));
 }
 
 #[test]

--- a/crates/sem-core/src/parser/import_resolution.rs
+++ b/crates/sem-core/src/parser/import_resolution.rs
@@ -82,6 +82,43 @@ where
     imported_files
 }
 
+pub fn js_ts_import_source_files_from_filesystem(
+    root: &Path,
+    file_path: &str,
+    content: &str,
+) -> Vec<String> {
+    js_ts_import_source_files_from_filesystem_with_unscoped(root, file_path, content).0
+}
+
+pub fn js_ts_import_source_files_from_filesystem_with_unscoped(
+    root: &Path,
+    file_path: &str,
+    content: &str,
+) -> (Vec<String>, bool) {
+    if !is_js_ts_file(file_path) {
+        return (Vec::new(), false);
+    }
+
+    let mut imported_files = HashSet::new();
+    let mut has_unscoped_imports = false;
+    for source in js_ts_import_sources(content) {
+        let Some(candidates) = import_file_candidates(file_path, source, JS_TS_EXTENSIONS) else {
+            has_unscoped_imports = true;
+            continue;
+        };
+        if let Some(imported_file) = candidates
+            .iter()
+            .find(|candidate| root.join(candidate).is_file())
+        {
+            imported_files.insert(imported_file.clone());
+        }
+    }
+
+    let mut imported_files: Vec<String> = imported_files.into_iter().collect();
+    sort_import_candidate_files(&mut imported_files, JS_TS_EXTENSIONS);
+    (imported_files, has_unscoped_imports)
+}
+
 fn js_ts_import_sources(content: &str) -> Vec<&str> {
     static FROM_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r#"\bfrom\s*['"]([^'"]+)['"]"#).unwrap());
@@ -100,6 +137,15 @@ fn js_ts_import_sources(content: &str) -> Vec<&str> {
         }
     }
     sources
+}
+
+pub fn js_ts_has_default_re_export_from_content(content: &str) -> bool {
+    static DEFAULT_REEXPORT_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r#"export\s+(?:type\s+)?\{[^}]*\bdefault\b[^}]*\}\s*from\s*['"][^'"]+['"]"#)
+            .unwrap()
+    });
+
+    DEFAULT_REEXPORT_RE.is_match(content)
 }
 
 pub(crate) fn js_ts_named_exports_from_content(content: &str) -> HashSet<String> {
@@ -461,6 +507,37 @@ export { a as publicA } from './a';
         let imports = js_ts_import_source_files_from_content("src/main.ts", content, &candidates);
 
         assert_eq!(imports, vec!["src/a.ts", "src/b.ts", "src/c/index.ts"]);
+    }
+
+    #[test]
+    fn js_ts_default_re_export_detection_handles_aliases() {
+        assert!(js_ts_has_default_re_export_from_content(
+            "export { default } from './target';"
+        ));
+        assert!(js_ts_has_default_re_export_from_content(
+            "export { default as PublicTarget } from './target';"
+        ));
+        assert!(!js_ts_has_default_re_export_from_content(
+            "export { value as PublicTarget } from './target';"
+        ));
+    }
+
+    #[test]
+    fn js_ts_import_source_files_from_filesystem_resolves_existing_relative_files() {
+        let root = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(root.path().join("src/c")).unwrap();
+        std::fs::write(root.path().join("src/a.ts"), "export const a = 1;\n").unwrap();
+        std::fs::write(root.path().join("src/c/index.ts"), "export const c = 1;\n").unwrap();
+        let content = r#"
+import { a } from './a';
+import './c';
+import './missing';
+"#;
+
+        let imports =
+            js_ts_import_source_files_from_filesystem(root.path(), "src/main.ts", content);
+
+        assert_eq!(imports, vec!["src/a.ts", "src/c/index.ts"]);
     }
 
     #[test]

--- a/crates/sem-core/src/parser/import_resolution.rs
+++ b/crates/sem-core/src/parser/import_resolution.rs
@@ -24,34 +24,82 @@ pub fn js_ts_import_source_files_from_content<P: AsRef<str>>(
         return Vec::new();
     }
 
-    static FROM_RE: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r#"\bfrom\s*['"]([^'"]+)['"]"#).unwrap());
-    static SIDE_EFFECT_IMPORT_RE: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r#"\bimport\s*['"]([^'"]+)['"]"#).unwrap());
-
     let mut imported_files = HashSet::new();
-    for cap in FROM_RE.captures_iter(content) {
-        if let Some(source) = cap.get(1).map(|m| m.as_str()) {
-            if let Some(imported_file) =
-                find_import_file(candidate_file_paths, source, file_path, JS_TS_EXTENSIONS)
-            {
-                imported_files.insert(imported_file.to_string());
-            }
-        }
-    }
-    for cap in SIDE_EFFECT_IMPORT_RE.captures_iter(content) {
-        if let Some(source) = cap.get(1).map(|m| m.as_str()) {
-            if let Some(imported_file) =
-                find_import_file(candidate_file_paths, source, file_path, JS_TS_EXTENSIONS)
-            {
-                imported_files.insert(imported_file.to_string());
-            }
+    for source in js_ts_import_sources(content) {
+        if let Some(imported_file) =
+            find_import_file(candidate_file_paths, source, file_path, JS_TS_EXTENSIONS)
+        {
+            imported_files.insert(imported_file.to_string());
         }
     }
 
     let mut imported_files: Vec<String> = imported_files.into_iter().collect();
     sort_import_candidate_files(&mut imported_files, JS_TS_EXTENSIONS);
     imported_files
+}
+
+pub fn js_ts_import_source_files_from_set<S>(
+    file_path: &str,
+    content: &str,
+    candidate_file_paths: &HashSet<&str, S>,
+) -> Vec<String>
+where
+    S: BuildHasher,
+{
+    if !is_js_ts_file(file_path) {
+        return Vec::new();
+    }
+
+    let mut imported_files = HashSet::new();
+    let mut sorted_candidates: Option<Vec<&str>> = None;
+    for source in js_ts_import_sources(content) {
+        if let Some(candidates) = import_file_candidates(file_path, source, JS_TS_EXTENSIONS) {
+            if let Some(imported_file) = candidates
+                .iter()
+                .find(|candidate| candidate_file_paths.contains(candidate.as_str()))
+            {
+                imported_files.insert(imported_file.clone());
+            }
+            continue;
+        }
+
+        let source_module = import_stem(source);
+        let candidates = sorted_candidates.get_or_insert_with(|| {
+            let mut candidates: Vec<&str> = candidate_file_paths.iter().copied().collect();
+            sort_import_candidate_files(&mut candidates, JS_TS_EXTENSIONS);
+            candidates
+        });
+        if let Some(imported_file) = candidates
+            .iter()
+            .find(|path| file_stem(path) == source_module)
+        {
+            imported_files.insert((*imported_file).to_string());
+        }
+    }
+
+    let mut imported_files: Vec<String> = imported_files.into_iter().collect();
+    sort_import_candidate_files(&mut imported_files, JS_TS_EXTENSIONS);
+    imported_files
+}
+
+fn js_ts_import_sources(content: &str) -> Vec<&str> {
+    static FROM_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r#"\bfrom\s*['"]([^'"]+)['"]"#).unwrap());
+    static SIDE_EFFECT_IMPORT_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r#"\bimport\s*['"]([^'"]+)['"]"#).unwrap());
+
+    let mut sources = Vec::new();
+    for cap in FROM_RE.captures_iter(content) {
+        if let Some(source) = cap.get(1).map(|m| m.as_str()) {
+            sources.push(source);
+        }
+    }
+    for cap in SIDE_EFFECT_IMPORT_RE.captures_iter(content) {
+        if let Some(source) = cap.get(1).map(|m| m.as_str()) {
+            sources.push(source);
+        }
+    }
+    sources
 }
 
 pub(crate) fn js_ts_named_exports_from_content(content: &str) -> HashSet<String> {

--- a/crates/sem-core/src/parser/mod.rs
+++ b/crates/sem-core/src/parser/mod.rs
@@ -1,12 +1,14 @@
-pub mod plugin;
-pub mod registry;
+pub mod context;
 pub mod differ;
 pub mod graph;
-pub mod plugins;
-pub mod test_detect;
-pub mod context;
 #[cfg(feature = "git")]
 pub mod hotspot;
 mod import_resolution;
-pub use import_resolution::js_ts_import_source_files_from_content;
+pub mod plugin;
+pub mod plugins;
+pub mod registry;
+pub mod test_detect;
+pub use import_resolution::{
+    js_ts_import_source_files_from_content, js_ts_import_source_files_from_set,
+};
 pub mod scope_resolve;

--- a/crates/sem-core/src/parser/mod.rs
+++ b/crates/sem-core/src/parser/mod.rs
@@ -9,6 +9,8 @@ pub mod plugins;
 pub mod registry;
 pub mod test_detect;
 pub use import_resolution::{
-    js_ts_import_source_files_from_content, js_ts_import_source_files_from_set,
+    js_ts_has_default_re_export_from_content, js_ts_import_source_files_from_content,
+    js_ts_import_source_files_from_filesystem,
+    js_ts_import_source_files_from_filesystem_with_unscoped, js_ts_import_source_files_from_set,
 };
 pub mod scope_resolve;

--- a/crates/sem-core/src/parser/plugin.rs
+++ b/crates/sem-core/src/parser/plugin.rs
@@ -4,6 +4,11 @@ pub trait SemanticParserPlugin: Send + Sync {
     fn id(&self) -> &str;
     fn extensions(&self) -> &[&str];
     fn extract_entities(&self, content: &str, file_path: &str) -> Vec<SemanticEntity>;
+    fn extract_entities_brief(&self, content: &str, file_path: &str) -> Vec<SemanticEntity> {
+        let mut entities = self.extract_entities(content, file_path);
+        strip_entity_payloads(&mut entities);
+        entities
+    }
     /// Extract entities and optionally return the tree-sitter Tree for reuse.
     /// Default returns None for the tree (non-code plugins).
     fn extract_entities_with_tree(
@@ -18,5 +23,13 @@ pub trait SemanticParserPlugin: Send + Sync {
     }
     fn compute_similarity(&self, a: &SemanticEntity, b: &SemanticEntity) -> f64 {
         crate::model::identity::default_similarity(a, b)
+    }
+}
+
+pub fn strip_entity_payloads(entities: &mut [SemanticEntity]) {
+    for entity in entities {
+        entity.content.clear();
+        entity.content_hash.clear();
+        entity.structural_hash = None;
     }
 }

--- a/crates/sem-core/src/parser/plugins/json.rs
+++ b/crates/sem-core/src/parser/plugins/json.rs
@@ -14,17 +14,32 @@ impl SemanticParserPlugin for JsonParserPlugin {
     }
 
     fn extract_entities(&self, content: &str, file_path: &str) -> Vec<SemanticEntity> {
+        self.extract_entities_with_payload(content, file_path, EntityPayloadMode::Full)
+    }
+
+    fn extract_entities_brief(&self, content: &str, file_path: &str) -> Vec<SemanticEntity> {
+        self.extract_entities_with_payload(content, file_path, EntityPayloadMode::Brief)
+    }
+}
+
+impl JsonParserPlugin {
+    fn extract_entities_with_payload(
+        &self,
+        content: &str,
+        file_path: &str,
+        payload_mode: EntityPayloadMode,
+    ) -> Vec<SemanticEntity> {
         let trimmed = content.trim_start();
         if trimmed.starts_with('{') {
-            return extract_entries(content, file_path, JsonContainerKind::Object);
+            return extract_entries(content, file_path, JsonContainerKind::Object, payload_mode);
         }
         if trimmed.starts_with('[') {
-            return extract_entries(content, file_path, JsonContainerKind::Array);
+            return extract_entries(content, file_path, JsonContainerKind::Array, payload_mode);
         }
         if trimmed.is_empty() {
             return Vec::new();
         }
-        vec![document_chunk_entity(content, file_path)]
+        vec![document_chunk_entity(content, file_path, payload_mode)]
     }
 }
 
@@ -32,6 +47,12 @@ impl SemanticParserPlugin for JsonParserPlugin {
 enum JsonContainerKind {
     Object,
     Array,
+}
+
+#[derive(Clone, Copy)]
+enum EntityPayloadMode {
+    Full,
+    Brief,
 }
 
 struct Frame {
@@ -52,6 +73,7 @@ fn extract_entries(
     content: &str,
     file_path: &str,
     container_kind: JsonContainerKind,
+    payload_mode: EntityPayloadMode,
 ) -> Vec<SemanticEntity> {
     let mut entities = Vec::new();
     let root_entries = match container_kind {
@@ -117,6 +139,14 @@ fn extract_entries(
             let entity_id = format!("{}::{}", file_path, pointer);
             let abs_start = frame.line_offset + entry.start_line - 1;
             let abs_end = frame.line_offset + end_line - 1;
+            let (stored_content, content_hash_value, structural_hash_value) = match payload_mode {
+                EntityPayloadMode::Full => (
+                    entity_content.clone(),
+                    content_hash(&entity_content),
+                    Some(content_hash(value_content)),
+                ),
+                EntityPayloadMode::Brief => (String::new(), String::new(), None),
+            };
 
             entities.push(SemanticEntity {
                 id: entity_id.clone(),
@@ -124,9 +154,9 @@ fn extract_entries(
                 entity_type: entry.entity_type.clone(),
                 name: entry.key.clone(),
                 parent_id: frame.parent_entity_id.clone(),
-                content_hash: content_hash(&entity_content),
-                structural_hash: Some(content_hash(value_content)),
-                content: entity_content.clone(),
+                content_hash: content_hash_value,
+                structural_hash: structural_hash_value,
+                content: stored_content,
                 start_line: abs_start,
                 end_line: abs_end,
                 metadata: None,
@@ -155,17 +185,25 @@ fn extract_entries(
     entities
 }
 
-fn document_chunk_entity(content: &str, file_path: &str) -> SemanticEntity {
+fn document_chunk_entity(
+    content: &str,
+    file_path: &str,
+    payload_mode: EntityPayloadMode,
+) -> SemanticEntity {
     let line_count = content.lines().count().max(1);
+    let (stored_content, content_hash_value) = match payload_mode {
+        EntityPayloadMode::Full => (content.to_string(), content_hash(content)),
+        EntityPayloadMode::Brief => (String::new(), String::new()),
+    };
     SemanticEntity {
         id: build_entity_id(file_path, "chunk", "(document)", None),
         file_path: file_path.to_string(),
         entity_type: "chunk".to_string(),
         name: "(document)".to_string(),
         parent_id: None,
-        content_hash: content_hash(content),
+        content_hash: content_hash_value,
         structural_hash: None,
-        content: content.to_string(),
+        content: stored_content,
         start_line: 1,
         end_line: line_count,
         metadata: None,
@@ -624,6 +662,24 @@ mod tests {
     fn find_change<'a>(changes: &'a [SemanticChange], name: &str, kind: ChangeType) -> &'a SemanticChange {
         changes.iter().find(|c| c.entity_name == name && c.change_type == kind)
             .unwrap_or_else(|| panic!("expected {:?} {} in changes; got: {:?}", kind, name, names(changes)))
+    }
+
+    #[test]
+    fn brief_extraction_drops_json_payloads() {
+        let content = r#"{
+  "scripts": {
+    "build": "tsc"
+  }
+}
+"#;
+        let plugin = JsonParserPlugin;
+        let entities = plugin.extract_entities_brief(content, "package.json");
+
+        assert!(entities.iter().any(|entity| entity.name == "scripts"));
+        assert!(entities.iter().any(|entity| entity.name == "build"));
+        assert!(entities.iter().all(|entity| entity.content.is_empty()));
+        assert!(entities.iter().all(|entity| entity.content_hash.is_empty()));
+        assert!(entities.iter().all(|entity| entity.structural_hash.is_none()));
     }
 
     #[test]

--- a/crates/sem-core/src/parser/registry.rs
+++ b/crates/sem-core/src/parser/registry.rs
@@ -13,7 +13,7 @@ macro_rules! maybe_par_iter {
         { $slice.iter() }
     }};
 }
-use super::plugin::SemanticParserPlugin;
+use super::plugin::{strip_entity_payloads, SemanticParserPlugin};
 
 pub struct ParserRegistry {
     plugins: Vec<Box<dyn SemanticParserPlugin>>,
@@ -251,6 +251,23 @@ impl ParserRegistry {
         entities
     }
 
+    /// Extract listing-only entities without retaining source content or hashes.
+    pub fn extract_entities_brief(&self, file_path: &str, content: &str) -> Vec<SemanticEntity> {
+        let resolved = self.resolve_file_path(file_path);
+        let detection_path = resolved.as_deref().unwrap_or(file_path);
+
+        let plugin = match self.get_plugin_with_content(detection_path, content) {
+            Some(p) => p,
+            None => return Vec::new(),
+        };
+
+        let mut entities = plugin.extract_entities_brief(content, detection_path);
+        if let Some(ref rp) = resolved {
+            fix_entity_paths(&mut entities, file_path, rp);
+        }
+        entities
+    }
+
     /// Extract entities with tree, transparently handling custom extension mappings.
     pub fn extract_entities_with_tree(
         &self,
@@ -286,6 +303,38 @@ impl ParserRegistry {
             .collect();
         resolve_go_method_parent_ids(&mut entities);
         entities
+    }
+
+    /// Extract listing-only entities from multiple files in parallel.
+    pub fn extract_all_entities_brief(
+        &self,
+        root: &Path,
+        file_paths: &[String],
+    ) -> Vec<SemanticEntity> {
+        let mut entities: Vec<SemanticEntity> = maybe_par_iter!(file_paths)
+            .flat_map(|fp| {
+                let full = root.join(fp);
+                let content = match std::fs::read_to_string(&full) {
+                    Ok(c) => c,
+                    Err(_) => return Vec::new(),
+                };
+                if self.needs_content_for_listing_parent_repair(fp, &content) {
+                    self.extract_entities(fp, &content)
+                } else {
+                    self.extract_entities_brief(fp, &content)
+                }
+            })
+            .collect();
+        resolve_go_method_parent_ids(&mut entities);
+        strip_entity_payloads(&mut entities);
+        entities
+    }
+
+    fn needs_content_for_listing_parent_repair(&self, file_path: &str, content: &str) -> bool {
+        let resolved = self.resolve_file_path(file_path);
+        let detection_path = resolved.as_deref().unwrap_or(file_path);
+        detection_path.ends_with(".go")
+            || detect_ext_from_content(content).as_deref() == Some(".go")
     }
 }
 
@@ -836,6 +885,37 @@ mod tests {
 
         assert_eq!(run.parent_id.as_deref(), Some(service.id.as_str()));
         assert_eq!(run.id, format!("{}::Run", service.id));
+    }
+
+    #[cfg(feature = "lang-go")]
+    #[test]
+    fn test_brief_go_method_parent_resolves_across_files() {
+        let registry = create_default_registry();
+        let dir = TempDir::new().unwrap();
+        write_file(&dir, "models.go", "package demo\n\ntype Service struct{}\n");
+        write_file(
+            &dir,
+            "methods.go",
+            "package demo\n\nfunc (s *Service) Run() {}\n",
+        );
+
+        let entities = registry.extract_all_entities_brief(
+            dir.path(),
+            &["models.go".to_string(), "methods.go".to_string()],
+        );
+        let service = entities
+            .iter()
+            .find(|e| e.name == "Service" && e.file_path == "models.go")
+            .expect("Service type should be extracted");
+        let run = entities
+            .iter()
+            .find(|e| e.name == "Run" && e.file_path == "methods.go")
+            .expect("Run method should be extracted");
+
+        assert_eq!(run.parent_id.as_deref(), Some(service.id.as_str()));
+        assert!(entities.iter().all(|e| e.content.is_empty()));
+        assert!(entities.iter().all(|e| e.content_hash.is_empty()));
+        assert!(entities.iter().all(|e| e.structural_hash.is_none()));
     }
 
     #[cfg(feature = "lang-go")]

--- a/crates/sem-core/src/utils/scan.rs
+++ b/crates/sem-core/src/utils/scan.rs
@@ -12,8 +12,13 @@ const DEFAULT_EXCLUDED_FILES: &[&str] = &[
     "flake.lock",
 ];
 
-/// Directory names that are excluded wherever they appear in repo-wide scans.
+/// Directory names excluded wherever they appear in repo-wide scans.
+/// This list includes generated artifacts and high-volume support trees that are
+/// usually not useful for entity lookup or impact analysis by default.
 const DEFAULT_EXCLUDED_ANY_DIRS: &[&str] = &[
+    "__generated__",
+    "_generated",
+    "generated",
     "fixtures",
     "fixture",
     "benchmarks",
@@ -30,7 +35,40 @@ const DEFAULT_EXCLUDED_ANY_DIRS: &[&str] = &[
 const DEFAULT_EXCLUDED_ROOT_DIRS: &[&str] = &["out", "dist", "build", "target"];
 
 /// File suffixes for generated text assets that do not produce useful entities.
-const DEFAULT_EXCLUDED_SUFFIXES: &[&str] = &[".min.js", ".min.css"];
+const DEFAULT_EXCLUDED_SUFFIXES: &[&str] = &[
+    ".min.js",
+    ".min.css",
+    ".generated.ts",
+    ".generated.tsx",
+    ".generated.js",
+    ".generated.jsx",
+    ".generated.mts",
+    ".generated.cts",
+    ".generated.mjs",
+    ".generated.cjs",
+    ".generated.d.ts",
+    ".gen.ts",
+    ".gen.tsx",
+    ".gen.js",
+    ".gen.jsx",
+    ".gen.mts",
+    ".gen.cts",
+    ".gen.mjs",
+    ".gen.cjs",
+    ".gen.d.ts",
+    ".module.css.d.ts",
+    ".module.scss.d.ts",
+    ".module.sass.d.ts",
+    ".module.less.d.ts",
+    ".svg.d.ts",
+    ".png.d.ts",
+    ".jpg.d.ts",
+    ".jpeg.d.ts",
+    ".webp.d.ts",
+    ".gif.d.ts",
+    ".avif.d.ts",
+    ".ico.d.ts",
+];
 
 /// File suffixes that are not useful source text for semantic extraction.
 const BINARY_FILE_SUFFIXES: &[&str] = &[
@@ -171,14 +209,30 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_excludes_generated_and_build_paths() {
+    fn default_excludes_generated_support_and_build_paths() {
         assert!(is_default_excluded("dist/app.js"));
         assert!(is_default_excluded("site/out/_next/static/chunks/app.js"));
         assert!(is_default_excluded("src/generated.min.js"));
+        assert!(is_default_excluded("src/__generated__/client.ts"));
+        assert!(is_default_excluded("src/_generated/tokens.ts"));
+        assert!(is_default_excluded("src/generated/schema.ts"));
+        assert!(is_default_excluded("src/api.generated.ts"));
+        assert!(is_default_excluded("src/api.generated.d.ts"));
+        assert!(is_default_excluded(
+            "src/components/Button.module.scss.d.ts"
+        ));
+        assert!(is_default_excluded("src/icons/logo.svg.d.ts"));
+        assert!(is_default_excluded("src/fixtures/example.ts"));
+        assert!(is_default_excluded("src/fixture/example.ts"));
+        assert!(is_default_excluded("packages/app/benchmarks/run.ts"));
+        assert!(is_default_excluded("packages/app/vendor/client.ts"));
+        assert!(is_default_excluded("tools/test-harness/main.ts"));
         assert!(is_default_excluded("target/debug/build.rs"));
         assert!(!is_default_excluded("src/app.js"));
+        assert!(!is_default_excluded("src/generated_value.ts"));
         assert!(!is_default_excluded("src/build/mod.rs"));
         assert!(!is_default_excluded("packages/compiler/build/index.ts"));
+        assert!(!is_default_excluded("src/cli/commands/codegen/run.ts"));
         assert!(!is_default_excluded("tools/dist/analyzer.py"));
     }
 

--- a/crates/sem-mcp/src/cache.rs
+++ b/crates/sem-mcp/src/cache.rs
@@ -10,7 +10,7 @@ use sem_core::parser::graph::{EntityGraph, EntityInfo, EntityRef, RefType};
 use sem_core::parser::js_ts_import_source_files_from_content;
 use sem_core::utils::hash::content_hash_bytes;
 
-pub const CACHE_SCHEMA_VERSION: i32 = 5;
+pub const CACHE_SCHEMA_VERSION: i32 = 6;
 pub const CACHE_KIND_FULL: &str = "full";
 pub const CACHE_KIND_TOPOLOGY: &str = "topology";
 pub const CACHE_INDEXES: &[(&str, &str, &str)] = &[
@@ -52,7 +52,16 @@ pub const CACHE_INDEXES: &[(&str, &str, &str)] = &[
 pub const CACHE_MANIFEST_FILES: &[(&str, &str)] = &[
     (".semrc", "\0sem-manifest:.semrc"),
     (".gitattributes", "\0sem-manifest:.gitattributes"),
+    (".semignore", "\0sem-manifest:.semignore"),
 ];
+pub const CACHE_SOURCE_SCOPE_KEY: &str = "source_scope";
+pub const CACHE_SOURCE_SCOPE_DEFAULT: &str = "default";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CacheSourceScope {
+    Default,
+    Custom,
+}
 
 const CACHE_SCHEMA_SQL: &str = "
 CREATE TABLE IF NOT EXISTS files (
@@ -134,6 +143,42 @@ pub fn set_cache_kind(tx: &Transaction<'_>, kind: &str) -> Result<(), rusqlite::
         params![kind],
     )?;
     Ok(())
+}
+
+pub fn set_cache_source_scope(
+    tx: &Transaction<'_>,
+    source_scope: CacheSourceScope,
+) -> Result<(), rusqlite::Error> {
+    tx.execute(
+        "DELETE FROM cache_metadata WHERE key = ?1",
+        params![CACHE_SOURCE_SCOPE_KEY],
+    )?;
+    if matches!(source_scope, CacheSourceScope::Default) {
+        tx.execute(
+            "INSERT INTO cache_metadata (key, value) VALUES (?1, ?2)",
+            params![CACHE_SOURCE_SCOPE_KEY, CACHE_SOURCE_SCOPE_DEFAULT],
+        )?;
+    }
+    Ok(())
+}
+
+pub fn cache_has_default_source_scope(conn: &Connection) -> bool {
+    conn.query_row(
+        "SELECT value FROM cache_metadata WHERE key = ?1",
+        params![CACHE_SOURCE_SCOPE_KEY],
+        |row| row.get::<_, String>(0),
+    )
+    .ok()
+    .as_deref()
+        == Some(CACHE_SOURCE_SCOPE_DEFAULT)
+}
+
+pub fn cache_has_source_scope(conn: &Connection, source_scope: CacheSourceScope) -> bool {
+    let is_default = cache_has_default_source_scope(conn);
+    match source_scope {
+        CacheSourceScope::Default => is_default,
+        CacheSourceScope::Custom => !is_default,
+    }
 }
 
 pub fn cache_has_kind(conn: &Connection, accepted: &[&str]) -> bool {
@@ -672,6 +717,7 @@ impl DiskCache {
         files: &[String],
         graph: &EntityGraph,
         entities: &[SemanticEntity],
+        source_scope: CacheSourceScope,
     ) -> Result<(), rusqlite::Error> {
         let tx = self.conn.unchecked_transaction()?;
 
@@ -737,6 +783,7 @@ impl DiskCache {
         }
 
         set_cache_kind(&tx, CACHE_KIND_FULL)?;
+        set_cache_source_scope(&tx, source_scope)?;
         tx.commit()?;
         Ok(())
     }
@@ -747,7 +794,20 @@ impl DiskCache {
         root: &Path,
         files: &[String],
     ) -> Option<(EntityGraph, Vec<SemanticEntity>)> {
+        self.load_with_source_scope(root, files, CacheSourceScope::Default)
+    }
+
+    pub fn load_with_source_scope(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: CacheSourceScope,
+    ) -> Option<(EntityGraph, Vec<SemanticEntity>)> {
         if !cache_has_kind(&self.conn, &[CACHE_KIND_FULL]) {
+            return None;
+        }
+
+        if !cache_has_source_scope(&self.conn, source_scope) {
             return None;
         }
 
@@ -875,7 +935,20 @@ impl DiskCache {
 
     /// Load only graph topology from a fresh cache.
     pub fn load_graph_topology(&self, root: &Path, files: &[String]) -> Option<EntityGraph> {
+        self.load_graph_topology_with_source_scope(root, files, CacheSourceScope::Default)
+    }
+
+    pub fn load_graph_topology_with_source_scope(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: CacheSourceScope,
+    ) -> Option<EntityGraph> {
         if !cache_has_kind(&self.conn, &[CACHE_KIND_FULL, CACHE_KIND_TOPOLOGY]) {
+            return None;
+        }
+
+        if !cache_has_source_scope(&self.conn, source_scope) {
             return None;
         }
 
@@ -995,7 +1068,20 @@ impl DiskCache {
     /// Load a partial cache: identify stale files and return clean cached data.
     /// Returns None if cache is empty or ALL files are stale (full rebuild is better).
     pub fn load_partial(&self, root: &Path, files: &[String]) -> Option<PartialCache> {
+        self.load_partial_with_source_scope(root, files, CacheSourceScope::Default)
+    }
+
+    pub fn load_partial_with_source_scope(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: CacheSourceScope,
+    ) -> Option<PartialCache> {
         if !cache_has_kind(&self.conn, &[CACHE_KIND_FULL]) {
+            return None;
+        }
+
+        if !cache_has_source_scope(&self.conn, source_scope) {
             return None;
         }
 
@@ -1176,6 +1262,7 @@ impl DiskCache {
         stale_files: &[String],
         graph: &EntityGraph,
         entities: &[SemanticEntity],
+        source_scope: CacheSourceScope,
     ) -> Result<(), rusqlite::Error> {
         self.save_incremental_with_repair_metadata(
             root,
@@ -1186,6 +1273,7 @@ impl DiskCache {
             false,
             &[],
             &[],
+            source_scope,
         )
     }
 
@@ -1200,6 +1288,7 @@ impl DiskCache {
         repair_changed_clean_entity_ids: bool,
         recomputed_edge_source_ids: &[String],
         deleted_entity_ids: &[String],
+        source_scope: CacheSourceScope,
     ) -> Result<(), rusqlite::Error> {
         let source_stale_files: Vec<&String> = stale_files
             .iter()
@@ -1406,6 +1495,7 @@ impl DiskCache {
         }
 
         set_cache_kind(&tx, CACHE_KIND_FULL)?;
+        set_cache_source_scope(&tx, source_scope)?;
         tx.commit()?;
         Ok(())
     }
@@ -1563,7 +1653,9 @@ mod tests {
 
     fn save_empty_cache(root: &Path, files: &[String]) -> DiskCache {
         let cache = DiskCache::open(root).unwrap();
-        cache.save(root, files, &empty_graph(), &[]).unwrap();
+        cache
+            .save(root, files, &empty_graph(), &[], CacheSourceScope::Default)
+            .unwrap();
         assert!(cache.load(root, files).is_some());
         cache
     }
@@ -1634,7 +1726,15 @@ mod tests {
         );
         let files = vec!["a.ts".to_string(), "b.ts".to_string(), "c.ts".to_string()];
         let cache = DiskCache::open(&root).unwrap();
-        cache.save(&root, &files, &empty_graph(), &[]).unwrap();
+        cache
+            .save(
+                &root,
+                &files,
+                &empty_graph(),
+                &[],
+                CacheSourceScope::Default,
+            )
+            .unwrap();
 
         assert_eq!(file_import_count(&cache, "a.ts", "b.ts"), 1);
 
@@ -1666,6 +1766,7 @@ mod tests {
                 false,
                 &[],
                 &[],
+                CacheSourceScope::Default,
             )
             .unwrap();
         assert_eq!(file_import_count(&cache, "a.ts", "b.ts"), 0);
@@ -1687,6 +1788,69 @@ mod tests {
         }
 
         panic!("mtime did not change for {}", path.display());
+    }
+
+    #[test]
+    fn cache_reuse_requires_matching_source_scope_and_incremental_preserves_it() {
+        let root = temp_repo_root("source-scope-cache-reuse");
+        write_file(&root.join("a.ts"), "export function a() { return 1; }\n");
+        write_file(&root.join("b.ts"), "export function b() { return a(); }\n");
+        let files = vec!["a.ts".to_string(), "b.ts".to_string()];
+        let entities = vec![
+            entity("a-id", "a.ts", "a", "export function a() { return 1; }"),
+            entity("b-id", "b.ts", "b", "export function b() { return a(); }"),
+        ];
+        let graph = graph_with_edges(&entities, vec![edge("b-id", "a-id")]);
+        let cache = DiskCache::open(&root).unwrap();
+
+        cache
+            .save(&root, &files, &graph, &entities, CacheSourceScope::Custom)
+            .unwrap();
+
+        assert!(cache
+            .load_with_source_scope(&root, &files, CacheSourceScope::Default)
+            .is_none());
+        assert!(cache
+            .load_with_source_scope(&root, &files, CacheSourceScope::Custom)
+            .is_some());
+        assert!(cache
+            .load_partial_with_source_scope(&root, &files, CacheSourceScope::Default)
+            .is_none());
+
+        rewrite_after_mtime_tick(&root.join("b.ts"), "export function b() { return 2; }\n");
+        let partial = cache
+            .load_partial_with_source_scope(&root, &files, CacheSourceScope::Custom)
+            .unwrap();
+        assert_eq!(partial.stale_files, vec!["b.ts"]);
+
+        let updated_entities = vec![
+            entity("a-id", "a.ts", "a", "export function a() { return 1; }"),
+            entity("b-id", "b.ts", "b", "export function b() { return 2; }"),
+        ];
+        let updated_graph = graph_with_edges(&updated_entities, vec![]);
+        cache
+            .save_incremental_with_repair_metadata(
+                &root,
+                &files,
+                &partial.stale_files,
+                &updated_graph,
+                &updated_entities,
+                false,
+                &["b-id".to_string()],
+                &[],
+                CacheSourceScope::Custom,
+            )
+            .unwrap();
+
+        assert!(cache
+            .load_with_source_scope(&root, &files, CacheSourceScope::Default)
+            .is_none());
+        assert!(cache
+            .load_with_source_scope(&root, &files, CacheSourceScope::Custom)
+            .is_some());
+
+        drop(cache);
+        cleanup(root);
     }
 
     fn read_user_version(cache: &DiskCache) -> i32 {
@@ -1949,6 +2113,7 @@ mod tests {
                     entity("stale-id", "stale.rs", "stale", "stale old"),
                     entity("clean-id", "clean.rs", "clean", "clean old"),
                 ],
+                CacheSourceScope::Default,
             )
             .unwrap();
 
@@ -1963,6 +2128,7 @@ mod tests {
                 &["stale.rs".to_string()],
                 &empty_graph(),
                 &entities,
+                CacheSourceScope::Default,
             )
             .unwrap();
 
@@ -2007,7 +2173,13 @@ mod tests {
             ],
         );
         cache
-            .save(&root, &files, &initial_graph, &entities)
+            .save(
+                &root,
+                &files,
+                &initial_graph,
+                &entities,
+                CacheSourceScope::Default,
+            )
             .unwrap();
 
         let updated_entities = vec![
@@ -2030,6 +2202,7 @@ mod tests {
                 &["stale.rs".to_string()],
                 &updated_graph,
                 &updated_entities,
+                CacheSourceScope::Default,
             )
             .unwrap();
 
@@ -2061,6 +2234,7 @@ mod tests {
                     entity("stale-id", "stale.rs", "stale", "stale old"),
                     entity("clean-old-id", "clean.rs", "clean", "clean old"),
                 ],
+                CacheSourceScope::Default,
             )
             .unwrap();
 
@@ -2078,6 +2252,7 @@ mod tests {
                 true,
                 &[],
                 &[],
+                CacheSourceScope::Default,
             )
             .unwrap();
 

--- a/crates/sem-mcp/src/cache.rs
+++ b/crates/sem-mcp/src/cache.rs
@@ -496,31 +496,50 @@ pub fn source_file_count(files: &[String]) -> usize {
         .count()
 }
 
-fn cached_file_mtime(conn: &Connection, cache_key: &str) -> Option<(i64, i64)> {
+fn cached_file_fingerprint(
+    conn: &Connection,
+    cache_key: &str,
+) -> Option<(i64, i64, Option<String>)> {
     conn.query_row(
-        "SELECT mtime_secs, mtime_nanos FROM files WHERE path = ?1",
+        "SELECT mtime_secs, mtime_nanos, content_hash FROM files WHERE path = ?1",
         params![cache_key],
-        |row| Ok((row.get(0)?, row.get(1)?)),
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
     )
     .ok()
 }
 
 pub fn is_manifest_stale(conn: &Connection, root: &Path) -> bool {
-    CACHE_MANIFEST_FILES.iter().any(|(file_name, cache_key)| {
+    let mut fingerprint_refreshes = Vec::new();
+    for (file_name, cache_key) in CACHE_MANIFEST_FILES {
         let full = root.join(file_name);
-        let cached = cached_file_mtime(conn, cache_key);
+        let cached = cached_file_fingerprint(conn, cache_key);
 
         match (full.exists(), cached) {
-            (true, None) | (false, Some(_)) => true,
-            (false, None) => false,
-            (true, Some((secs, nanos))) => match file_mtime_parts(&full) {
-                Some((current_secs, current_nanos)) => {
-                    secs != current_secs || nanos != current_nanos
+            (true, None) | (false, Some(_)) => return true,
+            (false, None) => {}
+            (true, Some((secs, nanos, content_hash))) => {
+                match file_freshness(&full, secs, nanos, content_hash.as_deref()) {
+                    Some(FileFreshness::Fresh) => {}
+                    Some(FileFreshness::FreshWithUpdatedFingerprint {
+                        secs,
+                        nanos,
+                        content_hash,
+                    }) => {
+                        fingerprint_refreshes.push(FileFingerprintRefresh {
+                            path: (*cache_key).to_string(),
+                            mtime_secs: secs,
+                            mtime_nanos: nanos,
+                            content_hash,
+                        });
+                    }
+                    Some(FileFreshness::Stale) | None => return true,
                 }
-                None => true,
-            },
+            }
         }
-    })
+    }
+
+    refresh_file_fingerprints_best_effort(conn, &fingerprint_refreshes);
+    false
 }
 
 pub fn manifest_entry_count(conn: &Connection) -> i64 {
@@ -546,12 +565,12 @@ pub fn refresh_manifest_entries(tx: &Transaction<'_>, root: &Path) -> Result<(),
     }
 
     let mut insert = tx.prepare(
-        "INSERT OR REPLACE INTO files (path, mtime_secs, mtime_nanos, content_hash) VALUES (?1, ?2, ?3, NULL)",
+        "INSERT OR REPLACE INTO files (path, mtime_secs, mtime_nanos, content_hash) VALUES (?1, ?2, ?3, ?4)",
     )?;
     for (file_name, cache_key) in CACHE_MANIFEST_FILES {
         let full = root.join(file_name);
-        if let Some((secs, nanos)) = file_mtime_parts(&full) {
-            insert.execute(params![cache_key, secs, nanos])?;
+        if let Some((secs, nanos, content_hash)) = file_fingerprint(&full) {
+            insert.execute(params![cache_key, secs, nanos, content_hash])?;
         }
     }
 

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -184,6 +184,14 @@ impl SemServer {
     }
 
     fn find_supported_files(root: &Path, registry: &ParserRegistry) -> Result<Vec<String>, String> {
+        Self::find_supported_files_with_options(root, registry, false)
+    }
+
+    fn find_supported_files_with_options(
+        root: &Path,
+        registry: &ParserRegistry,
+        no_default_excludes: bool,
+    ) -> Result<Vec<String>, String> {
         if !root.exists() {
             return Err(format!(
                 "Failed to read directory {}: No such file or directory",
@@ -201,6 +209,7 @@ impl SemServer {
         if semignore.exists() {
             builder.add_ignore(semignore);
         }
+        Self::prune_default_excluded_dirs(&mut builder, root, no_default_excludes);
         let walker = builder.build();
         for entry in walker.flatten() {
             let path = entry.path();
@@ -209,7 +218,9 @@ impl SemServer {
             }
             if let Ok(rel) = path.strip_prefix(root) {
                 let rel_str = rel.to_string_lossy().replace('\\', "/");
-                if is_default_excluded(&rel_str) || is_probably_binary_path(&rel_str) {
+                if (!no_default_excludes && is_default_excluded(&rel_str))
+                    || is_probably_binary_path(&rel_str)
+                {
                     continue;
                 }
                 if registry.get_plugin(&rel_str).is_none() {
@@ -226,10 +237,11 @@ impl SemServer {
     }
 
     /// Walk a subdirectory, returning paths relative to `prefix_root` (e.g. the repo root).
-    fn walk_dir_files(
+    fn walk_dir_files_with_options(
         dir: &Path,
         prefix_root: &Path,
         registry: &ParserRegistry,
+        no_default_excludes: bool,
     ) -> Result<Vec<String>, String> {
         let mut files = Vec::new();
         let mut builder = ignore::WalkBuilder::new(dir);
@@ -242,6 +254,7 @@ impl SemServer {
         if semignore.exists() {
             builder.add_ignore(semignore);
         }
+        Self::prune_default_excluded_dirs(&mut builder, prefix_root, no_default_excludes);
         let walker = builder.build();
         for entry in walker.flatten() {
             let path = entry.path();
@@ -250,7 +263,9 @@ impl SemServer {
             }
             if let Ok(rel) = path.strip_prefix(prefix_root) {
                 let rel_str = rel.to_string_lossy().replace('\\', "/");
-                if is_default_excluded(&rel_str) || is_probably_binary_path(&rel_str) {
+                if (!no_default_excludes && is_default_excluded(&rel_str))
+                    || is_probably_binary_path(&rel_str)
+                {
                     continue;
                 }
                 if registry.get_plugin(&rel_str).is_none() {
@@ -264,6 +279,32 @@ impl SemServer {
         }
         files.sort();
         Ok(files)
+    }
+
+    fn prune_default_excluded_dirs(
+        builder: &mut ignore::WalkBuilder,
+        prefix_root: &Path,
+        no_default_excludes: bool,
+    ) {
+        if no_default_excludes {
+            return;
+        }
+
+        let prefix_root = prefix_root.to_path_buf();
+        builder.filter_entry(move |entry| {
+            if !entry
+                .file_type()
+                .is_some_and(|file_type| file_type.is_dir())
+            {
+                return true;
+            }
+
+            let Ok(rel) = entry.path().strip_prefix(&prefix_root) else {
+                return true;
+            };
+            let rel_str = rel.to_string_lossy().replace('\\', "/");
+            !is_default_excluded(&rel_str)
+        });
     }
 
     fn read_file_at(abs_path: &Path, display_path: &str) -> Result<String, String> {
@@ -372,6 +413,7 @@ impl SemServer {
         &self,
         repo_root: &Path,
         file_paths: &[String],
+        source_scope: cache::CacheSourceScope,
     ) -> (Arc<EntityGraph>, Arc<Vec<SemanticEntity>>) {
         let manifest_hash = cache::compute_manifest_hash(repo_root, file_paths).unwrap_or(0);
 
@@ -388,7 +430,9 @@ impl SemServer {
         // Check SQLite cache (full hit, then incremental)
         if let Ok(disk) = cache::DiskCache::open(repo_root) {
             // Full cache hit
-            if let Some((graph, entities)) = disk.load(repo_root, file_paths) {
+            if let Some((graph, entities)) =
+                disk.load_with_source_scope(repo_root, file_paths, source_scope)
+            {
                 let graph = Arc::new(graph);
                 let entities = Arc::new(entities);
                 let mut guard = self.graph_cache.lock().await;
@@ -406,7 +450,9 @@ impl SemServer {
             }
 
             // Incremental: load clean cached data, rebuild only stale files
-            if let Some(partial) = disk.load_partial(repo_root, file_paths) {
+            if let Some(partial) =
+                disk.load_partial_with_source_scope(repo_root, file_paths, source_scope)
+            {
                 let (graph, entities, metadata) =
                     EntityGraph::build_incremental_with_metadata_and_import_candidates(
                         repo_root,
@@ -427,6 +473,7 @@ impl SemServer {
                     metadata.repaired_clean_entity_ids,
                     &metadata.recomputed_edge_source_ids,
                     &metadata.deleted_entity_ids,
+                    source_scope,
                 );
 
                 let graph = Arc::new(graph);
@@ -451,7 +498,7 @@ impl SemServer {
 
         // Persist to SQLite (best-effort)
         if let Ok(disk) = cache::DiskCache::open(repo_root) {
-            let _ = disk.save(repo_root, file_paths, &graph, &entities);
+            let _ = disk.save(repo_root, file_paths, &graph, &entities, source_scope);
         }
 
         let graph = Arc::new(graph);
@@ -481,6 +528,7 @@ impl SemServer {
         &self,
         repo_root: &Path,
         file_paths: &[String],
+        source_scope: cache::CacheSourceScope,
     ) -> Arc<EntityGraph> {
         let manifest_hash = cache::compute_manifest_hash(repo_root, file_paths).unwrap_or(0);
 
@@ -503,7 +551,9 @@ impl SemServer {
         }
 
         if let Ok(disk) = cache::DiskCache::open(repo_root) {
-            if let Some(graph) = disk.load_graph_topology(repo_root, file_paths) {
+            if let Some(graph) =
+                disk.load_graph_topology_with_source_scope(repo_root, file_paths, source_scope)
+            {
                 let graph = Arc::new(graph);
                 let mut guard = self.topology_cache.lock().await;
                 *guard = Some(CachedTopology {
@@ -514,8 +564,18 @@ impl SemServer {
             }
         }
 
-        let (graph, _) = self.get_or_build_graph(repo_root, file_paths).await;
+        let (graph, _) = self
+            .get_or_build_graph(repo_root, file_paths, source_scope)
+            .await;
         graph
+    }
+
+    fn cache_source_scope(repo_root: &Path, no_default_excludes: bool) -> cache::CacheSourceScope {
+        if no_default_excludes || repo_root.join(".semignore").exists() {
+            cache::CacheSourceScope::Custom
+        } else {
+            cache::CacheSourceScope::Default
+        }
     }
 
     /// Ensure the in-memory whole-repo caches are fresh with respect to the file
@@ -567,17 +627,17 @@ impl SemServer {
 
         // Rebuild (incrementally, via the disk cache) and repopulate the memory
         // caches that live_graph / live_topology read from.
-        let _ = self.get_or_build_graph(repo_root, &file_paths).await;
+        let source_scope = Self::cache_source_scope(repo_root, false);
+        let _ = self
+            .get_or_build_graph(repo_root, &file_paths, source_scope)
+            .await;
         slot.last_built_generation = drained.generation;
         slot.built_once = true;
         Some(file_paths)
     }
 
     /// Whole-repo (graph, entities), kept hot by the file watcher when active.
-    async fn live_graph(
-        &self,
-        repo_root: &Path,
-    ) -> (Arc<EntityGraph>, Arc<Vec<SemanticEntity>>) {
+    async fn live_graph(&self, repo_root: &Path) -> (Arc<EntityGraph>, Arc<Vec<SemanticEntity>>) {
         if self.ensure_live(repo_root).await.is_some() {
             let guard = self.graph_cache.lock().await;
             if let Some(ref cached) = *guard {
@@ -585,7 +645,9 @@ impl SemServer {
             }
         }
         let file_paths = Self::find_supported_files(repo_root, &self.registry).unwrap_or_default();
-        self.get_or_build_graph(repo_root, &file_paths).await
+        let source_scope = Self::cache_source_scope(repo_root, false);
+        self.get_or_build_graph(repo_root, &file_paths, source_scope)
+            .await
     }
 
     /// Whole-repo graph topology, kept hot by the file watcher when active.
@@ -605,7 +667,9 @@ impl SemServer {
             }
         }
         let file_paths = Self::find_supported_files(repo_root, &self.registry).unwrap_or_default();
-        self.get_or_build_graph_topology(repo_root, &file_paths).await
+        let source_scope = Self::cache_source_scope(repo_root, false);
+        self.get_or_build_graph_topology(repo_root, &file_paths, source_scope)
+            .await
     }
 }
 
@@ -642,6 +706,12 @@ impl SemServer {
 
         let (rel_path, abs_path) = Self::resolve_file_path(&ctx.repo_root, path);
         let (entities, include_file) = if abs_path.is_file() {
+            if !params.no_default_excludes() && is_default_excluded(&rel_path) {
+                return Ok(tool_error(format!(
+                    "Path is excluded by default: {}",
+                    rel_path
+                )));
+            }
             let content = match Self::read_file_at(&abs_path, &rel_path) {
                 Ok(content) => content,
                 Err(err) => return Ok(tool_error(err)),
@@ -655,7 +725,12 @@ impl SemServer {
             }
             (entities, false)
         } else if abs_path.is_dir() {
-            let file_paths = match Self::walk_dir_files(&abs_path, &ctx.repo_root, &self.registry) {
+            let file_paths = match Self::walk_dir_files_with_options(
+                &abs_path,
+                &ctx.repo_root,
+                &self.registry,
+                params.no_default_excludes(),
+            ) {
                 Ok(file_paths) => file_paths,
                 Err(err) => return Ok(tool_error(err)),
             };
@@ -856,6 +931,7 @@ impl SemServer {
         if self.registry.get_plugin(&rel_path).is_none() {
             return Ok(tool_error(format!("No parser for file: {}", rel_path)));
         }
+        let no_default_excludes = params.no_default_excludes.unwrap_or(false);
 
         let mode = params.mode.as_deref().unwrap_or("all");
         let valid_modes = ["all", "deps", "dependents", "tests"];
@@ -868,7 +944,21 @@ impl SemServer {
         }
 
         if matches!(mode, "deps" | "dependents") {
-            let graph = self.live_topology(&ctx.repo_root).await;
+            let graph = if no_default_excludes {
+                let file_paths = match Self::find_supported_files_with_options(
+                    &ctx.repo_root,
+                    &self.registry,
+                    no_default_excludes,
+                ) {
+                    Ok(file_paths) => file_paths,
+                    Err(err) => return Ok(tool_error(err)),
+                };
+                let source_scope = Self::cache_source_scope(&ctx.repo_root, no_default_excludes);
+                self.get_or_build_graph_topology(&ctx.repo_root, &file_paths, source_scope)
+                    .await
+            } else {
+                self.live_topology(&ctx.repo_root).await
+            };
             let entity_id = match Self::find_entity_in_graph(&graph, &params.entity_name, &rel_path)
             {
                 Ok(entity_id) => entity_id,
@@ -920,7 +1010,21 @@ impl SemServer {
             )]));
         }
 
-        let (graph, all_entities) = self.live_graph(&ctx.repo_root).await;
+        let (graph, all_entities) = if no_default_excludes {
+            let file_paths = match Self::find_supported_files_with_options(
+                &ctx.repo_root,
+                &self.registry,
+                no_default_excludes,
+            ) {
+                Ok(file_paths) => file_paths,
+                Err(err) => return Ok(tool_error(err)),
+            };
+            let source_scope = Self::cache_source_scope(&ctx.repo_root, no_default_excludes);
+            self.get_or_build_graph(&ctx.repo_root, &file_paths, source_scope)
+                .await
+        } else {
+            self.live_graph(&ctx.repo_root).await
+        };
 
         let entity_id = match Self::find_entity_in_graph(&graph, &params.entity_name, &rel_path) {
             Ok(entity_id) => entity_id,
@@ -929,7 +1033,11 @@ impl SemServer {
 
         let output = match mode {
             "tests" => {
-                let tests = graph.test_impact_with_custom_dirs(entity_id, &all_entities, &self.registry.custom_test_dirs);
+                let tests = graph.test_impact_with_custom_dirs(
+                    entity_id,
+                    &all_entities,
+                    &self.registry.custom_test_dirs,
+                );
                 let result: Vec<serde_json::Value> = tests
                     .iter()
                     .map(|d| {
@@ -953,7 +1061,11 @@ impl SemServer {
                 let deps = graph.get_dependencies(entity_id);
                 let dependents = graph.get_dependents(entity_id);
                 let impact = graph.impact_analysis(entity_id);
-                let tests = graph.test_impact_with_custom_dirs(entity_id, &all_entities, &self.registry.custom_test_dirs);
+                let tests = graph.test_impact_with_custom_dirs(
+                    entity_id,
+                    &all_entities,
+                    &self.registry.custom_test_dirs,
+                );
 
                 let map_entities =
                     |list: &[&sem_core::parser::graph::EntityInfo]| -> Vec<serde_json::Value> {
@@ -1141,8 +1253,23 @@ impl SemServer {
         if self.registry.get_plugin(&rel_path).is_none() {
             return Ok(tool_error(format!("No parser for file: {}", rel_path)));
         }
+        let no_default_excludes = params.no_default_excludes.unwrap_or(false);
 
-        let (graph, all_entities) = self.live_graph(&ctx.repo_root).await;
+        let (graph, all_entities) = if no_default_excludes {
+            let file_paths = match Self::find_supported_files_with_options(
+                &ctx.repo_root,
+                &self.registry,
+                no_default_excludes,
+            ) {
+                Ok(file_paths) => file_paths,
+                Err(err) => return Ok(tool_error(err)),
+            };
+            let source_scope = Self::cache_source_scope(&ctx.repo_root, no_default_excludes);
+            self.get_or_build_graph(&ctx.repo_root, &file_paths, source_scope)
+                .await
+        } else {
+            self.live_graph(&ctx.repo_root).await
+        };
 
         let entity_id = match Self::find_entity_in_graph(&graph, &params.entity_name, &rel_path) {
             Ok(entity_id) => entity_id,
@@ -1501,10 +1628,31 @@ mod tests {
     fn find_supported_files_skips_binary_and_default_excludes() {
         let root = temp_dir();
         fs::create_dir_all(root.join("src")).unwrap();
+        fs::create_dir_all(root.join("src/generated")).unwrap();
         fs::create_dir_all(root.join("dist")).unwrap();
         fs::write(root.join("src/app.js"), "export function app() {}\n").unwrap();
         fs::write(root.join("src/blob.weird"), b"abc\0def").unwrap();
         fs::write(root.join("src/icon.png"), b"\x89PNG\r\n").unwrap();
+        fs::write(
+            root.join("src/generated/schema.ts"),
+            "export function generatedSchema() {}\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("src/api.generated.ts"),
+            "export function generatedApi() {}\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("src/styles.module.scss.d.ts"),
+            "declare const styles: Record<string, string>;\nexport default styles;\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("src/logo.svg.d.ts"),
+            "declare const src: string;\nexport default src;\n",
+        )
+        .unwrap();
         fs::write(
             root.join("dist/generated.js"),
             "export function generated() {}\n",
@@ -1515,6 +1663,17 @@ mod tests {
         let files = SemServer::find_supported_files(&root, &registry).unwrap();
 
         assert_eq!(files, vec!["src/app.js".to_string()]);
+
+        let files_with_generated =
+            SemServer::find_supported_files_with_options(&root, &registry, true).unwrap();
+        assert!(files_with_generated.contains(&"src/app.js".to_string()));
+        assert!(files_with_generated.contains(&"src/generated/schema.ts".to_string()));
+        assert!(files_with_generated.contains(&"src/api.generated.ts".to_string()));
+        assert!(files_with_generated.contains(&"src/styles.module.scss.d.ts".to_string()));
+        assert!(files_with_generated.contains(&"src/logo.svg.d.ts".to_string()));
+        assert!(files_with_generated.contains(&"dist/generated.js".to_string()));
+        assert!(!files_with_generated.contains(&"src/blob.weird".to_string()));
+        assert!(!files_with_generated.contains(&"src/icon.png".to_string()));
 
         fs::remove_dir_all(root).unwrap();
     }
@@ -1578,11 +1737,55 @@ mod tests {
         let result = server
             .sem_entities(Parameters(EntitiesParams {
                 path: Some(missing_path.display().to_string()),
+                no_default_excludes: None,
             }))
             .await
             .unwrap();
 
         assert_tool_error(result, "Path not found:");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn sem_entities_can_opt_into_generated_file_path() {
+        let root = temp_git_repo("generated-entities-file");
+        std::fs::create_dir_all(root.join("src/generated")).unwrap();
+        std::fs::write(
+            root.join("src/generated/schema.ts"),
+            "export function generatedTarget() { return 1; }\n",
+        )
+        .unwrap();
+        let server = server_for_repo(&root).await;
+
+        let default_result = server
+            .sem_entities(Parameters(EntitiesParams {
+                path: Some("src/generated/schema.ts".to_string()),
+                no_default_excludes: None,
+            }))
+            .await
+            .unwrap();
+        assert_tool_error(default_result, "Path is excluded by default:");
+
+        let opt_in_result = server
+            .sem_entities(Parameters(EntitiesParams {
+                path: Some("src/generated/schema.ts".to_string()),
+                no_default_excludes: Some(true),
+            }))
+            .await
+            .unwrap();
+
+        let text = match &opt_in_result.content.first().unwrap().raw {
+            rmcp::model::RawContent::Text(text) => &text.text,
+            other => panic!("expected text content, got {other:?}"),
+        };
+        let payload: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert!(
+            payload.as_array().unwrap().iter().any(|entity| {
+                entity["name"] == "generatedTarget" && entity["type"] == "function"
+            }),
+            "generated target should be returned when default excludes are disabled: {payload}"
+        );
+
         let _ = std::fs::remove_dir_all(root);
     }
 
@@ -1678,6 +1881,7 @@ mod tests {
                 file_path: file_path.display().to_string(),
                 entity_name: "nonexistent_zzz".to_string(),
                 mode: None,
+                no_default_excludes: None,
             }))
             .await
             .unwrap();
@@ -1697,6 +1901,7 @@ mod tests {
                 file_path: file_path.display().to_string(),
                 entity_name: "anything".to_string(),
                 mode: None,
+                no_default_excludes: None,
             }))
             .await
             .unwrap();
@@ -1722,6 +1927,7 @@ mod tests {
                 file_path: file_path.display().to_string(),
                 entity_name: "known_entity".to_string(),
                 mode: None,
+                no_default_excludes: None,
             }))
             .await
             .unwrap();
@@ -1748,6 +1954,71 @@ mod tests {
                 file_path: "./sample.py".to_string(),
                 entity_name: "known_entity".to_string(),
                 mode: Some("deps".to_string()),
+                no_default_excludes: None,
+            }))
+            .await
+            .unwrap();
+
+        assert_tool_success(result);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn sem_impact_can_opt_into_generated_files() {
+        let root = temp_git_repo("generated-impact-file");
+        std::fs::create_dir_all(root.join("src/generated")).unwrap();
+        std::fs::write(
+            root.join("src/generated/schema.ts"),
+            "export function generatedTarget() { return 1; }\n",
+        )
+        .unwrap();
+        let server = server_for_repo(&root).await;
+
+        let default_result = server
+            .sem_impact(Parameters(ImpactAnalysisParams {
+                file_path: "src/generated/schema.ts".to_string(),
+                entity_name: "generatedTarget".to_string(),
+                mode: Some("deps".to_string()),
+                no_default_excludes: None,
+            }))
+            .await
+            .unwrap();
+        assert_tool_error(
+            default_result,
+            "Entity 'generatedTarget' not found in 'src/generated/schema.ts'",
+        );
+
+        let opt_in_result = server
+            .sem_impact(Parameters(ImpactAnalysisParams {
+                file_path: "src/generated/schema.ts".to_string(),
+                entity_name: "generatedTarget".to_string(),
+                mode: Some("deps".to_string()),
+                no_default_excludes: Some(true),
+            }))
+            .await
+            .unwrap();
+
+        assert_tool_success(opt_in_result);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn sem_context_can_opt_into_generated_files() {
+        let root = temp_git_repo("generated-context-file");
+        std::fs::create_dir_all(root.join("src/generated")).unwrap();
+        std::fs::write(
+            root.join("src/generated/schema.ts"),
+            "export function generatedTarget() { return 1; }\n",
+        )
+        .unwrap();
+        let server = server_for_repo(&root).await;
+
+        let result = server
+            .sem_context(Parameters(ContextParams {
+                file_path: "src/generated/schema.ts".to_string(),
+                entity_name: "generatedTarget".to_string(),
+                token_budget: Some(2000),
+                no_default_excludes: Some(true),
             }))
             .await
             .unwrap();
@@ -1773,6 +2044,7 @@ mod tests {
                 file_path: file_path.display().to_string(),
                 entity_name: "known_entity".to_string(),
                 token_budget: None,
+                no_default_excludes: None,
             }))
             .await
             .unwrap();
@@ -1796,6 +2068,7 @@ mod tests {
                 file_path: file_path.display().to_string(),
                 entity_name: "nonexistent_zzz".to_string(),
                 token_budget: None,
+                no_default_excludes: None,
             }))
             .await
             .unwrap();
@@ -1839,6 +2112,7 @@ mod tests {
                 file_path: file_path.display().to_string(),
                 entity_name: "known_entity".to_string(),
                 mode: Some("invalid".to_string()),
+                no_default_excludes: None,
             }))
             .await
             .unwrap();

--- a/crates/sem-mcp/src/tools.rs
+++ b/crates/sem-mcp/src/tools.rs
@@ -7,11 +7,19 @@ use serde::Deserialize;
 pub struct EntitiesParams {
     #[schemars(description = "Optional path to a file or directory. If omitted, defaults to '.'.")]
     pub path: Option<String>,
+    #[schemars(
+        description = "Include files and directories excluded by default, including generated, fixture, vendor, and benchmark paths."
+    )]
+    pub no_default_excludes: Option<bool>,
 }
 
 impl EntitiesParams {
     pub fn path(&self) -> Option<&str> {
         self.path.as_deref().filter(|p| !p.is_empty())
+    }
+
+    pub fn no_default_excludes(&self) -> bool {
+        self.no_default_excludes.unwrap_or(false)
     }
 }
 
@@ -46,6 +54,10 @@ pub struct ImpactAnalysisParams {
         description = "Analysis mode: 'all' (default, shows deps + dependents + transitive impact + tests), 'deps' (direct dependencies only), 'dependents' (direct dependents only), 'tests' (affected test entities only)"
     )]
     pub mode: Option<String>,
+    #[schemars(
+        description = "Include files and directories excluded by default, including generated, fixture, vendor, and benchmark paths."
+    )]
+    pub no_default_excludes: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -68,6 +80,10 @@ pub struct ContextParams {
     pub entity_name: String,
     #[schemars(description = "Maximum token budget. Defaults to 8000.")]
     pub token_budget: Option<usize>,
+    #[schemars(
+        description = "Include files and directories excluded by default, including generated, fixture, vendor, and benchmark paths."
+    )]
+    pub no_default_excludes: Option<bool>,
 }
 
 #[cfg(test)]
@@ -103,6 +119,7 @@ mod tests {
             serde_json::from_value(serde_json::json!({ "path": "src/lib.rs" })).unwrap();
 
         assert_eq!(params.path(), Some("src/lib.rs"));
+        assert!(!params.no_default_excludes());
     }
 
     #[test]
@@ -110,6 +127,15 @@ mod tests {
         let params: EntitiesParams = serde_json::from_value(serde_json::json!({})).unwrap();
 
         assert_eq!(params.path(), None);
+        assert!(!params.no_default_excludes());
+    }
+
+    #[test]
+    fn entities_params_accepts_no_default_excludes() {
+        let params: EntitiesParams =
+            serde_json::from_value(serde_json::json!({ "no_default_excludes": true })).unwrap();
+
+        assert!(params.no_default_excludes());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a cache-first `impact --deps` attempt that uses Git-backed source-set discovery before the full filesystem walker
- allow deps cache hits when unrelated files changed, while missing on source-set changes, target/dependency/import changes, deleted files, skip-worktree holes, and broken source symlinks
- store manifest content hashes and topology `file_imports`, and use indexed import metadata before falling back to a HashSet-backed import resolver for legacy empty import tables

## Validation
- `cargo test -p sem-core js_ts_import_source_files`
- `cargo test -p sem-cli`
- `cargo test -p sem-mcp cache`
- `cargo check -p sem-cli`
- `cargo build --release -p sem-cli`
- `git diff --check`
- subagent code-review and database/performance follow-ups reported no remaining findings

## Metrics
Target: `impact_command` in `crates/sem-cli/src/commands/impact.rs` with a temp cache and `SEM_TIMINGS=json`.

- cold internal time: 374.5ms
- warm internal time: 106.1ms
- warm SQL query phase: 0.40ms
- warm path avoids full `file_discovery`; remaining time is the conservative Git source-set proof
- cold/warm JSON output diff: empty

Notion cache probe: the copied existing `notion-next` topology cache is stale by source set, so the conservative path correctly misses rather than returning cached output. The current checkout has ~110k Git-listed entries and the copied cache has ~93.7k source rows.