### PR TITLE
Fix MCP entity resolution on Windows (forward-slash relative paths)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to sem are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- On Windows, the MCP tools `sem_impact`, `sem_context`, and `sem_log` never resolved an entity: `resolve_file_path` returned OS-native (backslash) relative paths while graph entities store forward-slash `file_path`s, so the `(name, file_path)` match always failed. Relative paths are now emitted with forward slashes on all platforms.
+
 ## [0.12.0] - 2026-06-15
 
 ### Added

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -154,13 +154,13 @@ impl SemServer {
                 .or_else(|| canonical_relative_path(repo_root, p))
                 .map(|path| normalize_relative_path(&path));
             let relative = relative_path
-                .map(|r| r.to_string_lossy().to_string())
-                .unwrap_or_else(|| file_path.to_string());
+                .map(|r| path_to_slash(&r))
+                .unwrap_or_else(|| file_path.replace('\\', "/"));
             (relative, p.to_path_buf())
         } else {
             let abs_path = repo_root.join(file_path);
             let relative_path = normalize_relative_path(p);
-            (relative_path.to_string_lossy().to_string(), abs_path)
+            (path_to_slash(&relative_path), abs_path)
         }
     }
 
@@ -1552,6 +1552,23 @@ mod tests {
         let _ = std::fs::remove_dir_all(root);
     }
 
+    #[test]
+    fn path_to_slash_converts_backslashes() {
+        assert_eq!(path_to_slash(Path::new("a\\b\\c.py")), "a/b/c.py");
+        assert_eq!(path_to_slash(Path::new("a/b/c.py")), "a/b/c.py");
+    }
+
+    #[test]
+    fn resolve_file_path_returns_forward_slashes() {
+        let root = temp_git_repo("forward-slash-relative");
+
+        let (rel_path, _) = SemServer::resolve_file_path(&root, "src/inner/file.py");
+
+        assert_eq!(rel_path, "src/inner/file.py");
+        assert!(!rel_path.contains('\\'));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
     #[tokio::test]
     async fn sem_entities_returns_tool_error_for_missing_path() {
         let root = temp_git_repo("missing-path");
@@ -1930,6 +1947,11 @@ fn normalize_relative_path(path: &Path) -> PathBuf {
     } else {
         normalized
     }
+}
+
+// Graph entity `file_path`s are forward-slash, so relative paths must be too or lookups miss on Windows.
+fn path_to_slash(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Fixes #366.

## Problem

On Windows, the MCP tools `sem_impact`, `sem_context`, and `sem_log` fail to resolve any entity, always returning `Entity '<name>' not found in '<file>' (existing candidates: <file>)` — including for entities `sem_entities` lists and the CLI resolves.

`resolve_file_path` (crates/sem-mcp/src/server.rs) stringifies a normalized `PathBuf` with `to_string_lossy()`, which yields backslashes on Windows. Graph `EntityInfo.file_path` is forward-slash. `find_entity_in_graph` compares them with `==`, so the match never succeeds on Windows. The CLI is unaffected because its `--file` hint is optional and compared raw.

## Fix

Emit relative paths from `resolve_file_path` with forward slashes via a `path_to_slash` helper. `abs_path` stays OS-native for file reads. On Unix `to_string_lossy()` contains no `\`, so output is unchanged.

## Tests

- `path_to_slash_converts_backslashes` — exercises the conversion on every platform.
- `resolve_file_path_returns_forward_slashes` — asserts no backslash in the returned relative path.

## CHANGELOG

Added a `Fixed` entry under `## [Unreleased]`.

## Note

I don't have a Rust toolchain on hand and have not compiled or run the tests locally. The change is mechanical; please run `cd crates && cargo test` and `cargo fmt`/`clippy` in CI.
