### PR TITLE
Exclude generated sources from default impact scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to sem are documented in this file.
 
 - `sem impact --deps` can reuse fresh caches when unrelated files change by validating the cached source set, hashes, and import metadata before falling back to a graph rebuild.
 - `sem impact --deps` narrows cache freshness checks to the queried entity, direct dependencies, and relevant JavaScript/TypeScript imports when the query scope is explicit.
+- Source scans skip default-excluded high-volume paths such as generated source directories, fixture/vendor/benchmark trees, generated file suffixes, CSS module declarations, and asset declarations; pass `--no-default-excludes` to include them.
 
 ## [0.13.0] - 2026-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@ All notable changes to sem are documented in this file.
 ### Added
 
 - `sem impact` can answer direct dependency queries from a fresh SQL topology cache without rebuilding the entity graph.
+- `sem entities` reports phase timings and listing counters when `SEM_TIMINGS` is enabled.
 
 ### Changed
 
 - `sem impact --deps` can reuse fresh caches when unrelated files change by validating the cached source set, hashes, and import metadata before falling back to a graph rebuild.
 - `sem impact --deps` narrows cache freshness checks to the queried entity, direct dependencies, and relevant JavaScript/TypeScript imports when the query scope is explicit.
 - Source scans skip default-excluded high-volume paths such as generated source directories, fixture/vendor/benchmark trees, generated file suffixes, CSS module declarations, and asset declarations; pass `--no-default-excludes` to include them.
+- `sem entities` accepts `--file-exts` for large directory scans and avoids duplicate directory-listing post-processing.
+- `sem entities` can list entities from a fresh SQLite topology cache instead of reparsing matching directory scans.
+- `sem entities --json` streams rows to stdout instead of materializing an intermediate JSON value array.
+- `sem entities` uses listing-only extraction so local listings do not retain source text or entity hashes.
 
 ## [0.13.0] - 2026-06-16
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ sem impact authenticateUser --json
 # Disambiguate by file
 sem impact authenticateUser --file src/auth.ts
 
-# Include generated/build directories that repo-wide scans skip by default
+# Include default-excluded paths such as generated, fixture, vendor, benchmark, and build trees
 sem impact authenticateUser --no-default-excludes
 ```
 
@@ -220,7 +220,7 @@ sem entities src/auth.ts
 sem entities --json
 sem entities src/auth.ts --json
 
-# Include generated/build directories that repo-wide scans skip by default
+# Include default-excluded paths such as generated, fixture, vendor, benchmark, and build trees
 sem entities --no-default-excludes
 ```
 
@@ -238,7 +238,7 @@ sem context authenticateUser --budget 4000
 # JSON output
 sem context authenticateUser --json
 
-# Include generated/build directories that repo-wide scans skip by default
+# Include default-excluded paths such as generated, fixture, vendor, benchmark, and build trees
 sem context authenticateUser --no-default-excludes
 ```
 

--- a/crates/sem-cli/src/cache.rs
+++ b/crates/sem-cli/src/cache.rs
@@ -9,6 +9,7 @@ use sem_core::parser::{
     js_ts_has_default_re_export_from_content,
     js_ts_import_source_files_from_filesystem_with_unscoped,
 };
+use sem_core::utils::scan::is_default_excluded;
 use sem_mcp::cache as shared_cache;
 
 const CACHED_TEST_IMPACT_LIMIT: usize = 10_000;
@@ -233,12 +234,22 @@ impl DiskCache {
         Ok(())
     }
 
+    #[cfg(test)]
     pub fn load(
         &self,
         root: &Path,
         files: &[String],
     ) -> Option<(EntityGraph, Vec<SemanticEntity>)> {
-        if !self.has_fresh_complete_cache(root, files) {
+        self.load_with_source_scope(root, files, shared_cache::CacheSourceScope::Default)
+    }
+
+    pub fn load_with_source_scope(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+    ) -> Option<(EntityGraph, Vec<SemanticEntity>)> {
+        if !self.has_fresh_complete_cache(root, files, source_scope) {
             return None;
         }
 
@@ -313,20 +324,48 @@ impl DiskCache {
     }
 
     /// Load only graph topology from a fresh cache.
+    #[cfg(test)]
     pub fn load_graph_topology(&self, root: &Path, files: &[String]) -> Option<EntityGraph> {
-        if !self.has_fresh_topology_cache(root, files) {
+        self.load_graph_topology_with_source_scope(
+            root,
+            files,
+            shared_cache::CacheSourceScope::Default,
+        )
+    }
+
+    pub fn load_graph_topology_with_source_scope(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+    ) -> Option<EntityGraph> {
+        if !self.has_fresh_topology_cache(root, files, source_scope) {
             return None;
         }
 
         self.load_graph_topology_rows()
     }
 
+    #[cfg(test)]
     pub fn load_graph_topology_with_test_ids(
         &self,
         root: &Path,
         files: &[String],
     ) -> Option<(EntityGraph, HashSet<String>)> {
-        if !self.has_fresh_topology_only_cache(root, files) {
+        self.load_graph_topology_with_test_ids_and_source_scope(
+            root,
+            files,
+            shared_cache::CacheSourceScope::Default,
+        )
+    }
+
+    pub fn load_graph_topology_with_test_ids_and_source_scope(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+    ) -> Option<(EntityGraph, HashSet<String>)> {
+        if !self.has_fresh_topology_only_cache(root, files, source_scope) {
             return None;
         }
 
@@ -341,6 +380,7 @@ impl DiskCache {
         &self,
         root: &Path,
         files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
         cache_first: bool,
         entity_name: Option<&str>,
         entity_id: Option<&str>,
@@ -368,6 +408,7 @@ impl DiskCache {
             return self.query_dependency_impact_topology(
                 root,
                 files,
+                source_scope,
                 cache_first,
                 entity_name,
                 entity_id,
@@ -375,7 +416,7 @@ impl DiskCache {
             );
         }
 
-        if !self.has_fresh_cache(root, files) {
+        if !self.has_fresh_cache(root, files, source_scope) {
             return Ok(None);
         }
 
@@ -445,6 +486,7 @@ impl DiskCache {
         &self,
         root: &Path,
         files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
         cache_first: bool,
         entity_name: Option<&str>,
         entity_id: Option<&str>,
@@ -458,7 +500,7 @@ impl DiskCache {
             if !shared_cache::cache_has_default_source_scope(&self.conn) {
                 return Ok(None);
             }
-        } else if !self.has_fresh_cache(root, files) {
+        } else if !self.has_fresh_cache(root, files, source_scope) {
             return Ok(None);
         }
 
@@ -965,9 +1007,10 @@ impl DiskCache {
         &self,
         root: &Path,
         files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
         mut writer: W,
     ) -> std::io::Result<bool> {
-        if !self.has_fresh_topology_cache(root, files) {
+        if !self.has_fresh_topology_cache(root, files, source_scope) {
             return Ok(false);
         }
 
@@ -1052,15 +1095,25 @@ impl DiskCache {
         Ok(true)
     }
 
-    fn has_fresh_complete_cache(&self, root: &Path, files: &[String]) -> bool {
+    fn has_fresh_complete_cache(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+    ) -> bool {
         if !shared_cache::cache_has_kind(&self.conn, &[shared_cache::CACHE_KIND_FULL]) {
             return false;
         }
 
-        self.has_fresh_cache(root, files)
+        self.has_fresh_cache(root, files, source_scope)
     }
 
-    fn has_fresh_topology_cache(&self, root: &Path, files: &[String]) -> bool {
+    fn has_fresh_topology_cache(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+    ) -> bool {
         if !shared_cache::cache_has_kind(
             &self.conn,
             &[
@@ -1071,18 +1124,32 @@ impl DiskCache {
             return false;
         }
 
-        self.has_fresh_cache(root, files)
+        self.has_fresh_cache(root, files, source_scope)
     }
 
-    fn has_fresh_topology_only_cache(&self, root: &Path, files: &[String]) -> bool {
+    fn has_fresh_topology_only_cache(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+    ) -> bool {
         if !shared_cache::cache_has_kind(&self.conn, &[shared_cache::CACHE_KIND_TOPOLOGY]) {
             return false;
         }
 
-        self.has_fresh_cache(root, files)
+        self.has_fresh_cache(root, files, source_scope)
     }
 
-    fn has_fresh_cache(&self, root: &Path, files: &[String]) -> bool {
+    fn has_fresh_cache(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+    ) -> bool {
+        if !shared_cache::cache_has_source_scope(&self.conn, source_scope) {
+            return false;
+        }
+
         if shared_cache::is_manifest_stale(&self.conn, root) {
             return false;
         }
@@ -1181,8 +1248,22 @@ impl DiskCache {
 
     /// Load a partial cache: identify stale files and return clean cached data.
     /// Returns None if cache is empty or ALL files are stale (full rebuild is better).
+    #[cfg(test)]
     pub fn load_partial(&self, root: &Path, files: &[String]) -> Option<PartialCache> {
+        self.load_partial_with_source_scope(root, files, shared_cache::CacheSourceScope::Default)
+    }
+
+    pub fn load_partial_with_source_scope(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+    ) -> Option<PartialCache> {
         if !shared_cache::cache_has_kind(&self.conn, &[shared_cache::CACHE_KIND_FULL]) {
+            return None;
+        }
+
+        if !shared_cache::cache_has_source_scope(&self.conn, source_scope) {
             return None;
         }
 
@@ -1371,6 +1452,7 @@ impl DiskCache {
         repair_changed_clean_entity_ids: bool,
         recomputed_edge_source_ids: &[String],
         deleted_entity_ids: &[String],
+        source_scope: shared_cache::CacheSourceScope,
     ) -> Result<(), rusqlite::Error> {
         let source_stale_files: Vec<&String> = stale_files
             .iter()
@@ -1580,6 +1662,7 @@ impl DiskCache {
         }
 
         shared_cache::set_cache_kind(&tx, shared_cache::CACHE_KIND_FULL)?;
+        shared_cache::set_cache_source_scope(&tx, source_scope)?;
         tx.commit()?;
         Ok(())
     }
@@ -1628,7 +1711,10 @@ fn current_imported_files(
     if has_unscoped_imports || !is_js_ts_cache_freshness_supported(file_path) {
         return Ok(None);
     }
-    let files = files.into_iter().collect();
+    let files = files
+        .into_iter()
+        .filter(|file| !is_default_excluded(file))
+        .collect();
     Ok(Some(CurrentImports {
         files,
         has_default_re_export: js_ts_has_default_re_export_from_content(&content),
@@ -1855,7 +1941,12 @@ mod tests {
 
         let mut output = Vec::new();
         assert!(cache
-            .write_graph_json_topology(&root, &files, &mut output)
+            .write_graph_json_topology(
+                &root,
+                &files,
+                shared_cache::CacheSourceScope::Default,
+                &mut output
+            )
             .unwrap());
         let value: serde_json::Value = serde_json::from_slice(&output).unwrap();
 
@@ -1921,7 +2012,12 @@ mod tests {
 
         let mut output = Vec::new();
         assert!(cache
-            .write_graph_json_topology(&root, &files, &mut output)
+            .write_graph_json_topology(
+                &root,
+                &files,
+                shared_cache::CacheSourceScope::Default,
+                &mut output
+            )
             .unwrap());
         let value: serde_json::Value = serde_json::from_slice(&output).unwrap();
         assert_eq!(
@@ -1983,6 +2079,131 @@ mod tests {
     }
 
     #[test]
+    fn cache_reuse_requires_matching_source_scope_and_incremental_preserves_it() {
+        let root = temp_repo_root("source-scope-cache-reuse");
+        write_file(&root.join("a.ts"), "export function a() { return 1; }\n");
+        write_file(&root.join("b.ts"), "export function b() { return a(); }\n");
+        let files = vec!["a.ts".to_string(), "b.ts".to_string()];
+        let entities = vec![
+            entity("a-id", "a.ts", "a", "export function a() { return 1; }"),
+            entity("b-id", "b.ts", "b", "export function b() { return a(); }"),
+        ];
+        let graph = graph_with_edges(&entities, vec![edge("b-id", "a-id")]);
+        let cache = DiskCache::open(&root).unwrap();
+
+        cache
+            .save(
+                &root,
+                &files,
+                &graph,
+                &entities,
+                shared_cache::CacheSourceScope::Custom,
+            )
+            .unwrap();
+
+        assert!(cache
+            .load_with_source_scope(&root, &files, shared_cache::CacheSourceScope::Default)
+            .is_none());
+        assert!(cache
+            .load_with_source_scope(&root, &files, shared_cache::CacheSourceScope::Custom)
+            .is_some());
+        assert!(cache
+            .load_partial_with_source_scope(&root, &files, shared_cache::CacheSourceScope::Default)
+            .is_none());
+
+        rewrite_after_mtime_tick(&root.join("b.ts"), "export function b() { return 2; }\n");
+        let partial = cache
+            .load_partial_with_source_scope(&root, &files, shared_cache::CacheSourceScope::Custom)
+            .unwrap();
+        assert_eq!(partial.stale_files, vec!["b.ts"]);
+
+        let updated_entities = vec![
+            entity("a-id", "a.ts", "a", "export function a() { return 1; }"),
+            entity("b-id", "b.ts", "b", "export function b() { return 2; }"),
+        ];
+        let updated_graph = graph_with_edges(&updated_entities, vec![]);
+        cache
+            .save_incremental_with_repair_metadata(
+                &root,
+                &files,
+                &partial.stale_files,
+                &updated_graph,
+                &updated_entities,
+                false,
+                &["b-id".to_string()],
+                &[],
+                shared_cache::CacheSourceScope::Custom,
+            )
+            .unwrap();
+
+        assert!(cache
+            .load_with_source_scope(&root, &files, shared_cache::CacheSourceScope::Default)
+            .is_none());
+        assert!(cache
+            .load_with_source_scope(&root, &files, shared_cache::CacheSourceScope::Custom)
+            .is_some());
+
+        drop(cache);
+        cleanup(root);
+    }
+
+    #[test]
+    fn cache_first_dependency_impact_ignores_default_excluded_imports() {
+        let root = temp_repo_root("impact-ignores-excluded-imports");
+        std::fs::create_dir_all(root.join("src/generated")).unwrap();
+        write_file(
+            &root.join("src/a.ts"),
+            "import { generated } from './generated/client';\nexport function target() { return generated(); }\n",
+        );
+        write_file(
+            &root.join("src/generated/client.ts"),
+            "export function generated() { return 1; }\n",
+        );
+        let files = vec!["src/a.ts".to_string()];
+        let entities = vec![entity(
+            "a-id",
+            "src/a.ts",
+            "target",
+            "export function target() { return generated(); }",
+        )];
+        let graph = graph_with_edges(&entities, vec![]);
+        let cache = DiskCache::open(&root).unwrap();
+
+        cache
+            .save_topology(
+                &root,
+                &files,
+                &graph,
+                &entities,
+                &[],
+                shared_cache::CacheSourceScope::Default,
+            )
+            .unwrap();
+
+        let result = cache
+            .query_impact_topology(
+                &root,
+                &[],
+                shared_cache::CacheSourceScope::Default,
+                true,
+                Some("target"),
+                None,
+                Some("src/a.ts"),
+                CachedImpactMode::Deps,
+                2,
+            )
+            .unwrap();
+
+        assert!(
+            result.is_some(),
+            "default-scoped cache-first deps should ignore imports outside the default source set"
+        );
+
+        drop(cache);
+        cleanup(root);
+    }
+
+    #[test]
     fn query_impact_topology_reads_cached_adjacency_without_graph_load() {
         let root = temp_repo_root("impact-topology-query");
         write_file(&root.join("a.rs"), "fn target() {}\n");
@@ -2038,6 +2259,7 @@ mod tests {
             .query_impact_topology(
                 &root,
                 &files,
+                shared_cache::CacheSourceScope::Default,
                 false,
                 Some("target"),
                 None,
@@ -2218,6 +2440,7 @@ mod tests {
             .query_impact_topology(
                 &root,
                 &files,
+                shared_cache::CacheSourceScope::Default,
                 false,
                 Some("root"),
                 None,
@@ -2395,6 +2618,7 @@ mod tests {
                 false,
                 &[],
                 &[],
+                shared_cache::CacheSourceScope::Default,
             )
             .unwrap();
         assert_eq!(file_import_count(&cache, "a.ts", "b.ts"), 0);
@@ -2617,6 +2841,7 @@ mod tests {
                 false,
                 &["stale-id".to_string()],
                 &[],
+                shared_cache::CacheSourceScope::Default,
             )
             .unwrap();
 
@@ -2667,6 +2892,7 @@ mod tests {
                 true,
                 &[],
                 &[],
+                shared_cache::CacheSourceScope::Default,
             )
             .unwrap();
 
@@ -2740,6 +2966,7 @@ mod tests {
                 false,
                 &["stale-id".to_string()],
                 &["old-target-id".to_string()],
+                shared_cache::CacheSourceScope::Default,
             )
             .unwrap();
 

--- a/crates/sem-cli/src/cache.rs
+++ b/crates/sem-cli/src/cache.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::path::Path;
 
-use rusqlite::{params, params_from_iter, Connection, OptionalExtension};
+use rusqlite::{params, params_from_iter, Connection, OpenFlags, OptionalExtension};
 use sem_core::model::entity::SemanticEntity;
 use sem_core::parser::graph::{EntityGraph, EntityInfo, EntityRef, RefType};
 use sem_core::parser::{
@@ -11,6 +11,7 @@ use sem_core::parser::{
 };
 use sem_core::utils::scan::is_default_excluded;
 use sem_mcp::cache as shared_cache;
+use serde::Serialize;
 
 const CACHED_TEST_IMPACT_LIMIT: usize = 10_000;
 const SQL_PARAM_CHUNK: usize = 500;
@@ -46,6 +47,18 @@ pub struct CachedImpactResult {
     pub tests_truncated: bool,
 }
 
+#[derive(Serialize)]
+struct EntityListingJsonRow<'a> {
+    name: &'a str,
+    #[serde(rename = "type")]
+    entity_type: &'a str,
+    start_line: usize,
+    end_line: usize,
+    parent_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    file: Option<&'a str>,
+}
+
 #[derive(Debug)]
 pub enum CachedImpactError {
     CacheReadFailed,
@@ -72,6 +85,17 @@ impl DiskCache {
 
         shared_cache::initialize_schema(&conn)?;
 
+        Ok(Self { conn })
+    }
+
+    pub fn open_existing_readonly(repo_root: &Path) -> Result<Self, rusqlite::Error> {
+        let db_path = shared_cache::cache_db_path(repo_root)
+            .ok_or_else(|| rusqlite::Error::InvalidPath(repo_root.to_path_buf()))?;
+        if !db_path.exists() {
+            return Err(rusqlite::Error::InvalidPath(db_path));
+        }
+
+        let conn = Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
         Ok(Self { conn })
     }
 
@@ -1095,6 +1119,135 @@ impl DiskCache {
         Ok(true)
     }
 
+    pub fn query_entities_listing(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+    ) -> Result<Option<Vec<EntityInfo>>, rusqlite::Error> {
+        if !self.has_fresh_topology_cache_for_files(root, files, source_scope) {
+            return Ok(None);
+        }
+
+        if files.is_empty() {
+            return Ok(Some(Vec::new()));
+        }
+
+        let mut entities = Vec::new();
+        for chunk in files.chunks(SQL_PARAM_CHUNK) {
+            let placeholders = repeat_vars(chunk.len());
+            let sql = format!(
+                "SELECT id, name, entity_type, file_path, start_line, end_line, parent_id
+                 FROM entities
+                 WHERE file_path IN ({placeholders})
+                 ORDER BY file_path, start_line, end_line, entity_type, name"
+            );
+            let mut stmt = self.conn.prepare(&sql)?;
+            let rows = stmt.query_map(
+                params_from_iter(chunk.iter().map(String::as_str)),
+                entity_info_from_row,
+            )?;
+            entities.extend(rows.collect::<Result<Vec<_>, _>>()?);
+        }
+        sort_entity_infos(&mut entities);
+        Ok(Some(entities))
+    }
+
+    fn has_fresh_topology_cache_for_files(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+    ) -> bool {
+        if !shared_cache::cache_has_kind(
+            &self.conn,
+            &[
+                shared_cache::CACHE_KIND_FULL,
+                shared_cache::CACHE_KIND_TOPOLOGY,
+            ],
+        ) {
+            return false;
+        }
+
+        if !shared_cache::cache_has_source_scope(&self.conn, source_scope) {
+            return false;
+        }
+
+        if shared_cache::is_manifest_stale(&self.conn, root) {
+            return false;
+        }
+
+        self.cached_files_are_fresh(
+            root,
+            files
+                .iter()
+                .filter(|file| !shared_cache::is_manifest_file_name(file))
+                .cloned()
+                .collect(),
+        )
+        .unwrap_or(false)
+    }
+
+    pub fn write_entities_listing_json<W: Write>(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+        include_file: bool,
+        writer: &mut W,
+    ) -> std::io::Result<Option<u64>> {
+        if !self.has_fresh_topology_cache_for_files(root, files, source_scope) {
+            return Ok(None);
+        }
+
+        writer.write_all(b"[")?;
+        let mut first = true;
+        let mut count = 0u64;
+        for chunk in files.chunks(SQL_PARAM_CHUNK) {
+            if chunk.is_empty() {
+                continue;
+            }
+            let placeholders = repeat_vars(chunk.len());
+            let sql = format!(
+                "SELECT name, entity_type, file_path, start_line, end_line, parent_id
+                 FROM entities
+                 WHERE file_path IN ({placeholders})
+                 ORDER BY file_path, start_line, end_line, entity_type, name"
+            );
+            let mut stmt = self.conn.prepare(&sql).map_err(sql_io_error)?;
+            let mut rows = stmt
+                .query(params_from_iter(chunk.iter().map(String::as_str)))
+                .map_err(sql_io_error)?;
+            while let Some(row) = rows.next().map_err(sql_io_error)? {
+                if first {
+                    first = false;
+                } else {
+                    writer.write_all(b",")?;
+                }
+
+                let name: String = row.get(0).map_err(sql_io_error)?;
+                let entity_type: String = row.get(1).map_err(sql_io_error)?;
+                let file_path: String = row.get(2).map_err(sql_io_error)?;
+                let start_line = row.get::<_, i64>(3).map_err(sql_io_error)? as usize;
+                let end_line = row.get::<_, i64>(4).map_err(sql_io_error)? as usize;
+                let parent_id: Option<String> = row.get(5).map_err(sql_io_error)?;
+                let listing = EntityListingJsonRow {
+                    name: &name,
+                    entity_type: &entity_type,
+                    start_line,
+                    end_line,
+                    parent_id: parent_id.as_deref(),
+                    file: include_file.then_some(file_path.as_str()),
+                };
+                serde_json::to_writer(&mut *writer, &listing).map_err(json_io_error)?;
+                count += 1;
+            }
+        }
+        writer.write_all(b"]\n")?;
+
+        Ok(Some(count))
+    }
+
     fn has_fresh_complete_cache(
         &self,
         root: &Path,
@@ -1678,6 +1831,17 @@ fn entity_info_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<EntityInfo>
         end_line: row.get::<_, i64>(5)? as usize,
         parent_id: row.get(6)?,
     })
+}
+
+fn sort_entity_infos(entities: &mut [EntityInfo]) {
+    entities.sort_by(|a, b| {
+        a.file_path
+            .cmp(&b.file_path)
+            .then(a.start_line.cmp(&b.start_line))
+            .then(a.end_line.cmp(&b.end_line))
+            .then(a.entity_type.cmp(&b.entity_type))
+            .then(a.name.cmp(&b.name))
+    });
 }
 
 fn repeat_vars(len: usize) -> String {
@@ -3072,6 +3236,18 @@ mod tests {
         assert!(!root.join(".sem").exists());
 
         drop(cache);
+        cleanup(root);
+    }
+
+    #[test]
+    fn open_existing_readonly_does_not_create_missing_cache() {
+        let root = temp_repo_root("readonly-missing");
+        let db_path = shared_cache::cache_db_path(&root).unwrap();
+
+        assert!(!db_path.exists());
+        assert!(DiskCache::open_existing_readonly(&root).is_err());
+        assert!(!db_path.exists());
+
         cleanup(root);
     }
 

--- a/crates/sem-cli/src/commands/entities.rs
+++ b/crates/sem-cli/src/commands/entities.rs
@@ -1,18 +1,25 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
+use crate::{cache::DiskCache, timings::Timings};
 use colored::Colorize;
 use sem_core::model::entity::SemanticEntity;
-use sem_core::parser::registry::{resolve_go_method_parent_ids, ParserRegistry};
+use sem_core::parser::graph::EntityInfo;
+use sem_core::parser::registry::ParserRegistry;
+use serde::Serialize;
 
 pub struct EntitiesOptions {
     pub cwd: String,
     pub paths: Vec<String>,
     pub json: bool,
     pub no_default_excludes: bool,
+    pub file_exts: Vec<String>,
 }
 
 pub fn entities_command(opts: EntitiesOptions) {
+    let mut timings = Timings::from_env("entities");
+
     // Normalize to a non-empty list of path args, defaulting to ".".
     let path_args: Vec<String> = {
         let cleaned: Vec<String> = opts
@@ -27,9 +34,18 @@ pub fn entities_command(opts: EntitiesOptions) {
             cleaned
         }
     };
+    timings.counter("input_paths", path_args.len() as u64);
+    timings.mark("path_args");
+
+    let ext_filter = super::graph::normalize_exts(&opts.file_exts);
 
     // The cloud fast-path only helps the whole-repo single listing.
-    if path_args.len() == 1 && super::cloud::try_cloud_entities(&opts).is_some() {
+    if ext_filter.is_empty()
+        && path_args.len() == 1
+        && super::cloud::try_cloud_entities(&opts).is_some()
+    {
+        timings.mark("cloud_entities");
+        timings.finish();
         return;
     }
 
@@ -38,9 +54,15 @@ pub fn entities_command(opts: EntitiesOptions) {
 
     let mut entities: Vec<SemanticEntity> = Vec::new();
     let mut dir_count = 0usize;
+    let mut file_arg_count = 0usize;
+    let mut processed_file_count = 0usize;
+    let mut discovered_file_count = 0usize;
+    let mut extracted_entities = false;
     for path_arg in &path_args {
         let (path_label, full_path) = resolve_path(root, path_arg);
         if full_path.is_file() {
+            file_arg_count += 1;
+            processed_file_count += 1;
             let file_entities = extract_file_entities(&full_path, &registry, &path_label)
                 .unwrap_or_else(|e| {
                     eprintln!(
@@ -52,20 +74,57 @@ pub fn entities_command(opts: EntitiesOptions) {
                     std::process::exit(1);
                 });
             entities.extend(file_entities);
+            extracted_entities = true;
         } else if full_path.is_dir() {
             dir_count += 1;
             let file_paths = super::files::find_supported_files_in_path(
                 root,
                 &full_path,
                 &registry,
-                &[],
+                &ext_filter,
                 opts.no_default_excludes,
             );
-            entities.extend(extract_files_entities(root, &file_paths, &registry));
+            discovered_file_count += file_paths.len();
+            processed_file_count += file_paths.len();
+            timings.mark("file_discovery");
+            if opts.json
+                && path_args.len() == 1
+                && try_write_cached_entities_json(
+                    root,
+                    &file_paths,
+                    &ext_filter,
+                    opts.no_default_excludes,
+                    &mut timings,
+                )
+            {
+                timings.counter("input_files", processed_file_count as u64);
+                timings.counter("input_file_args", file_arg_count as u64);
+                timings.counter("input_dirs", dir_count as u64);
+                timings.counter("processed_files", processed_file_count as u64);
+                timings.counter("discovered_files", discovered_file_count as u64);
+                timings.mark("output_serialization");
+                timings.finish();
+                return;
+            }
+            if let Some(cached_entities) = try_cached_entities(
+                root,
+                &file_paths,
+                &ext_filter,
+                opts.no_default_excludes,
+                &mut timings,
+            ) {
+                entities.extend(cached_entities);
+            } else {
+                entities.extend(extract_files_entities(root, &file_paths, &registry));
+                extracted_entities = true;
+            }
         } else {
             eprintln!("{} Path not found '{}'", "error:".red().bold(), path_arg);
             std::process::exit(1);
         }
+    }
+    if extracted_entities {
+        timings.mark("extract_entities");
     }
 
     // Overlapping paths (e.g. a directory and a file inside it) can surface the
@@ -79,6 +138,7 @@ pub fn entities_command(opts: EntitiesOptions) {
             .then(a.name.cmp(&b.name))
     });
     entities.dedup_by(|a, b| a.id == b.id);
+    timings.mark("sort_dedup");
 
     // Show the file column whenever results span more than one file. This keeps
     // the prior single-file vs directory behavior and covers multi-path input.
@@ -90,13 +150,20 @@ pub fn entities_command(opts: EntitiesOptions) {
     };
     let include_file = dir_count > 0 || distinct_files > 1;
     let display_label = path_args.join(" ");
+    timings.counter("input_files", processed_file_count as u64);
+    timings.counter("input_file_args", file_arg_count as u64);
+    timings.counter("input_dirs", dir_count as u64);
+    timings.counter("processed_files", processed_file_count as u64);
+    timings.counter("discovered_files", discovered_file_count as u64);
+    timings.counter("distinct_files", distinct_files as u64);
+    timings.counter("entities", entities.len() as u64);
 
     if opts.json {
-        let output: Vec<_> = entities
-            .iter()
-            .map(|e| entity_json(e, include_file))
-            .collect();
-        println!("{}", serde_json::to_string(&output).unwrap());
+        let json_bytes = write_entities_json(&entities, include_file).unwrap_or_else(|e| {
+            eprintln!("{} Cannot write JSON output: {}", "error:".red().bold(), e);
+            std::process::exit(1);
+        });
+        timings.counter("json_bytes", json_bytes);
     } else if should_group_by_file(&entities) {
         print_grouped_entities(&display_label, &entities);
     } else if let Some(file_path) = entities.first().map(|e| e.file_path.as_str()) {
@@ -104,6 +171,8 @@ pub fn entities_command(opts: EntitiesOptions) {
     } else {
         println!("{} {}\n", "entities:".green().bold(), display_label.bold());
     }
+    timings.mark("output_serialization");
+    timings.finish();
 }
 
 fn resolve_path(root: &Path, path_arg: &str) -> (String, PathBuf) {
@@ -128,17 +197,103 @@ fn extract_files_entities(
     file_paths: &[String],
     registry: &ParserRegistry,
 ) -> Vec<SemanticEntity> {
-    let mut entities = registry.extract_all_entities(root, file_paths);
-    resolve_go_method_parent_ids(&mut entities);
-    entities.sort_by(|a, b| {
-        a.file_path
-            .cmp(&b.file_path)
-            .then(a.start_line.cmp(&b.start_line))
-            .then(a.end_line.cmp(&b.end_line))
-            .then(a.entity_type.cmp(&b.entity_type))
-            .then(a.name.cmp(&b.name))
-    });
-    entities
+    registry.extract_all_entities_brief(root, file_paths)
+}
+
+fn try_cached_entities(
+    root: &Path,
+    file_paths: &[String],
+    ext_filter: &[String],
+    no_default_excludes: bool,
+    timings: &mut Timings,
+) -> Option<Vec<SemanticEntity>> {
+    let source_scope = super::graph::cache_source_scope(root, ext_filter, no_default_excludes);
+    let cache = match DiskCache::open_existing_readonly(root) {
+        Ok(cache) => {
+            timings.mark("cache_open");
+            cache
+        }
+        Err(_) => {
+            timings.mark("cache_open_failed");
+            return None;
+        }
+    };
+
+    match cache.query_entities_listing(root, file_paths, source_scope) {
+        Ok(Some(entities)) => {
+            timings.counter("cached_entities", entities.len() as u64);
+            timings.mark("cache_entities_query");
+            Some(entities.into_iter().map(entity_info_to_entity).collect())
+        }
+        Ok(None) => {
+            timings.mark("cache_entities_miss");
+            None
+        }
+        Err(_) => {
+            timings.mark("cache_entities_query_failed");
+            None
+        }
+    }
+}
+
+fn try_write_cached_entities_json(
+    root: &Path,
+    file_paths: &[String],
+    ext_filter: &[String],
+    no_default_excludes: bool,
+    timings: &mut Timings,
+) -> bool {
+    let source_scope = super::graph::cache_source_scope(root, ext_filter, no_default_excludes);
+    let cache = match DiskCache::open_existing_readonly(root) {
+        Ok(cache) => {
+            timings.mark("cache_open");
+            cache
+        }
+        Err(_) => {
+            timings.mark("cache_open_failed");
+            return false;
+        }
+    };
+
+    let stdout = io::stdout();
+    let mut writer = CountingWriter::new(stdout.lock());
+    match cache.write_entities_listing_json(root, file_paths, source_scope, true, &mut writer) {
+        Ok(Some(entity_count)) => {
+            timings.counter("cached_entities", entity_count);
+            timings.counter("entities", entity_count);
+            timings.counter("json_bytes", writer.bytes());
+            timings.mark("cache_entities_query");
+            true
+        }
+        Ok(None) => {
+            timings.mark("cache_entities_miss");
+            false
+        }
+        Err(error) => {
+            eprintln!(
+                "{} Cannot write cached JSON output: {}",
+                "error:".red().bold(),
+                error
+            );
+            std::process::exit(1);
+        }
+    }
+}
+
+fn entity_info_to_entity(entity: EntityInfo) -> SemanticEntity {
+    SemanticEntity {
+        id: entity.id,
+        file_path: entity.file_path,
+        entity_type: entity.entity_type,
+        name: entity.name,
+        parent_id: entity.parent_id,
+        content: String::new(),
+        content_hash: String::new(),
+        structural_hash: None,
+        start_line: entity.start_line,
+        end_line: entity.end_line,
+        metadata: None,
+    }
 }
 
 fn file_path_for_entity(root: &Path, path: &Path) -> String {
@@ -151,23 +306,69 @@ fn extract_file_entities(
     file_path: &str,
 ) -> Result<Vec<SemanticEntity>, std::io::Error> {
     let content = std::fs::read_to_string(&full_path)?;
-    Ok(registry.extract_entities(file_path, &content))
+    Ok(registry.extract_entities_brief(file_path, &content))
 }
 
-fn entity_json(entity: &SemanticEntity, include_file: bool) -> serde_json::Value {
-    let mut value = serde_json::json!({
-        "name": entity.name,
-        "type": entity.entity_type,
-        "start_line": entity.start_line,
-        "end_line": entity.end_line,
-        "parent_id": entity.parent_id,
-    });
+#[derive(Serialize)]
+struct EntityJsonRow<'a> {
+    name: &'a str,
+    #[serde(rename = "type")]
+    entity_type: &'a str,
+    start_line: usize,
+    end_line: usize,
+    parent_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    file: Option<&'a str>,
+}
 
-    if include_file {
-        value["file"] = serde_json::json!(entity.file_path);
+fn write_entities_json(entities: &[SemanticEntity], include_file: bool) -> io::Result<u64> {
+    let stdout = io::stdout();
+    let mut writer = CountingWriter::new(stdout.lock());
+    writer.write_all(b"[")?;
+    for (index, entity) in entities.iter().enumerate() {
+        if index > 0 {
+            writer.write_all(b",")?;
+        }
+        let row = EntityJsonRow {
+            name: &entity.name,
+            entity_type: &entity.entity_type,
+            start_line: entity.start_line,
+            end_line: entity.end_line,
+            parent_id: entity.parent_id.as_deref(),
+            file: include_file.then_some(entity.file_path.as_str()),
+        };
+        serde_json::to_writer(&mut writer, &row)
+            .map_err(|error| io::Error::new(io::ErrorKind::Other, error))?;
+    }
+    writer.write_all(b"]\n")?;
+    Ok(writer.bytes())
+}
+
+struct CountingWriter<W> {
+    inner: W,
+    bytes: u64,
+}
+
+impl<W> CountingWriter<W> {
+    fn new(inner: W) -> Self {
+        Self { inner, bytes: 0 }
     }
 
-    value
+    fn bytes(&self) -> u64 {
+        self.bytes
+    }
+}
+
+impl<W: Write> Write for CountingWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let written = self.inner.write(buf)?;
+        self.bytes += written as u64;
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
 }
 
 fn print_file_entities(file_path: &str, entities: &[SemanticEntity]) {
@@ -205,7 +406,10 @@ fn print_entity_rows(entities: &[SemanticEntity], base_indent: &str) {
 }
 
 fn entities_by_id(entities: &[SemanticEntity]) -> HashMap<&str, &SemanticEntity> {
-    entities.iter().map(|entity| (entity.id.as_str(), entity)).collect()
+    entities
+        .iter()
+        .map(|entity| (entity.id.as_str(), entity))
+        .collect()
 }
 
 fn entity_indent(
@@ -213,7 +417,10 @@ fn entity_indent(
     entities_by_id: &HashMap<&str, &SemanticEntity>,
     base_indent: &str,
 ) -> String {
-    format!("{base_indent}{}", "  ".repeat(entity_depth(entity, entities_by_id)))
+    format!(
+        "{base_indent}{}",
+        "  ".repeat(entity_depth(entity, entities_by_id))
+    )
 }
 
 fn entity_depth(entity: &SemanticEntity, entities_by_id: &HashMap<&str, &SemanticEntity>) -> usize {

--- a/crates/sem-cli/src/commands/files.rs
+++ b/crates/sem-cli/src/commands/files.rs
@@ -149,6 +149,7 @@ mod tests {
     fn scan_skips_binary_files_and_default_excludes() {
         let root = temp_dir();
         fs::create_dir_all(root.join("src")).unwrap();
+        fs::create_dir_all(root.join("src/generated")).unwrap();
         fs::create_dir_all(root.join("dist")).unwrap();
         fs::write(root.join("src/main.rs"), "fn main() {}\n").unwrap();
         fs::write(
@@ -159,6 +160,26 @@ mod tests {
         fs::write(root.join("src/notes.weird"), "plain text\n").unwrap();
         fs::write(root.join("src/blob.weird"), b"abc\0def").unwrap();
         fs::write(root.join("src/icon.png"), b"\x89PNG\r\n").unwrap();
+        fs::write(
+            root.join("src/generated/schema.ts"),
+            "export function generatedSchema() {}\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("src/api.generated.ts"),
+            "export function generatedApi() {}\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("src/styles.module.scss.d.ts"),
+            "declare const styles: Record<string, string>;\nexport default styles;\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("src/logo.svg.d.ts"),
+            "declare const src: string;\nexport default src;\n",
+        )
+        .unwrap();
         fs::write(root.join("dist/generated.js"), "function generated() {}\n").unwrap();
 
         let registry = create_default_registry();
@@ -172,6 +193,10 @@ mod tests {
         let files_with_generated = find_supported_files_in_path(&root, &root, &registry, &[], true);
         assert!(files_with_generated.contains(&"src/main.rs".to_string()));
         assert!(files_with_generated.contains(&"src/run".to_string()));
+        assert!(files_with_generated.contains(&"src/generated/schema.ts".to_string()));
+        assert!(files_with_generated.contains(&"src/api.generated.ts".to_string()));
+        assert!(files_with_generated.contains(&"src/styles.module.scss.d.ts".to_string()));
+        assert!(files_with_generated.contains(&"src/logo.svg.d.ts".to_string()));
         assert!(files_with_generated.contains(&"dist/generated.js".to_string()));
         assert!(!files_with_generated.contains(&"src/notes.weird".to_string()));
         assert!(!files_with_generated.contains(&"src/blob.weird".to_string()));

--- a/crates/sem-cli/src/commands/graph.rs
+++ b/crates/sem-cli/src/commands/graph.rs
@@ -36,7 +36,7 @@ pub fn graph_command(opts: GraphOptions) {
         if let Ok(disk) = DiskCache::open(root) {
             timings.mark("cache_open");
             let stdout = std::io::stdout();
-            match disk.write_graph_json_topology(root, &file_paths, stdout.lock()) {
+            match disk.write_graph_json_topology(root, &file_paths, source_scope, stdout.lock()) {
                 Ok(true) => {
                     timings.mark("cache_topology_json_stream");
                     timings.finish();
@@ -281,12 +281,14 @@ pub fn get_or_build_graph_with_test_data_and_topology_save_on_miss_with_timings(
     if !no_cache {
         if let Ok(disk) = DiskCache::open(root) {
             timings.mark("cache_open");
-            if let Some((graph, entities)) = disk.load(root, file_paths) {
+            if let Some((graph, entities)) =
+                disk.load_with_source_scope(root, file_paths, source_scope)
+            {
                 timings.mark("cache_full_load");
                 return GraphWithTestData::Full(graph, entities);
             }
-            if let Some((graph, test_entity_ids)) =
-                disk.load_graph_topology_with_test_ids(root, file_paths)
+            if let Some((graph, test_entity_ids)) = disk
+                .load_graph_topology_with_test_ids_and_source_scope(root, file_paths, source_scope)
             {
                 timings.mark("cache_topology_load");
                 return GraphWithTestData::Topology {
@@ -295,7 +297,9 @@ pub fn get_or_build_graph_with_test_data_and_topology_save_on_miss_with_timings(
                 };
             }
 
-            if let Some(partial) = disk.load_partial(root, file_paths) {
+            if let Some(partial) =
+                disk.load_partial_with_source_scope(root, file_paths, source_scope)
+            {
                 timings.mark("cache_partial_load");
                 let (graph, entities, metadata) =
                     EntityGraph::build_incremental_with_metadata_and_import_candidates(
@@ -318,6 +322,7 @@ pub fn get_or_build_graph_with_test_data_and_topology_save_on_miss_with_timings(
                     metadata.repaired_clean_entity_ids,
                     &metadata.recomputed_edge_source_ids,
                     &metadata.deleted_entity_ids,
+                    source_scope,
                 );
                 timings.mark("cache_incremental_save");
                 return GraphWithTestData::Full(graph, entities);
@@ -364,13 +369,15 @@ fn get_or_build_graph_with_cache_policy(
         if let Ok(disk) = DiskCache::open(root) {
             timings.mark("cache_open");
             // Try full cache hit
-            if let Some(cached) = disk.load(root, file_paths) {
+            if let Some(cached) = disk.load_with_source_scope(root, file_paths, source_scope) {
                 timings.mark("cache_full_load");
                 return cached;
             }
 
             // Try incremental: load clean cached data, rebuild only stale files
-            if let Some(partial) = disk.load_partial(root, file_paths) {
+            if let Some(partial) =
+                disk.load_partial_with_source_scope(root, file_paths, source_scope)
+            {
                 timings.mark("cache_partial_load");
                 let (graph, entities, metadata) =
                     EntityGraph::build_incremental_with_metadata_and_import_candidates(
@@ -393,6 +400,7 @@ fn get_or_build_graph_with_cache_policy(
                     metadata.repaired_clean_entity_ids,
                     &metadata.recomputed_edge_source_ids,
                     &metadata.deleted_entity_ids,
+                    source_scope,
                 );
                 timings.mark("cache_incremental_save");
                 return (graph, entities);
@@ -442,7 +450,9 @@ pub fn get_or_build_graph_topology_with_timings(
     if !no_cache {
         if let Ok(disk) = DiskCache::open(root) {
             timings.mark("cache_open");
-            if let Some(graph) = disk.load_graph_topology(root, file_paths) {
+            if let Some(graph) =
+                disk.load_graph_topology_with_source_scope(root, file_paths, source_scope)
+            {
                 timings.mark("cache_topology_load");
                 return graph;
             }
@@ -471,7 +481,9 @@ pub fn get_or_build_graph_topology_with_topology_save_on_miss_with_timings(
     if !no_cache {
         if let Ok(disk) = DiskCache::open(root) {
             timings.mark("cache_open");
-            if let Some(graph) = disk.load_graph_topology(root, file_paths) {
+            if let Some(graph) =
+                disk.load_graph_topology_with_source_scope(root, file_paths, source_scope)
+            {
                 timings.mark("cache_topology_load");
                 return graph;
             }
@@ -494,6 +506,7 @@ pub fn get_or_build_direct_dependency_graph_with_timings<F>(
     file_paths: &[String],
     registry: &ParserRegistry,
     no_cache: bool,
+    source_scope: CacheSourceScope,
     timings: &mut Timings,
     should_resolve: F,
 ) -> EntityGraph
@@ -503,7 +516,9 @@ where
     if !no_cache {
         if let Ok(disk) = DiskCache::open(root) {
             timings.mark("cache_open");
-            if let Some(graph) = disk.load_graph_topology(root, file_paths) {
+            if let Some(graph) =
+                disk.load_graph_topology_with_source_scope(root, file_paths, source_scope)
+            {
                 timings.mark("cache_topology_load");
                 return graph;
             }

--- a/crates/sem-cli/src/commands/impact.rs
+++ b/crates/sem-cli/src/commands/impact.rs
@@ -85,6 +85,7 @@ pub fn impact_command(opts: ImpactOptions) {
                     &[],
                     &opts,
                     file_hint.as_deref(),
+                    source_scope,
                     true,
                     &mut timings,
                 ) {
@@ -115,6 +116,7 @@ pub fn impact_command(opts: ImpactOptions) {
                     &file_paths,
                     &opts,
                     file_hint.as_deref(),
+                    source_scope,
                     false,
                     &mut timings,
                 ) {
@@ -141,6 +143,7 @@ pub fn impact_command(opts: ImpactOptions) {
                             &file_paths,
                             &registry,
                             opts.no_cache,
+                            source_scope,
                             &mut timings,
                             move |entity| {
                                 if let Some(id) = entity_id.as_deref() {
@@ -345,12 +348,14 @@ fn try_cached_impact_query(
     file_paths: &[String],
     opts: &ImpactOptions,
     file_hint: Option<&str>,
+    source_scope: CacheSourceScope,
     cache_first: bool,
     timings: &mut Timings,
 ) -> bool {
     match disk.query_impact_topology(
         root,
         file_paths,
+        source_scope,
         cache_first,
         opts.entity_name.as_deref(),
         opts.entity_id.as_deref(),

--- a/crates/sem-cli/src/main.rs
+++ b/crates/sem-cli/src/main.rs
@@ -157,7 +157,7 @@ enum Commands {
         #[arg(long)]
         no_cache: bool,
 
-        /// Include directories and generated files that are excluded by default
+        /// Include files and directories excluded by default (generated, fixtures, vendor, benchmarks)
         #[arg(long)]
         no_default_excludes: bool,
     },
@@ -183,7 +183,7 @@ enum Commands {
         #[arg(long)]
         no_cache: bool,
 
-        /// Include directories and generated files that are excluded by default
+        /// Include files and directories excluded by default (generated, fixtures, vendor, benchmarks)
         #[arg(long)]
         no_default_excludes: bool,
     },
@@ -241,7 +241,7 @@ enum Commands {
         #[arg(long)]
         json: bool,
 
-        /// Include directories and generated files that are excluded by default
+        /// Include files and directories excluded by default (generated, fixtures, vendor, benchmarks)
         #[arg(long)]
         no_default_excludes: bool,
     },
@@ -279,7 +279,7 @@ enum Commands {
         #[arg(long)]
         no_cache: bool,
 
-        /// Include directories and generated files that are excluded by default
+        /// Include files and directories excluded by default (generated, fixtures, vendor, benchmarks)
         #[arg(long)]
         no_default_excludes: bool,
     },

--- a/crates/sem-cli/src/main.rs
+++ b/crates/sem-cli/src/main.rs
@@ -244,6 +244,10 @@ enum Commands {
         /// Include files and directories excluded by default (generated, fixtures, vendor, benchmarks)
         #[arg(long)]
         no_default_excludes: bool,
+
+        /// Only include files with these extensions (e.g. --file-exts .ts .tsx)
+        #[arg(long, num_args = 1..)]
+        file_exts: Vec<String>,
     },
     /// Show token-budgeted context for an entity
     Context {
@@ -528,6 +532,7 @@ fn main() {
             format,
             json,
             no_default_excludes,
+            file_exts,
         }) => {
             entities_command(EntitiesOptions {
                 cwd: std::env::current_dir()
@@ -537,6 +542,7 @@ fn main() {
                 paths,
                 json: resolve_json(format, json),
                 no_default_excludes,
+                file_exts,
             });
         }
         Some(Commands::Context {

--- a/crates/sem-cli/src/timings.rs
+++ b/crates/sem-cli/src/timings.rs
@@ -7,11 +7,17 @@ pub struct Timings {
     start: Instant,
     last: Instant,
     entries: Vec<TimingEntry>,
+    counters: Vec<TimingCounter>,
 }
 
 struct TimingEntry {
     name: &'static str,
     duration_ms: f64,
+}
+
+struct TimingCounter {
+    name: &'static str,
+    value: u64,
 }
 
 impl Timings {
@@ -26,6 +32,7 @@ impl Timings {
             start: now,
             last: now,
             entries: Vec::new(),
+            counters: Vec::new(),
         }
     }
 
@@ -38,6 +45,7 @@ impl Timings {
             start: now,
             last: now,
             entries: Vec::new(),
+            counters: Vec::new(),
         }
     }
 
@@ -51,6 +59,13 @@ impl Timings {
             duration_ms: elapsed_ms(now.duration_since(self.last)),
         });
         self.last = now;
+    }
+
+    pub fn counter(&mut self, name: &'static str, value: u64) {
+        if !self.enabled {
+            return;
+        }
+        self.counters.push(TimingCounter { name, value });
     }
 
     pub fn finish(&self) {
@@ -69,16 +84,31 @@ impl Timings {
                     })
                 })
                 .collect::<Vec<_>>();
-            let output = serde_json::json!({
+            let mut output = serde_json::json!({
                 "command": self.command,
                 "phases": phases,
                 "totalMs": total_ms,
             });
+            if !self.counters.is_empty() {
+                output["counters"] = serde_json::json!(self
+                    .counters
+                    .iter()
+                    .map(|counter| {
+                        serde_json::json!({
+                            "name": counter.name,
+                            "value": counter.value,
+                        })
+                    })
+                    .collect::<Vec<_>>());
+            }
             eprintln!("{}", serde_json::to_string(&output).unwrap());
         } else {
             eprintln!("sem timings ({})", self.command);
             for entry in &self.entries {
                 eprintln!("  {:<32} {:>8.3} ms", entry.name, entry.duration_ms);
+            }
+            for counter in &self.counters {
+                eprintln!("  {:<32} {:>8}", counter.name, counter.value);
             }
             eprintln!("  {:<32} {:>8.3} ms", "total", total_ms);
         }

--- a/crates/sem-cli/tests/entities_cli.rs
+++ b/crates/sem-cli/tests/entities_cli.rs
@@ -1,0 +1,341 @@
+use std::{collections::HashMap, fs, process::Command};
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn run_sem_entities_json(repo: &TempDir) -> (Value, Value) {
+    run_sem_entities_json_with_args(repo, &["entities", ".", "--json"])
+}
+
+fn run_sem_entities_json_with_args(repo: &TempDir, args: &[&str]) -> (Value, Value) {
+    let output = Command::new(env!("CARGO_BIN_EXE_sem"))
+        .current_dir(repo.path())
+        .env("DO_NOT_TRACK", "1")
+        .env("SEM_LOCAL", "1")
+        .env("SEM_TIMINGS", "json")
+        .args(args)
+        .output()
+        .expect("run sem entities");
+
+    assert!(
+        output.status.success(),
+        "sem entities failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = serde_json::from_slice(&output.stdout).expect("entities stdout json");
+    let stderr = String::from_utf8(output.stderr).expect("timings stderr utf8");
+    let timings = serde_json::from_str(stderr.trim()).expect("timings stderr json");
+    (stdout, timings)
+}
+
+fn run_sem_entities_json_value_with_args(repo: &TempDir, args: &[&str]) -> Value {
+    let output = Command::new(env!("CARGO_BIN_EXE_sem"))
+        .current_dir(repo.path())
+        .env("DO_NOT_TRACK", "1")
+        .env("SEM_LOCAL", "1")
+        .args(args)
+        .output()
+        .expect("run sem entities");
+
+    assert!(
+        output.status.success(),
+        "sem entities failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stderr), "");
+
+    serde_json::from_slice(&output.stdout).expect("entities stdout json")
+}
+
+fn run_sem_graph_json(repo: &TempDir, cache: &TempDir) {
+    let output = Command::new(env!("CARGO_BIN_EXE_sem"))
+        .current_dir(repo.path())
+        .env("DO_NOT_TRACK", "1")
+        .env("SEM_LOCAL", "1")
+        .env("SEM_CACHE_DIR", cache.path())
+        .args(["graph", ".", "--json"])
+        .output()
+        .expect("run sem graph");
+
+    assert!(
+        output.status.success(),
+        "sem graph failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn run_cached_sem_entities_json(repo: &TempDir, cache: &TempDir) -> (Value, Value) {
+    run_cached_sem_entities_json_with_args(repo, cache, &["entities", ".", "--json"])
+}
+
+fn run_cached_sem_entities_json_with_args(
+    repo: &TempDir,
+    cache: &TempDir,
+    args: &[&str],
+) -> (Value, Value) {
+    let output = Command::new(env!("CARGO_BIN_EXE_sem"))
+        .current_dir(repo.path())
+        .env("DO_NOT_TRACK", "1")
+        .env("SEM_LOCAL", "1")
+        .env("SEM_CACHE_DIR", cache.path())
+        .env("SEM_TIMINGS", "json")
+        .args(args)
+        .output()
+        .expect("run sem entities");
+
+    assert!(
+        output.status.success(),
+        "sem entities failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = serde_json::from_slice(&output.stdout).expect("entities stdout json");
+    let stderr = String::from_utf8(output.stderr).expect("timings stderr utf8");
+    let timings = serde_json::from_str(stderr.trim()).expect("timings stderr json");
+    (stdout, timings)
+}
+
+#[test]
+fn entities_json_emits_timings_and_counters() {
+    let repo = TempDir::new().expect("temp repo");
+    fs::write(
+        repo.path().join("a.ts"),
+        "export function alpha() { return 1; }\n",
+    )
+    .unwrap();
+    fs::write(
+        repo.path().join("b.ts"),
+        "export const beta = () => alpha();\n",
+    )
+    .unwrap();
+
+    let (entities, timings) = run_sem_entities_json(&repo);
+    let entities = entities.as_array().expect("entities array");
+    assert!(entities.iter().any(|entity| entity["name"] == "alpha"));
+    assert!(entities.iter().any(|entity| entity["name"] == "beta"));
+
+    assert_eq!(timings["command"], "entities");
+    let phase_names = timings["phases"]
+        .as_array()
+        .expect("phases array")
+        .iter()
+        .map(|phase| phase["name"].as_str().expect("phase name"))
+        .collect::<Vec<_>>();
+    for expected in [
+        "path_args",
+        "file_discovery",
+        "extract_entities",
+        "sort_dedup",
+        "output_serialization",
+    ] {
+        assert!(
+            phase_names.contains(&expected),
+            "missing phase {expected}; got {phase_names:?}"
+        );
+    }
+
+    let counters = timings["counters"]
+        .as_array()
+        .expect("counters array")
+        .iter()
+        .map(|counter| {
+            (
+                counter["name"].as_str().expect("counter name"),
+                counter["value"].as_u64().expect("counter value"),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    assert_eq!(counters["input_paths"], 1);
+    assert_eq!(counters["input_dirs"], 1);
+    assert_eq!(counters["input_files"], 2);
+    assert_eq!(counters["input_file_args"], 0);
+    assert_eq!(counters["processed_files"], 2);
+    assert_eq!(counters["discovered_files"], 2);
+    assert_eq!(counters["entities"], entities.len() as u64);
+    assert!(counters["json_bytes"] > 0);
+}
+
+#[test]
+fn entities_json_counts_explicit_file_inputs_separately() {
+    let repo = TempDir::new().expect("temp repo");
+    fs::write(
+        repo.path().join("a.ts"),
+        "export function alpha() { return 1; }\n",
+    )
+    .unwrap();
+
+    let (entities, timings) =
+        run_sem_entities_json_with_args(&repo, &["entities", "a.ts", "--json"]);
+    let entities = entities.as_array().expect("entities array");
+    assert!(entities.iter().any(|entity| entity["name"] == "alpha"));
+
+    let counters = timings["counters"]
+        .as_array()
+        .expect("counters array")
+        .iter()
+        .map(|counter| {
+            (
+                counter["name"].as_str().expect("counter name"),
+                counter["value"].as_u64().expect("counter value"),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    assert_eq!(counters["input_paths"], 1);
+    assert_eq!(counters["input_dirs"], 0);
+    assert_eq!(counters["input_files"], 1);
+    assert_eq!(counters["input_file_args"], 1);
+    assert_eq!(counters["processed_files"], 1);
+    assert_eq!(counters["discovered_files"], 0);
+    assert_eq!(counters["entities"], entities.len() as u64);
+}
+
+#[test]
+fn entities_file_exts_filter_directory_scans() {
+    let repo = TempDir::new().expect("temp repo");
+    fs::write(
+        repo.path().join("a.ts"),
+        "export function alpha() { return 1; }\n",
+    )
+    .unwrap();
+    fs::write(repo.path().join("config.json"), r#"{"ignored": true}"#).unwrap();
+
+    let entities = run_sem_entities_json_value_with_args(
+        &repo,
+        &["entities", ".", "--json", "--file-exts", ".ts"],
+    );
+    let entities = entities.as_array().expect("entities array");
+
+    assert!(entities.iter().any(|entity| entity["name"] == "alpha"));
+    assert!(
+        entities.iter().all(|entity| entity["file"]
+            .as_str()
+            .is_some_and(|file| file.ends_with(".ts"))),
+        "expected only .ts entities, got {entities:?}"
+    );
+
+    let bare_ext_entities = run_sem_entities_json_value_with_args(
+        &repo,
+        &["entities", ".", "--json", "--file-exts", "ts"],
+    );
+    assert_eq!(bare_ext_entities, Value::Array(entities.clone()));
+}
+
+#[test]
+fn entities_uses_fresh_topology_cache() {
+    let repo = TempDir::new().expect("temp repo");
+    let cache = TempDir::new().expect("temp cache");
+    fs::write(
+        repo.path().join("a.ts"),
+        "export function alpha() { return 1; }\n",
+    )
+    .unwrap();
+    fs::write(
+        repo.path().join("b.ts"),
+        "export function beta() { return alpha(); }\n",
+    )
+    .unwrap();
+
+    run_sem_graph_json(&repo, &cache);
+    let (entities, timings) = run_cached_sem_entities_json(&repo, &cache);
+    let entities = entities.as_array().expect("entities array");
+    assert!(entities.iter().any(|entity| entity["name"] == "alpha"));
+    assert!(entities.iter().any(|entity| entity["name"] == "beta"));
+
+    let phase_names = timings["phases"]
+        .as_array()
+        .expect("phases array")
+        .iter()
+        .map(|phase| phase["name"].as_str().expect("phase name"))
+        .collect::<Vec<_>>();
+    assert!(
+        phase_names.contains(&"cache_entities_query"),
+        "expected cache hit phase, got {phase_names:?}"
+    );
+    assert!(
+        !phase_names.contains(&"extract_entities"),
+        "cache hit should not parse files; got {phase_names:?}"
+    );
+    assert!(
+        !phase_names.contains(&"sort_dedup"),
+        "streamed cache hit should not materialize and sort entities; got {phase_names:?}"
+    );
+
+    let counters = timings["counters"]
+        .as_array()
+        .expect("counters array")
+        .iter()
+        .map(|counter| {
+            (
+                counter["name"].as_str().expect("counter name"),
+                counter["value"].as_u64().expect("counter value"),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    assert_eq!(counters["cached_entities"], entities.len() as u64);
+}
+
+#[test]
+fn entities_uses_whole_repo_cache_for_subdirectory_listing() {
+    let repo = TempDir::new().expect("temp repo");
+    let cache = TempDir::new().expect("temp cache");
+    fs::create_dir_all(repo.path().join("src")).unwrap();
+    fs::create_dir_all(repo.path().join("tests")).unwrap();
+    fs::write(
+        repo.path().join("src").join("a.ts"),
+        "export function alpha() { return 1; }\n",
+    )
+    .unwrap();
+    fs::write(
+        repo.path().join("tests").join("b.ts"),
+        "export function beta() { return 2; }\n",
+    )
+    .unwrap();
+
+    run_sem_graph_json(&repo, &cache);
+    let (entities, timings) =
+        run_cached_sem_entities_json_with_args(&repo, &cache, &["entities", "src", "--json"]);
+    let entities = entities.as_array().expect("entities array");
+    assert!(entities.iter().any(|entity| entity["name"] == "alpha"));
+    assert!(!entities.iter().any(|entity| entity["name"] == "beta"));
+    assert!(
+        entities.iter().all(|entity| entity["file"]
+            .as_str()
+            .is_some_and(|file| file.starts_with("src/"))),
+        "expected only src entities, got {entities:?}"
+    );
+
+    let phase_names = timings["phases"]
+        .as_array()
+        .expect("phases array")
+        .iter()
+        .map(|phase| phase["name"].as_str().expect("phase name"))
+        .collect::<Vec<_>>();
+    assert!(
+        phase_names.contains(&"cache_entities_query"),
+        "expected cache hit phase, got {phase_names:?}"
+    );
+    assert!(
+        !phase_names.contains(&"extract_entities"),
+        "cache hit should not parse files; got {phase_names:?}"
+    );
+
+    let counters = timings["counters"]
+        .as_array()
+        .expect("counters array")
+        .iter()
+        .map(|counter| {
+            (
+                counter["name"].as_str().expect("counter name"),
+                counter["value"].as_u64().expect("counter value"),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    assert_eq!(counters["cached_entities"], entities.len() as u64);
+    assert_eq!(counters["input_files"], 1);
+    assert_eq!(counters["discovered_files"], 1);
+}

--- a/crates/sem-core/src/parser/plugin.rs
+++ b/crates/sem-core/src/parser/plugin.rs
@@ -4,6 +4,11 @@ pub trait SemanticParserPlugin: Send + Sync {
     fn id(&self) -> &str;
     fn extensions(&self) -> &[&str];
     fn extract_entities(&self, content: &str, file_path: &str) -> Vec<SemanticEntity>;
+    fn extract_entities_brief(&self, content: &str, file_path: &str) -> Vec<SemanticEntity> {
+        let mut entities = self.extract_entities(content, file_path);
+        strip_entity_payloads(&mut entities);
+        entities
+    }
     /// Extract entities and optionally return the tree-sitter Tree for reuse.
     /// Default returns None for the tree (non-code plugins).
     fn extract_entities_with_tree(
@@ -18,5 +23,13 @@ pub trait SemanticParserPlugin: Send + Sync {
     }
     fn compute_similarity(&self, a: &SemanticEntity, b: &SemanticEntity) -> f64 {
         crate::model::identity::default_similarity(a, b)
+    }
+}
+
+pub fn strip_entity_payloads(entities: &mut [SemanticEntity]) {
+    for entity in entities {
+        entity.content.clear();
+        entity.content_hash.clear();
+        entity.structural_hash = None;
     }
 }

--- a/crates/sem-core/src/parser/plugins/json.rs
+++ b/crates/sem-core/src/parser/plugins/json.rs
@@ -14,17 +14,32 @@ impl SemanticParserPlugin for JsonParserPlugin {
     }
 
     fn extract_entities(&self, content: &str, file_path: &str) -> Vec<SemanticEntity> {
+        self.extract_entities_with_payload(content, file_path, EntityPayloadMode::Full)
+    }
+
+    fn extract_entities_brief(&self, content: &str, file_path: &str) -> Vec<SemanticEntity> {
+        self.extract_entities_with_payload(content, file_path, EntityPayloadMode::Brief)
+    }
+}
+
+impl JsonParserPlugin {
+    fn extract_entities_with_payload(
+        &self,
+        content: &str,
+        file_path: &str,
+        payload_mode: EntityPayloadMode,
+    ) -> Vec<SemanticEntity> {
         let trimmed = content.trim_start();
         if trimmed.starts_with('{') {
-            return extract_entries(content, file_path, JsonContainerKind::Object);
+            return extract_entries(content, file_path, JsonContainerKind::Object, payload_mode);
         }
         if trimmed.starts_with('[') {
-            return extract_entries(content, file_path, JsonContainerKind::Array);
+            return extract_entries(content, file_path, JsonContainerKind::Array, payload_mode);
         }
         if trimmed.is_empty() {
             return Vec::new();
         }
-        vec![document_chunk_entity(content, file_path)]
+        vec![document_chunk_entity(content, file_path, payload_mode)]
     }
 }
 
@@ -32,6 +47,12 @@ impl SemanticParserPlugin for JsonParserPlugin {
 enum JsonContainerKind {
     Object,
     Array,
+}
+
+#[derive(Clone, Copy)]
+enum EntityPayloadMode {
+    Full,
+    Brief,
 }
 
 struct Frame {
@@ -52,6 +73,7 @@ fn extract_entries(
     content: &str,
     file_path: &str,
     container_kind: JsonContainerKind,
+    payload_mode: EntityPayloadMode,
 ) -> Vec<SemanticEntity> {
     let mut entities = Vec::new();
     let root_entries = match container_kind {
@@ -117,6 +139,14 @@ fn extract_entries(
             let entity_id = format!("{}::{}", file_path, pointer);
             let abs_start = frame.line_offset + entry.start_line - 1;
             let abs_end = frame.line_offset + end_line - 1;
+            let (stored_content, content_hash_value, structural_hash_value) = match payload_mode {
+                EntityPayloadMode::Full => (
+                    entity_content.clone(),
+                    content_hash(&entity_content),
+                    Some(content_hash(value_content)),
+                ),
+                EntityPayloadMode::Brief => (String::new(), String::new(), None),
+            };
 
             entities.push(SemanticEntity {
                 id: entity_id.clone(),
@@ -124,9 +154,9 @@ fn extract_entries(
                 entity_type: entry.entity_type.clone(),
                 name: entry.key.clone(),
                 parent_id: frame.parent_entity_id.clone(),
-                content_hash: content_hash(&entity_content),
-                structural_hash: Some(content_hash(value_content)),
-                content: entity_content.clone(),
+                content_hash: content_hash_value,
+                structural_hash: structural_hash_value,
+                content: stored_content,
                 start_line: abs_start,
                 end_line: abs_end,
                 metadata: None,
@@ -155,17 +185,25 @@ fn extract_entries(
     entities
 }
 
-fn document_chunk_entity(content: &str, file_path: &str) -> SemanticEntity {
+fn document_chunk_entity(
+    content: &str,
+    file_path: &str,
+    payload_mode: EntityPayloadMode,
+) -> SemanticEntity {
     let line_count = content.lines().count().max(1);
+    let (stored_content, content_hash_value) = match payload_mode {
+        EntityPayloadMode::Full => (content.to_string(), content_hash(content)),
+        EntityPayloadMode::Brief => (String::new(), String::new()),
+    };
     SemanticEntity {
         id: build_entity_id(file_path, "chunk", "(document)", None),
         file_path: file_path.to_string(),
         entity_type: "chunk".to_string(),
         name: "(document)".to_string(),
         parent_id: None,
-        content_hash: content_hash(content),
+        content_hash: content_hash_value,
         structural_hash: None,
-        content: content.to_string(),
+        content: stored_content,
         start_line: 1,
         end_line: line_count,
         metadata: None,
@@ -624,6 +662,24 @@ mod tests {
     fn find_change<'a>(changes: &'a [SemanticChange], name: &str, kind: ChangeType) -> &'a SemanticChange {
         changes.iter().find(|c| c.entity_name == name && c.change_type == kind)
             .unwrap_or_else(|| panic!("expected {:?} {} in changes; got: {:?}", kind, name, names(changes)))
+    }
+
+    #[test]
+    fn brief_extraction_drops_json_payloads() {
+        let content = r#"{
+  "scripts": {
+    "build": "tsc"
+  }
+}
+"#;
+        let plugin = JsonParserPlugin;
+        let entities = plugin.extract_entities_brief(content, "package.json");
+
+        assert!(entities.iter().any(|entity| entity.name == "scripts"));
+        assert!(entities.iter().any(|entity| entity.name == "build"));
+        assert!(entities.iter().all(|entity| entity.content.is_empty()));
+        assert!(entities.iter().all(|entity| entity.content_hash.is_empty()));
+        assert!(entities.iter().all(|entity| entity.structural_hash.is_none()));
     }
 
     #[test]

--- a/crates/sem-core/src/parser/registry.rs
+++ b/crates/sem-core/src/parser/registry.rs
@@ -13,7 +13,7 @@ macro_rules! maybe_par_iter {
         { $slice.iter() }
     }};
 }
-use super::plugin::SemanticParserPlugin;
+use super::plugin::{strip_entity_payloads, SemanticParserPlugin};
 
 pub struct ParserRegistry {
     plugins: Vec<Box<dyn SemanticParserPlugin>>,
@@ -251,6 +251,23 @@ impl ParserRegistry {
         entities
     }
 
+    /// Extract listing-only entities without retaining source content or hashes.
+    pub fn extract_entities_brief(&self, file_path: &str, content: &str) -> Vec<SemanticEntity> {
+        let resolved = self.resolve_file_path(file_path);
+        let detection_path = resolved.as_deref().unwrap_or(file_path);
+
+        let plugin = match self.get_plugin_with_content(detection_path, content) {
+            Some(p) => p,
+            None => return Vec::new(),
+        };
+
+        let mut entities = plugin.extract_entities_brief(content, detection_path);
+        if let Some(ref rp) = resolved {
+            fix_entity_paths(&mut entities, file_path, rp);
+        }
+        entities
+    }
+
     /// Extract entities with tree, transparently handling custom extension mappings.
     pub fn extract_entities_with_tree(
         &self,
@@ -286,6 +303,38 @@ impl ParserRegistry {
             .collect();
         resolve_go_method_parent_ids(&mut entities);
         entities
+    }
+
+    /// Extract listing-only entities from multiple files in parallel.
+    pub fn extract_all_entities_brief(
+        &self,
+        root: &Path,
+        file_paths: &[String],
+    ) -> Vec<SemanticEntity> {
+        let mut entities: Vec<SemanticEntity> = maybe_par_iter!(file_paths)
+            .flat_map(|fp| {
+                let full = root.join(fp);
+                let content = match std::fs::read_to_string(&full) {
+                    Ok(c) => c,
+                    Err(_) => return Vec::new(),
+                };
+                if self.needs_content_for_listing_parent_repair(fp, &content) {
+                    self.extract_entities(fp, &content)
+                } else {
+                    self.extract_entities_brief(fp, &content)
+                }
+            })
+            .collect();
+        resolve_go_method_parent_ids(&mut entities);
+        strip_entity_payloads(&mut entities);
+        entities
+    }
+
+    fn needs_content_for_listing_parent_repair(&self, file_path: &str, content: &str) -> bool {
+        let resolved = self.resolve_file_path(file_path);
+        let detection_path = resolved.as_deref().unwrap_or(file_path);
+        detection_path.ends_with(".go")
+            || detect_ext_from_content(content).as_deref() == Some(".go")
     }
 }
 
@@ -836,6 +885,37 @@ mod tests {
 
         assert_eq!(run.parent_id.as_deref(), Some(service.id.as_str()));
         assert_eq!(run.id, format!("{}::Run", service.id));
+    }
+
+    #[cfg(feature = "lang-go")]
+    #[test]
+    fn test_brief_go_method_parent_resolves_across_files() {
+        let registry = create_default_registry();
+        let dir = TempDir::new().unwrap();
+        write_file(&dir, "models.go", "package demo\n\ntype Service struct{}\n");
+        write_file(
+            &dir,
+            "methods.go",
+            "package demo\n\nfunc (s *Service) Run() {}\n",
+        );
+
+        let entities = registry.extract_all_entities_brief(
+            dir.path(),
+            &["models.go".to_string(), "methods.go".to_string()],
+        );
+        let service = entities
+            .iter()
+            .find(|e| e.name == "Service" && e.file_path == "models.go")
+            .expect("Service type should be extracted");
+        let run = entities
+            .iter()
+            .find(|e| e.name == "Run" && e.file_path == "methods.go")
+            .expect("Run method should be extracted");
+
+        assert_eq!(run.parent_id.as_deref(), Some(service.id.as_str()));
+        assert!(entities.iter().all(|e| e.content.is_empty()));
+        assert!(entities.iter().all(|e| e.content_hash.is_empty()));
+        assert!(entities.iter().all(|e| e.structural_hash.is_none()));
     }
 
     #[cfg(feature = "lang-go")]

--- a/crates/sem-core/src/utils/scan.rs
+++ b/crates/sem-core/src/utils/scan.rs
@@ -12,8 +12,13 @@ const DEFAULT_EXCLUDED_FILES: &[&str] = &[
     "flake.lock",
 ];
 
-/// Directory names that are excluded wherever they appear in repo-wide scans.
+/// Directory names excluded wherever they appear in repo-wide scans.
+/// This list includes generated artifacts and high-volume support trees that are
+/// usually not useful for entity lookup or impact analysis by default.
 const DEFAULT_EXCLUDED_ANY_DIRS: &[&str] = &[
+    "__generated__",
+    "_generated",
+    "generated",
     "fixtures",
     "fixture",
     "benchmarks",
@@ -30,7 +35,40 @@ const DEFAULT_EXCLUDED_ANY_DIRS: &[&str] = &[
 const DEFAULT_EXCLUDED_ROOT_DIRS: &[&str] = &["out", "dist", "build", "target"];
 
 /// File suffixes for generated text assets that do not produce useful entities.
-const DEFAULT_EXCLUDED_SUFFIXES: &[&str] = &[".min.js", ".min.css"];
+const DEFAULT_EXCLUDED_SUFFIXES: &[&str] = &[
+    ".min.js",
+    ".min.css",
+    ".generated.ts",
+    ".generated.tsx",
+    ".generated.js",
+    ".generated.jsx",
+    ".generated.mts",
+    ".generated.cts",
+    ".generated.mjs",
+    ".generated.cjs",
+    ".generated.d.ts",
+    ".gen.ts",
+    ".gen.tsx",
+    ".gen.js",
+    ".gen.jsx",
+    ".gen.mts",
+    ".gen.cts",
+    ".gen.mjs",
+    ".gen.cjs",
+    ".gen.d.ts",
+    ".module.css.d.ts",
+    ".module.scss.d.ts",
+    ".module.sass.d.ts",
+    ".module.less.d.ts",
+    ".svg.d.ts",
+    ".png.d.ts",
+    ".jpg.d.ts",
+    ".jpeg.d.ts",
+    ".webp.d.ts",
+    ".gif.d.ts",
+    ".avif.d.ts",
+    ".ico.d.ts",
+];
 
 /// File suffixes that are not useful source text for semantic extraction.
 const BINARY_FILE_SUFFIXES: &[&str] = &[
@@ -171,14 +209,30 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_excludes_generated_and_build_paths() {
+    fn default_excludes_generated_support_and_build_paths() {
         assert!(is_default_excluded("dist/app.js"));
         assert!(is_default_excluded("site/out/_next/static/chunks/app.js"));
         assert!(is_default_excluded("src/generated.min.js"));
+        assert!(is_default_excluded("src/__generated__/client.ts"));
+        assert!(is_default_excluded("src/_generated/tokens.ts"));
+        assert!(is_default_excluded("src/generated/schema.ts"));
+        assert!(is_default_excluded("src/api.generated.ts"));
+        assert!(is_default_excluded("src/api.generated.d.ts"));
+        assert!(is_default_excluded(
+            "src/components/Button.module.scss.d.ts"
+        ));
+        assert!(is_default_excluded("src/icons/logo.svg.d.ts"));
+        assert!(is_default_excluded("src/fixtures/example.ts"));
+        assert!(is_default_excluded("src/fixture/example.ts"));
+        assert!(is_default_excluded("packages/app/benchmarks/run.ts"));
+        assert!(is_default_excluded("packages/app/vendor/client.ts"));
+        assert!(is_default_excluded("tools/test-harness/main.ts"));
         assert!(is_default_excluded("target/debug/build.rs"));
         assert!(!is_default_excluded("src/app.js"));
+        assert!(!is_default_excluded("src/generated_value.ts"));
         assert!(!is_default_excluded("src/build/mod.rs"));
         assert!(!is_default_excluded("packages/compiler/build/index.ts"));
+        assert!(!is_default_excluded("src/cli/commands/codegen/run.ts"));
         assert!(!is_default_excluded("tools/dist/analyzer.py"));
     }
 

--- a/crates/sem-mcp/src/cache.rs
+++ b/crates/sem-mcp/src/cache.rs
@@ -10,7 +10,7 @@ use sem_core::parser::graph::{EntityGraph, EntityInfo, EntityRef, RefType};
 use sem_core::parser::js_ts_import_source_files_from_content;
 use sem_core::utils::hash::content_hash_bytes;
 
-pub const CACHE_SCHEMA_VERSION: i32 = 5;
+pub const CACHE_SCHEMA_VERSION: i32 = 6;
 pub const CACHE_KIND_FULL: &str = "full";
 pub const CACHE_KIND_TOPOLOGY: &str = "topology";
 pub const CACHE_INDEXES: &[(&str, &str, &str)] = &[
@@ -171,6 +171,14 @@ pub fn cache_has_default_source_scope(conn: &Connection) -> bool {
     .ok()
     .as_deref()
         == Some(CACHE_SOURCE_SCOPE_DEFAULT)
+}
+
+pub fn cache_has_source_scope(conn: &Connection, source_scope: CacheSourceScope) -> bool {
+    let is_default = cache_has_default_source_scope(conn);
+    match source_scope {
+        CacheSourceScope::Default => is_default,
+        CacheSourceScope::Custom => !is_default,
+    }
 }
 
 pub fn cache_has_kind(conn: &Connection, accepted: &[&str]) -> bool {
@@ -786,7 +794,20 @@ impl DiskCache {
         root: &Path,
         files: &[String],
     ) -> Option<(EntityGraph, Vec<SemanticEntity>)> {
+        self.load_with_source_scope(root, files, CacheSourceScope::Default)
+    }
+
+    pub fn load_with_source_scope(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: CacheSourceScope,
+    ) -> Option<(EntityGraph, Vec<SemanticEntity>)> {
         if !cache_has_kind(&self.conn, &[CACHE_KIND_FULL]) {
+            return None;
+        }
+
+        if !cache_has_source_scope(&self.conn, source_scope) {
             return None;
         }
 
@@ -914,7 +935,20 @@ impl DiskCache {
 
     /// Load only graph topology from a fresh cache.
     pub fn load_graph_topology(&self, root: &Path, files: &[String]) -> Option<EntityGraph> {
+        self.load_graph_topology_with_source_scope(root, files, CacheSourceScope::Default)
+    }
+
+    pub fn load_graph_topology_with_source_scope(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: CacheSourceScope,
+    ) -> Option<EntityGraph> {
         if !cache_has_kind(&self.conn, &[CACHE_KIND_FULL, CACHE_KIND_TOPOLOGY]) {
+            return None;
+        }
+
+        if !cache_has_source_scope(&self.conn, source_scope) {
             return None;
         }
 
@@ -1034,7 +1068,20 @@ impl DiskCache {
     /// Load a partial cache: identify stale files and return clean cached data.
     /// Returns None if cache is empty or ALL files are stale (full rebuild is better).
     pub fn load_partial(&self, root: &Path, files: &[String]) -> Option<PartialCache> {
+        self.load_partial_with_source_scope(root, files, CacheSourceScope::Default)
+    }
+
+    pub fn load_partial_with_source_scope(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: CacheSourceScope,
+    ) -> Option<PartialCache> {
         if !cache_has_kind(&self.conn, &[CACHE_KIND_FULL]) {
+            return None;
+        }
+
+        if !cache_has_source_scope(&self.conn, source_scope) {
             return None;
         }
 
@@ -1215,6 +1262,7 @@ impl DiskCache {
         stale_files: &[String],
         graph: &EntityGraph,
         entities: &[SemanticEntity],
+        source_scope: CacheSourceScope,
     ) -> Result<(), rusqlite::Error> {
         self.save_incremental_with_repair_metadata(
             root,
@@ -1225,6 +1273,7 @@ impl DiskCache {
             false,
             &[],
             &[],
+            source_scope,
         )
     }
 
@@ -1239,6 +1288,7 @@ impl DiskCache {
         repair_changed_clean_entity_ids: bool,
         recomputed_edge_source_ids: &[String],
         deleted_entity_ids: &[String],
+        source_scope: CacheSourceScope,
     ) -> Result<(), rusqlite::Error> {
         let source_stale_files: Vec<&String> = stale_files
             .iter()
@@ -1445,6 +1495,7 @@ impl DiskCache {
         }
 
         set_cache_kind(&tx, CACHE_KIND_FULL)?;
+        set_cache_source_scope(&tx, source_scope)?;
         tx.commit()?;
         Ok(())
     }
@@ -1715,6 +1766,7 @@ mod tests {
                 false,
                 &[],
                 &[],
+                CacheSourceScope::Default,
             )
             .unwrap();
         assert_eq!(file_import_count(&cache, "a.ts", "b.ts"), 0);
@@ -1736,6 +1788,69 @@ mod tests {
         }
 
         panic!("mtime did not change for {}", path.display());
+    }
+
+    #[test]
+    fn cache_reuse_requires_matching_source_scope_and_incremental_preserves_it() {
+        let root = temp_repo_root("source-scope-cache-reuse");
+        write_file(&root.join("a.ts"), "export function a() { return 1; }\n");
+        write_file(&root.join("b.ts"), "export function b() { return a(); }\n");
+        let files = vec!["a.ts".to_string(), "b.ts".to_string()];
+        let entities = vec![
+            entity("a-id", "a.ts", "a", "export function a() { return 1; }"),
+            entity("b-id", "b.ts", "b", "export function b() { return a(); }"),
+        ];
+        let graph = graph_with_edges(&entities, vec![edge("b-id", "a-id")]);
+        let cache = DiskCache::open(&root).unwrap();
+
+        cache
+            .save(&root, &files, &graph, &entities, CacheSourceScope::Custom)
+            .unwrap();
+
+        assert!(cache
+            .load_with_source_scope(&root, &files, CacheSourceScope::Default)
+            .is_none());
+        assert!(cache
+            .load_with_source_scope(&root, &files, CacheSourceScope::Custom)
+            .is_some());
+        assert!(cache
+            .load_partial_with_source_scope(&root, &files, CacheSourceScope::Default)
+            .is_none());
+
+        rewrite_after_mtime_tick(&root.join("b.ts"), "export function b() { return 2; }\n");
+        let partial = cache
+            .load_partial_with_source_scope(&root, &files, CacheSourceScope::Custom)
+            .unwrap();
+        assert_eq!(partial.stale_files, vec!["b.ts"]);
+
+        let updated_entities = vec![
+            entity("a-id", "a.ts", "a", "export function a() { return 1; }"),
+            entity("b-id", "b.ts", "b", "export function b() { return 2; }"),
+        ];
+        let updated_graph = graph_with_edges(&updated_entities, vec![]);
+        cache
+            .save_incremental_with_repair_metadata(
+                &root,
+                &files,
+                &partial.stale_files,
+                &updated_graph,
+                &updated_entities,
+                false,
+                &["b-id".to_string()],
+                &[],
+                CacheSourceScope::Custom,
+            )
+            .unwrap();
+
+        assert!(cache
+            .load_with_source_scope(&root, &files, CacheSourceScope::Default)
+            .is_none());
+        assert!(cache
+            .load_with_source_scope(&root, &files, CacheSourceScope::Custom)
+            .is_some());
+
+        drop(cache);
+        cleanup(root);
     }
 
     fn read_user_version(cache: &DiskCache) -> i32 {
@@ -2013,6 +2128,7 @@ mod tests {
                 &["stale.rs".to_string()],
                 &empty_graph(),
                 &entities,
+                CacheSourceScope::Default,
             )
             .unwrap();
 
@@ -2086,6 +2202,7 @@ mod tests {
                 &["stale.rs".to_string()],
                 &updated_graph,
                 &updated_entities,
+                CacheSourceScope::Default,
             )
             .unwrap();
 
@@ -2135,6 +2252,7 @@ mod tests {
                 true,
                 &[],
                 &[],
+                CacheSourceScope::Default,
             )
             .unwrap();
 

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -184,6 +184,14 @@ impl SemServer {
     }
 
     fn find_supported_files(root: &Path, registry: &ParserRegistry) -> Result<Vec<String>, String> {
+        Self::find_supported_files_with_options(root, registry, false)
+    }
+
+    fn find_supported_files_with_options(
+        root: &Path,
+        registry: &ParserRegistry,
+        no_default_excludes: bool,
+    ) -> Result<Vec<String>, String> {
         if !root.exists() {
             return Err(format!(
                 "Failed to read directory {}: No such file or directory",
@@ -201,6 +209,7 @@ impl SemServer {
         if semignore.exists() {
             builder.add_ignore(semignore);
         }
+        Self::prune_default_excluded_dirs(&mut builder, root, no_default_excludes);
         let walker = builder.build();
         for entry in walker.flatten() {
             let path = entry.path();
@@ -209,7 +218,9 @@ impl SemServer {
             }
             if let Ok(rel) = path.strip_prefix(root) {
                 let rel_str = rel.to_string_lossy().replace('\\', "/");
-                if is_default_excluded(&rel_str) || is_probably_binary_path(&rel_str) {
+                if (!no_default_excludes && is_default_excluded(&rel_str))
+                    || is_probably_binary_path(&rel_str)
+                {
                     continue;
                 }
                 if registry.get_plugin(&rel_str).is_none() {
@@ -226,10 +237,11 @@ impl SemServer {
     }
 
     /// Walk a subdirectory, returning paths relative to `prefix_root` (e.g. the repo root).
-    fn walk_dir_files(
+    fn walk_dir_files_with_options(
         dir: &Path,
         prefix_root: &Path,
         registry: &ParserRegistry,
+        no_default_excludes: bool,
     ) -> Result<Vec<String>, String> {
         let mut files = Vec::new();
         let mut builder = ignore::WalkBuilder::new(dir);
@@ -242,6 +254,7 @@ impl SemServer {
         if semignore.exists() {
             builder.add_ignore(semignore);
         }
+        Self::prune_default_excluded_dirs(&mut builder, prefix_root, no_default_excludes);
         let walker = builder.build();
         for entry in walker.flatten() {
             let path = entry.path();
@@ -250,7 +263,9 @@ impl SemServer {
             }
             if let Ok(rel) = path.strip_prefix(prefix_root) {
                 let rel_str = rel.to_string_lossy().replace('\\', "/");
-                if is_default_excluded(&rel_str) || is_probably_binary_path(&rel_str) {
+                if (!no_default_excludes && is_default_excluded(&rel_str))
+                    || is_probably_binary_path(&rel_str)
+                {
                     continue;
                 }
                 if registry.get_plugin(&rel_str).is_none() {
@@ -264,6 +279,32 @@ impl SemServer {
         }
         files.sort();
         Ok(files)
+    }
+
+    fn prune_default_excluded_dirs(
+        builder: &mut ignore::WalkBuilder,
+        prefix_root: &Path,
+        no_default_excludes: bool,
+    ) {
+        if no_default_excludes {
+            return;
+        }
+
+        let prefix_root = prefix_root.to_path_buf();
+        builder.filter_entry(move |entry| {
+            if !entry
+                .file_type()
+                .is_some_and(|file_type| file_type.is_dir())
+            {
+                return true;
+            }
+
+            let Ok(rel) = entry.path().strip_prefix(&prefix_root) else {
+                return true;
+            };
+            let rel_str = rel.to_string_lossy().replace('\\', "/");
+            !is_default_excluded(&rel_str)
+        });
     }
 
     fn read_file_at(abs_path: &Path, display_path: &str) -> Result<String, String> {
@@ -372,6 +413,7 @@ impl SemServer {
         &self,
         repo_root: &Path,
         file_paths: &[String],
+        source_scope: cache::CacheSourceScope,
     ) -> (Arc<EntityGraph>, Arc<Vec<SemanticEntity>>) {
         let manifest_hash = cache::compute_manifest_hash(repo_root, file_paths).unwrap_or(0);
 
@@ -388,7 +430,9 @@ impl SemServer {
         // Check SQLite cache (full hit, then incremental)
         if let Ok(disk) = cache::DiskCache::open(repo_root) {
             // Full cache hit
-            if let Some((graph, entities)) = disk.load(repo_root, file_paths) {
+            if let Some((graph, entities)) =
+                disk.load_with_source_scope(repo_root, file_paths, source_scope)
+            {
                 let graph = Arc::new(graph);
                 let entities = Arc::new(entities);
                 let mut guard = self.graph_cache.lock().await;
@@ -406,7 +450,9 @@ impl SemServer {
             }
 
             // Incremental: load clean cached data, rebuild only stale files
-            if let Some(partial) = disk.load_partial(repo_root, file_paths) {
+            if let Some(partial) =
+                disk.load_partial_with_source_scope(repo_root, file_paths, source_scope)
+            {
                 let (graph, entities, metadata) =
                     EntityGraph::build_incremental_with_metadata_and_import_candidates(
                         repo_root,
@@ -427,6 +473,7 @@ impl SemServer {
                     metadata.repaired_clean_entity_ids,
                     &metadata.recomputed_edge_source_ids,
                     &metadata.deleted_entity_ids,
+                    source_scope,
                 );
 
                 let graph = Arc::new(graph);
@@ -451,11 +498,6 @@ impl SemServer {
 
         // Persist to SQLite (best-effort)
         if let Ok(disk) = cache::DiskCache::open(repo_root) {
-            let source_scope = if repo_root.join(".semignore").exists() {
-                cache::CacheSourceScope::Custom
-            } else {
-                cache::CacheSourceScope::Default
-            };
             let _ = disk.save(repo_root, file_paths, &graph, &entities, source_scope);
         }
 
@@ -486,6 +528,7 @@ impl SemServer {
         &self,
         repo_root: &Path,
         file_paths: &[String],
+        source_scope: cache::CacheSourceScope,
     ) -> Arc<EntityGraph> {
         let manifest_hash = cache::compute_manifest_hash(repo_root, file_paths).unwrap_or(0);
 
@@ -508,7 +551,9 @@ impl SemServer {
         }
 
         if let Ok(disk) = cache::DiskCache::open(repo_root) {
-            if let Some(graph) = disk.load_graph_topology(repo_root, file_paths) {
+            if let Some(graph) =
+                disk.load_graph_topology_with_source_scope(repo_root, file_paths, source_scope)
+            {
                 let graph = Arc::new(graph);
                 let mut guard = self.topology_cache.lock().await;
                 *guard = Some(CachedTopology {
@@ -519,8 +564,18 @@ impl SemServer {
             }
         }
 
-        let (graph, _) = self.get_or_build_graph(repo_root, file_paths).await;
+        let (graph, _) = self
+            .get_or_build_graph(repo_root, file_paths, source_scope)
+            .await;
         graph
+    }
+
+    fn cache_source_scope(repo_root: &Path, no_default_excludes: bool) -> cache::CacheSourceScope {
+        if no_default_excludes || repo_root.join(".semignore").exists() {
+            cache::CacheSourceScope::Custom
+        } else {
+            cache::CacheSourceScope::Default
+        }
     }
 
     /// Ensure the in-memory whole-repo caches are fresh with respect to the file
@@ -572,7 +627,10 @@ impl SemServer {
 
         // Rebuild (incrementally, via the disk cache) and repopulate the memory
         // caches that live_graph / live_topology read from.
-        let _ = self.get_or_build_graph(repo_root, &file_paths).await;
+        let source_scope = Self::cache_source_scope(repo_root, false);
+        let _ = self
+            .get_or_build_graph(repo_root, &file_paths, source_scope)
+            .await;
         slot.last_built_generation = drained.generation;
         slot.built_once = true;
         Some(file_paths)
@@ -587,7 +645,9 @@ impl SemServer {
             }
         }
         let file_paths = Self::find_supported_files(repo_root, &self.registry).unwrap_or_default();
-        self.get_or_build_graph(repo_root, &file_paths).await
+        let source_scope = Self::cache_source_scope(repo_root, false);
+        self.get_or_build_graph(repo_root, &file_paths, source_scope)
+            .await
     }
 
     /// Whole-repo graph topology, kept hot by the file watcher when active.
@@ -607,7 +667,8 @@ impl SemServer {
             }
         }
         let file_paths = Self::find_supported_files(repo_root, &self.registry).unwrap_or_default();
-        self.get_or_build_graph_topology(repo_root, &file_paths)
+        let source_scope = Self::cache_source_scope(repo_root, false);
+        self.get_or_build_graph_topology(repo_root, &file_paths, source_scope)
             .await
     }
 }
@@ -645,6 +706,12 @@ impl SemServer {
 
         let (rel_path, abs_path) = Self::resolve_file_path(&ctx.repo_root, path);
         let (entities, include_file) = if abs_path.is_file() {
+            if !params.no_default_excludes() && is_default_excluded(&rel_path) {
+                return Ok(tool_error(format!(
+                    "Path is excluded by default: {}",
+                    rel_path
+                )));
+            }
             let content = match Self::read_file_at(&abs_path, &rel_path) {
                 Ok(content) => content,
                 Err(err) => return Ok(tool_error(err)),
@@ -658,7 +725,12 @@ impl SemServer {
             }
             (entities, false)
         } else if abs_path.is_dir() {
-            let file_paths = match Self::walk_dir_files(&abs_path, &ctx.repo_root, &self.registry) {
+            let file_paths = match Self::walk_dir_files_with_options(
+                &abs_path,
+                &ctx.repo_root,
+                &self.registry,
+                params.no_default_excludes(),
+            ) {
                 Ok(file_paths) => file_paths,
                 Err(err) => return Ok(tool_error(err)),
             };
@@ -859,6 +931,7 @@ impl SemServer {
         if self.registry.get_plugin(&rel_path).is_none() {
             return Ok(tool_error(format!("No parser for file: {}", rel_path)));
         }
+        let no_default_excludes = params.no_default_excludes.unwrap_or(false);
 
         let mode = params.mode.as_deref().unwrap_or("all");
         let valid_modes = ["all", "deps", "dependents", "tests"];
@@ -871,7 +944,21 @@ impl SemServer {
         }
 
         if matches!(mode, "deps" | "dependents") {
-            let graph = self.live_topology(&ctx.repo_root).await;
+            let graph = if no_default_excludes {
+                let file_paths = match Self::find_supported_files_with_options(
+                    &ctx.repo_root,
+                    &self.registry,
+                    no_default_excludes,
+                ) {
+                    Ok(file_paths) => file_paths,
+                    Err(err) => return Ok(tool_error(err)),
+                };
+                let source_scope = Self::cache_source_scope(&ctx.repo_root, no_default_excludes);
+                self.get_or_build_graph_topology(&ctx.repo_root, &file_paths, source_scope)
+                    .await
+            } else {
+                self.live_topology(&ctx.repo_root).await
+            };
             let entity_id = match Self::find_entity_in_graph(&graph, &params.entity_name, &rel_path)
             {
                 Ok(entity_id) => entity_id,
@@ -923,7 +1010,21 @@ impl SemServer {
             )]));
         }
 
-        let (graph, all_entities) = self.live_graph(&ctx.repo_root).await;
+        let (graph, all_entities) = if no_default_excludes {
+            let file_paths = match Self::find_supported_files_with_options(
+                &ctx.repo_root,
+                &self.registry,
+                no_default_excludes,
+            ) {
+                Ok(file_paths) => file_paths,
+                Err(err) => return Ok(tool_error(err)),
+            };
+            let source_scope = Self::cache_source_scope(&ctx.repo_root, no_default_excludes);
+            self.get_or_build_graph(&ctx.repo_root, &file_paths, source_scope)
+                .await
+        } else {
+            self.live_graph(&ctx.repo_root).await
+        };
 
         let entity_id = match Self::find_entity_in_graph(&graph, &params.entity_name, &rel_path) {
             Ok(entity_id) => entity_id,
@@ -1152,8 +1253,23 @@ impl SemServer {
         if self.registry.get_plugin(&rel_path).is_none() {
             return Ok(tool_error(format!("No parser for file: {}", rel_path)));
         }
+        let no_default_excludes = params.no_default_excludes.unwrap_or(false);
 
-        let (graph, all_entities) = self.live_graph(&ctx.repo_root).await;
+        let (graph, all_entities) = if no_default_excludes {
+            let file_paths = match Self::find_supported_files_with_options(
+                &ctx.repo_root,
+                &self.registry,
+                no_default_excludes,
+            ) {
+                Ok(file_paths) => file_paths,
+                Err(err) => return Ok(tool_error(err)),
+            };
+            let source_scope = Self::cache_source_scope(&ctx.repo_root, no_default_excludes);
+            self.get_or_build_graph(&ctx.repo_root, &file_paths, source_scope)
+                .await
+        } else {
+            self.live_graph(&ctx.repo_root).await
+        };
 
         let entity_id = match Self::find_entity_in_graph(&graph, &params.entity_name, &rel_path) {
             Ok(entity_id) => entity_id,
@@ -1512,10 +1628,31 @@ mod tests {
     fn find_supported_files_skips_binary_and_default_excludes() {
         let root = temp_dir();
         fs::create_dir_all(root.join("src")).unwrap();
+        fs::create_dir_all(root.join("src/generated")).unwrap();
         fs::create_dir_all(root.join("dist")).unwrap();
         fs::write(root.join("src/app.js"), "export function app() {}\n").unwrap();
         fs::write(root.join("src/blob.weird"), b"abc\0def").unwrap();
         fs::write(root.join("src/icon.png"), b"\x89PNG\r\n").unwrap();
+        fs::write(
+            root.join("src/generated/schema.ts"),
+            "export function generatedSchema() {}\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("src/api.generated.ts"),
+            "export function generatedApi() {}\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("src/styles.module.scss.d.ts"),
+            "declare const styles: Record<string, string>;\nexport default styles;\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("src/logo.svg.d.ts"),
+            "declare const src: string;\nexport default src;\n",
+        )
+        .unwrap();
         fs::write(
             root.join("dist/generated.js"),
             "export function generated() {}\n",
@@ -1526,6 +1663,17 @@ mod tests {
         let files = SemServer::find_supported_files(&root, &registry).unwrap();
 
         assert_eq!(files, vec!["src/app.js".to_string()]);
+
+        let files_with_generated =
+            SemServer::find_supported_files_with_options(&root, &registry, true).unwrap();
+        assert!(files_with_generated.contains(&"src/app.js".to_string()));
+        assert!(files_with_generated.contains(&"src/generated/schema.ts".to_string()));
+        assert!(files_with_generated.contains(&"src/api.generated.ts".to_string()));
+        assert!(files_with_generated.contains(&"src/styles.module.scss.d.ts".to_string()));
+        assert!(files_with_generated.contains(&"src/logo.svg.d.ts".to_string()));
+        assert!(files_with_generated.contains(&"dist/generated.js".to_string()));
+        assert!(!files_with_generated.contains(&"src/blob.weird".to_string()));
+        assert!(!files_with_generated.contains(&"src/icon.png".to_string()));
 
         fs::remove_dir_all(root).unwrap();
     }
@@ -1589,11 +1737,55 @@ mod tests {
         let result = server
             .sem_entities(Parameters(EntitiesParams {
                 path: Some(missing_path.display().to_string()),
+                no_default_excludes: None,
             }))
             .await
             .unwrap();
 
         assert_tool_error(result, "Path not found:");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn sem_entities_can_opt_into_generated_file_path() {
+        let root = temp_git_repo("generated-entities-file");
+        std::fs::create_dir_all(root.join("src/generated")).unwrap();
+        std::fs::write(
+            root.join("src/generated/schema.ts"),
+            "export function generatedTarget() { return 1; }\n",
+        )
+        .unwrap();
+        let server = server_for_repo(&root).await;
+
+        let default_result = server
+            .sem_entities(Parameters(EntitiesParams {
+                path: Some("src/generated/schema.ts".to_string()),
+                no_default_excludes: None,
+            }))
+            .await
+            .unwrap();
+        assert_tool_error(default_result, "Path is excluded by default:");
+
+        let opt_in_result = server
+            .sem_entities(Parameters(EntitiesParams {
+                path: Some("src/generated/schema.ts".to_string()),
+                no_default_excludes: Some(true),
+            }))
+            .await
+            .unwrap();
+
+        let text = match &opt_in_result.content.first().unwrap().raw {
+            rmcp::model::RawContent::Text(text) => &text.text,
+            other => panic!("expected text content, got {other:?}"),
+        };
+        let payload: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert!(
+            payload.as_array().unwrap().iter().any(|entity| {
+                entity["name"] == "generatedTarget" && entity["type"] == "function"
+            }),
+            "generated target should be returned when default excludes are disabled: {payload}"
+        );
+
         let _ = std::fs::remove_dir_all(root);
     }
 
@@ -1689,6 +1881,7 @@ mod tests {
                 file_path: file_path.display().to_string(),
                 entity_name: "nonexistent_zzz".to_string(),
                 mode: None,
+                no_default_excludes: None,
             }))
             .await
             .unwrap();
@@ -1708,6 +1901,7 @@ mod tests {
                 file_path: file_path.display().to_string(),
                 entity_name: "anything".to_string(),
                 mode: None,
+                no_default_excludes: None,
             }))
             .await
             .unwrap();
@@ -1733,6 +1927,7 @@ mod tests {
                 file_path: file_path.display().to_string(),
                 entity_name: "known_entity".to_string(),
                 mode: None,
+                no_default_excludes: None,
             }))
             .await
             .unwrap();
@@ -1759,6 +1954,71 @@ mod tests {
                 file_path: "./sample.py".to_string(),
                 entity_name: "known_entity".to_string(),
                 mode: Some("deps".to_string()),
+                no_default_excludes: None,
+            }))
+            .await
+            .unwrap();
+
+        assert_tool_success(result);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn sem_impact_can_opt_into_generated_files() {
+        let root = temp_git_repo("generated-impact-file");
+        std::fs::create_dir_all(root.join("src/generated")).unwrap();
+        std::fs::write(
+            root.join("src/generated/schema.ts"),
+            "export function generatedTarget() { return 1; }\n",
+        )
+        .unwrap();
+        let server = server_for_repo(&root).await;
+
+        let default_result = server
+            .sem_impact(Parameters(ImpactAnalysisParams {
+                file_path: "src/generated/schema.ts".to_string(),
+                entity_name: "generatedTarget".to_string(),
+                mode: Some("deps".to_string()),
+                no_default_excludes: None,
+            }))
+            .await
+            .unwrap();
+        assert_tool_error(
+            default_result,
+            "Entity 'generatedTarget' not found in 'src/generated/schema.ts'",
+        );
+
+        let opt_in_result = server
+            .sem_impact(Parameters(ImpactAnalysisParams {
+                file_path: "src/generated/schema.ts".to_string(),
+                entity_name: "generatedTarget".to_string(),
+                mode: Some("deps".to_string()),
+                no_default_excludes: Some(true),
+            }))
+            .await
+            .unwrap();
+
+        assert_tool_success(opt_in_result);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn sem_context_can_opt_into_generated_files() {
+        let root = temp_git_repo("generated-context-file");
+        std::fs::create_dir_all(root.join("src/generated")).unwrap();
+        std::fs::write(
+            root.join("src/generated/schema.ts"),
+            "export function generatedTarget() { return 1; }\n",
+        )
+        .unwrap();
+        let server = server_for_repo(&root).await;
+
+        let result = server
+            .sem_context(Parameters(ContextParams {
+                file_path: "src/generated/schema.ts".to_string(),
+                entity_name: "generatedTarget".to_string(),
+                token_budget: Some(2000),
+                no_default_excludes: Some(true),
             }))
             .await
             .unwrap();
@@ -1784,6 +2044,7 @@ mod tests {
                 file_path: file_path.display().to_string(),
                 entity_name: "known_entity".to_string(),
                 token_budget: None,
+                no_default_excludes: None,
             }))
             .await
             .unwrap();
@@ -1807,6 +2068,7 @@ mod tests {
                 file_path: file_path.display().to_string(),
                 entity_name: "nonexistent_zzz".to_string(),
                 token_budget: None,
+                no_default_excludes: None,
             }))
             .await
             .unwrap();
@@ -1850,6 +2112,7 @@ mod tests {
                 file_path: file_path.display().to_string(),
                 entity_name: "known_entity".to_string(),
                 mode: Some("invalid".to_string()),
+                no_default_excludes: None,
             }))
             .await
             .unwrap();

--- a/crates/sem-mcp/src/tools.rs
+++ b/crates/sem-mcp/src/tools.rs
@@ -7,11 +7,19 @@ use serde::Deserialize;
 pub struct EntitiesParams {
     #[schemars(description = "Optional path to a file or directory. If omitted, defaults to '.'.")]
     pub path: Option<String>,
+    #[schemars(
+        description = "Include files and directories excluded by default, including generated, fixture, vendor, and benchmark paths."
+    )]
+    pub no_default_excludes: Option<bool>,
 }
 
 impl EntitiesParams {
     pub fn path(&self) -> Option<&str> {
         self.path.as_deref().filter(|p| !p.is_empty())
+    }
+
+    pub fn no_default_excludes(&self) -> bool {
+        self.no_default_excludes.unwrap_or(false)
     }
 }
 
@@ -46,6 +54,10 @@ pub struct ImpactAnalysisParams {
         description = "Analysis mode: 'all' (default, shows deps + dependents + transitive impact + tests), 'deps' (direct dependencies only), 'dependents' (direct dependents only), 'tests' (affected test entities only)"
     )]
     pub mode: Option<String>,
+    #[schemars(
+        description = "Include files and directories excluded by default, including generated, fixture, vendor, and benchmark paths."
+    )]
+    pub no_default_excludes: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -68,6 +80,10 @@ pub struct ContextParams {
     pub entity_name: String,
     #[schemars(description = "Maximum token budget. Defaults to 8000.")]
     pub token_budget: Option<usize>,
+    #[schemars(
+        description = "Include files and directories excluded by default, including generated, fixture, vendor, and benchmark paths."
+    )]
+    pub no_default_excludes: Option<bool>,
 }
 
 #[cfg(test)]
@@ -103,6 +119,7 @@ mod tests {
             serde_json::from_value(serde_json::json!({ "path": "src/lib.rs" })).unwrap();
 
         assert_eq!(params.path(), Some("src/lib.rs"));
+        assert!(!params.no_default_excludes());
     }
 
     #[test]
@@ -110,6 +127,15 @@ mod tests {
         let params: EntitiesParams = serde_json::from_value(serde_json::json!({})).unwrap();
 
         assert_eq!(params.path(), None);
+        assert!(!params.no_default_excludes());
+    }
+
+    #[test]
+    fn entities_params_accepts_no_default_excludes() {
+        let params: EntitiesParams =
+            serde_json::from_value(serde_json::json!({ "no_default_excludes": true })).unwrap();
+
+        assert!(params.no_default_excludes());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- exclude generated directories, generated/gen source suffixes, CSS module declaration stubs, and asset declaration stubs from default source scans
- keep generated files available via `--no-default-excludes` and MCP `no_default_excludes` for entities, impact, and context
- make CLI/MCP cache reuse source-scope aware and bump the cache schema to invalidate older default-scope caches
- filter default-excluded imports in cache-first dependency freshness to avoid repeated misses when a source imports an excluded generated file

## Validation
- `cargo check -p sem-cli`
- `cargo check -p sem-mcp`
- `cargo test -p sem-cli`
- `cargo test -p sem-mcp`
- `cargo test -p sem-core`
- `cargo build --release -p sem-cli`
- `git diff --check`

## Metrics and sanity checks
- Notion default source-like file estimate: 81,569 total, 4,279 excluded by the final conservative policy, 77,290 remaining default sources, 5.25% reduction. Excluded families: generated dirs 301, generated/gen suffixes 89, CSS module declarations 678, asset declarations 3,229. Measured but intentionally not excluded: 2,232 `*.validators.ts` files.
- Notion cold `sem impact normalizeUuidRouteParam --file src/frontend/router/src/helpers/normalizeUuidRouteParam.ts --deps --json`: wall 328.80s, internal 327.761s; discovery 2.590s; direct dependency graph build 324.446s; output resolves the target and returns 0 dependencies.
- Attempted same-command warm run after cold direct-deps build, but stopped after 30s: the large-repo direct-deps cold path does not seed a reusable full topology cache. Recorded as residual behavior rather than counted as a warm metric.
- Sem repo cold/warm isolated-cache impact for `impact_command`: cold wall 0.39s, warm wall 0.02s; warm internal 7.517ms with `cache_topology_impact_query` 0.443ms. Cold and warm JSON outputs matched exactly. First dependency slice included `DiskCache::open`, `try_cloud_impact`, `cache_source_scope`, `find_supported_files_with_options`, and graph builders.

## Reviewers
- code review found MCP generated-target opt-in and MCP directory pruning gaps; fixed with `no_default_excludes` plumbing and walker pruning
- performance/cache review found old default cache reuse, scoped import freshness, and broad validator exclusion risks; fixed with schema bump, source-scope cache validation, scoped import filtering, and removal of `*.validators.ts`
- final re-review reported no findings

## Notes
- Full Notion topology-cache priming with `sem graph` was attempted for a cached Notion impact metric but stopped after an extended run; this block still validates the cache-backed path on the sem repo and records the Notion cold-path behavior explicitly.