### PR TITLE
Add entities timing counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to sem are documented in this file.
 ### Added
 
 - `sem impact` can answer direct dependency queries from a fresh SQL topology cache without rebuilding the entity graph.
+- `sem entities` reports phase timings and listing counters when `SEM_TIMINGS` is enabled.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to sem are documented in this file.
 - `sem impact --deps` can reuse fresh caches when unrelated files change by validating the cached source set, hashes, and import metadata before falling back to a graph rebuild.
 - `sem impact --deps` narrows cache freshness checks to the queried entity, direct dependencies, and relevant JavaScript/TypeScript imports when the query scope is explicit.
 - Source scans skip default-excluded high-volume paths such as generated source directories, fixture/vendor/benchmark trees, generated file suffixes, CSS module declarations, and asset declarations; pass `--no-default-excludes` to include them.
+- `sem entities` accepts `--file-exts` for large directory scans and avoids duplicate directory-listing post-processing.
+- `sem entities` can list entities from a fresh SQLite topology cache instead of reparsing matching directory scans.
+- `sem entities --json` streams rows to stdout instead of materializing an intermediate JSON value array.
+- `sem entities` uses listing-only extraction so local listings do not retain source text or entity hashes.
 
 ## [0.13.0] - 2026-06-16
 

--- a/crates/sem-cli/src/cache.rs
+++ b/crates/sem-cli/src/cache.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::path::Path;
 
-use rusqlite::{params, params_from_iter, Connection, OptionalExtension};
+use rusqlite::{params, params_from_iter, Connection, OpenFlags, OptionalExtension};
 use sem_core::model::entity::SemanticEntity;
 use sem_core::parser::graph::{EntityGraph, EntityInfo, EntityRef, RefType};
 use sem_core::parser::{
@@ -11,6 +11,7 @@ use sem_core::parser::{
 };
 use sem_core::utils::scan::is_default_excluded;
 use sem_mcp::cache as shared_cache;
+use serde::Serialize;
 
 const CACHED_TEST_IMPACT_LIMIT: usize = 10_000;
 const SQL_PARAM_CHUNK: usize = 500;
@@ -46,6 +47,18 @@ pub struct CachedImpactResult {
     pub tests_truncated: bool,
 }
 
+#[derive(Serialize)]
+struct EntityListingJsonRow<'a> {
+    name: &'a str,
+    #[serde(rename = "type")]
+    entity_type: &'a str,
+    start_line: usize,
+    end_line: usize,
+    parent_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    file: Option<&'a str>,
+}
+
 #[derive(Debug)]
 pub enum CachedImpactError {
     CacheReadFailed,
@@ -72,6 +85,17 @@ impl DiskCache {
 
         shared_cache::initialize_schema(&conn)?;
 
+        Ok(Self { conn })
+    }
+
+    pub fn open_existing_readonly(repo_root: &Path) -> Result<Self, rusqlite::Error> {
+        let db_path = shared_cache::cache_db_path(repo_root)
+            .ok_or_else(|| rusqlite::Error::InvalidPath(repo_root.to_path_buf()))?;
+        if !db_path.exists() {
+            return Err(rusqlite::Error::InvalidPath(db_path));
+        }
+
+        let conn = Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
         Ok(Self { conn })
     }
 
@@ -1095,6 +1119,135 @@ impl DiskCache {
         Ok(true)
     }
 
+    pub fn query_entities_listing(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+    ) -> Result<Option<Vec<EntityInfo>>, rusqlite::Error> {
+        if !self.has_fresh_topology_cache_for_files(root, files, source_scope) {
+            return Ok(None);
+        }
+
+        if files.is_empty() {
+            return Ok(Some(Vec::new()));
+        }
+
+        let mut entities = Vec::new();
+        for chunk in files.chunks(SQL_PARAM_CHUNK) {
+            let placeholders = repeat_vars(chunk.len());
+            let sql = format!(
+                "SELECT id, name, entity_type, file_path, start_line, end_line, parent_id
+                 FROM entities
+                 WHERE file_path IN ({placeholders})
+                 ORDER BY file_path, start_line, end_line, entity_type, name"
+            );
+            let mut stmt = self.conn.prepare(&sql)?;
+            let rows = stmt.query_map(
+                params_from_iter(chunk.iter().map(String::as_str)),
+                entity_info_from_row,
+            )?;
+            entities.extend(rows.collect::<Result<Vec<_>, _>>()?);
+        }
+        sort_entity_infos(&mut entities);
+        Ok(Some(entities))
+    }
+
+    fn has_fresh_topology_cache_for_files(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+    ) -> bool {
+        if !shared_cache::cache_has_kind(
+            &self.conn,
+            &[
+                shared_cache::CACHE_KIND_FULL,
+                shared_cache::CACHE_KIND_TOPOLOGY,
+            ],
+        ) {
+            return false;
+        }
+
+        if !shared_cache::cache_has_source_scope(&self.conn, source_scope) {
+            return false;
+        }
+
+        if shared_cache::is_manifest_stale(&self.conn, root) {
+            return false;
+        }
+
+        self.cached_files_are_fresh(
+            root,
+            files
+                .iter()
+                .filter(|file| !shared_cache::is_manifest_file_name(file))
+                .cloned()
+                .collect(),
+        )
+        .unwrap_or(false)
+    }
+
+    pub fn write_entities_listing_json<W: Write>(
+        &self,
+        root: &Path,
+        files: &[String],
+        source_scope: shared_cache::CacheSourceScope,
+        include_file: bool,
+        writer: &mut W,
+    ) -> std::io::Result<Option<u64>> {
+        if !self.has_fresh_topology_cache_for_files(root, files, source_scope) {
+            return Ok(None);
+        }
+
+        writer.write_all(b"[")?;
+        let mut first = true;
+        let mut count = 0u64;
+        for chunk in files.chunks(SQL_PARAM_CHUNK) {
+            if chunk.is_empty() {
+                continue;
+            }
+            let placeholders = repeat_vars(chunk.len());
+            let sql = format!(
+                "SELECT name, entity_type, file_path, start_line, end_line, parent_id
+                 FROM entities
+                 WHERE file_path IN ({placeholders})
+                 ORDER BY file_path, start_line, end_line, entity_type, name"
+            );
+            let mut stmt = self.conn.prepare(&sql).map_err(sql_io_error)?;
+            let mut rows = stmt
+                .query(params_from_iter(chunk.iter().map(String::as_str)))
+                .map_err(sql_io_error)?;
+            while let Some(row) = rows.next().map_err(sql_io_error)? {
+                if first {
+                    first = false;
+                } else {
+                    writer.write_all(b",")?;
+                }
+
+                let name: String = row.get(0).map_err(sql_io_error)?;
+                let entity_type: String = row.get(1).map_err(sql_io_error)?;
+                let file_path: String = row.get(2).map_err(sql_io_error)?;
+                let start_line = row.get::<_, i64>(3).map_err(sql_io_error)? as usize;
+                let end_line = row.get::<_, i64>(4).map_err(sql_io_error)? as usize;
+                let parent_id: Option<String> = row.get(5).map_err(sql_io_error)?;
+                let listing = EntityListingJsonRow {
+                    name: &name,
+                    entity_type: &entity_type,
+                    start_line,
+                    end_line,
+                    parent_id: parent_id.as_deref(),
+                    file: include_file.then_some(file_path.as_str()),
+                };
+                serde_json::to_writer(&mut *writer, &listing).map_err(json_io_error)?;
+                count += 1;
+            }
+        }
+        writer.write_all(b"]\n")?;
+
+        Ok(Some(count))
+    }
+
     fn has_fresh_complete_cache(
         &self,
         root: &Path,
@@ -1678,6 +1831,17 @@ fn entity_info_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<EntityInfo>
         end_line: row.get::<_, i64>(5)? as usize,
         parent_id: row.get(6)?,
     })
+}
+
+fn sort_entity_infos(entities: &mut [EntityInfo]) {
+    entities.sort_by(|a, b| {
+        a.file_path
+            .cmp(&b.file_path)
+            .then(a.start_line.cmp(&b.start_line))
+            .then(a.end_line.cmp(&b.end_line))
+            .then(a.entity_type.cmp(&b.entity_type))
+            .then(a.name.cmp(&b.name))
+    });
 }
 
 fn repeat_vars(len: usize) -> String {
@@ -3072,6 +3236,18 @@ mod tests {
         assert!(!root.join(".sem").exists());
 
         drop(cache);
+        cleanup(root);
+    }
+
+    #[test]
+    fn open_existing_readonly_does_not_create_missing_cache() {
+        let root = temp_repo_root("readonly-missing");
+        let db_path = shared_cache::cache_db_path(&root).unwrap();
+
+        assert!(!db_path.exists());
+        assert!(DiskCache::open_existing_readonly(&root).is_err());
+        assert!(!db_path.exists());
+
         cleanup(root);
     }
 

--- a/crates/sem-cli/src/commands/entities.rs
+++ b/crates/sem-cli/src/commands/entities.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
+use crate::timings::Timings;
 use colored::Colorize;
 use sem_core::model::entity::SemanticEntity;
 use sem_core::parser::registry::{resolve_go_method_parent_ids, ParserRegistry};
@@ -13,6 +14,8 @@ pub struct EntitiesOptions {
 }
 
 pub fn entities_command(opts: EntitiesOptions) {
+    let mut timings = Timings::from_env("entities");
+
     // Normalize to a non-empty list of path args, defaulting to ".".
     let path_args: Vec<String> = {
         let cleaned: Vec<String> = opts
@@ -27,9 +30,13 @@ pub fn entities_command(opts: EntitiesOptions) {
             cleaned
         }
     };
+    timings.counter("input_paths", path_args.len() as u64);
+    timings.mark("path_args");
 
     // The cloud fast-path only helps the whole-repo single listing.
     if path_args.len() == 1 && super::cloud::try_cloud_entities(&opts).is_some() {
+        timings.mark("cloud_entities");
+        timings.finish();
         return;
     }
 
@@ -38,9 +45,15 @@ pub fn entities_command(opts: EntitiesOptions) {
 
     let mut entities: Vec<SemanticEntity> = Vec::new();
     let mut dir_count = 0usize;
+    let mut file_arg_count = 0usize;
+    let mut processed_file_count = 0usize;
+    let mut discovered_file_count = 0usize;
+    let mut extracted_entities = false;
     for path_arg in &path_args {
         let (path_label, full_path) = resolve_path(root, path_arg);
         if full_path.is_file() {
+            file_arg_count += 1;
+            processed_file_count += 1;
             let file_entities = extract_file_entities(&full_path, &registry, &path_label)
                 .unwrap_or_else(|e| {
                     eprintln!(
@@ -52,6 +65,7 @@ pub fn entities_command(opts: EntitiesOptions) {
                     std::process::exit(1);
                 });
             entities.extend(file_entities);
+            extracted_entities = true;
         } else if full_path.is_dir() {
             dir_count += 1;
             let file_paths = super::files::find_supported_files_in_path(
@@ -61,11 +75,18 @@ pub fn entities_command(opts: EntitiesOptions) {
                 &[],
                 opts.no_default_excludes,
             );
+            discovered_file_count += file_paths.len();
+            processed_file_count += file_paths.len();
+            timings.mark("file_discovery");
             entities.extend(extract_files_entities(root, &file_paths, &registry));
+            extracted_entities = true;
         } else {
             eprintln!("{} Path not found '{}'", "error:".red().bold(), path_arg);
             std::process::exit(1);
         }
+    }
+    if extracted_entities {
+        timings.mark("extract_entities");
     }
 
     // Overlapping paths (e.g. a directory and a file inside it) can surface the
@@ -79,6 +100,7 @@ pub fn entities_command(opts: EntitiesOptions) {
             .then(a.name.cmp(&b.name))
     });
     entities.dedup_by(|a, b| a.id == b.id);
+    timings.mark("sort_dedup");
 
     // Show the file column whenever results span more than one file. This keeps
     // the prior single-file vs directory behavior and covers multi-path input.
@@ -90,13 +112,22 @@ pub fn entities_command(opts: EntitiesOptions) {
     };
     let include_file = dir_count > 0 || distinct_files > 1;
     let display_label = path_args.join(" ");
+    timings.counter("input_files", processed_file_count as u64);
+    timings.counter("input_file_args", file_arg_count as u64);
+    timings.counter("input_dirs", dir_count as u64);
+    timings.counter("processed_files", processed_file_count as u64);
+    timings.counter("discovered_files", discovered_file_count as u64);
+    timings.counter("distinct_files", distinct_files as u64);
+    timings.counter("entities", entities.len() as u64);
 
     if opts.json {
         let output: Vec<_> = entities
             .iter()
             .map(|e| entity_json(e, include_file))
             .collect();
-        println!("{}", serde_json::to_string(&output).unwrap());
+        let serialized = serde_json::to_string(&output).unwrap();
+        timings.counter("json_bytes", serialized.len() as u64);
+        println!("{serialized}");
     } else if should_group_by_file(&entities) {
         print_grouped_entities(&display_label, &entities);
     } else if let Some(file_path) = entities.first().map(|e| e.file_path.as_str()) {
@@ -104,6 +135,8 @@ pub fn entities_command(opts: EntitiesOptions) {
     } else {
         println!("{} {}\n", "entities:".green().bold(), display_label.bold());
     }
+    timings.mark("output_serialization");
+    timings.finish();
 }
 
 fn resolve_path(root: &Path, path_arg: &str) -> (String, PathBuf) {
@@ -205,7 +238,10 @@ fn print_entity_rows(entities: &[SemanticEntity], base_indent: &str) {
 }
 
 fn entities_by_id(entities: &[SemanticEntity]) -> HashMap<&str, &SemanticEntity> {
-    entities.iter().map(|entity| (entity.id.as_str(), entity)).collect()
+    entities
+        .iter()
+        .map(|entity| (entity.id.as_str(), entity))
+        .collect()
 }
 
 fn entity_indent(
@@ -213,7 +249,10 @@ fn entity_indent(
     entities_by_id: &HashMap<&str, &SemanticEntity>,
     base_indent: &str,
 ) -> String {
-    format!("{base_indent}{}", "  ".repeat(entity_depth(entity, entities_by_id)))
+    format!(
+        "{base_indent}{}",
+        "  ".repeat(entity_depth(entity, entities_by_id))
+    )
 }
 
 fn entity_depth(entity: &SemanticEntity, entities_by_id: &HashMap<&str, &SemanticEntity>) -> usize {

--- a/crates/sem-cli/src/commands/entities.rs
+++ b/crates/sem-cli/src/commands/entities.rs
@@ -1,16 +1,20 @@
 use std::collections::{BTreeSet, HashMap, HashSet};
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
-use crate::timings::Timings;
+use crate::{cache::DiskCache, timings::Timings};
 use colored::Colorize;
 use sem_core::model::entity::SemanticEntity;
-use sem_core::parser::registry::{resolve_go_method_parent_ids, ParserRegistry};
+use sem_core::parser::graph::EntityInfo;
+use sem_core::parser::registry::ParserRegistry;
+use serde::Serialize;
 
 pub struct EntitiesOptions {
     pub cwd: String,
     pub paths: Vec<String>,
     pub json: bool,
     pub no_default_excludes: bool,
+    pub file_exts: Vec<String>,
 }
 
 pub fn entities_command(opts: EntitiesOptions) {
@@ -33,8 +37,13 @@ pub fn entities_command(opts: EntitiesOptions) {
     timings.counter("input_paths", path_args.len() as u64);
     timings.mark("path_args");
 
+    let ext_filter = super::graph::normalize_exts(&opts.file_exts);
+
     // The cloud fast-path only helps the whole-repo single listing.
-    if path_args.len() == 1 && super::cloud::try_cloud_entities(&opts).is_some() {
+    if ext_filter.is_empty()
+        && path_args.len() == 1
+        && super::cloud::try_cloud_entities(&opts).is_some()
+    {
         timings.mark("cloud_entities");
         timings.finish();
         return;
@@ -72,14 +81,43 @@ pub fn entities_command(opts: EntitiesOptions) {
                 root,
                 &full_path,
                 &registry,
-                &[],
+                &ext_filter,
                 opts.no_default_excludes,
             );
             discovered_file_count += file_paths.len();
             processed_file_count += file_paths.len();
             timings.mark("file_discovery");
-            entities.extend(extract_files_entities(root, &file_paths, &registry));
-            extracted_entities = true;
+            if opts.json
+                && path_args.len() == 1
+                && try_write_cached_entities_json(
+                    root,
+                    &file_paths,
+                    &ext_filter,
+                    opts.no_default_excludes,
+                    &mut timings,
+                )
+            {
+                timings.counter("input_files", processed_file_count as u64);
+                timings.counter("input_file_args", file_arg_count as u64);
+                timings.counter("input_dirs", dir_count as u64);
+                timings.counter("processed_files", processed_file_count as u64);
+                timings.counter("discovered_files", discovered_file_count as u64);
+                timings.mark("output_serialization");
+                timings.finish();
+                return;
+            }
+            if let Some(cached_entities) = try_cached_entities(
+                root,
+                &file_paths,
+                &ext_filter,
+                opts.no_default_excludes,
+                &mut timings,
+            ) {
+                entities.extend(cached_entities);
+            } else {
+                entities.extend(extract_files_entities(root, &file_paths, &registry));
+                extracted_entities = true;
+            }
         } else {
             eprintln!("{} Path not found '{}'", "error:".red().bold(), path_arg);
             std::process::exit(1);
@@ -121,13 +159,11 @@ pub fn entities_command(opts: EntitiesOptions) {
     timings.counter("entities", entities.len() as u64);
 
     if opts.json {
-        let output: Vec<_> = entities
-            .iter()
-            .map(|e| entity_json(e, include_file))
-            .collect();
-        let serialized = serde_json::to_string(&output).unwrap();
-        timings.counter("json_bytes", serialized.len() as u64);
-        println!("{serialized}");
+        let json_bytes = write_entities_json(&entities, include_file).unwrap_or_else(|e| {
+            eprintln!("{} Cannot write JSON output: {}", "error:".red().bold(), e);
+            std::process::exit(1);
+        });
+        timings.counter("json_bytes", json_bytes);
     } else if should_group_by_file(&entities) {
         print_grouped_entities(&display_label, &entities);
     } else if let Some(file_path) = entities.first().map(|e| e.file_path.as_str()) {
@@ -161,17 +197,103 @@ fn extract_files_entities(
     file_paths: &[String],
     registry: &ParserRegistry,
 ) -> Vec<SemanticEntity> {
-    let mut entities = registry.extract_all_entities(root, file_paths);
-    resolve_go_method_parent_ids(&mut entities);
-    entities.sort_by(|a, b| {
-        a.file_path
-            .cmp(&b.file_path)
-            .then(a.start_line.cmp(&b.start_line))
-            .then(a.end_line.cmp(&b.end_line))
-            .then(a.entity_type.cmp(&b.entity_type))
-            .then(a.name.cmp(&b.name))
-    });
-    entities
+    registry.extract_all_entities_brief(root, file_paths)
+}
+
+fn try_cached_entities(
+    root: &Path,
+    file_paths: &[String],
+    ext_filter: &[String],
+    no_default_excludes: bool,
+    timings: &mut Timings,
+) -> Option<Vec<SemanticEntity>> {
+    let source_scope = super::graph::cache_source_scope(root, ext_filter, no_default_excludes);
+    let cache = match DiskCache::open_existing_readonly(root) {
+        Ok(cache) => {
+            timings.mark("cache_open");
+            cache
+        }
+        Err(_) => {
+            timings.mark("cache_open_failed");
+            return None;
+        }
+    };
+
+    match cache.query_entities_listing(root, file_paths, source_scope) {
+        Ok(Some(entities)) => {
+            timings.counter("cached_entities", entities.len() as u64);
+            timings.mark("cache_entities_query");
+            Some(entities.into_iter().map(entity_info_to_entity).collect())
+        }
+        Ok(None) => {
+            timings.mark("cache_entities_miss");
+            None
+        }
+        Err(_) => {
+            timings.mark("cache_entities_query_failed");
+            None
+        }
+    }
+}
+
+fn try_write_cached_entities_json(
+    root: &Path,
+    file_paths: &[String],
+    ext_filter: &[String],
+    no_default_excludes: bool,
+    timings: &mut Timings,
+) -> bool {
+    let source_scope = super::graph::cache_source_scope(root, ext_filter, no_default_excludes);
+    let cache = match DiskCache::open_existing_readonly(root) {
+        Ok(cache) => {
+            timings.mark("cache_open");
+            cache
+        }
+        Err(_) => {
+            timings.mark("cache_open_failed");
+            return false;
+        }
+    };
+
+    let stdout = io::stdout();
+    let mut writer = CountingWriter::new(stdout.lock());
+    match cache.write_entities_listing_json(root, file_paths, source_scope, true, &mut writer) {
+        Ok(Some(entity_count)) => {
+            timings.counter("cached_entities", entity_count);
+            timings.counter("entities", entity_count);
+            timings.counter("json_bytes", writer.bytes());
+            timings.mark("cache_entities_query");
+            true
+        }
+        Ok(None) => {
+            timings.mark("cache_entities_miss");
+            false
+        }
+        Err(error) => {
+            eprintln!(
+                "{} Cannot write cached JSON output: {}",
+                "error:".red().bold(),
+                error
+            );
+            std::process::exit(1);
+        }
+    }
+}
+
+fn entity_info_to_entity(entity: EntityInfo) -> SemanticEntity {
+    SemanticEntity {
+        id: entity.id,
+        file_path: entity.file_path,
+        entity_type: entity.entity_type,
+        name: entity.name,
+        parent_id: entity.parent_id,
+        content: String::new(),
+        content_hash: String::new(),
+        structural_hash: None,
+        start_line: entity.start_line,
+        end_line: entity.end_line,
+        metadata: None,
+    }
 }
 
 fn file_path_for_entity(root: &Path, path: &Path) -> String {
@@ -184,23 +306,69 @@ fn extract_file_entities(
     file_path: &str,
 ) -> Result<Vec<SemanticEntity>, std::io::Error> {
     let content = std::fs::read_to_string(&full_path)?;
-    Ok(registry.extract_entities(file_path, &content))
+    Ok(registry.extract_entities_brief(file_path, &content))
 }
 
-fn entity_json(entity: &SemanticEntity, include_file: bool) -> serde_json::Value {
-    let mut value = serde_json::json!({
-        "name": entity.name,
-        "type": entity.entity_type,
-        "start_line": entity.start_line,
-        "end_line": entity.end_line,
-        "parent_id": entity.parent_id,
-    });
+#[derive(Serialize)]
+struct EntityJsonRow<'a> {
+    name: &'a str,
+    #[serde(rename = "type")]
+    entity_type: &'a str,
+    start_line: usize,
+    end_line: usize,
+    parent_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    file: Option<&'a str>,
+}
 
-    if include_file {
-        value["file"] = serde_json::json!(entity.file_path);
+fn write_entities_json(entities: &[SemanticEntity], include_file: bool) -> io::Result<u64> {
+    let stdout = io::stdout();
+    let mut writer = CountingWriter::new(stdout.lock());
+    writer.write_all(b"[")?;
+    for (index, entity) in entities.iter().enumerate() {
+        if index > 0 {
+            writer.write_all(b",")?;
+        }
+        let row = EntityJsonRow {
+            name: &entity.name,
+            entity_type: &entity.entity_type,
+            start_line: entity.start_line,
+            end_line: entity.end_line,
+            parent_id: entity.parent_id.as_deref(),
+            file: include_file.then_some(entity.file_path.as_str()),
+        };
+        serde_json::to_writer(&mut writer, &row)
+            .map_err(|error| io::Error::new(io::ErrorKind::Other, error))?;
+    }
+    writer.write_all(b"]\n")?;
+    Ok(writer.bytes())
+}
+
+struct CountingWriter<W> {
+    inner: W,
+    bytes: u64,
+}
+
+impl<W> CountingWriter<W> {
+    fn new(inner: W) -> Self {
+        Self { inner, bytes: 0 }
     }
 
-    value
+    fn bytes(&self) -> u64 {
+        self.bytes
+    }
+}
+
+impl<W: Write> Write for CountingWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let written = self.inner.write(buf)?;
+        self.bytes += written as u64;
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
 }
 
 fn print_file_entities(file_path: &str, entities: &[SemanticEntity]) {

--- a/crates/sem-cli/src/main.rs
+++ b/crates/sem-cli/src/main.rs
@@ -244,6 +244,10 @@ enum Commands {
         /// Include files and directories excluded by default (generated, fixtures, vendor, benchmarks)
         #[arg(long)]
         no_default_excludes: bool,
+
+        /// Only include files with these extensions (e.g. --file-exts .ts .tsx)
+        #[arg(long, num_args = 1..)]
+        file_exts: Vec<String>,
     },
     /// Show token-budgeted context for an entity
     Context {
@@ -528,6 +532,7 @@ fn main() {
             format,
             json,
             no_default_excludes,
+            file_exts,
         }) => {
             entities_command(EntitiesOptions {
                 cwd: std::env::current_dir()
@@ -537,6 +542,7 @@ fn main() {
                 paths,
                 json: resolve_json(format, json),
                 no_default_excludes,
+                file_exts,
             });
         }
         Some(Commands::Context {

--- a/crates/sem-cli/src/timings.rs
+++ b/crates/sem-cli/src/timings.rs
@@ -7,11 +7,17 @@ pub struct Timings {
     start: Instant,
     last: Instant,
     entries: Vec<TimingEntry>,
+    counters: Vec<TimingCounter>,
 }
 
 struct TimingEntry {
     name: &'static str,
     duration_ms: f64,
+}
+
+struct TimingCounter {
+    name: &'static str,
+    value: u64,
 }
 
 impl Timings {
@@ -26,6 +32,7 @@ impl Timings {
             start: now,
             last: now,
             entries: Vec::new(),
+            counters: Vec::new(),
         }
     }
 
@@ -38,6 +45,7 @@ impl Timings {
             start: now,
             last: now,
             entries: Vec::new(),
+            counters: Vec::new(),
         }
     }
 
@@ -51,6 +59,13 @@ impl Timings {
             duration_ms: elapsed_ms(now.duration_since(self.last)),
         });
         self.last = now;
+    }
+
+    pub fn counter(&mut self, name: &'static str, value: u64) {
+        if !self.enabled {
+            return;
+        }
+        self.counters.push(TimingCounter { name, value });
     }
 
     pub fn finish(&self) {
@@ -69,16 +84,31 @@ impl Timings {
                     })
                 })
                 .collect::<Vec<_>>();
-            let output = serde_json::json!({
+            let mut output = serde_json::json!({
                 "command": self.command,
                 "phases": phases,
                 "totalMs": total_ms,
             });
+            if !self.counters.is_empty() {
+                output["counters"] = serde_json::json!(self
+                    .counters
+                    .iter()
+                    .map(|counter| {
+                        serde_json::json!({
+                            "name": counter.name,
+                            "value": counter.value,
+                        })
+                    })
+                    .collect::<Vec<_>>());
+            }
             eprintln!("{}", serde_json::to_string(&output).unwrap());
         } else {
             eprintln!("sem timings ({})", self.command);
             for entry in &self.entries {
                 eprintln!("  {:<32} {:>8.3} ms", entry.name, entry.duration_ms);
+            }
+            for counter in &self.counters {
+                eprintln!("  {:<32} {:>8}", counter.name, counter.value);
             }
             eprintln!("  {:<32} {:>8.3} ms", "total", total_ms);
         }

--- a/crates/sem-cli/tests/entities_cli.rs
+++ b/crates/sem-cli/tests/entities_cli.rs
@@ -1,0 +1,125 @@
+use std::{collections::HashMap, fs, process::Command};
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn run_sem_entities_json(repo: &TempDir) -> (Value, Value) {
+    run_sem_entities_json_with_args(repo, &["entities", ".", "--json"])
+}
+
+fn run_sem_entities_json_with_args(repo: &TempDir, args: &[&str]) -> (Value, Value) {
+    let output = Command::new(env!("CARGO_BIN_EXE_sem"))
+        .current_dir(repo.path())
+        .env("DO_NOT_TRACK", "1")
+        .env("SEM_LOCAL", "1")
+        .env("SEM_TIMINGS", "json")
+        .args(args)
+        .output()
+        .expect("run sem entities");
+
+    assert!(
+        output.status.success(),
+        "sem entities failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = serde_json::from_slice(&output.stdout).expect("entities stdout json");
+    let stderr = String::from_utf8(output.stderr).expect("timings stderr utf8");
+    let timings = serde_json::from_str(stderr.trim()).expect("timings stderr json");
+    (stdout, timings)
+}
+
+#[test]
+fn entities_json_emits_timings_and_counters() {
+    let repo = TempDir::new().expect("temp repo");
+    fs::write(
+        repo.path().join("a.ts"),
+        "export function alpha() { return 1; }\n",
+    )
+    .unwrap();
+    fs::write(
+        repo.path().join("b.ts"),
+        "export const beta = () => alpha();\n",
+    )
+    .unwrap();
+
+    let (entities, timings) = run_sem_entities_json(&repo);
+    let entities = entities.as_array().expect("entities array");
+    assert!(entities.iter().any(|entity| entity["name"] == "alpha"));
+    assert!(entities.iter().any(|entity| entity["name"] == "beta"));
+
+    assert_eq!(timings["command"], "entities");
+    let phase_names = timings["phases"]
+        .as_array()
+        .expect("phases array")
+        .iter()
+        .map(|phase| phase["name"].as_str().expect("phase name"))
+        .collect::<Vec<_>>();
+    for expected in [
+        "path_args",
+        "file_discovery",
+        "extract_entities",
+        "sort_dedup",
+        "output_serialization",
+    ] {
+        assert!(
+            phase_names.contains(&expected),
+            "missing phase {expected}; got {phase_names:?}"
+        );
+    }
+
+    let counters = timings["counters"]
+        .as_array()
+        .expect("counters array")
+        .iter()
+        .map(|counter| {
+            (
+                counter["name"].as_str().expect("counter name"),
+                counter["value"].as_u64().expect("counter value"),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    assert_eq!(counters["input_paths"], 1);
+    assert_eq!(counters["input_dirs"], 1);
+    assert_eq!(counters["input_files"], 2);
+    assert_eq!(counters["input_file_args"], 0);
+    assert_eq!(counters["processed_files"], 2);
+    assert_eq!(counters["discovered_files"], 2);
+    assert_eq!(counters["entities"], entities.len() as u64);
+    assert!(counters["json_bytes"] > 0);
+}
+
+#[test]
+fn entities_json_counts_explicit_file_inputs_separately() {
+    let repo = TempDir::new().expect("temp repo");
+    fs::write(
+        repo.path().join("a.ts"),
+        "export function alpha() { return 1; }\n",
+    )
+    .unwrap();
+
+    let (entities, timings) =
+        run_sem_entities_json_with_args(&repo, &["entities", "a.ts", "--json"]);
+    let entities = entities.as_array().expect("entities array");
+    assert!(entities.iter().any(|entity| entity["name"] == "alpha"));
+
+    let counters = timings["counters"]
+        .as_array()
+        .expect("counters array")
+        .iter()
+        .map(|counter| {
+            (
+                counter["name"].as_str().expect("counter name"),
+                counter["value"].as_u64().expect("counter value"),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    assert_eq!(counters["input_paths"], 1);
+    assert_eq!(counters["input_dirs"], 0);
+    assert_eq!(counters["input_files"], 1);
+    assert_eq!(counters["input_file_args"], 1);
+    assert_eq!(counters["processed_files"], 1);
+    assert_eq!(counters["discovered_files"], 0);
+    assert_eq!(counters["entities"], entities.len() as u64);
+}

--- a/crates/sem-cli/tests/entities_cli.rs
+++ b/crates/sem-cli/tests/entities_cli.rs
@@ -30,6 +30,76 @@ fn run_sem_entities_json_with_args(repo: &TempDir, args: &[&str]) -> (Value, Val
     (stdout, timings)
 }
 
+fn run_sem_entities_json_value_with_args(repo: &TempDir, args: &[&str]) -> Value {
+    let output = Command::new(env!("CARGO_BIN_EXE_sem"))
+        .current_dir(repo.path())
+        .env("DO_NOT_TRACK", "1")
+        .env("SEM_LOCAL", "1")
+        .args(args)
+        .output()
+        .expect("run sem entities");
+
+    assert!(
+        output.status.success(),
+        "sem entities failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stderr), "");
+
+    serde_json::from_slice(&output.stdout).expect("entities stdout json")
+}
+
+fn run_sem_graph_json(repo: &TempDir, cache: &TempDir) {
+    let output = Command::new(env!("CARGO_BIN_EXE_sem"))
+        .current_dir(repo.path())
+        .env("DO_NOT_TRACK", "1")
+        .env("SEM_LOCAL", "1")
+        .env("SEM_CACHE_DIR", cache.path())
+        .args(["graph", ".", "--json"])
+        .output()
+        .expect("run sem graph");
+
+    assert!(
+        output.status.success(),
+        "sem graph failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn run_cached_sem_entities_json(repo: &TempDir, cache: &TempDir) -> (Value, Value) {
+    run_cached_sem_entities_json_with_args(repo, cache, &["entities", ".", "--json"])
+}
+
+fn run_cached_sem_entities_json_with_args(
+    repo: &TempDir,
+    cache: &TempDir,
+    args: &[&str],
+) -> (Value, Value) {
+    let output = Command::new(env!("CARGO_BIN_EXE_sem"))
+        .current_dir(repo.path())
+        .env("DO_NOT_TRACK", "1")
+        .env("SEM_LOCAL", "1")
+        .env("SEM_CACHE_DIR", cache.path())
+        .env("SEM_TIMINGS", "json")
+        .args(args)
+        .output()
+        .expect("run sem entities");
+
+    assert!(
+        output.status.success(),
+        "sem entities failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = serde_json::from_slice(&output.stdout).expect("entities stdout json");
+    let stderr = String::from_utf8(output.stderr).expect("timings stderr utf8");
+    let timings = serde_json::from_str(stderr.trim()).expect("timings stderr json");
+    (stdout, timings)
+}
+
 #[test]
 fn entities_json_emits_timings_and_counters() {
     let repo = TempDir::new().expect("temp repo");
@@ -122,4 +192,150 @@ fn entities_json_counts_explicit_file_inputs_separately() {
     assert_eq!(counters["processed_files"], 1);
     assert_eq!(counters["discovered_files"], 0);
     assert_eq!(counters["entities"], entities.len() as u64);
+}
+
+#[test]
+fn entities_file_exts_filter_directory_scans() {
+    let repo = TempDir::new().expect("temp repo");
+    fs::write(
+        repo.path().join("a.ts"),
+        "export function alpha() { return 1; }\n",
+    )
+    .unwrap();
+    fs::write(repo.path().join("config.json"), r#"{"ignored": true}"#).unwrap();
+
+    let entities = run_sem_entities_json_value_with_args(
+        &repo,
+        &["entities", ".", "--json", "--file-exts", ".ts"],
+    );
+    let entities = entities.as_array().expect("entities array");
+
+    assert!(entities.iter().any(|entity| entity["name"] == "alpha"));
+    assert!(
+        entities.iter().all(|entity| entity["file"]
+            .as_str()
+            .is_some_and(|file| file.ends_with(".ts"))),
+        "expected only .ts entities, got {entities:?}"
+    );
+
+    let bare_ext_entities = run_sem_entities_json_value_with_args(
+        &repo,
+        &["entities", ".", "--json", "--file-exts", "ts"],
+    );
+    assert_eq!(bare_ext_entities, Value::Array(entities.clone()));
+}
+
+#[test]
+fn entities_uses_fresh_topology_cache() {
+    let repo = TempDir::new().expect("temp repo");
+    let cache = TempDir::new().expect("temp cache");
+    fs::write(
+        repo.path().join("a.ts"),
+        "export function alpha() { return 1; }\n",
+    )
+    .unwrap();
+    fs::write(
+        repo.path().join("b.ts"),
+        "export function beta() { return alpha(); }\n",
+    )
+    .unwrap();
+
+    run_sem_graph_json(&repo, &cache);
+    let (entities, timings) = run_cached_sem_entities_json(&repo, &cache);
+    let entities = entities.as_array().expect("entities array");
+    assert!(entities.iter().any(|entity| entity["name"] == "alpha"));
+    assert!(entities.iter().any(|entity| entity["name"] == "beta"));
+
+    let phase_names = timings["phases"]
+        .as_array()
+        .expect("phases array")
+        .iter()
+        .map(|phase| phase["name"].as_str().expect("phase name"))
+        .collect::<Vec<_>>();
+    assert!(
+        phase_names.contains(&"cache_entities_query"),
+        "expected cache hit phase, got {phase_names:?}"
+    );
+    assert!(
+        !phase_names.contains(&"extract_entities"),
+        "cache hit should not parse files; got {phase_names:?}"
+    );
+    assert!(
+        !phase_names.contains(&"sort_dedup"),
+        "streamed cache hit should not materialize and sort entities; got {phase_names:?}"
+    );
+
+    let counters = timings["counters"]
+        .as_array()
+        .expect("counters array")
+        .iter()
+        .map(|counter| {
+            (
+                counter["name"].as_str().expect("counter name"),
+                counter["value"].as_u64().expect("counter value"),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    assert_eq!(counters["cached_entities"], entities.len() as u64);
+}
+
+#[test]
+fn entities_uses_whole_repo_cache_for_subdirectory_listing() {
+    let repo = TempDir::new().expect("temp repo");
+    let cache = TempDir::new().expect("temp cache");
+    fs::create_dir_all(repo.path().join("src")).unwrap();
+    fs::create_dir_all(repo.path().join("tests")).unwrap();
+    fs::write(
+        repo.path().join("src").join("a.ts"),
+        "export function alpha() { return 1; }\n",
+    )
+    .unwrap();
+    fs::write(
+        repo.path().join("tests").join("b.ts"),
+        "export function beta() { return 2; }\n",
+    )
+    .unwrap();
+
+    run_sem_graph_json(&repo, &cache);
+    let (entities, timings) =
+        run_cached_sem_entities_json_with_args(&repo, &cache, &["entities", "src", "--json"]);
+    let entities = entities.as_array().expect("entities array");
+    assert!(entities.iter().any(|entity| entity["name"] == "alpha"));
+    assert!(!entities.iter().any(|entity| entity["name"] == "beta"));
+    assert!(
+        entities.iter().all(|entity| entity["file"]
+            .as_str()
+            .is_some_and(|file| file.starts_with("src/"))),
+        "expected only src entities, got {entities:?}"
+    );
+
+    let phase_names = timings["phases"]
+        .as_array()
+        .expect("phases array")
+        .iter()
+        .map(|phase| phase["name"].as_str().expect("phase name"))
+        .collect::<Vec<_>>();
+    assert!(
+        phase_names.contains(&"cache_entities_query"),
+        "expected cache hit phase, got {phase_names:?}"
+    );
+    assert!(
+        !phase_names.contains(&"extract_entities"),
+        "cache hit should not parse files; got {phase_names:?}"
+    );
+
+    let counters = timings["counters"]
+        .as_array()
+        .expect("counters array")
+        .iter()
+        .map(|counter| {
+            (
+                counter["name"].as_str().expect("counter name"),
+                counter["value"].as_u64().expect("counter value"),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    assert_eq!(counters["cached_entities"], entities.len() as u64);
+    assert_eq!(counters["input_files"], 1);
+    assert_eq!(counters["discovered_files"], 1);
 }

--- a/crates/sem-core/src/parser/plugin.rs
+++ b/crates/sem-core/src/parser/plugin.rs
@@ -4,6 +4,11 @@ pub trait SemanticParserPlugin: Send + Sync {
     fn id(&self) -> &str;
     fn extensions(&self) -> &[&str];
     fn extract_entities(&self, content: &str, file_path: &str) -> Vec<SemanticEntity>;
+    fn extract_entities_brief(&self, content: &str, file_path: &str) -> Vec<SemanticEntity> {
+        let mut entities = self.extract_entities(content, file_path);
+        strip_entity_payloads(&mut entities);
+        entities
+    }
     /// Extract entities and optionally return the tree-sitter Tree for reuse.
     /// Default returns None for the tree (non-code plugins).
     fn extract_entities_with_tree(
@@ -18,5 +23,13 @@ pub trait SemanticParserPlugin: Send + Sync {
     }
     fn compute_similarity(&self, a: &SemanticEntity, b: &SemanticEntity) -> f64 {
         crate::model::identity::default_similarity(a, b)
+    }
+}
+
+pub fn strip_entity_payloads(entities: &mut [SemanticEntity]) {
+    for entity in entities {
+        entity.content.clear();
+        entity.content_hash.clear();
+        entity.structural_hash = None;
     }
 }

--- a/crates/sem-core/src/parser/plugins/json.rs
+++ b/crates/sem-core/src/parser/plugins/json.rs
@@ -14,17 +14,32 @@ impl SemanticParserPlugin for JsonParserPlugin {
     }
 
     fn extract_entities(&self, content: &str, file_path: &str) -> Vec<SemanticEntity> {
+        self.extract_entities_with_payload(content, file_path, EntityPayloadMode::Full)
+    }
+
+    fn extract_entities_brief(&self, content: &str, file_path: &str) -> Vec<SemanticEntity> {
+        self.extract_entities_with_payload(content, file_path, EntityPayloadMode::Brief)
+    }
+}
+
+impl JsonParserPlugin {
+    fn extract_entities_with_payload(
+        &self,
+        content: &str,
+        file_path: &str,
+        payload_mode: EntityPayloadMode,
+    ) -> Vec<SemanticEntity> {
         let trimmed = content.trim_start();
         if trimmed.starts_with('{') {
-            return extract_entries(content, file_path, JsonContainerKind::Object);
+            return extract_entries(content, file_path, JsonContainerKind::Object, payload_mode);
         }
         if trimmed.starts_with('[') {
-            return extract_entries(content, file_path, JsonContainerKind::Array);
+            return extract_entries(content, file_path, JsonContainerKind::Array, payload_mode);
         }
         if trimmed.is_empty() {
             return Vec::new();
         }
-        vec![document_chunk_entity(content, file_path)]
+        vec![document_chunk_entity(content, file_path, payload_mode)]
     }
 }
 
@@ -32,6 +47,12 @@ impl SemanticParserPlugin for JsonParserPlugin {
 enum JsonContainerKind {
     Object,
     Array,
+}
+
+#[derive(Clone, Copy)]
+enum EntityPayloadMode {
+    Full,
+    Brief,
 }
 
 struct Frame {
@@ -52,6 +73,7 @@ fn extract_entries(
     content: &str,
     file_path: &str,
     container_kind: JsonContainerKind,
+    payload_mode: EntityPayloadMode,
 ) -> Vec<SemanticEntity> {
     let mut entities = Vec::new();
     let root_entries = match container_kind {
@@ -117,6 +139,14 @@ fn extract_entries(
             let entity_id = format!("{}::{}", file_path, pointer);
             let abs_start = frame.line_offset + entry.start_line - 1;
             let abs_end = frame.line_offset + end_line - 1;
+            let (stored_content, content_hash_value, structural_hash_value) = match payload_mode {
+                EntityPayloadMode::Full => (
+                    entity_content.clone(),
+                    content_hash(&entity_content),
+                    Some(content_hash(value_content)),
+                ),
+                EntityPayloadMode::Brief => (String::new(), String::new(), None),
+            };
 
             entities.push(SemanticEntity {
                 id: entity_id.clone(),
@@ -124,9 +154,9 @@ fn extract_entries(
                 entity_type: entry.entity_type.clone(),
                 name: entry.key.clone(),
                 parent_id: frame.parent_entity_id.clone(),
-                content_hash: content_hash(&entity_content),
-                structural_hash: Some(content_hash(value_content)),
-                content: entity_content.clone(),
+                content_hash: content_hash_value,
+                structural_hash: structural_hash_value,
+                content: stored_content,
                 start_line: abs_start,
                 end_line: abs_end,
                 metadata: None,
@@ -155,17 +185,25 @@ fn extract_entries(
     entities
 }
 
-fn document_chunk_entity(content: &str, file_path: &str) -> SemanticEntity {
+fn document_chunk_entity(
+    content: &str,
+    file_path: &str,
+    payload_mode: EntityPayloadMode,
+) -> SemanticEntity {
     let line_count = content.lines().count().max(1);
+    let (stored_content, content_hash_value) = match payload_mode {
+        EntityPayloadMode::Full => (content.to_string(), content_hash(content)),
+        EntityPayloadMode::Brief => (String::new(), String::new()),
+    };
     SemanticEntity {
         id: build_entity_id(file_path, "chunk", "(document)", None),
         file_path: file_path.to_string(),
         entity_type: "chunk".to_string(),
         name: "(document)".to_string(),
         parent_id: None,
-        content_hash: content_hash(content),
+        content_hash: content_hash_value,
         structural_hash: None,
-        content: content.to_string(),
+        content: stored_content,
         start_line: 1,
         end_line: line_count,
         metadata: None,
@@ -624,6 +662,24 @@ mod tests {
     fn find_change<'a>(changes: &'a [SemanticChange], name: &str, kind: ChangeType) -> &'a SemanticChange {
         changes.iter().find(|c| c.entity_name == name && c.change_type == kind)
             .unwrap_or_else(|| panic!("expected {:?} {} in changes; got: {:?}", kind, name, names(changes)))
+    }
+
+    #[test]
+    fn brief_extraction_drops_json_payloads() {
+        let content = r#"{
+  "scripts": {
+    "build": "tsc"
+  }
+}
+"#;
+        let plugin = JsonParserPlugin;
+        let entities = plugin.extract_entities_brief(content, "package.json");
+
+        assert!(entities.iter().any(|entity| entity.name == "scripts"));
+        assert!(entities.iter().any(|entity| entity.name == "build"));
+        assert!(entities.iter().all(|entity| entity.content.is_empty()));
+        assert!(entities.iter().all(|entity| entity.content_hash.is_empty()));
+        assert!(entities.iter().all(|entity| entity.structural_hash.is_none()));
     }
 
     #[test]

--- a/crates/sem-core/src/parser/registry.rs
+++ b/crates/sem-core/src/parser/registry.rs
@@ -13,7 +13,7 @@ macro_rules! maybe_par_iter {
         { $slice.iter() }
     }};
 }
-use super::plugin::SemanticParserPlugin;
+use super::plugin::{strip_entity_payloads, SemanticParserPlugin};
 
 pub struct ParserRegistry {
     plugins: Vec<Box<dyn SemanticParserPlugin>>,
@@ -251,6 +251,23 @@ impl ParserRegistry {
         entities
     }
 
+    /// Extract listing-only entities without retaining source content or hashes.
+    pub fn extract_entities_brief(&self, file_path: &str, content: &str) -> Vec<SemanticEntity> {
+        let resolved = self.resolve_file_path(file_path);
+        let detection_path = resolved.as_deref().unwrap_or(file_path);
+
+        let plugin = match self.get_plugin_with_content(detection_path, content) {
+            Some(p) => p,
+            None => return Vec::new(),
+        };
+
+        let mut entities = plugin.extract_entities_brief(content, detection_path);
+        if let Some(ref rp) = resolved {
+            fix_entity_paths(&mut entities, file_path, rp);
+        }
+        entities
+    }
+
     /// Extract entities with tree, transparently handling custom extension mappings.
     pub fn extract_entities_with_tree(
         &self,
@@ -286,6 +303,38 @@ impl ParserRegistry {
             .collect();
         resolve_go_method_parent_ids(&mut entities);
         entities
+    }
+
+    /// Extract listing-only entities from multiple files in parallel.
+    pub fn extract_all_entities_brief(
+        &self,
+        root: &Path,
+        file_paths: &[String],
+    ) -> Vec<SemanticEntity> {
+        let mut entities: Vec<SemanticEntity> = maybe_par_iter!(file_paths)
+            .flat_map(|fp| {
+                let full = root.join(fp);
+                let content = match std::fs::read_to_string(&full) {
+                    Ok(c) => c,
+                    Err(_) => return Vec::new(),
+                };
+                if self.needs_content_for_listing_parent_repair(fp, &content) {
+                    self.extract_entities(fp, &content)
+                } else {
+                    self.extract_entities_brief(fp, &content)
+                }
+            })
+            .collect();
+        resolve_go_method_parent_ids(&mut entities);
+        strip_entity_payloads(&mut entities);
+        entities
+    }
+
+    fn needs_content_for_listing_parent_repair(&self, file_path: &str, content: &str) -> bool {
+        let resolved = self.resolve_file_path(file_path);
+        let detection_path = resolved.as_deref().unwrap_or(file_path);
+        detection_path.ends_with(".go")
+            || detect_ext_from_content(content).as_deref() == Some(".go")
     }
 }
 
@@ -836,6 +885,37 @@ mod tests {
 
         assert_eq!(run.parent_id.as_deref(), Some(service.id.as_str()));
         assert_eq!(run.id, format!("{}::Run", service.id));
+    }
+
+    #[cfg(feature = "lang-go")]
+    #[test]
+    fn test_brief_go_method_parent_resolves_across_files() {
+        let registry = create_default_registry();
+        let dir = TempDir::new().unwrap();
+        write_file(&dir, "models.go", "package demo\n\ntype Service struct{}\n");
+        write_file(
+            &dir,
+            "methods.go",
+            "package demo\n\nfunc (s *Service) Run() {}\n",
+        );
+
+        let entities = registry.extract_all_entities_brief(
+            dir.path(),
+            &["models.go".to_string(), "methods.go".to_string()],
+        );
+        let service = entities
+            .iter()
+            .find(|e| e.name == "Service" && e.file_path == "models.go")
+            .expect("Service type should be extracted");
+        let run = entities
+            .iter()
+            .find(|e| e.name == "Run" && e.file_path == "methods.go")
+            .expect("Run method should be extracted");
+
+        assert_eq!(run.parent_id.as_deref(), Some(service.id.as_str()));
+        assert!(entities.iter().all(|e| e.content.is_empty()));
+        assert!(entities.iter().all(|e| e.content_hash.is_empty()));
+        assert!(entities.iter().all(|e| e.structural_hash.is_none()));
     }
 
     #[cfg(feature = "lang-go")]


### PR DESCRIPTION
## Summary
- add `SEM_TIMINGS` phase and counter instrumentation to `sem entities`
- report input, discovery, entity, distinct-file, and JSON-byte counters
- cover the timings JSON shape in the entities CLI test

## Changelog
- Added an Unreleased `CHANGELOG.md` entry for entities timings and counters.

## Validation
- `cargo test -p sem-cli --test entities_cli`
- `cargo check -p sem-cli`
- `git diff --check`