### PR TITLE
Add brief entities extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to sem are documented in this file.
 - `sem entities` accepts `--file-exts` for large directory scans and avoids duplicate directory-listing post-processing.
 - `sem entities` can list entities from a fresh SQLite topology cache instead of reparsing matching directory scans.
 - `sem entities --json` streams rows to stdout instead of materializing an intermediate JSON value array.
+- `sem entities` uses listing-only extraction so local listings do not retain source text or entity hashes.
 
 ## [0.13.0] - 2026-06-16
 

--- a/crates/sem-cli/src/commands/entities.rs
+++ b/crates/sem-cli/src/commands/entities.rs
@@ -197,7 +197,7 @@ fn extract_files_entities(
     file_paths: &[String],
     registry: &ParserRegistry,
 ) -> Vec<SemanticEntity> {
-    registry.extract_all_entities(root, file_paths)
+    registry.extract_all_entities_brief(root, file_paths)
 }
 
 fn try_cached_entities(
@@ -306,7 +306,7 @@ fn extract_file_entities(
     file_path: &str,
 ) -> Result<Vec<SemanticEntity>, std::io::Error> {
     let content = std::fs::read_to_string(&full_path)?;
-    Ok(registry.extract_entities(file_path, &content))
+    Ok(registry.extract_entities_brief(file_path, &content))
 }
 
 #[derive(Serialize)]

--- a/crates/sem-core/src/parser/plugin.rs
+++ b/crates/sem-core/src/parser/plugin.rs
@@ -4,6 +4,11 @@ pub trait SemanticParserPlugin: Send + Sync {
     fn id(&self) -> &str;
     fn extensions(&self) -> &[&str];
     fn extract_entities(&self, content: &str, file_path: &str) -> Vec<SemanticEntity>;
+    fn extract_entities_brief(&self, content: &str, file_path: &str) -> Vec<SemanticEntity> {
+        let mut entities = self.extract_entities(content, file_path);
+        strip_entity_payloads(&mut entities);
+        entities
+    }
     /// Extract entities and optionally return the tree-sitter Tree for reuse.
     /// Default returns None for the tree (non-code plugins).
     fn extract_entities_with_tree(
@@ -18,5 +23,13 @@ pub trait SemanticParserPlugin: Send + Sync {
     }
     fn compute_similarity(&self, a: &SemanticEntity, b: &SemanticEntity) -> f64 {
         crate::model::identity::default_similarity(a, b)
+    }
+}
+
+pub fn strip_entity_payloads(entities: &mut [SemanticEntity]) {
+    for entity in entities {
+        entity.content.clear();
+        entity.content_hash.clear();
+        entity.structural_hash = None;
     }
 }

--- a/crates/sem-core/src/parser/plugins/json.rs
+++ b/crates/sem-core/src/parser/plugins/json.rs
@@ -14,17 +14,32 @@ impl SemanticParserPlugin for JsonParserPlugin {
     }
 
     fn extract_entities(&self, content: &str, file_path: &str) -> Vec<SemanticEntity> {
+        self.extract_entities_with_payload(content, file_path, EntityPayloadMode::Full)
+    }
+
+    fn extract_entities_brief(&self, content: &str, file_path: &str) -> Vec<SemanticEntity> {
+        self.extract_entities_with_payload(content, file_path, EntityPayloadMode::Brief)
+    }
+}
+
+impl JsonParserPlugin {
+    fn extract_entities_with_payload(
+        &self,
+        content: &str,
+        file_path: &str,
+        payload_mode: EntityPayloadMode,
+    ) -> Vec<SemanticEntity> {
         let trimmed = content.trim_start();
         if trimmed.starts_with('{') {
-            return extract_entries(content, file_path, JsonContainerKind::Object);
+            return extract_entries(content, file_path, JsonContainerKind::Object, payload_mode);
         }
         if trimmed.starts_with('[') {
-            return extract_entries(content, file_path, JsonContainerKind::Array);
+            return extract_entries(content, file_path, JsonContainerKind::Array, payload_mode);
         }
         if trimmed.is_empty() {
             return Vec::new();
         }
-        vec![document_chunk_entity(content, file_path)]
+        vec![document_chunk_entity(content, file_path, payload_mode)]
     }
 }
 
@@ -32,6 +47,12 @@ impl SemanticParserPlugin for JsonParserPlugin {
 enum JsonContainerKind {
     Object,
     Array,
+}
+
+#[derive(Clone, Copy)]
+enum EntityPayloadMode {
+    Full,
+    Brief,
 }
 
 struct Frame {
@@ -52,6 +73,7 @@ fn extract_entries(
     content: &str,
     file_path: &str,
     container_kind: JsonContainerKind,
+    payload_mode: EntityPayloadMode,
 ) -> Vec<SemanticEntity> {
     let mut entities = Vec::new();
     let root_entries = match container_kind {
@@ -117,6 +139,14 @@ fn extract_entries(
             let entity_id = format!("{}::{}", file_path, pointer);
             let abs_start = frame.line_offset + entry.start_line - 1;
             let abs_end = frame.line_offset + end_line - 1;
+            let (stored_content, content_hash_value, structural_hash_value) = match payload_mode {
+                EntityPayloadMode::Full => (
+                    entity_content.clone(),
+                    content_hash(&entity_content),
+                    Some(content_hash(value_content)),
+                ),
+                EntityPayloadMode::Brief => (String::new(), String::new(), None),
+            };
 
             entities.push(SemanticEntity {
                 id: entity_id.clone(),
@@ -124,9 +154,9 @@ fn extract_entries(
                 entity_type: entry.entity_type.clone(),
                 name: entry.key.clone(),
                 parent_id: frame.parent_entity_id.clone(),
-                content_hash: content_hash(&entity_content),
-                structural_hash: Some(content_hash(value_content)),
-                content: entity_content.clone(),
+                content_hash: content_hash_value,
+                structural_hash: structural_hash_value,
+                content: stored_content,
                 start_line: abs_start,
                 end_line: abs_end,
                 metadata: None,
@@ -155,17 +185,25 @@ fn extract_entries(
     entities
 }
 
-fn document_chunk_entity(content: &str, file_path: &str) -> SemanticEntity {
+fn document_chunk_entity(
+    content: &str,
+    file_path: &str,
+    payload_mode: EntityPayloadMode,
+) -> SemanticEntity {
     let line_count = content.lines().count().max(1);
+    let (stored_content, content_hash_value) = match payload_mode {
+        EntityPayloadMode::Full => (content.to_string(), content_hash(content)),
+        EntityPayloadMode::Brief => (String::new(), String::new()),
+    };
     SemanticEntity {
         id: build_entity_id(file_path, "chunk", "(document)", None),
         file_path: file_path.to_string(),
         entity_type: "chunk".to_string(),
         name: "(document)".to_string(),
         parent_id: None,
-        content_hash: content_hash(content),
+        content_hash: content_hash_value,
         structural_hash: None,
-        content: content.to_string(),
+        content: stored_content,
         start_line: 1,
         end_line: line_count,
         metadata: None,
@@ -624,6 +662,24 @@ mod tests {
     fn find_change<'a>(changes: &'a [SemanticChange], name: &str, kind: ChangeType) -> &'a SemanticChange {
         changes.iter().find(|c| c.entity_name == name && c.change_type == kind)
             .unwrap_or_else(|| panic!("expected {:?} {} in changes; got: {:?}", kind, name, names(changes)))
+    }
+
+    #[test]
+    fn brief_extraction_drops_json_payloads() {
+        let content = r#"{
+  "scripts": {
+    "build": "tsc"
+  }
+}
+"#;
+        let plugin = JsonParserPlugin;
+        let entities = plugin.extract_entities_brief(content, "package.json");
+
+        assert!(entities.iter().any(|entity| entity.name == "scripts"));
+        assert!(entities.iter().any(|entity| entity.name == "build"));
+        assert!(entities.iter().all(|entity| entity.content.is_empty()));
+        assert!(entities.iter().all(|entity| entity.content_hash.is_empty()));
+        assert!(entities.iter().all(|entity| entity.structural_hash.is_none()));
     }
 
     #[test]

--- a/crates/sem-core/src/parser/registry.rs
+++ b/crates/sem-core/src/parser/registry.rs
@@ -13,7 +13,7 @@ macro_rules! maybe_par_iter {
         { $slice.iter() }
     }};
 }
-use super::plugin::SemanticParserPlugin;
+use super::plugin::{strip_entity_payloads, SemanticParserPlugin};
 
 pub struct ParserRegistry {
     plugins: Vec<Box<dyn SemanticParserPlugin>>,
@@ -251,6 +251,23 @@ impl ParserRegistry {
         entities
     }
 
+    /// Extract listing-only entities without retaining source content or hashes.
+    pub fn extract_entities_brief(&self, file_path: &str, content: &str) -> Vec<SemanticEntity> {
+        let resolved = self.resolve_file_path(file_path);
+        let detection_path = resolved.as_deref().unwrap_or(file_path);
+
+        let plugin = match self.get_plugin_with_content(detection_path, content) {
+            Some(p) => p,
+            None => return Vec::new(),
+        };
+
+        let mut entities = plugin.extract_entities_brief(content, detection_path);
+        if let Some(ref rp) = resolved {
+            fix_entity_paths(&mut entities, file_path, rp);
+        }
+        entities
+    }
+
     /// Extract entities with tree, transparently handling custom extension mappings.
     pub fn extract_entities_with_tree(
         &self,
@@ -286,6 +303,38 @@ impl ParserRegistry {
             .collect();
         resolve_go_method_parent_ids(&mut entities);
         entities
+    }
+
+    /// Extract listing-only entities from multiple files in parallel.
+    pub fn extract_all_entities_brief(
+        &self,
+        root: &Path,
+        file_paths: &[String],
+    ) -> Vec<SemanticEntity> {
+        let mut entities: Vec<SemanticEntity> = maybe_par_iter!(file_paths)
+            .flat_map(|fp| {
+                let full = root.join(fp);
+                let content = match std::fs::read_to_string(&full) {
+                    Ok(c) => c,
+                    Err(_) => return Vec::new(),
+                };
+                if self.needs_content_for_listing_parent_repair(fp, &content) {
+                    self.extract_entities(fp, &content)
+                } else {
+                    self.extract_entities_brief(fp, &content)
+                }
+            })
+            .collect();
+        resolve_go_method_parent_ids(&mut entities);
+        strip_entity_payloads(&mut entities);
+        entities
+    }
+
+    fn needs_content_for_listing_parent_repair(&self, file_path: &str, content: &str) -> bool {
+        let resolved = self.resolve_file_path(file_path);
+        let detection_path = resolved.as_deref().unwrap_or(file_path);
+        detection_path.ends_with(".go")
+            || detect_ext_from_content(content).as_deref() == Some(".go")
     }
 }
 
@@ -836,6 +885,37 @@ mod tests {
 
         assert_eq!(run.parent_id.as_deref(), Some(service.id.as_str()));
         assert_eq!(run.id, format!("{}::Run", service.id));
+    }
+
+    #[cfg(feature = "lang-go")]
+    #[test]
+    fn test_brief_go_method_parent_resolves_across_files() {
+        let registry = create_default_registry();
+        let dir = TempDir::new().unwrap();
+        write_file(&dir, "models.go", "package demo\n\ntype Service struct{}\n");
+        write_file(
+            &dir,
+            "methods.go",
+            "package demo\n\nfunc (s *Service) Run() {}\n",
+        );
+
+        let entities = registry.extract_all_entities_brief(
+            dir.path(),
+            &["models.go".to_string(), "methods.go".to_string()],
+        );
+        let service = entities
+            .iter()
+            .find(|e| e.name == "Service" && e.file_path == "models.go")
+            .expect("Service type should be extracted");
+        let run = entities
+            .iter()
+            .find(|e| e.name == "Run" && e.file_path == "methods.go")
+            .expect("Run method should be extracted");
+
+        assert_eq!(run.parent_id.as_deref(), Some(service.id.as_str()));
+        assert!(entities.iter().all(|e| e.content.is_empty()));
+        assert!(entities.iter().all(|e| e.content_hash.is_empty()));
+        assert!(entities.iter().all(|e| e.structural_hash.is_none()));
     }
 
     #[cfg(feature = "lang-go")]


### PR DESCRIPTION
## Summary
- add listing-only parser extraction that drops source content and entity hashes for `sem entities`
- optimize JSON brief extraction so large data files do not clone/hash payload content for listings
- keep Go cross-file method parent repair intact before stripping payload fields

## Changelog
- Added an Unreleased `CHANGELOG.md` entry for listing-only entities extraction.

## Validation
- `cargo test -p sem-core parser::registry::tests::test_brief_go_method_parent_resolves_across_files`
- `cargo test -p sem-core parser::plugins::json::tests::brief_extraction_drops_json_payloads`
- `cargo test -p sem-cli --test entities_cli`
- `cargo check -p sem-cli`
- `cargo test -p sem-core -p sem-cli`
- `git diff --check`