### PR TITLE
fix: build and publish Intel macOS (x86_64-apple-darwin)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,9 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-14
             name: sem-darwin-arm64
+          - target: x86_64-apple-darwin
+            os: macos-13
+            name: sem-darwin-x86_64
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             name: sem-windows-x86_64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ All notable changes to sem are documented in this file.
 - `sem entities --json` streams rows to stdout instead of materializing an intermediate JSON value array.
 - `sem entities` uses listing-only extraction so local listings do not retain source text or entity hashes.
 
+### Fixed
+
+- Intel macOS (`x86_64-apple-darwin`) is now built and published. The release matrix only produced Apple Silicon (`arm64`) macOS binaries, so Intel Mac users got a 404 from `install.sh` and "Unsupported platform darwin:x64" from npm. Added the `x86_64-apple-darwin` target to the release build and the `darwin:x64` mapping to the npm wrapper. Thanks @stark-bit for the report (#374).
+
 ## [0.13.0] - 2026-06-16
 
 ### Fixed

--- a/scripts/package-meta.mjs
+++ b/scripts/package-meta.mjs
@@ -34,11 +34,13 @@ export function resolveReleaseArtifact({
       return 'sem-linux-arm64.tar.gz';
     case 'darwin:arm64':
       return 'sem-darwin-arm64.tar.gz';
+    case 'darwin:x64':
+      return 'sem-darwin-x86_64.tar.gz';
     case 'win32:x64':
       return 'sem-windows-x86_64.tar.gz';
     default:
       throw new Error(
-        `Unsupported platform ${key}. Supported targets: linux/x64, linux/arm64, darwin/arm64, win32/x64.`,
+        `Unsupported platform ${key}. Supported targets: linux/x64, linux/arm64, darwin/x64, darwin/arm64, win32/x64.`,
       );
   }
 }

--- a/scripts/package-meta.test.mjs
+++ b/scripts/package-meta.test.mjs
@@ -19,6 +19,10 @@ test('resolveReleaseArtifact maps supported targets to release assets', () => {
     'sem-darwin-arm64.tar.gz',
   );
   assert.equal(
+    resolveReleaseArtifact({ platform: 'darwin', arch: 'x64' }),
+    'sem-darwin-x86_64.tar.gz',
+  );
+  assert.equal(
     resolveReleaseArtifact({ platform: 'win32', arch: 'x64' }),
     'sem-windows-x86_64.tar.gz',
   );


### PR DESCRIPTION
## Problem

v0.13.0 shipped binaries for every platform except Intel macOS. The release matrix had `aarch64-apple-darwin` (Apple Silicon) but no `x86_64-apple-darwin`, so Intel Mac users hit a 404 from `install.sh` and "Unsupported platform darwin:x64" from the npm wrapper. There was no `sem-darwin-x86_64` asset at all.

## Fix

- **release.yml**: add the `x86_64-apple-darwin` target, built natively on the Intel `macos-13` runner (mirrors how arm64 builds on `macos-14`).
- **package-meta.mjs**: add the `darwin:x64 -> sem-darwin-x86_64.tar.gz` mapping (the literal source of the npm error) and update the supported-targets message.
- **package-meta.test.mjs**: assert the new mapping.

`install.sh` already mapped Intel macOS to `sem-darwin-x86_64`; the asset simply never existed. Takes effect on the next tagged release.

Fixes #374. Thanks @stark-bit for the report.
