### PR TITLE
feat: bias agents toward sem (MCP guidance) + optional clickable entity links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ All notable changes to sem are documented in this file.
 
 - `sem impact` can answer direct dependency queries from a fresh SQL topology cache without rebuilding the entity graph.
 - `sem entities` reports phase timings and listing counters when `SEM_TIMINGS` is enabled.
+- Optional OSC8 terminal hyperlinks on entity names in `sem diff`, so a supporting terminal (kitty, WezTerm, iTerm2, Ghostty, ...) renders them clickable and can open the definition at `file:line`. Off by default; enable with `SEM_HYPERLINK` set to an editor preset (`vscode`, `cursor`, `windsurf`, `zed`, `idea`, `file`) or a raw URI template using `{file}` and `{line}` (e.g. `SEM_HYPERLINK="vscode://file/{file}:{line}"`). Strictly TTY-only, so pipes, JSON output, and MCP/agent sessions never see escape codes. Force off with `SEM_NO_HYPERLINKS=1`. Thanks @olejorgenb for the request (#381).
 
 ### Changed
 
+- The `sem mcp` server now sends usage guidance to the agent instead of a bare tool list. The instructions tell the agent to prefer `sem_impact`/`sem_context`/`sem_entities` over grep/find for structural questions (what calls X, understand X, where is X) and to keep grep for text search and non-code files. Availability alone wasn't changing agent behavior; this biases agents toward the entity graph the moment the server connects, with no extra setup.
 - `sem impact --deps` can reuse fresh caches when unrelated files change by validating the cached source set, hashes, and import metadata before falling back to a graph rebuild.
 - `sem impact --deps` narrows cache freshness checks to the queried entity, direct dependencies, and relevant JavaScript/TypeScript imports when the query scope is explicit.
 - Source scans skip default-excluded high-volume paths such as generated source directories, fixture/vendor/benchmark trees, generated file suffixes, CSS module declarations, and asset declarations; pass `--no-default-excludes` to include them.

--- a/crates/sem-cli/src/formatters/terminal.rs
+++ b/crates/sem-cli/src/formatters/terminal.rs
@@ -167,7 +167,17 @@ pub fn format_terminal(
                 Some(p) => format!("{}::{base_name}", sanitize_terminal_text(p)),
                 None => base_name,
             };
-            let name_label = format!("{:<25}", display_name);
+            // Optionally make the entity name a clickable link to its
+            // definition (file:line). Pad on the visible text so the OSC8
+            // escape (zero-width) doesn't break column alignment.
+            let name_label = if crate::hyperlinks::enabled() {
+                let pad = 25usize.saturating_sub(display_name.chars().count());
+                let linked =
+                    crate::hyperlinks::link(&display_name, &change.file_path, change.start_line);
+                format!("{linked}{}", " ".repeat(pad))
+            } else {
+                format!("{:<25}", display_name)
+            };
 
             push_line(
                 &mut output,

--- a/crates/sem-cli/src/hyperlinks.rs
+++ b/crates/sem-cli/src/hyperlinks.rs
@@ -1,0 +1,129 @@
+//! Optional OSC8 terminal hyperlinks for entity references.
+//!
+//! When enabled, entity names in the terminal output are wrapped in OSC8
+//! hyperlink escape sequences pointing at `file:line`, so a supporting terminal
+//! (kitty, WezTerm, iTerm2, Ghostty, ...) renders them clickable and can open
+//! the definition in your editor.
+//!
+//! Off by default. Enable by setting `SEM_HYPERLINK` to an editor preset
+//! (`vscode`, `cursor`, `windsurf`, `zed`, `idea`, `file`) or a raw URI template
+//! using `{file}` and `{line}` placeholders, e.g.
+//! `SEM_HYPERLINK="vscode://file/{file}:{line}"`.
+//!
+//! Strictly gated: links are emitted only when stdout is a TTY, so pipes, JSON
+//! output, and MCP/agent sessions never see escape codes. Force off with
+//! `SEM_NO_HYPERLINKS=1`.
+
+use std::io::IsTerminal;
+use std::sync::OnceLock;
+
+/// Resolved link template (`None` = hyperlinks disabled). Computed once: honors
+/// `SEM_NO_HYPERLINKS`, requires a TTY on stdout, and requires `SEM_HYPERLINK`.
+static LINK_TEMPLATE: OnceLock<Option<String>> = OnceLock::new();
+
+fn resolve() -> Option<&'static String> {
+    LINK_TEMPLATE
+        .get_or_init(|| {
+            if std::env::var("SEM_NO_HYPERLINKS").is_ok_and(|v| !v.is_empty() && v != "0") {
+                return None;
+            }
+            // Escape codes would corrupt anything that isn't a live terminal
+            // (pipes, files, JSON consumers, agent/MCP sessions).
+            if !std::io::stdout().is_terminal() {
+                return None;
+            }
+            let raw = std::env::var("SEM_HYPERLINK").ok()?;
+            let raw = raw.trim();
+            if raw.is_empty() {
+                return None;
+            }
+            Some(expand_preset(raw))
+        })
+        .as_ref()
+}
+
+/// Expand a known editor preset to a URI template, or pass through a raw
+/// template unchanged.
+fn expand_preset(raw: &str) -> String {
+    match raw {
+        "file" => "file://{file}".to_string(),
+        "vscode" => "vscode://file/{file}:{line}".to_string(),
+        "vscode-insiders" => "vscode-insiders://file/{file}:{line}".to_string(),
+        "cursor" => "cursor://file/{file}:{line}".to_string(),
+        "windsurf" => "windsurf://file/{file}:{line}".to_string(),
+        "zed" => "zed://file/{file}:{line}".to_string(),
+        "idea" | "jetbrains" => "idea://open?file={file}&line={line}".to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Whether hyperlinks are active for this run.
+pub fn enabled() -> bool {
+    resolve().is_some()
+}
+
+/// Best-effort absolute path (no filesystem IO, so it stays cheap per entity).
+fn absolutize(file_path: &str) -> String {
+    let p = std::path::Path::new(file_path);
+    if p.is_absolute() {
+        return file_path.to_string();
+    }
+    match std::env::current_dir() {
+        Ok(cwd) => cwd.join(p).to_string_lossy().into_owned(),
+        Err(_) => file_path.to_string(),
+    }
+}
+
+fn render_uri(template: &str, file_abs: &str, line: usize) -> String {
+    template
+        .replace("{file}", file_abs)
+        .replace("{line}", &line.to_string())
+}
+
+fn osc8(text: &str, uri: &str) -> String {
+    // OSC 8 ; params ; URI ST  <text>  OSC 8 ; ; ST
+    format!("\x1b]8;;{uri}\x1b\\{text}\x1b]8;;\x1b\\")
+}
+
+/// Wrap `text` in an OSC8 hyperlink to `file:line` when hyperlinks are enabled;
+/// otherwise return `text` unchanged. `text` may already contain ANSI color
+/// codes (OSC8 nests cleanly with them).
+pub fn link(text: &str, file_path: &str, line: usize) -> String {
+    match resolve() {
+        Some(template) => {
+            let abs = absolutize(file_path);
+            osc8(text, &render_uri(template, &abs, line))
+        }
+        None => text.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn presets_expand() {
+        assert_eq!(expand_preset("vscode"), "vscode://file/{file}:{line}");
+        assert_eq!(expand_preset("file"), "file://{file}");
+        assert_eq!(expand_preset("idea"), "idea://open?file={file}&line={line}");
+        // Raw templates pass through untouched.
+        assert_eq!(expand_preset("my://{file}#{line}"), "my://{file}#{line}");
+    }
+
+    #[test]
+    fn uri_substitutes_placeholders() {
+        assert_eq!(
+            render_uri("vscode://file/{file}:{line}", "/abs/foo.rs", 42),
+            "vscode://file//abs/foo.rs:42"
+        );
+    }
+
+    #[test]
+    fn osc8_wraps_text_and_uri() {
+        assert_eq!(
+            osc8("drain", "file:///abs/foo.rs"),
+            "\x1b]8;;file:///abs/foo.rs\x1b\\drain\x1b]8;;\x1b\\"
+        );
+    }
+}

--- a/crates/sem-cli/src/main.rs
+++ b/crates/sem-cli/src/main.rs
@@ -1,6 +1,7 @@
 mod cache;
 mod commands;
 mod formatters;
+mod hyperlinks;
 mod progress;
 mod stats;
 mod telemetry;

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -25,8 +25,16 @@ use crate::cache;
 use crate::tools::*;
 use crate::watch::{watch_enabled, RepoWatcher};
 
-const MCP_INSTRUCTIONS: &str = "sem MCP server for entity-level semantic code intelligence. \
-                                6 tools: sem_entities, sem_diff, sem_blame, sem_impact, sem_log, sem_context.";
+const MCP_INSTRUCTIONS: &str = "sem: entity-level code intelligence \
+    (functions/classes/methods plus a real cross-file call and import graph). \
+    Prefer these over grep/find for structural questions:\n\
+    - \"what calls X / what breaks if I change X\" -> sem_impact (not grep)\n\
+    - \"understand X with its real callers and callees\" -> sem_context (not reading whole files)\n\
+    - \"where is X / list the entities here\" -> sem_entities\n\
+    - entity-level change review -> sem_diff; who last changed X -> sem_blame; how X evolved -> sem_log\n\
+    Use grep/find only for text/string search, error messages, config keys, \
+    discovery by an unknown name, and non-code files. sem is deterministic and \
+    cross-file, so it won't hallucinate edges or miss callers the way a text search does.";
 
 const ENTITY_LOOKUP_CANDIDATE_LIMIT: usize = 10;
 


### PR DESCRIPTION
Two small, tested agent-experience improvements.

## 1. `sem mcp` sends usage guidance, not a bare tool list
The MCP server's instructions were just an inventory of tool names, so MCP-registered agents still reflexively reached for grep. They now tell the agent to prefer `sem_impact` / `sem_context` / `sem_entities` over grep/find for structural questions (what calls X, understand X, where is X), and to keep grep for text search and non-code files. This biases agents toward the entity graph the moment the server connects, with no extra setup or new commands.

## 2. Optional OSC8 clickable entity links in `sem diff` (#381)
Supporting terminals (kitty, WezTerm, iTerm2, Ghostty) render entity names clickable to their `file:line`.
- **Off by default.** Enable with `SEM_HYPERLINK` set to an editor preset (`vscode`, `cursor`, `windsurf`, `zed`, `idea`, `file`) or a raw URI template using `{file}`/`{line}`.
- **Strictly TTY-only**, so pipes, JSON output, and MCP/agent sessions never see escape codes.
- Force off with `SEM_NO_HYPERLINKS=1`.

## Tests
54 sem-mcp tests pass (incl. the instructions-reference test); 3 new hyperlink unit tests; gating verified (no escapes when piped/off). No new regressions.

Closes #381.
