### PR TITLE
feat(orient): share ranking via sem-core + expose to agents via sem_entities query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to sem are documented in this file.
 ### Added
 
 - `sem orient <query>` finds the entities most relevant to a query, structural code search for when you're dropped into an unfamiliar codebase and don't know the symbol name yet (e.g. `sem orient "where is the retry logic"`). Two-pass ranking: lexical score over entity name (subtoken + prefix/stem + substring), file path, and signature line, then a graph-centrality re-rank so a central, widely-used entity outranks a trivially-named helper. Results show the entity, its `file:line`, signature, and dependent count. `--json` and `--limit` supported. This is the structural counterpart to grep: grep finds text, orient finds the entity and how connected it is.
+- The `sem_entities` MCP tool accepts a `query` parameter for the same intent search, so agents can find code by what it does (not just by name) without falling back to grep. The ranking is shared with the CLI (`sem_core::parser::orient`).
 - `sem entities` accepts `--only <kind>` and `--except <kind>` (both repeatable) to filter the listing by entity kind, e.g. `sem entities --only function --only struct` or `sem entities --except import`. The two flags are mutually exclusive. Because entity kinds are language-dependent, an unknown kind reports the kinds actually found in the scanned files rather than guessing a static list. Thanks @aleclarson for the request (#378).
 
 ## [0.13.1] - 2026-06-23

--- a/crates/sem-cli/src/commands/orient.rs
+++ b/crates/sem-cli/src/commands/orient.rs
@@ -1,23 +1,15 @@
-//! `sem orient <query>` — find the entities most relevant to a query, so an
-//! agent (or human) dropped into an unfamiliar codebase can locate the right
-//! function/class without already knowing its name.
+//! `sem orient <query>` — structural code search. Finds the entities most
+//! relevant to a query so an agent (or human) dropped into an unfamiliar
+//! codebase can locate the right function/class without knowing its name.
 //!
-//! Two-pass ranking, mirroring the cloud `orient` endpoint:
-//!   1. Lexical score over entity name (subtoken + prefix + substring), file
-//!      path, and the signature line.
-//!   2. Re-rank the strongest lexical candidates by graph centrality, so a
-//!      well-named-but-trivial helper loses to a central, widely-used entity.
-//!
-//! This is the structural-discovery counterpart to grep: grep finds text, this
-//! finds the entity and reports how connected it is.
+//! The ranking lives in `sem_core::parser::orient` (shared with the
+//! `sem_entities` MCP tool's query mode); this is the CLI/IO wrapper.
 
-use std::collections::HashSet;
 use std::path::Path;
 
 use colored::Colorize;
 use sem_core::git::bridge::GitBridge;
-use sem_core::model::entity::SemanticEntity;
-use sem_core::parser::graph::EntityGraph;
+use sem_core::parser::orient::{orient, query_terms, OrientHit};
 use serde::Serialize;
 
 pub struct OrientOptions {
@@ -30,90 +22,8 @@ pub struct OrientOptions {
     pub no_default_excludes: bool,
 }
 
-const STOPWORDS: &[&str] = &[
-    "the", "a", "an", "to", "for", "of", "in", "on", "and", "or", "is", "it", "add", "fix", "make",
-    "with", "this", "that", "how", "where", "what", "when", "find", "get", "does", "we", "my",
-];
-
-/// Split a query into meaningful lowercase terms (drops stopwords and very
-/// short tokens).
-fn query_terms(query: &str) -> Vec<String> {
-    query
-        .split(|c: char| !c.is_alphanumeric())
-        .filter(|t| t.len() >= 3)
-        .map(|t| t.to_lowercase())
-        .filter(|t| !STOPWORDS.contains(&t.as_str()))
-        .collect()
-}
-
-/// Split an identifier into lowercase subtokens across camelCase and
-/// snake_case boundaries: `getUserId` -> [get, user, id].
-fn ident_subtokens(name: &str) -> Vec<String> {
-    let mut tokens = Vec::new();
-    let mut cur = String::new();
-    let mut prev_lower = false;
-    for c in name.chars() {
-        if c == '_' || c == '-' || c == '.' {
-            if !cur.is_empty() {
-                tokens.push(std::mem::take(&mut cur));
-            }
-            prev_lower = false;
-            continue;
-        }
-        if c.is_uppercase() && prev_lower && !cur.is_empty() {
-            tokens.push(std::mem::take(&mut cur));
-        }
-        cur.push(c.to_ascii_lowercase());
-        prev_lower = c.is_lowercase();
-    }
-    if !cur.is_empty() {
-        tokens.push(cur);
-    }
-    tokens
-}
-
-/// Prefix/stem match so `watch` matches `watcher` and `diff` matches
-/// `difference`, requiring a shared prefix of at least 4 chars.
-fn token_prefix_match(tok: &str, term: &str) -> bool {
-    let shared = tok.len().min(term.len());
-    shared >= 4 && (tok.starts_with(term) || term.starts_with(tok))
-}
-
-fn lexical_score(e: &SemanticEntity, terms: &[String]) -> f64 {
-    let name_lower = e.name.to_lowercase();
-    let name_tokens = ident_subtokens(&e.name);
-    let path_lower = e.file_path.to_lowercase();
-    // Body-aware: the signature line (first line of the entity) often carries
-    // the intent words (parameters, return type).
-    let mut sig_tokens: HashSet<String> = HashSet::new();
-    if let Some(sig) = e.content.lines().next() {
-        for word in sig.split(|c: char| !c.is_alphanumeric()) {
-            for t in ident_subtokens(word) {
-                sig_tokens.insert(t);
-            }
-        }
-    }
-    let mut score = 0.0;
-    for term in terms {
-        if name_tokens.iter().any(|t| t == term) {
-            score += 3.0; // exact name-subtoken hit
-        } else if name_tokens.iter().any(|t| token_prefix_match(t, term)) {
-            score += 2.5; // stem/prefix hit
-        } else if name_lower.contains(term.as_str()) {
-            score += 2.0; // substring of the name
-        }
-        if path_lower.contains(term.as_str()) {
-            score += 1.0; // appears in the file path
-        }
-        if sig_tokens.contains(term) {
-            score += 1.5; // appears in the signature
-        }
-    }
-    score
-}
-
 #[derive(Serialize)]
-struct OrientHit {
+struct OrientHitJson {
     name: String,
     #[serde(rename = "type")]
     entity_type: String,
@@ -125,44 +35,23 @@ struct OrientHit {
     score: f64,
 }
 
-/// Rank entities by lexical relevance, then re-rank the top candidates by graph
-/// centrality. Pure and testable; the command wrapper handles IO.
-fn rank<'a>(
-    entities: &'a [SemanticEntity],
-    graph: &EntityGraph,
-    terms: &[String],
-    limit: usize,
-) -> Vec<(f64, &'a SemanticEntity)> {
-    let mut scored: Vec<(f64, &SemanticEntity)> = entities
-        .iter()
-        .filter_map(|e| {
-            let s = lexical_score(e, terms);
-            (s > 0.0).then_some((s, e))
-        })
-        .collect();
-    scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
-
-    // Re-rank only the strongest lexical candidates by centrality.
-    let cap = (limit * 4).max(20);
-    scored.truncate(cap);
-    let mut hits: Vec<(f64, &SemanticEntity)> = scored
-        .into_iter()
-        .map(|(lexical, e)| {
-            let deps = graph.get_dependencies(&e.id).len();
-            let dependents = graph.get_dependents(&e.id).len();
-            // Saturating centrality boost so a few hot entities don't dominate.
-            let centrality = ((deps + dependents) as f64 + 1.0).ln();
-            (lexical * 10.0 + centrality, e)
-        })
-        .collect();
-    hits.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
-    hits.truncate(limit);
-    hits
+impl From<&OrientHit> for OrientHitJson {
+    fn from(h: &OrientHit) -> Self {
+        OrientHitJson {
+            name: h.name.clone(),
+            entity_type: h.entity_type.clone(),
+            file: h.file_path.clone(),
+            start_line: h.start_line,
+            signature: h.signature.clone(),
+            dependencies: h.dependencies,
+            dependents: h.dependents,
+            score: h.score,
+        }
+    }
 }
 
 pub fn orient_command(opts: OrientOptions) {
-    let terms = query_terms(&opts.query);
-    if terms.is_empty() {
+    if query_terms(&opts.query).is_empty() {
         eprintln!(
             "{} query has no searchable terms (drop stopwords / use words of 3+ chars)",
             "error:".red().bold()
@@ -194,23 +83,11 @@ pub fn orient_command(opts: OrientOptions) {
         super::graph::fmt_count(file_paths.len())
     ));
 
-    let ranked = rank(&all_entities, &graph, &terms, opts.limit);
+    let hits = orient(&all_entities, &graph, &opts.query, opts.limit);
 
     if opts.json {
-        let hits: Vec<OrientHit> = ranked
-            .iter()
-            .map(|(score, e)| OrientHit {
-                name: e.name.clone(),
-                entity_type: e.entity_type.clone(),
-                file: e.file_path.clone(),
-                start_line: e.start_line,
-                signature: e.content.lines().next().unwrap_or("").trim().to_string(),
-                dependencies: graph.get_dependencies(&e.id).len(),
-                dependents: graph.get_dependents(&e.id).len(),
-                score: *score,
-            })
-            .collect();
-        match serde_json::to_string_pretty(&hits) {
+        let rows: Vec<OrientHitJson> = hits.iter().map(OrientHitJson::from).collect();
+        match serde_json::to_string_pretty(&rows) {
             Ok(s) => println!("{s}"),
             Err(e) => {
                 eprintln!("{} {e}", "error:".red().bold());
@@ -220,7 +97,7 @@ pub fn orient_command(opts: OrientOptions) {
         return;
     }
 
-    if ranked.is_empty() {
+    if hits.is_empty() {
         println!(
             "{} no entities matched {}",
             "orient:".yellow().bold(),
@@ -229,49 +106,20 @@ pub fn orient_command(opts: OrientOptions) {
         return;
     }
 
-    println!(
-        "{} {}\n",
-        "orient:".green().bold(),
-        opts.query.bold()
-    );
-    for (_score, e) in &ranked {
-        let loc = format!("{}:{}", e.file_path, e.start_line);
-        let dependents = graph.get_dependents(&e.id).len();
-        let sig = e.content.lines().next().unwrap_or("").trim();
+    println!("{} {}\n", "orient:".green().bold(), opts.query.bold());
+    for h in &hits {
+        let loc = format!("{}:{}", h.file_path, h.start_line);
         println!(
             "  {} {}  {}",
-            format!("{:<9}", e.entity_type).dimmed(),
-            e.name.bold(),
+            format!("{:<9}", h.entity_type).dimmed(),
+            h.name.bold(),
             loc.dimmed(),
         );
-        if !sig.is_empty() {
-            println!("    {}", sig.dimmed());
+        if !h.signature.is_empty() {
+            println!("    {}", h.signature.dimmed());
         }
-        if dependents > 0 {
-            println!("    {}", format!("{dependents} dependents").cyan());
+        if h.dependents > 0 {
+            println!("    {}", format!("{} dependents", h.dependents).cyan());
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn query_terms_drop_stopwords_and_short() {
-        assert_eq!(query_terms("where is the retry logic"), vec!["retry", "logic"]);
-    }
-
-    #[test]
-    fn subtokens_split_camel_and_snake() {
-        assert_eq!(ident_subtokens("getUserId"), vec!["get", "user", "id"]);
-        assert_eq!(ident_subtokens("read_file"), vec!["read", "file"]);
-    }
-
-    #[test]
-    fn prefix_match_handles_stems() {
-        assert!(token_prefix_match("watcher", "watch"));
-        assert!(token_prefix_match("diff", "difference"));
-        assert!(!token_prefix_match("cat", "category")); // shared < 4
     }
 }

--- a/crates/sem-core/src/parser/mod.rs
+++ b/crates/sem-core/src/parser/mod.rs
@@ -3,6 +3,7 @@ pub mod differ;
 pub mod graph;
 #[cfg(feature = "git")]
 pub mod hotspot;
+pub mod orient;
 mod import_resolution;
 pub mod plugin;
 pub mod plugins;

--- a/crates/sem-core/src/parser/orient.rs
+++ b/crates/sem-core/src/parser/orient.rs
@@ -1,0 +1,193 @@
+//! Structural code search: rank entities by relevance to a free-text query.
+//!
+//! Two passes:
+//!   1. Lexical score over entity name (camelCase/snake_case subtokens, prefix/
+//!      stem match, substring), file path, and the signature line.
+//!   2. Re-rank the strongest lexical candidates by graph centrality, so a
+//!      central, widely-used entity outranks a trivially-named helper.
+//!
+//! This is the structural counterpart to text search: grep finds text, orient
+//! finds the entity (and reports how connected it is). Shared by the `sem
+//! orient` CLI command and the `sem_entities` MCP tool's query mode.
+
+use std::collections::HashSet;
+
+use crate::model::entity::SemanticEntity;
+use crate::parser::graph::EntityGraph;
+
+const STOPWORDS: &[&str] = &[
+    "the", "a", "an", "to", "for", "of", "in", "on", "and", "or", "is", "it", "add", "fix", "make",
+    "with", "this", "that", "how", "where", "what", "when", "find", "get", "does", "we", "my",
+];
+
+/// One ranked search result.
+#[derive(Debug, Clone)]
+pub struct OrientHit {
+    pub id: String,
+    pub name: String,
+    pub entity_type: String,
+    pub file_path: String,
+    pub start_line: usize,
+    pub signature: String,
+    pub dependencies: usize,
+    pub dependents: usize,
+    pub score: f64,
+}
+
+/// Split a query into meaningful lowercase terms (drops stopwords and tokens
+/// shorter than 3 chars).
+pub fn query_terms(query: &str) -> Vec<String> {
+    query
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|t| t.len() >= 3)
+        .map(|t| t.to_lowercase())
+        .filter(|t| !STOPWORDS.contains(&t.as_str()))
+        .collect()
+}
+
+/// Split an identifier into lowercase subtokens across camelCase and
+/// snake_case boundaries: `getUserId` -> [get, user, id].
+fn ident_subtokens(name: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut cur = String::new();
+    let mut prev_lower = false;
+    for c in name.chars() {
+        if c == '_' || c == '-' || c == '.' {
+            if !cur.is_empty() {
+                tokens.push(std::mem::take(&mut cur));
+            }
+            prev_lower = false;
+            continue;
+        }
+        if c.is_uppercase() && prev_lower && !cur.is_empty() {
+            tokens.push(std::mem::take(&mut cur));
+        }
+        cur.push(c.to_ascii_lowercase());
+        prev_lower = c.is_lowercase();
+    }
+    if !cur.is_empty() {
+        tokens.push(cur);
+    }
+    tokens
+}
+
+/// Prefix/stem match so `watch` matches `watcher` and `diff` matches
+/// `difference`, requiring a shared prefix of at least 4 chars.
+fn token_prefix_match(tok: &str, term: &str) -> bool {
+    let shared = tok.len().min(term.len());
+    shared >= 4 && (tok.starts_with(term) || term.starts_with(tok))
+}
+
+fn lexical_score(e: &SemanticEntity, terms: &[String]) -> f64 {
+    let name_lower = e.name.to_lowercase();
+    let name_tokens = ident_subtokens(&e.name);
+    let path_lower = e.file_path.to_lowercase();
+    let mut sig_tokens: HashSet<String> = HashSet::new();
+    if let Some(sig) = e.content.lines().next() {
+        for word in sig.split(|c: char| !c.is_alphanumeric()) {
+            for t in ident_subtokens(word) {
+                sig_tokens.insert(t);
+            }
+        }
+    }
+    let mut score = 0.0;
+    for term in terms {
+        if name_tokens.iter().any(|t| t == term) {
+            score += 3.0;
+        } else if name_tokens.iter().any(|t| token_prefix_match(t, term)) {
+            score += 2.5;
+        } else if name_lower.contains(term.as_str()) {
+            score += 2.0;
+        }
+        if path_lower.contains(term.as_str()) {
+            score += 1.0;
+        }
+        if sig_tokens.contains(term) {
+            score += 1.5;
+        }
+    }
+    score
+}
+
+/// Rank `entities` against `query`, returning up to `limit` hits best-first.
+/// Returns empty if the query has no searchable terms or nothing matches.
+pub fn orient(
+    entities: &[SemanticEntity],
+    graph: &EntityGraph,
+    query: &str,
+    limit: usize,
+) -> Vec<OrientHit> {
+    let terms = query_terms(query);
+    if terms.is_empty() {
+        return Vec::new();
+    }
+
+    let mut scored: Vec<(f64, &SemanticEntity)> = entities
+        .iter()
+        .filter_map(|e| {
+            let s = lexical_score(e, &terms);
+            (s > 0.0).then_some((s, e))
+        })
+        .collect();
+    scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    // Re-rank only the strongest lexical candidates by centrality.
+    let cap = (limit * 4).max(20);
+    scored.truncate(cap);
+    let mut hits: Vec<OrientHit> = scored
+        .into_iter()
+        .map(|(lexical, e)| {
+            let dependencies = graph.get_dependencies(&e.id).len();
+            let dependents = graph.get_dependents(&e.id).len();
+            let centrality = ((dependencies + dependents) as f64 + 1.0).ln();
+            OrientHit {
+                id: e.id.clone(),
+                name: e.name.clone(),
+                entity_type: e.entity_type.clone(),
+                file_path: e.file_path.clone(),
+                start_line: e.start_line,
+                signature: e.content.lines().next().unwrap_or("").trim().to_string(),
+                dependencies,
+                dependents,
+                score: lexical * 10.0 + centrality,
+            }
+        })
+        .collect();
+    hits.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+    hits.truncate(limit);
+    hits
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn query_terms_drop_stopwords_and_short() {
+        assert_eq!(query_terms("where is the retry logic"), vec!["retry", "logic"]);
+    }
+
+    #[test]
+    fn subtokens_split_camel_and_snake() {
+        assert_eq!(ident_subtokens("getUserId"), vec!["get", "user", "id"]);
+        assert_eq!(ident_subtokens("read_file"), vec!["read", "file"]);
+    }
+
+    #[test]
+    fn prefix_match_handles_stems() {
+        assert!(token_prefix_match("watcher", "watch"));
+        assert!(token_prefix_match("diff", "difference"));
+        assert!(!token_prefix_match("cat", "category"));
+    }
+
+    #[test]
+    fn empty_query_returns_no_hits() {
+        let g = EntityGraph {
+            entities: Default::default(),
+            edges: Default::default(),
+            dependents: Default::default(),
+            dependencies: Default::default(),
+        };
+        assert!(orient(&[], &g, "the a of", 5).is_empty());
+    }
+}

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -30,7 +30,8 @@ const MCP_INSTRUCTIONS: &str = "sem: entity-level code intelligence \
     Prefer these over grep/find for structural questions:\n\
     - \"what calls X / what breaks if I change X\" -> sem_impact (not grep)\n\
     - \"understand X with its real callers and callees\" -> sem_context (not reading whole files)\n\
-    - \"where is X / list the entities here\" -> sem_entities\n\
+    - \"where is X / find the code that does Y\" (you don't know the name) -> sem_entities with a `query` (ranked structural search), not grep\n\
+    - \"list the entities in this file/dir\" -> sem_entities with a `path`\n\
     - entity-level change review -> sem_diff; who last changed X -> sem_blame; how X evolved -> sem_log\n\
     Use grep/find only for text/string search, error messages, config keys, \
     discovery by an unknown name, and non-code files. sem is deterministic and \
@@ -700,7 +701,7 @@ impl SemServer {
     // ── Tool 1: Entities ──
 
     #[tool(
-        description = "List semantic entities (functions, classes, etc.) under a file or directory path. Defaults to '.'."
+        description = "List semantic entities (functions, classes, etc.) under a file or directory path (defaults to '.'). Pass `query` to instead search the whole repo by intent and find the most relevant entities when you don't know the name (prefer this over grep for \"where is X\")."
     )]
     async fn sem_entities(
         &self,
@@ -711,6 +712,35 @@ impl SemServer {
             Ok(ctx) => ctx,
             Err(err) => return Ok(tool_error(err)),
         };
+
+        // Query mode: rank the whole-repo entity graph by relevance to the
+        // query (structural search), instead of listing a path.
+        if let Some(query) = params.query() {
+            let (graph, all_entities) = self.live_graph(&ctx.repo_root).await;
+            let hits = sem_core::parser::orient::orient(
+                &all_entities,
+                &graph,
+                query,
+                params.limit(),
+            );
+            let result: Vec<serde_json::Value> = hits
+                .iter()
+                .map(|h| {
+                    serde_json::json!({
+                        "name": h.name,
+                        "type": h.entity_type,
+                        "file": h.file_path,
+                        "start_line": h.start_line,
+                        "signature": h.signature,
+                        "dependents": h.dependents,
+                        "dependencies": h.dependencies,
+                    })
+                })
+                .collect();
+            return Ok(CallToolResult::success(vec![Content::text(
+                serde_json::to_string_pretty(&result).unwrap_or_default(),
+            )]));
+        }
 
         let (rel_path, abs_path) = Self::resolve_file_path(&ctx.repo_root, path);
         let (entities, include_file) = if abs_path.is_file() {
@@ -1746,6 +1776,8 @@ mod tests {
             .sem_entities(Parameters(EntitiesParams {
                 path: Some(missing_path.display().to_string()),
                 no_default_excludes: None,
+                query: None,
+                limit: None,
             }))
             .await
             .unwrap();
@@ -1769,6 +1801,8 @@ mod tests {
             .sem_entities(Parameters(EntitiesParams {
                 path: Some("src/generated/schema.ts".to_string()),
                 no_default_excludes: None,
+                query: None,
+                limit: None,
             }))
             .await
             .unwrap();
@@ -1778,6 +1812,8 @@ mod tests {
             .sem_entities(Parameters(EntitiesParams {
                 path: Some("src/generated/schema.ts".to_string()),
                 no_default_excludes: Some(true),
+                query: None,
+                limit: None,
             }))
             .await
             .unwrap();

--- a/crates/sem-mcp/src/tools.rs
+++ b/crates/sem-mcp/src/tools.rs
@@ -11,6 +11,12 @@ pub struct EntitiesParams {
         description = "Include files and directories excluded by default, including generated, fixture, vendor, and benchmark paths."
     )]
     pub no_default_excludes: Option<bool>,
+    #[schemars(
+        description = "Optional free-text query to find entities by intent across the whole repo (e.g. \"where is the retry logic\"), when you don't know the entity name. Ranks by name/signature relevance and graph centrality; returns file:line and dependent counts. Ignores `path` when set."
+    )]
+    pub query: Option<String>,
+    #[schemars(description = "Max results for `query` mode (default 10).")]
+    pub limit: Option<usize>,
 }
 
 impl EntitiesParams {
@@ -20,6 +26,14 @@ impl EntitiesParams {
 
     pub fn no_default_excludes(&self) -> bool {
         self.no_default_excludes.unwrap_or(false)
+    }
+
+    pub fn query(&self) -> Option<&str> {
+        self.query.as_deref().map(str::trim).filter(|q| !q.is_empty())
+    }
+
+    pub fn limit(&self) -> usize {
+        self.limit.unwrap_or(10).clamp(1, 100)
     }
 }
 


### PR DESCRIPTION
Follow-up to #384: makes `sem orient` reachable by agents, the agent-native payoff.

## What
1. **Shared ranking in sem-core.** Moves the orient ranking into `sem_core::parser::orient` as a pure `orient(entities, graph, query, limit) -> Vec<OrientHit>`. The `sem orient` CLI now delegates to it.
2. **`sem_entities` MCP tool gains a `query` param.** When set, it ranks the whole-repo entity graph by relevance (using the warm watcher graph) instead of listing a path, so agents can find code by intent ("where is X / find the code that does Y") without falling back to grep. The MCP instructions now point agents here for name-unknown lookups.

## Why folded into `sem_entities` (no new tool)
Keeps the MCP surface at 6 tools instead of proliferating a 7th. "List the entities relevant to this query" is a natural extension of "list the entities here."

## Tests
sem-core orient unit tests (query terms, subtokens, prefix/stem, empty query); all 54 sem-mcp tests pass; CLI verified live.

## Release note
This adds public API to sem-core (`parser::orient`), so the **next release must be a minor bump (0.14.0)** — `cargo-semver-checks` will reject a patch.
