### PR TITLE
feat(diff): SEM_WIDTH configures terminal-diff box width (#380)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to sem are documented in this file.
 - The `sem_entities` MCP tool accepts a `query` parameter for the same intent search, so agents can find code by what it does (not just by name) without falling back to grep. The ranking is shared with the CLI (`sem_core::parser::orient`).
 - `sem orient` down-weights entities in test files so implementation outranks an equivalently-named test. Test functions often match a query strongly by name, but the implementation is almost always what you want; tests stay findable, just below the real code.
 - `sem entities` accepts `--only <kind>` and `--except <kind>` (both repeatable) to filter the listing by entity kind, e.g. `sem entities --only function --only struct` or `sem entities --except import`. The two flags are mutually exclusive. Because entity kinds are language-dependent, an unknown kind reports the kinds actually found in the scanned files rather than guessing a static list. Thanks @aleclarson for the request (#378).
+- `SEM_WIDTH` sets the terminal-diff box width. sem's per-file box was a fixed 55 columns with no TTY attached, so it didn't match the surrounding pane when used as a pager (e.g. `lazygit`). Set `SEM_WIDTH=<columns>` to control it. Thanks @franky47 for the request (#380).
 
 ## [0.13.1] - 2026-06-23
 

--- a/crates/sem-cli/src/formatters/terminal.rs
+++ b/crates/sem-cli/src/formatters/terminal.rs
@@ -49,6 +49,25 @@ fn render_inline_diff(old_line: &str, new_line: &str) -> (String, String) {
     (del, ins)
 }
 
+/// Default inner width of the per-file box (number of `─` after the corner).
+const DEFAULT_BOX_WIDTH: usize = 55;
+
+/// Resolve the box width. `SEM_WIDTH` overrides the default, which matters when
+/// sem runs without a TTY (e.g. as a `lazygit` pager) where it otherwise falls
+/// back to a fixed width that may not match the surrounding pane. The value is
+/// the total box width in columns; the inner dash budget is one less (the
+/// corner glyph). Clamped to a sane minimum.
+fn resolve_box_width(sem_width: Option<&str>) -> usize {
+    match sem_width.and_then(|v| v.trim().parse::<usize>().ok()) {
+        Some(w) => w.saturating_sub(1).max(8),
+        None => DEFAULT_BOX_WIDTH,
+    }
+}
+
+fn box_width() -> usize {
+    resolve_box_width(std::env::var("SEM_WIDTH").ok().as_deref())
+}
+
 pub fn format_terminal(
     result: &DiffResult,
     binary_changes: &[BinaryFileChange],
@@ -57,6 +76,8 @@ pub fn format_terminal(
     if !has_reportable_changes(result, binary_changes) {
         return "No semantic changes detected.".dimmed().to_string();
     }
+
+    let box_width = box_width();
 
     let mut output =
         String::with_capacity(estimated_output_capacity(result, binary_changes, verbose));
@@ -82,7 +103,7 @@ pub fn format_terminal(
         }
 
         let header = format!("─ {} ", sanitize_terminal_text(file_path));
-        let pad_len = 55usize.saturating_sub(header.len());
+        let pad_len = box_width.saturating_sub(header.len());
         push_line(
             &mut output,
             format!("┌{header}{}", "─".repeat(pad_len))
@@ -347,7 +368,7 @@ pub fn format_terminal(
         push_line(&mut output, "│".dimmed().to_string());
         push_line(
             &mut output,
-            format!("└{}", "─".repeat(55)).dimmed().to_string(),
+            format!("└{}", "─".repeat(box_width)).dimmed().to_string(),
         );
         push_line(&mut output, "");
     }
@@ -480,6 +501,15 @@ pub fn format_terminal(
 mod tests {
     use super::*;
     use sem_core::model::change::SemanticChange;
+
+    #[test]
+    fn box_width_resolves_from_sem_width() {
+        assert_eq!(resolve_box_width(None), DEFAULT_BOX_WIDTH);
+        assert_eq!(resolve_box_width(Some("80")), 79); // total width minus the corner glyph
+        assert_eq!(resolve_box_width(Some("  120 ")), 119);
+        assert_eq!(resolve_box_width(Some("garbage")), DEFAULT_BOX_WIDTH);
+        assert_eq!(resolve_box_width(Some("3")), 8); // clamped to a sane minimum
+    }
 
     #[test]
     fn terminal_source_content_escapes_control_characters() {


### PR DESCRIPTION
Implements #380. sem's per-file diff box was a fixed 55 columns (a hardcoded constant, no terminal-size read), so with no TTY attached, e.g. driving sem as a `lazygit` pager, the box never matched the surrounding pane.

`SEM_WIDTH=<columns>` now sets the box width (inner dash budget is width-1 for the corner glyph, clamped to a sane minimum). Pure `resolve_box_width` helper with a unit test; verified live that the box widens with `SEM_WIDTH`.

Scoped to the env var (the contributor's suggested mechanism and the natural fit for the non-TTY pager case); a `--width` flag would be an easy additive follow-up. Thanks @franky47.

Closes #380.