### PR TITLE
feat(context): --hops to bound context by graph distance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to sem are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `sem context --hops N` bounds the related entities to N graph hops from the target (instead of filling to the token budget), so you can ask for "the entity and just its immediate neighborhood." The `sem_context` MCP tool gains the same `hops` parameter. 0 (the default) keeps the existing unbounded, budget-driven behavior.
+
 ### Changed
 
 - The `sem mcp` instructions now tell agents to read code with `sem_context` (which returns an entity's full source plus its callers/callees, addressed by name) rather than opening the file, reserving direct file reads for editing and non-code. Reading by entity is robust to line drift and arrives with the dependency context.

--- a/crates/sem-cli/src/commands/context.rs
+++ b/crates/sem-cli/src/commands/context.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use colored::Colorize;
 use sem_core::git::bridge::GitBridge;
-use sem_core::parser::context::build_context_result;
+use sem_core::parser::context::build_context_result_bounded;
 use sem_core::parser::graph::EntityGraph;
 
 pub struct ContextOptions {
@@ -11,6 +11,8 @@ pub struct ContextOptions {
     pub entity_id: Option<String>,
     pub file_path: Option<String>,
     pub budget: usize,
+    /// Bound transitive related entities to this many graph hops (0 = unbounded).
+    pub hops: usize,
     pub json: bool,
     pub file_exts: Vec<String>,
     pub no_cache: bool,
@@ -57,7 +59,8 @@ pub fn context_command(opts: ContextOptions) {
         opts.entity_id.as_deref(),
         file_path.as_deref(),
     );
-    let context_result = build_context_result(&graph, &entity.id, &all_entities, opts.budget);
+    let context_result =
+        build_context_result_bounded(&graph, &entity.id, &all_entities, opts.budget, opts.hops);
 
     if opts.json {
         let output = serde_json::json!({

--- a/crates/sem-cli/src/main.rs
+++ b/crates/sem-cli/src/main.rs
@@ -309,6 +309,10 @@ enum Commands {
         #[arg(long, default_value = "8000")]
         budget: usize,
 
+        /// Bound related entities to this many graph hops from the target (0 = unbounded)
+        #[arg(long, default_value = "0")]
+        hops: usize,
+
         /// Output format
         #[arg(long, value_parser = ["terminal", "json"])]
         format: Option<String>,
@@ -619,6 +623,7 @@ fn main() {
             entity_id,
             file,
             budget,
+            hops,
             format,
             json,
             file_exts,
@@ -634,6 +639,7 @@ fn main() {
                 entity_id,
                 file_path: file,
                 budget,
+                hops,
                 json: resolve_json(format, json),
                 file_exts,
                 no_cache,

--- a/crates/sem-core/src/parser/context.rs
+++ b/crates/sem-core/src/parser/context.rs
@@ -54,12 +54,26 @@ pub fn build_context(
     build_context_result(graph, entity_id, all_entities, token_budget).entries
 }
 
-/// Build a context set plus budget metadata for a target entity.
+/// Build a context set plus budget metadata for a target entity. Unbounded
+/// transitive reach (capped only by the token budget).
 pub fn build_context_result(
     graph: &EntityGraph,
     entity_id: &str,
     all_entities: &[SemanticEntity],
     token_budget: usize,
+) -> ContextResult {
+    build_context_result_bounded(graph, entity_id, all_entities, token_budget, 0)
+}
+
+/// Like [`build_context_result`], but bounds transitive related entities to
+/// `max_hops` graph hops from the target (0 = unbounded). Lets callers ask for
+/// "the entity and everything within N hops" instead of "fill the token budget".
+pub fn build_context_result_bounded(
+    graph: &EntityGraph,
+    entity_id: &str,
+    all_entities: &[SemanticEntity],
+    token_budget: usize,
+    max_hops: usize,
 ) -> ContextResult {
     // Build content lookup: entity_id -> SemanticEntity
     let entity_lookup: HashMap<&str, &SemanticEntity> =
@@ -132,7 +146,7 @@ pub fn build_context_result(
     let direct_dependent_ids: HashSet<&str> =
         direct_dependents.iter().map(|d| d.id.as_str()).collect();
 
-    for dep_info in collect_reachable_related(graph, entity_id, &graph.dependencies) {
+    for dep_info in collect_reachable_related(graph, entity_id, &graph.dependencies, max_hops) {
         if direct_dependency_ids.contains(dep_info.id.as_str()) {
             continue;
         }
@@ -146,7 +160,7 @@ pub fn build_context_result(
         );
     }
 
-    for dep_info in collect_reachable_related(graph, entity_id, &graph.dependents) {
+    for dep_info in collect_reachable_related(graph, entity_id, &graph.dependents, max_hops) {
         if direct_dependent_ids.contains(dep_info.id.as_str()) {
             continue;
         }
@@ -249,16 +263,19 @@ fn add_signature(
     }
 }
 
-/// Collect related entities reachable from `entity_id`, excluding the starting entity.
+/// Collect related entities reachable from `entity_id`, excluding the starting
+/// entity. `max_hops` of 0 means unbounded (capped only by MAX_VISITED);
+/// otherwise the BFS stops expanding past that many hops.
 fn collect_reachable_related<'a>(
     graph: &'a EntityGraph,
     entity_id: &str,
     relationships: &'a EntityAdjacencyMap,
+    max_hops: usize,
 ) -> Vec<&'a crate::parser::graph::EntityInfo> {
     const MAX_VISITED: usize = 10_000;
 
     let mut visited: HashSet<&str> = HashSet::new();
-    let mut queue: VecDeque<&str> = VecDeque::new();
+    let mut queue: VecDeque<(&str, usize)> = VecDeque::new();
     let mut result = Vec::new();
 
     let start_key = match graph.entities.get_key_value(entity_id) {
@@ -266,12 +283,15 @@ fn collect_reachable_related<'a>(
         None => return result,
     };
 
-    queue.push_back(start_key);
+    queue.push_back((start_key, 0));
     visited.insert(start_key);
 
-    while let Some(current) = queue.pop_front() {
+    while let Some((current, depth)) = queue.pop_front() {
         if result.len() >= MAX_VISITED {
             break;
+        }
+        if max_hops > 0 && depth >= max_hops {
+            continue;
         }
 
         if let Some(next_ids) = relationships.get(current) {
@@ -283,7 +303,7 @@ fn collect_reachable_related<'a>(
                             return result;
                         }
                     }
-                    queue.push_back(next_id.as_str());
+                    queue.push_back((next_id.as_str(), depth + 1));
                 }
             }
         }
@@ -431,9 +451,32 @@ mod tests {
 
         let graph = graph_from_entities(&entities, edges);
         let result =
-            collect_reachable_related(&graph, "a.py::function::helper_0", &graph.dependencies);
+            collect_reachable_related(&graph, "a.py::function::helper_0", &graph.dependencies, 0);
 
         assert_eq!(result.len(), 10_000);
+    }
+
+    #[test]
+    fn collect_reachable_related_respects_max_hops() {
+        // Chain: a -> b -> c -> d (each depends on the next).
+        let ids = ["a.py::function::a", "a.py::function::b", "a.py::function::c", "a.py::function::d"];
+        let entities: Vec<SemanticEntity> = ids
+            .iter()
+            .map(|id| entity(id, id.rsplit("::").next().unwrap(), "fn x() {}"))
+            .collect();
+        let edges = vec![
+            edge(ids[0], ids[1]),
+            edge(ids[1], ids[2]),
+            edge(ids[2], ids[3]),
+        ];
+        let graph = graph_from_entities(&entities, edges);
+
+        let hop1 = collect_reachable_related(&graph, ids[0], &graph.dependencies, 1);
+        assert_eq!(hop1.len(), 1, "1 hop reaches only b");
+        let hop2 = collect_reachable_related(&graph, ids[0], &graph.dependencies, 2);
+        assert_eq!(hop2.len(), 2, "2 hops reach b and c");
+        let unbounded = collect_reachable_related(&graph, ids[0], &graph.dependencies, 0);
+        assert_eq!(unbounded.len(), 3, "unbounded reaches b, c, d");
     }
 
     fn entity(id: &str, name: &str, content: &str) -> SemanticEntity {

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -1318,11 +1318,13 @@ impl SemServer {
         };
 
         let budget = params.token_budget.unwrap_or(8000);
-        let context_result = sem_core::parser::context::build_context_result(
+        let hops = params.hops.unwrap_or(0);
+        let context_result = sem_core::parser::context::build_context_result_bounded(
             &graph,
             entity_id,
             &all_entities,
             budget,
+            hops,
         );
 
         let result: Vec<serde_json::Value> = context_result
@@ -2065,6 +2067,7 @@ mod tests {
                 file_path: "src/generated/schema.ts".to_string(),
                 entity_name: "generatedTarget".to_string(),
                 token_budget: Some(2000),
+                hops: None,
                 no_default_excludes: Some(true),
             }))
             .await
@@ -2091,6 +2094,7 @@ mod tests {
                 file_path: file_path.display().to_string(),
                 entity_name: "known_entity".to_string(),
                 token_budget: None,
+                hops: None,
                 no_default_excludes: None,
             }))
             .await
@@ -2115,6 +2119,7 @@ mod tests {
                 file_path: file_path.display().to_string(),
                 entity_name: "nonexistent_zzz".to_string(),
                 token_budget: None,
+                hops: None,
                 no_default_excludes: None,
             }))
             .await

--- a/crates/sem-mcp/src/tools.rs
+++ b/crates/sem-mcp/src/tools.rs
@@ -95,6 +95,10 @@ pub struct ContextParams {
     #[schemars(description = "Maximum token budget. Defaults to 8000.")]
     pub token_budget: Option<usize>,
     #[schemars(
+        description = "Bound related entities to this many graph hops from the target (0 or omitted = unbounded, fill to the token budget). Use e.g. 1-2 for the immediate neighborhood."
+    )]
+    pub hops: Option<usize>,
+    #[schemars(
         description = "Include files and directories excluded by default, including generated, fixture, vendor, and benchmark paths."
     )]
     pub no_default_excludes: Option<bool>,


### PR DESCRIPTION
Folds the N-hop minimal-context idea into the existing `sem context` (no new command).

`sem context <entity> --hops N` and the `sem_context` MCP tool's new `hops` param bound the related entities to N graph hops from the target, instead of filling to the token budget:
- `--hops 1` → the entity + its immediate callers/callees
- `--hops 2+` → N-hop minimal context
- `--hops 0` (default) → unbounded, current budget-driven behavior

Implemented by depth-bounding the existing `collect_reachable_related` BFS plus a non-breaking `build_context_result_bounded` (the old `build_context_result` delegates with 0). Unit test for the hop bounding; all context + 54 sem-mcp tests pass; verified live.