### PR TITLE
feat: gate self-update behind a default-on Cargo feature (#390)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to sem are documented in this file.
 
 ### Added
 
+- `self-update` Cargo feature (on by default) gates the built-in `sem update` and the background update-available check. Distro and package-manager builds that own the binary's lifecycle can opt out with `cargo build --no-default-features`; `sem update` then prints a "update through your package manager" message instead of replacing the binary. Thanks @0323pin (pkgsrc/NetBSD) for the request (#390).
+
+### Added
+
 - `sem context --hops N` bounds the related entities to N graph hops from the target (instead of filling to the token budget), so you can ask for "the entity and just its immediate neighborhood." The `sem_context` MCP tool gains the same `hops` parameter. 0 (the default) keeps the existing unbounded, budget-driven behavior.
 
 ### Changed

--- a/crates/sem-cli/Cargo.toml
+++ b/crates/sem-cli/Cargo.toml
@@ -50,6 +50,12 @@ pkg-url = "{ repo }/releases/download/v{ version }/sem-windows-x86_64.zip"
 pkg-fmt = "zip"
 
 [features]
+default = ["self-update"]
+# Built-in `sem update` (downloads and replaces the binary) and the background
+# update-available check. On by default for the curl/npm installs; distro and
+# package-manager builds that own the binary lifecycle can opt out with
+# `--no-default-features` so the binary never tries to update itself.
+self-update = []
 vendored-openssl = ["openssl-sys/vendored"]
 
 [dev-dependencies]

--- a/crates/sem-cli/src/commands/mod.rs
+++ b/crates/sem-cli/src/commands/mod.rs
@@ -10,7 +10,25 @@ pub mod log;
 pub mod orient;
 pub mod setup;
 pub mod stats;
+
+#[cfg(feature = "self-update")]
 pub mod update;
+
+/// When built without the `self-update` feature (e.g. distro/package-manager
+/// builds that own the binary's lifecycle), self-update and the background
+/// update check are disabled. These no-op stubs keep the call sites compiling.
+#[cfg(not(feature = "self-update"))]
+pub mod update {
+    pub fn maybe_notify(_command: &str) {}
+    pub fn background_check() {}
+    pub fn run() -> Result<(), Box<dyn std::error::Error>> {
+        println!(
+            "This build of sem has self-update disabled. Update it through the \
+             package manager it was installed with (e.g. pkgsrc, Homebrew, apt)."
+        );
+        Ok(())
+    }
+}
 
 use sem_core::parser::plugins::create_default_registry;
 use sem_core::parser::registry::ParserRegistry;


### PR DESCRIPTION
Implements #390 (requested by @0323pin, pkgsrc/NetBSD maintainer).

Package managers own the binary's lifecycle, so a self-replacing `sem update` breaks distro builds. This puts `sem update` + the background update-available check behind a **`self-update` feature, on by default**:
- **curl/npm installs**: unchanged (feature on).
- **distro builds**: `cargo build --no-default-features` → `sem update` prints "update through your package manager" instead of overwriting the binary, and the background check is a no-op.

The real update module (ureq download, checksum verify, binary replace) only compiles with the feature; no-op stubs keep call sites compiling when off. `ureq` stays a dependency regardless (cloud + telemetry use it).

Verified: both `cargo build -p sem-cli` and `--no-default-features` compile; OFF binary prints the package-manager message, ON binary still does the real version check.

Closes #390.

(Related: a packager may also want telemetry behind a build-time opt-out, can follow up if @0323pin wants it.)