### PR TITLE
feat: Lua support (#393) + byte offsets on SemanticEntity

### DIFF
--- a/.claude/hooks/sem-first.sh
+++ b/.claude/hooks/sem-first.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: make sem the prevalent tool for code-symbol search.
+
+When the agent runs the Grep tool with a bare code identifier (a function /
+type / variable name), block it and steer to the sem MCP tools, which answer
+structural questions grep cannot (cross-file callers/callees, blast radius)
+without false positives.
+
+Deliberately NOT a hard wall:
+  - Only Grep-tool calls whose pattern is a bare identifier are redirected.
+  - Real text search (regex, quoted strings, error messages, config keys),
+    discovery by unknown name, and non-code files pass straight through.
+  - Bash `grep`/`find` are never intercepted, so there's always an escape hatch.
+This matches sem's calibrated role: sem for structure, grep for text.
+"""
+import sys, json, re
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)  # never block on a parse error
+
+tool = data.get("tool_name", "")
+pattern = (data.get("tool_input") or {}).get("pattern", "") or ""
+
+# A "bare code identifier": starts with a letter/underscore, only word chars,
+# at least 3 chars. Anything with regex metacharacters, spaces, or quotes is
+# treated as genuine text search and allowed through.
+is_symbol = re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]{2,}", pattern) is not None
+
+if tool == "Grep" and is_symbol:
+    reason = (
+        f'"{pattern}" looks like a code symbol. Prefer sem (the entity graph) over grep here:\n'
+        f'  - sem_impact  — what depends on / calls "{pattern}" (blast radius, cross-file, no false positives)\n'
+        f'  - sem_context — pull "{pattern}" plus its real callers and callees, token-budgeted\n'
+        f'  - sem_entities — locate "{pattern}" and its definition (file:line)\n'
+        "Grep is still the right tool for text/string search, error messages, config keys, "
+        "discovery by an unknown name, and non-code files. If this is genuinely a text search, "
+        "re-run it with Bash `grep` (not intercepted)."
+    )
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }))
+    sys.exit(0)
+
+sys.exit(0)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/sem-first.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to sem are documented in this file.
 
 ### Added
 
+- Lua support, via the `tree-sitter-lua` grammar (gated behind the `lang-lua` feature in `grammar-all`). Extracts global, `local`, table (`t.f`), and method (`t:f`) functions. Thanks @mmgeorge for the request (#393).
+- `SemanticEntity` now carries optional `start_byte`/`end_byte` offsets, populated from the underlying tree-sitter node during code extraction. A consumer can slice the exact original bytes of an entity out of a file given only its `file_path` and span, without re-parsing. Persisted through the entity cache and surfaced in `sem entities --json`. Thanks to Thomas J. for the request.
+
+### Added
+
 - `npx @ataraxy-labs/sem-skill`: one-command setup of sem for coding agents. Installs the sem skill into `~/.claude/skills/` and registers the `sem mcp` server, so an agent uses sem (impact / context / orient / diff) over grep for structural questions without manual setup. Builds on the skill contributed in #376.
 
 ### Added

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1639,6 +1639,7 @@ dependencies = [
  "tree-sitter-java",
  "tree-sitter-javascript",
  "tree-sitter-kotlin-ng",
+ "tree-sitter-lua",
  "tree-sitter-nix",
  "tree-sitter-ocaml",
  "tree-sitter-php",
@@ -2290,6 +2291,16 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-lua"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8daaf5f4235188a58603c39760d5fa5d4b920d36a299c934adddae757f32a10c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree-sitter-nix"

--- a/crates/sem-cli/src/cache.rs
+++ b/crates/sem-cli/src/cache.rs
@@ -134,7 +134,7 @@ impl DiskCache {
         // Insert entities with prepared statement (already in a transaction, so fast)
         {
             let mut stmt = tx.prepare(
-                "INSERT OR REPLACE INTO entities (id, name, entity_type, file_path, start_line, end_line, content, content_hash, structural_hash, parent_id, metadata_json) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                "INSERT OR REPLACE INTO entities (id, name, entity_type, file_path, start_line, end_line, start_byte, end_byte, content, content_hash, structural_hash, parent_id, metadata_json) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
             )?;
             for e in entities {
                 let metadata_json = e
@@ -148,6 +148,8 @@ impl DiskCache {
                     e.file_path,
                     e.start_line as i64,
                     e.end_line as i64,
+                    e.start_byte.map(|v| v as i64),
+                    e.end_byte.map(|v| v as i64),
                     e.content,
                     e.content_hash,
                     e.structural_hash,
@@ -279,7 +281,7 @@ impl DiskCache {
 
         let mut entity_stmt = self
             .conn
-            .prepare("SELECT id, name, entity_type, file_path, start_line, end_line, content, content_hash, structural_hash, parent_id, metadata_json FROM entities")
+            .prepare("SELECT id, name, entity_type, file_path, start_line, end_line, content, content_hash, structural_hash, parent_id, metadata_json, start_byte, end_byte FROM entities")
             .ok()?;
         let entities: Vec<SemanticEntity> = entity_stmt
             .query_map([], |row| {
@@ -292,6 +294,8 @@ impl DiskCache {
                     file_path: row.get(3)?,
                     start_line: row.get::<_, i64>(4)? as usize,
                     end_line: row.get::<_, i64>(5)? as usize,
+                    start_byte: row.get::<_, Option<i64>>(11)?.map(|v| v as usize),
+                    end_byte: row.get::<_, Option<i64>>(12)?.map(|v| v as usize),
                     content: row.get(6)?,
                     content_hash: row.get(7)?,
                     structural_hash: row.get(8)?,
@@ -1535,7 +1539,7 @@ impl DiskCache {
         // Load ALL entities, split into clean vs stale-file
         let mut entity_stmt = self
             .conn
-            .prepare("SELECT id, name, entity_type, file_path, start_line, end_line, content, content_hash, structural_hash, parent_id, metadata_json FROM entities")
+            .prepare("SELECT id, name, entity_type, file_path, start_line, end_line, content, content_hash, structural_hash, parent_id, metadata_json, start_byte, end_byte FROM entities")
             .ok()?;
         let mut cached_entities = Vec::new();
         let mut stale_file_entities = Vec::new();
@@ -1549,6 +1553,8 @@ impl DiskCache {
                 file_path: row.get(3).ok()?,
                 start_line: row.get::<_, i64>(4).ok()? as usize,
                 end_line: row.get::<_, i64>(5).ok()? as usize,
+                start_byte: row.get::<_, Option<i64>>(11).ok()?.map(|v| v as usize),
+                end_byte: row.get::<_, Option<i64>>(12).ok()?.map(|v| v as usize),
                 content: row.get(6).ok()?,
                 content_hash: row.get(7).ok()?,
                 structural_hash: row.get(8).ok()?,
@@ -1713,7 +1719,7 @@ impl DiskCache {
 
         {
             let mut ins = tx.prepare(
-                "INSERT OR REPLACE INTO entities (id, name, entity_type, file_path, start_line, end_line, content, content_hash, structural_hash, parent_id, metadata_json) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                "INSERT OR REPLACE INTO entities (id, name, entity_type, file_path, start_line, end_line, start_byte, end_byte, content, content_hash, structural_hash, parent_id, metadata_json) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
             )?;
             for e in entities {
                 if !repair_changed_clean_entity_ids
@@ -1733,6 +1739,8 @@ impl DiskCache {
                     e.file_path,
                     e.start_line as i64,
                     e.end_line as i64,
+                    e.start_byte.map(|v| v as i64),
+                    e.end_byte.map(|v| v as i64),
                     e.content,
                     e.content_hash,
                     e.structural_hash,
@@ -1964,6 +1972,8 @@ mod tests {
             structural_hash: None,
             start_line: 1,
             end_line: 1,
+            start_byte: None,
+            end_byte: None,
             metadata: None,
         }
     }

--- a/crates/sem-cli/src/commands/entities.rs
+++ b/crates/sem-cli/src/commands/entities.rs
@@ -356,6 +356,8 @@ fn entity_info_to_entity(entity: EntityInfo) -> SemanticEntity {
         structural_hash: None,
         start_line: entity.start_line,
         end_line: entity.end_line,
+        start_byte: None,
+        end_byte: None,
         metadata: None,
     }
 }
@@ -380,6 +382,10 @@ struct EntityJsonRow<'a> {
     entity_type: &'a str,
     start_line: usize,
     end_line: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    start_byte: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    end_byte: Option<usize>,
     parent_id: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     file: Option<&'a str>,
@@ -398,6 +404,8 @@ fn write_entities_json(entities: &[SemanticEntity], include_file: bool) -> io::R
             entity_type: &entity.entity_type,
             start_line: entity.start_line,
             end_line: entity.end_line,
+            start_byte: entity.start_byte,
+            end_byte: entity.end_byte,
             parent_id: entity.parent_id.as_deref(),
             file: include_file.then_some(entity.file_path.as_str()),
         };
@@ -532,6 +540,8 @@ mod tests {
             structural_hash: None,
             start_line: 1,
             end_line: 1,
+            start_byte: None,
+            end_byte: None,
             metadata: None,
         }
     }

--- a/crates/sem-core/Cargo.toml
+++ b/crates/sem-core/Cargo.toml
@@ -34,6 +34,7 @@ grammar-all = [
     "lang-edn",
     "lang-d",
     "lang-sql",
+    "lang-lua",
 ]
 
 # Individual grammar features
@@ -69,6 +70,7 @@ lang-clojure = ["dep:tree-sitter-clojure-orchard"]
 lang-edn = ["dep:tree-sitter-clojure-orchard"]
 lang-d = ["dep:tree-sitter-d"]
 lang-sql = ["dep:tree-sitter-sequel"]
+lang-lua = ["dep:tree-sitter-lua"]
 
 [dependencies]
 git2 = { version = "0.20", optional = true }
@@ -115,6 +117,7 @@ tree-sitter-haskell = { version = "0.23", optional = true }
 tree-sitter-elm = { version = "5.9", optional = true }
 tree-sitter-clojure-orchard = { version = "0.2.5", optional = true }
 tree-sitter-d = { version = "0.8.2", optional = true }
+tree-sitter-lua = { version = "0.5.0", optional = true }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/sem-core/src/model/entity.rs
+++ b/crates/sem-core/src/model/entity.rs
@@ -19,6 +19,17 @@ pub struct SemanticEntity {
     pub structural_hash: Option<String>,
     pub start_line: usize,
     pub end_line: usize,
+    /// Byte offset of the entity's first byte in the source file (inclusive).
+    /// `None` for entities from parsers that don't expose byte spans (most
+    /// non-tree-sitter plugins). Set for code entities, where it equals the
+    /// underlying tree-sitter node's `start_byte()`. Lets a consumer slice the
+    /// exact original bytes out of the file given only `file_path` + this span.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_byte: Option<usize>,
+    /// Byte offset just past the entity's last byte in the source file
+    /// (exclusive), matching tree-sitter's `end_byte()`. `None` when unknown.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_byte: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, String>>,
 }

--- a/crates/sem-core/src/model/identity.rs
+++ b/crates/sem-core/src/model/identity.rs
@@ -829,6 +829,8 @@ mod tests {
             structural_hash: None,
             start_line: 1,
             end_line: 1,
+            start_byte: None,
+            end_byte: None,
             metadata: None,
         }
     }
@@ -1090,6 +1092,8 @@ mod tests {
             structural_hash: None,
             start_line: 1,
             end_line: 10,
+            start_byte: None,
+            end_byte: None,
             metadata: None,
         };
         let method_before = SemanticEntity {
@@ -1103,6 +1107,8 @@ mod tests {
             structural_hash: None,
             start_line: 5,
             end_line: 8,
+            start_byte: None,
+            end_byte: None,
             metadata: None,
         };
 
@@ -1117,6 +1123,8 @@ mod tests {
             structural_hash: None,
             start_line: 1,
             end_line: 10,
+            start_byte: None,
+            end_byte: None,
             metadata: None,
         };
         let method_after = SemanticEntity {
@@ -1130,6 +1138,8 @@ mod tests {
             structural_hash: None,
             start_line: 5,
             end_line: 8,
+            start_byte: None,
+            end_byte: None,
             metadata: None,
         };
 
@@ -1158,6 +1168,8 @@ mod tests {
             structural_hash: None,
             start_line: 1,
             end_line: 5,
+            start_byte: None,
+            end_byte: None,
             metadata: None,
         };
         let method_before = SemanticEntity {
@@ -1171,6 +1183,8 @@ mod tests {
             structural_hash: None,
             start_line: 2,
             end_line: 4,
+            start_byte: None,
+            end_byte: None,
             metadata: None,
         };
 
@@ -1185,6 +1199,8 @@ mod tests {
             structural_hash: None,
             start_line: 1,
             end_line: 6,
+            start_byte: None,
+            end_byte: None,
             metadata: None,
         };
         let method_after = SemanticEntity {
@@ -1198,6 +1214,8 @@ mod tests {
             structural_hash: None,
             start_line: 3,
             end_line: 5,
+            start_byte: None,
+            end_byte: None,
             metadata: None,
         };
 
@@ -1229,6 +1247,8 @@ mod tests {
             structural_hash: None,
             start_line: 1,
             end_line: 1,
+            start_byte: None,
+            end_byte: None,
             metadata: None,
         }
     }
@@ -1302,6 +1322,8 @@ mod tests {
             structural_hash: None,
             start_line: line,
             end_line: line + 2,
+            start_byte: None,
+            end_byte: None,
             metadata: None,
         }
     }

--- a/crates/sem-core/src/parser/context.rs
+++ b/crates/sem-core/src/parser/context.rs
@@ -459,7 +459,12 @@ mod tests {
     #[test]
     fn collect_reachable_related_respects_max_hops() {
         // Chain: a -> b -> c -> d (each depends on the next).
-        let ids = ["a.py::function::a", "a.py::function::b", "a.py::function::c", "a.py::function::d"];
+        let ids = [
+            "a.py::function::a",
+            "a.py::function::b",
+            "a.py::function::c",
+            "a.py::function::d",
+        ];
         let entities: Vec<SemanticEntity> = ids
             .iter()
             .map(|id| entity(id, id.rsplit("::").next().unwrap(), "fn x() {}"))
@@ -491,6 +496,8 @@ mod tests {
             structural_hash: None,
             start_line: 1,
             end_line: content.lines().count(),
+            start_byte: None,
+            end_byte: None,
             metadata: None,
         }
     }

--- a/crates/sem-core/src/parser/differ.rs
+++ b/crates/sem-core/src/parser/differ.rs
@@ -749,6 +749,8 @@ mod tests {
             structural_hash: None,
             start_line,
             end_line,
+            start_byte: None,
+            end_byte: None,
             metadata: None,
         }
     }

--- a/crates/sem-core/src/parser/graph.rs
+++ b/crates/sem-core/src/parser/graph.rs
@@ -5218,6 +5218,8 @@ export { default as PublicDefault, X as PublicX } from './stale';
             structural_hash: None,
             start_line: 1,
             end_line: 7,
+            start_byte: None,
+            end_byte: None,
             metadata: None,
         };
         let mut child_line_ranges = HashMap::default();
@@ -8856,6 +8858,8 @@ export function caller() {
             file_path: file_path.to_string(),
             start_line: 1,
             end_line: 5,
+            start_byte: None,
+            end_byte: None,
             content: content.to_string(),
             content_hash: String::new(),
             structural_hash: None,

--- a/crates/sem-core/src/parser/mod.rs
+++ b/crates/sem-core/src/parser/mod.rs
@@ -3,8 +3,8 @@ pub mod differ;
 pub mod graph;
 #[cfg(feature = "git")]
 pub mod hotspot;
-pub mod orient;
 mod import_resolution;
+pub mod orient;
 pub mod plugin;
 pub mod plugins;
 pub mod registry;

--- a/crates/sem-core/src/parser/orient.rs
+++ b/crates/sem-core/src/parser/orient.rs
@@ -165,7 +165,11 @@ pub fn orient(
             }
         })
         .collect();
-    hits.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+    hits.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
     hits.truncate(limit);
     hits
 }
@@ -176,7 +180,10 @@ mod tests {
 
     #[test]
     fn query_terms_drop_stopwords_and_short() {
-        assert_eq!(query_terms("where is the retry logic"), vec!["retry", "logic"]);
+        assert_eq!(
+            query_terms("where is the retry logic"),
+            vec!["retry", "logic"]
+        );
     }
 
     #[test]
@@ -215,6 +222,8 @@ mod tests {
             structural_hash: None,
             start_line: 1,
             end_line: 1,
+            start_byte: None,
+            end_byte: None,
             metadata: None,
         }
     }

--- a/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
+++ b/crates/sem-core/src/parser/plugins/code/entity_extractor.rs
@@ -292,6 +292,8 @@ fn visit_node(
                     content,
                     start_line: node.start_position().row + 1,
                     end_line: node.end_position().row + 1,
+                    start_byte: Some(node.start_byte()),
+                    end_byte: Some(node.end_byte()),
                     metadata: None,
                 };
 
@@ -350,6 +352,8 @@ fn visit_node(
                     content,
                     start_line: key.start_position().row + 1,
                     end_line: value.end_position().row + 1,
+                    start_byte: Some(key.start_byte()),
+                    end_byte: Some(value.end_byte()),
                     metadata: None,
                 };
                 entities.push(entity);
@@ -377,6 +381,8 @@ fn visit_node(
                     content,
                     start_line: node.start_position().row + 1,
                     end_line: node.end_position().row + 1,
+                    start_byte: Some(node.start_byte()),
+                    end_byte: Some(node.end_byte()),
                     metadata: None,
                 };
                 entities.push(entity);
@@ -414,6 +420,8 @@ fn visit_node(
                             content: content.clone(),
                             start_line: binding.start_position().row + 1,
                             end_line: binding.end_position().row + 1,
+                            start_byte: Some(binding.start_byte()),
+                            end_byte: Some(binding.end_byte()),
                             metadata: None,
                         };
                         entities.push(entity);
@@ -508,6 +516,8 @@ fn visit_node(
                                     content,
                                     start_line: declarator.start_position().row + 1,
                                     end_line: declarator.end_position().row + 1,
+                                    start_byte: Some(declarator.start_byte()),
+                                    end_byte: Some(declarator.end_byte()),
                                     metadata: None,
                                 };
 
@@ -565,6 +575,8 @@ fn visit_node(
                             content: binding.content,
                             start_line: binding.start_line,
                             end_line: binding.end_line,
+                            start_byte: None,
+                            end_byte: None,
                             metadata: None,
                         });
                     }
@@ -618,6 +630,8 @@ fn visit_node(
                                 content,
                                 start_line: spec.start_position().row + 1,
                                 end_line: spec.end_position().row + 1,
+                                start_byte: Some(spec.start_byte()),
+                                end_byte: Some(spec.end_byte()),
                                 metadata: None,
                             };
                             entities.push(entity);
@@ -649,6 +663,8 @@ fn visit_node(
                     content,
                     start_line: node.start_position().row + 1,
                     end_line: node.end_position().row + 1,
+                    start_byte: Some(node.start_byte()),
+                    end_byte: Some(node.end_byte()),
                     metadata: None,
                 };
 
@@ -696,6 +712,8 @@ fn visit_node(
                 content,
                 start_line: node.start_position().row + 1,
                 end_line: node.end_position().row + 1,
+                start_byte: Some(node.start_byte()),
+                end_byte: Some(node.end_byte()),
                 metadata: None,
             };
 
@@ -765,6 +783,8 @@ fn visit_node(
                         content,
                         start_line,
                         end_line,
+                        start_byte: Some(start_byte),
+                        end_byte: Some(end_byte),
                         metadata: None,
                     };
 
@@ -905,6 +925,8 @@ fn emit_js_ts_re_export_entities(
                     content,
                     start_line: child.start_position().row + 1,
                     end_line: child.end_position().row + 1,
+                    start_byte: Some(child.start_byte()),
+                    end_byte: Some(child.end_byte()),
                     metadata: Some(metadata),
                 });
                 emitted = true;
@@ -1033,6 +1055,8 @@ fn recover_swift_conditional_compilation_containers(
             content,
             start_line: container.start_line,
             end_line: container.end_line,
+            start_byte: Some(container.start_byte),
+            end_byte: Some(container.end_byte),
             metadata: None,
         });
     }
@@ -3333,6 +3357,8 @@ fn extract_ocaml_named_bindings(
                 content,
                 start_line: binding.start_position().row + 1,
                 end_line: binding.end_position().row + 1,
+                start_byte: Some(binding.start_byte()),
+                end_byte: Some(binding.end_byte()),
                 metadata: None,
             };
 

--- a/crates/sem-core/src/parser/plugins/code/languages.rs
+++ b/crates/sem-core/src/parser/plugins/code/languages.rs
@@ -390,6 +390,11 @@ fn get_d() -> Option<Language> {
     Some(tree_sitter_d::LANGUAGE.into())
 }
 
+#[cfg(feature = "lang-lua")]
+fn get_lua() -> Option<Language> {
+    Some(tree_sitter_lua::LANGUAGE.into())
+}
+
 /// Inside JS/TS function bodies, suppress variable declarations so that local
 /// variables are not extracted as nested entities. Inner function/class
 /// declarations are still extracted for diff granularity.
@@ -1253,6 +1258,21 @@ static D_CONFIG: LanguageConfig = LanguageConfig {
     ],
     scope_boundary_types: &["function_body", "block_statement"],
     get_language: get_d,
+    scope_resolve: None,
+};
+
+#[cfg(feature = "lang-lua")]
+static LUA_CONFIG: LanguageConfig = LanguageConfig {
+    id: "lua",
+    extensions: &[".lua"],
+    // tree-sitter-grammars/tree-sitter-lua: `function_declaration` covers
+    // `function f()`, `local function f()`, `function t.a.b()` and `function t:m()`.
+    entity_node_types: &["function_declaration"],
+    container_node_types: &["block"],
+    call_entity_identifiers: &[],
+    suppressed_nested_entities: &[],
+    scope_boundary_types: &[],
+    get_language: get_lua,
     scope_resolve: None,
 };
 
@@ -2557,6 +2577,8 @@ macro_rules! all_configs {
             &EDN_CONFIG,
             #[cfg(feature = "lang-d")]
             &D_CONFIG,
+            #[cfg(feature = "lang-lua")]
+            &LUA_CONFIG,
         ]
     }};
 }

--- a/crates/sem-core/src/parser/plugins/code/mod.rs
+++ b/crates/sem-core/src/parser/plugins/code/mod.rs
@@ -1396,6 +1396,49 @@ echo "main script"
     }
 
     #[test]
+    #[cfg(feature = "lang-lua")]
+    fn test_lua_entity_extraction() {
+        let code = r#"local M = {}
+
+function greet(name)
+    return "hello " .. name
+end
+
+local function helper(x)
+    return x * 2
+end
+
+function M.compute(a, b)
+    return helper(a) + helper(b)
+end
+
+function M:method(v)
+    return v
+end
+
+return M
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "demo.lua");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+
+        // global, local, table (dot) and method (colon) forms all extract
+        assert!(names.contains(&"greet"), "global function, got: {:?}", names);
+        assert!(names.contains(&"helper"), "local function, got: {:?}", names);
+        assert!(
+            names.contains(&"M.compute"),
+            "table function, got: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"M:method"),
+            "method function, got: {:?}",
+            names
+        );
+        assert_eq!(entities.len(), 4, "only functions, got: {:?}", names);
+    }
+
+    #[test]
     fn test_typescript_entity_extraction() {
         // Existing language should still work
         let code = r#"

--- a/crates/sem-core/src/parser/plugins/code/mod.rs
+++ b/crates/sem-core/src/parser/plugins/code/mod.rs
@@ -1396,6 +1396,33 @@ echo "main script"
     }
 
     #[test]
+    fn test_entity_byte_offsets_slice_source_exactly() {
+        // Byte offsets must let a consumer slice the exact original bytes of an
+        // entity out of the source given only file_path + the span (#requested
+        // by a sem-core user: pull exact content from git by file + entity id).
+        let code =
+            "import os\n\ndef first(a):\n    return a + 1\n\ndef second(b):\n    return b * 2\n";
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "demo.py");
+        let bytes = code.as_bytes();
+        let funcs: Vec<_> = entities
+            .iter()
+            .filter(|e| e.entity_type == "function")
+            .collect();
+        assert_eq!(funcs.len(), 2, "expected 2 functions, got {:?}", funcs);
+        for e in funcs {
+            let sb = e.start_byte.expect("function entity must carry start_byte");
+            let eb = e.end_byte.expect("function entity must carry end_byte");
+            let sliced = std::str::from_utf8(&bytes[sb..eb]).unwrap();
+            assert!(
+                sliced.starts_with(&format!("def {}", e.name)),
+                "bytes[{sb}..{eb}] = {sliced:?} should be the body of {}",
+                e.name
+            );
+        }
+    }
+
+    #[test]
     #[cfg(feature = "lang-lua")]
     fn test_lua_entity_extraction() {
         let code = r#"local M = {}
@@ -1423,8 +1450,16 @@ return M
         let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
 
         // global, local, table (dot) and method (colon) forms all extract
-        assert!(names.contains(&"greet"), "global function, got: {:?}", names);
-        assert!(names.contains(&"helper"), "local function, got: {:?}", names);
+        assert!(
+            names.contains(&"greet"),
+            "global function, got: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"helper"),
+            "local function, got: {:?}",
+            names
+        );
         assert!(
             names.contains(&"M.compute"),
             "table function, got: {:?}",

--- a/crates/sem-core/src/parser/plugins/csv_plugin.rs
+++ b/crates/sem-core/src/parser/plugins/csv_plugin.rs
@@ -52,6 +52,8 @@ impl SemanticParserPlugin for CsvParserPlugin {
                 content: line.to_string(),
                 start_line: i + 1,
                 end_line: i + 1,
+                start_byte: None,
+                end_byte: None,
                 metadata: Some(metadata),
             });
         }

--- a/crates/sem-core/src/parser/plugins/erb.rs
+++ b/crates/sem-core/src/parser/plugins/erb.rs
@@ -47,6 +47,8 @@ impl SemanticParserPlugin for ErbParserPlugin {
             structural_hash: None,
             start_line: 1,
             end_line: lines.len(),
+            start_byte: None,
+            end_byte: None,
             metadata: None,
         });
 
@@ -82,6 +84,8 @@ impl SemanticParserPlugin for ErbParserPlugin {
                             structural_hash: None,
                             start_line: opener.start_line,
                             end_line: tag.end_line,
+                            start_byte: None,
+                            end_byte: None,
                             metadata: None,
                         });
                     }
@@ -100,6 +104,8 @@ impl SemanticParserPlugin for ErbParserPlugin {
                         structural_hash: None,
                         start_line: tag.start_line,
                         end_line: tag.end_line,
+                        start_byte: None,
+                        end_byte: None,
                         metadata: None,
                     });
                 } // No separate Code variant needed; expressions cover all non-block tags

--- a/crates/sem-core/src/parser/plugins/fallback.rs
+++ b/crates/sem-core/src/parser/plugins/fallback.rs
@@ -39,6 +39,8 @@ impl SemanticParserPlugin for FallbackParserPlugin {
                 content: chunk_content,
                 start_line,
                 end_line,
+                start_byte: None,
+                end_byte: None,
                 metadata: None,
             });
 

--- a/crates/sem-core/src/parser/plugins/json.rs
+++ b/crates/sem-core/src/parser/plugins/json.rs
@@ -155,6 +155,8 @@ fn extract_entries(
                 content: stored_content,
                 start_line: abs_start,
                 end_line: abs_end,
+                start_byte: None,
+                end_byte: None,
                 metadata: None,
             });
 
@@ -202,6 +204,8 @@ fn document_chunk_entity(
         content: stored_content,
         start_line: 1,
         end_line: line_count,
+        start_byte: None,
+        end_byte: None,
         metadata: None,
     }
 }

--- a/crates/sem-core/src/parser/plugins/latex.rs
+++ b/crates/sem-core/src/parser/plugins/latex.rs
@@ -148,6 +148,8 @@ impl SemanticParserPlugin for LatexParserPlugin {
                     content: preamble_content,
                     start_line: p_start + 1,
                     end_line: p_end,
+                    start_byte: None,
+                    end_byte: None,
                     metadata: None,
                 });
 
@@ -200,6 +202,8 @@ impl SemanticParserPlugin for LatexParserPlugin {
                                 content: def_content,
                                 start_line: p_start + def_start + 1,
                                 end_line: p_start + def_end + 1,
+                                start_byte: None,
+                                end_byte: None,
                                 metadata: None,
                             });
 
@@ -325,6 +329,8 @@ impl SemanticParserPlugin for LatexParserPlugin {
                 content: section_content,
                 start_line: section.start_line,
                 end_line: section.start_line + section.lines.len() - 1,
+                start_byte: None,
+                end_byte: None,
                 metadata: None,
             });
         }
@@ -437,6 +443,8 @@ impl SemanticParserPlugin for LatexParserPlugin {
                 content: env.content.clone(),
                 start_line: env.start_line,
                 end_line: env.end_line,
+                start_byte: None,
+                end_byte: None,
                 metadata: Some(metadata),
             });
         }

--- a/crates/sem-core/src/parser/plugins/markdown.rs
+++ b/crates/sem-core/src/parser/plugins/markdown.rs
@@ -130,6 +130,8 @@ impl SemanticParserPlugin for MarkdownParserPlugin {
                 content: section_content,
                 start_line: section.start_line,
                 end_line: section.start_line + section.lines.len() - 1,
+                start_byte: None,
+                end_byte: None,
                 metadata: None,
             });
         }

--- a/crates/sem-core/src/parser/plugins/svelte.rs
+++ b/crates/sem-core/src/parser/plugins/svelte.rs
@@ -611,6 +611,8 @@ impl<'a> SvelteLowerer<'a> {
             content,
             start_line,
             end_line,
+            start_byte: None,
+            end_byte: None,
             metadata,
         }
     }
@@ -747,6 +749,8 @@ fn extract_svelte_module_entities(
         content: content.to_string(),
         start_line: 1,
         end_line: last_line_number(content),
+        start_byte: None,
+        end_byte: None,
         metadata: Some(metadata),
     };
 

--- a/crates/sem-core/src/parser/plugins/toml_plugin.rs
+++ b/crates/sem-core/src/parser/plugins/toml_plugin.rs
@@ -75,7 +75,11 @@ impl SemanticParserPlugin for TomlParserPlugin {
                     vs,
                 )
             } else {
-                (section.key.clone(), "property".to_string(), entity_content.clone())
+                (
+                    section.key.clone(),
+                    "property".to_string(),
+                    entity_content.clone(),
+                )
             };
 
             let id = build_entity_id(file_path, &entity_type, &name, None);
@@ -90,6 +94,8 @@ impl SemanticParserPlugin for TomlParserPlugin {
                 content: entity_content,
                 start_line: section.line,
                 end_line,
+                start_byte: None,
+                end_byte: None,
                 metadata: None,
             });
         }

--- a/crates/sem-core/src/parser/plugins/vue.rs
+++ b/crates/sem-core/src/parser/plugins/vue.rs
@@ -31,6 +31,8 @@ impl SemanticParserPlugin for VueParserPlugin {
                 content: block.full_content.clone(),
                 start_line: block.start_line,
                 end_line: block.end_line,
+                start_byte: None,
+                end_byte: None,
                 metadata: None,
             };
 

--- a/crates/sem-core/src/parser/plugins/yaml.rs
+++ b/crates/sem-core/src/parser/plugins/yaml.rs
@@ -35,6 +35,8 @@ impl SemanticParserPlugin for YamlParserPlugin {
                     content: content.to_string(),
                     start_line: 1,
                     end_line: lines.len(),
+                    start_byte: None,
+                    end_byte: None,
                     metadata: None,
                 }];
             }
@@ -72,6 +74,8 @@ impl SemanticParserPlugin for YamlParserPlugin {
                         content: preamble_content,
                         start_line: 1,
                         end_line: preamble_end,
+                        start_byte: None,
+                        end_byte: None,
                         metadata: None,
                     });
                 }
@@ -102,6 +106,8 @@ impl SemanticParserPlugin for YamlParserPlugin {
                 content: entity_content,
                 start_line: tk.line,
                 end_line,
+                start_byte: None,
+                end_byte: None,
                 metadata: None,
             });
         }

--- a/crates/sem-mcp/src/cache.rs
+++ b/crates/sem-mcp/src/cache.rs
@@ -10,7 +10,7 @@ use sem_core::parser::graph::{EntityGraph, EntityInfo, EntityRef, RefType};
 use sem_core::parser::js_ts_import_source_files_from_content;
 use sem_core::utils::hash::content_hash_bytes;
 
-pub const CACHE_SCHEMA_VERSION: i32 = 6;
+pub const CACHE_SCHEMA_VERSION: i32 = 7;
 pub const CACHE_KIND_FULL: &str = "full";
 pub const CACHE_KIND_TOPOLOGY: &str = "topology";
 pub const CACHE_INDEXES: &[(&str, &str, &str)] = &[
@@ -77,6 +77,8 @@ CREATE TABLE IF NOT EXISTS entities (
     file_path TEXT NOT NULL,
     start_line INTEGER NOT NULL,
     end_line INTEGER NOT NULL,
+    start_byte INTEGER,
+    end_byte INTEGER,
     content TEXT NOT NULL,
     content_hash TEXT NOT NULL,
     structural_hash TEXT,
@@ -745,7 +747,7 @@ impl DiskCache {
 
         {
             let mut stmt = tx.prepare(
-                "INSERT INTO entities (id, name, entity_type, file_path, start_line, end_line, content, content_hash, structural_hash, parent_id, metadata_json) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                "INSERT INTO entities (id, name, entity_type, file_path, start_line, end_line, start_byte, end_byte, content, content_hash, structural_hash, parent_id, metadata_json) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
             )?;
             for e in entities {
                 let metadata_json = e
@@ -759,6 +761,8 @@ impl DiskCache {
                     e.file_path,
                     e.start_line as i64,
                     e.end_line as i64,
+                    e.start_byte.map(|v| v as i64),
+                    e.end_byte.map(|v| v as i64),
                     e.content,
                     e.content_hash,
                     e.structural_hash,
@@ -863,7 +867,7 @@ impl DiskCache {
         // Load entities
         let mut entity_stmt = self
             .conn
-            .prepare("SELECT id, name, entity_type, file_path, start_line, end_line, content, content_hash, structural_hash, parent_id, metadata_json FROM entities")
+            .prepare("SELECT id, name, entity_type, file_path, start_line, end_line, content, content_hash, structural_hash, parent_id, metadata_json, start_byte, end_byte FROM entities")
             .ok()?;
         let entities: Vec<SemanticEntity> = entity_stmt
             .query_map([], |row| {
@@ -876,6 +880,8 @@ impl DiskCache {
                     file_path: row.get(3)?,
                     start_line: row.get::<_, i64>(4)? as usize,
                     end_line: row.get::<_, i64>(5)? as usize,
+                    start_byte: row.get::<_, Option<i64>>(11)?.map(|v| v as usize),
+                    end_byte: row.get::<_, Option<i64>>(12)?.map(|v| v as usize),
                     content: row.get(6)?,
                     content_hash: row.get(7)?,
                     structural_hash: row.get(8)?,
@@ -1188,7 +1194,7 @@ impl DiskCache {
         // Load ALL entities, split into clean vs stale-file
         let mut entity_stmt = self
             .conn
-            .prepare("SELECT id, name, entity_type, file_path, start_line, end_line, content, content_hash, structural_hash, parent_id, metadata_json FROM entities")
+            .prepare("SELECT id, name, entity_type, file_path, start_line, end_line, content, content_hash, structural_hash, parent_id, metadata_json, start_byte, end_byte FROM entities")
             .ok()?;
         let all_cached: Vec<SemanticEntity> = entity_stmt
             .query_map([], |row| {
@@ -1201,6 +1207,8 @@ impl DiskCache {
                     file_path: row.get(3)?,
                     start_line: row.get::<_, i64>(4)? as usize,
                     end_line: row.get::<_, i64>(5)? as usize,
+                    start_byte: row.get::<_, Option<i64>>(11)?.map(|v| v as usize),
+                    end_byte: row.get::<_, Option<i64>>(12)?.map(|v| v as usize),
                     content: row.get(6)?,
                     content_hash: row.get(7)?,
                     structural_hash: row.get(8)?,
@@ -1393,7 +1401,7 @@ impl DiskCache {
 
         {
             let mut ins = tx.prepare(
-                "INSERT OR REPLACE INTO entities (id, name, entity_type, file_path, start_line, end_line, content, content_hash, structural_hash, parent_id, metadata_json) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                "INSERT OR REPLACE INTO entities (id, name, entity_type, file_path, start_line, end_line, start_byte, end_byte, content, content_hash, structural_hash, parent_id, metadata_json) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
             )?;
             for e in entities {
                 if !repair_changed_clean_entity_ids
@@ -1413,6 +1421,8 @@ impl DiskCache {
                     e.file_path,
                     e.start_line as i64,
                     e.end_line as i64,
+                    e.start_byte.map(|v| v as i64),
+                    e.end_byte.map(|v| v as i64),
                     e.content,
                     e.content_hash,
                     e.structural_hash,
@@ -1560,6 +1570,8 @@ mod tests {
             structural_hash: None,
             start_line: 1,
             end_line: 1,
+            start_byte: None,
+            end_byte: None,
             metadata: None,
         }
     }

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -758,12 +758,8 @@ impl SemServer {
         // query (structural search), instead of listing a path.
         if let Some(query) = params.query() {
             let (graph, all_entities) = self.live_graph(&ctx.repo_root).await;
-            let hits = sem_core::parser::orient::orient(
-                &all_entities,
-                &graph,
-                query,
-                params.limit(),
-            );
+            let hits =
+                sem_core::parser::orient::orient(&all_entities, &graph, query, params.limit());
             let result: Vec<serde_json::Value> = hits
                 .iter()
                 .map(|h| {

--- a/crates/sem-mcp/src/tools.rs
+++ b/crates/sem-mcp/src/tools.rs
@@ -29,7 +29,10 @@ impl EntitiesParams {
     }
 
     pub fn query(&self) -> Option<&str> {
-        self.query.as_deref().map(str::trim).filter(|q| !q.is_empty())
+        self.query
+            .as_deref()
+            .map(str::trim)
+            .filter(|q| !q.is_empty())
     }
 
     pub fn limit(&self) -> usize {


### PR DESCRIPTION
Two user-requested sem-core additions.

## Lua support (closes #393)
Adds the Lua grammar via `tree-sitter-lua` (tree-sitter-grammars/tree-sitter-lua, the de-facto standard maintained grammar @mmgeorge linked), gated behind a `lang-lua` feature in `grammar-all`. One node type, `function_declaration`, covers global, local, table (`t.f`) and method (`t:f`) forms. Verified with `sem entities` / `sem diff` on real Lua.

## Byte offsets on SemanticEntity
Adds optional `start_byte`/`end_byte`, populated from the tree-sitter node during code extraction, so a consumer can slice the exact original bytes of an entity out of a file given only `file_path` + the span (no re-parsing). `None` for parsers that don't expose byte spans. Persisted through the sem-mcp/sem-cli SQLite entity cache (two nullable columns, schema v6→v7) and surfaced in `sem entities --json`. Requested by a sem-core user (Thomas J).

Tests: full suites pass (sem-core 404, sem-mcp 55); regression tests for both. Note: public-API addition to `SemanticEntity` → minor version bump at release.