### PR TITLE
feat(cli): sem xref — cross-repo dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to sem are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `sem xref` lists cross-repo dependencies across your indexed repos: entities in one repo that depend on entities in another. A single-repo local graph can't see this, so it's a cloud feature (requires `sem login`) and is gated to the team/enterprise tier. Adds `cross_deps()` to the shared cloud client.
+
 ### Documentation
 
 - README: documented the optional cloud acceleration flow (`sem login` serves `impact`/`context`/`entities` from a warm pre-built graph for large repos; local is unchanged and `SEM_LOCAL=1` forces local), and added Lua to the supported-languages table.

--- a/crates/sem-cli/src/commands/cloud.rs
+++ b/crates/sem-cli/src/commands/cloud.rs
@@ -264,6 +264,66 @@ fn show_cloud_banner() {
     }
 }
 
+/// Show cross-repo dependencies across all of your indexed repos. Cloud-only:
+/// the local CLI only ever sees one repo, so "what in my other repos depends on
+/// this" is a question only the cloud (which holds the graph across all your
+/// repos) can answer. This is a reason to log in.
+pub fn xref(json: bool) -> Result<(), Box<dyn std::error::Error>> {
+    let client = CloudClient::from_credentials()
+        .ok_or("Not logged in. Cross-repo dependencies are a sem cloud feature. Run: sem login")?;
+    let resp = client.cross_deps()?;
+
+    if json {
+        let edges: Vec<serde_json::Value> = resp
+            .edges
+            .iter()
+            .map(|e| {
+                serde_json::json!({
+                    "fromRepoId": e.from_repo_id,
+                    "fromEntity": e.from_entity_id,
+                    "toRepoId": e.to_repo_id,
+                    "toEntity": e.to_entity_id,
+                    "refType": e.ref_type,
+                })
+            })
+            .collect();
+        let out = serde_json::json!({ "edges": edges, "total": resp.total });
+        println!("{}", serde_json::to_string_pretty(&out)?);
+        return Ok(());
+    }
+
+    if resp.edges.is_empty() {
+        println!("No cross-repo dependencies found.");
+        println!(
+            "{}",
+            "Cross-repo edges appear once you have 2+ repos indexed in sem cloud.".dimmed()
+        );
+        return Ok(());
+    }
+
+    println!(
+        "{} ({} edges, {}ms)",
+        "Cross-repo dependencies".bold(),
+        resp.total,
+        resp.query_ms
+    );
+    for e in &resp.edges {
+        let kind = if e.ref_type.is_empty() {
+            String::new()
+        } else {
+            format!("  [{}]", e.ref_type)
+        };
+        println!(
+            "  {} {} {}{}",
+            e.from_entity_id,
+            "→".dimmed(),
+            e.to_entity_id.bold(),
+            kind.dimmed()
+        );
+    }
+    Ok(())
+}
+
 // ─── try_cloud_* helpers ─────────────────────────────────────────────────
 
 /// Attempt to open GitBridge and get remote URL for cloud resolution.

--- a/crates/sem-cli/src/main.rs
+++ b/crates/sem-cli/src/main.rs
@@ -354,6 +354,12 @@ enum Commands {
     Logout,
     /// Show current sem cloud identity
     Whoami,
+    /// Show cross-repo dependencies across your indexed repos (requires sem login)
+    Xref {
+        /// JSON output
+        #[arg(long)]
+        json: bool,
+    },
     /// Update sem to the latest released version
     Update,
     /// Generate shell completions
@@ -389,6 +395,7 @@ fn telemetry_command_name(command: &Option<Commands>) -> Option<&'static str> {
         Some(Commands::Login { .. }) => "login",
         Some(Commands::Logout) => "logout",
         Some(Commands::Whoami) => "whoami",
+        Some(Commands::Xref { .. }) => "xref",
         Some(Commands::Update) => "update",
         Some(Commands::Completions { .. }) => "completions",
         Some(Commands::TelemetryFlush) | Some(Commands::UpdateCheck) => return None,
@@ -682,6 +689,12 @@ fn main() {
         }
         Some(Commands::Whoami) => {
             if let Err(e) = commands::cloud::whoami() {
+                eprintln!("{} {}", "error:".red().bold(), e);
+                std::process::exit(1);
+            }
+        }
+        Some(Commands::Xref { json }) => {
+            if let Err(e) = commands::cloud::xref(json) {
                 eprintln!("{} {}", "error:".red().bold(), e);
                 std::process::exit(1);
             }

--- a/crates/sem-cloud-client/src/lib.rs
+++ b/crates/sem-cloud-client/src/lib.rs
@@ -135,6 +135,30 @@ pub struct CloudRepoResponse {
     pub file_count: Option<usize>,
 }
 
+/// One cross-repo dependency edge: an entity in one of your repos that depends
+/// on an entity in another of your repos. Cloud-only (the local CLI sees one
+/// repo at a time; only the cloud holds the graph across all your repos).
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CloudCrossRepoEdge {
+    pub from_repo_id: String,
+    pub from_entity_id: String,
+    pub to_repo_id: String,
+    pub to_entity_id: String,
+    #[serde(default)]
+    pub ref_type: String,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CloudCrossDepsResponse {
+    pub edges: Vec<CloudCrossRepoEdge>,
+    #[serde(default)]
+    pub total: usize,
+    #[serde(default)]
+    pub query_ms: u64,
+}
+
 #[allow(dead_code)]
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -537,6 +561,19 @@ impl CloudClient {
         let resp = self
             .agent
             .get(&self.api_url(&url))
+            .set("Authorization", &self.auth_header())
+            .call()?
+            .into_json()?;
+        Ok(resp)
+    }
+
+    /// Cross-repo dependency edges across all of your indexed repos. This is
+    /// cloud-only: it answers "what in my other repos depends on this," which a
+    /// single-repo local graph can't see.
+    pub fn cross_deps(&self) -> Result<CloudCrossDepsResponse, Box<dyn std::error::Error>> {
+        let resp: CloudCrossDepsResponse = self
+            .agent
+            .get(&self.api_url("/v1/cross-deps"))
             .set("Authorization", &self.auth_header())
             .call()?
             .into_json()?;


### PR DESCRIPTION
Adds `sem xref`, which lists cross-repo dependencies across your indexed repos (entities in one repo that depend on entities in another). A single-repo local graph cannot see this, so it is a cloud feature (requires `sem login`) and is gated to the team/enterprise tier (free/pro get a clear gate). Adds `cross_deps()` to the shared sem-cloud-client. JSON output supported.

The cloud-side detection engine and `/v1/cross-deps` endpoint are already live; this surfaces them in the CLI.