### PR TITLE
feat(diff): contextual cloud-login nudge on interactive diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to sem are documented in this file.
 ### Added
 
 - `sem xref` lists cross-repo dependencies across your indexed repos: entities in one repo that depend on entities in another. A single-repo local graph can't see this, so it's a cloud feature (requires `sem login`) and is gated to the team/enterprise tier. Adds `cross_deps()` to the shared cloud client.
+- `sem diff` now prints a one-line hint, when run interactively and logged out, that `sem login` reveals what your changes break across repos (a cross-repo question a local single-repo diff can't answer). It is heavily throttled (at most once a week), shown only on a terminal with real entity changes, and stays completely silent in CI, pipes, `--json`/non-terminal output, and for logged-in users.
 
 ### Documentation
 

--- a/crates/sem-cli/src/commands/cloud.rs
+++ b/crates/sem-cli/src/commands/cloud.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::io::{self, Write};
+use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
@@ -27,6 +27,84 @@ use super::impact::ImpactOptions;
 use super::log::LogOptions;
 
 const GITHUB_CLIENT_ID: &str = "Ov23lioE75FJYz4Mn7ZH";
+
+// ─── Cloud conversion nudge ─────────────────────────────────────────────────
+
+/// After a `sem diff` that had real entity changes, print one dimmed line
+/// suggesting `sem login` to see what those changes break across repos — a
+/// cross-repo question a local single-repo diff cannot answer. Heavily
+/// guard-railed so it can never become noise:
+///   * silent when there were no entity changes,
+///   * silent unless stderr is an interactive terminal (skips CI, pipes, agents),
+///   * silent when already logged in,
+///   * shown at most once a week (throttled via `~/.sem/.login_hint`).
+///
+/// Printed to stderr so it never pollutes stdout / piped / `--json` output.
+pub fn maybe_suggest_cloud_after_diff(entity_changes: usize) {
+    if entity_changes == 0 {
+        return;
+    }
+    if !io::stderr().is_terminal() {
+        return;
+    }
+    if load_credentials().is_some() {
+        return;
+    }
+    if !login_hint_due() {
+        return;
+    }
+    let noun = if entity_changes == 1 {
+        "entity"
+    } else {
+        "entities"
+    };
+    eprintln!(
+        "{} {} changed. {} to see what they break across your repos.",
+        "↗".cyan(),
+        format!("{entity_changes} {noun}").dimmed(),
+        "sem login".cyan().bold(),
+    );
+    mark_login_hint_shown();
+}
+
+fn login_hint_path() -> Option<PathBuf> {
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .ok()?;
+    Some(PathBuf::from(home).join(".sem").join(".login_hint"))
+}
+
+/// True if the hint hasn't been shown in the last week (or ever).
+fn login_hint_due() -> bool {
+    const THROTTLE_SECS: u64 = 7 * 24 * 3600;
+    let Some(path) = login_hint_path() else {
+        return false;
+    };
+    match fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+    {
+        Some(last) => now_secs().saturating_sub(last) >= THROTTLE_SECS,
+        None => true,
+    }
+}
+
+fn mark_login_hint_shown() {
+    let Some(path) = login_hint_path() else {
+        return;
+    };
+    if let Some(dir) = path.parent() {
+        let _ = fs::create_dir_all(dir);
+    }
+    let _ = fs::write(&path, now_secs().to_string());
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
 
 // ─── sem login ────────────────────────────────────────────────────────────
 

--- a/crates/sem-cli/src/commands/diff.rs
+++ b/crates/sem-cli/src/commands/diff.rs
@@ -1729,6 +1729,14 @@ fn run_diff_pipeline(
         );
         eprintln!("\x1b[2m─────────────────────────────────────────────\x1b[0m");
     }
+
+    // Conversion nudge: after an interactive diff with real entity changes,
+    // hint (at most weekly, logged-out only) that the cloud can show what these
+    // changes break across repos — something a local single-repo diff can't.
+    // Only for human terminal output; JSON/plain/markdown (piping, CI) skip it.
+    if matches!(opts.format, OutputFormat::Terminal) {
+        crate::commands::cloud::maybe_suggest_cloud_after_diff(result.changes.len());
+    }
 }
 
 fn retain_non_cosmetic_changes(result: &mut DiffResult) {


### PR DESCRIPTION
Turns the highest-traffic command (`sem diff`) into a gentle conversion funnel toward the cloud, without ever spamming.

A diff naturally raises 'what does this change break?' A local single-repo graph can't answer that across repos; the cloud can. So after an interactive diff with real entity changes, sem prints one dimmed line:

```
↗ 3 entities changed. sem login to see what they break across your repos.
```

**Heavily guard-railed so it can't become noise:**
- TTY-only — completely silent in CI, pipes, `--json`, and agent/non-terminal use (so it never touches the automation traffic that dominates diff usage).
- Logged-out only — logged-in users never see it.
- Real entity changes only (skips whitespace/empty diffs).
- Throttled to at most once a week (`~/.sem/.login_hint`).
- stderr only — never pollutes stdout/piped output.

Verified: positive path fires on a TTY when logged out; second run within a week is silent; piped/non-TTY is silent.