### PR TITLE
perf(cache): parallelize per-file freshness scan (#351)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to sem are documented in this file.
 - `sem xref` lists cross-repo dependencies across your indexed repos: entities in one repo that depend on entities in another. A single-repo local graph can't see this, so it's a cloud feature (requires `sem login`) and is gated to the team/enterprise tier. Adds `cross_deps()` to the shared cloud client.
 - `sem diff` now prints a one-line hint, when run interactively and logged out, that `sem login` reveals what your changes break across repos (a cross-repo question a local single-repo diff can't answer). It is heavily throttled (at most once a week), shown only on a terminal with real entity changes, and stays completely silent in CI, pipes, `--json`/non-terminal output, and for logged-in users.
 
+### Performance
+
+- Cache freshness checks now run the per-file `stat` + content-hash scan in parallel (rayon) instead of sequentially (#351). On touched-file cache hits over large repos, the freshness scan was the dominant remaining cost (~42ms of sequential filesystem/hash work on a 5K-file touched scenario); it now scales across cores. SQLite reads stay serial (the connection isn't shared across threads) and fingerprint-refresh writes remain serial and best-effort — only the pure filesystem+hash work is parallelized, so cache-hit validity is unchanged.
+
 ### Documentation
 
 - README: documented the optional cloud acceleration flow (`sem login` serves `impact`/`context`/`entities` from a warm pre-built graph for large repos; local is unchanged and `SEM_LOCAL=1` forces local), and added Lua to the supported-languages table.

--- a/crates/sem-cli/Cargo.toml
+++ b/crates/sem-cli/Cargo.toml
@@ -27,6 +27,7 @@ ignore = "0.4"
 openssl-sys = { version = "0.9", optional = true }
 serde_json = "1"
 rusqlite = { version = "0.32", features = ["bundled"] }
+rayon = "1.10"
 clap_complete_command = "0.6.1"
 mimalloc = "0.1"
 ureq = { version = "2", features = ["json"] }

--- a/crates/sem-cli/src/cache.rs
+++ b/crates/sem-cli/src/cache.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::path::Path;
 
+use rayon::prelude::*;
 use rusqlite::{params, params_from_iter, Connection, OpenFlags, OptionalExtension};
 use sem_core::model::entity::SemanticEntity;
 use sem_core::parser::graph::{EntityGraph, EntityInfo, EntityRef, RefType};
@@ -612,12 +613,16 @@ impl DiskCache {
         root: &Path,
         files: HashSet<String>,
     ) -> Result<bool, rusqlite::Error> {
+        // Phase 1 (serial, SQLite): read each file's cached fingerprint. The
+        // rusqlite connection isn't shareable across threads, so all DB reads
+        // happen here. A file missing from the cache means the cache can't be
+        // trusted — bail immediately.
         let mut stmt = self.conn.prepare(
             "SELECT mtime_secs, mtime_nanos, content_hash
              FROM files WHERE path = ?1",
         )?;
-        let mut fingerprint_refreshes = Vec::new();
-
+        let mut cached_meta: Vec<(String, i64, i64, Option<String>)> =
+            Vec::with_capacity(files.len());
         for file in files {
             let cached: Option<(i64, i64, Option<String>)> = stmt
                 .query_row(params![file], |row| {
@@ -627,26 +632,51 @@ impl DiskCache {
             let Some((secs, nanos, content_hash)) = cached else {
                 return Ok(false);
             };
-            match shared_cache::file_freshness(
-                &root.join(&file),
-                secs,
-                nanos,
-                content_hash.as_deref(),
-            ) {
-                Some(shared_cache::FileFreshness::Fresh) => {}
-                Some(shared_cache::FileFreshness::FreshWithUpdatedFingerprint {
+            cached_meta.push((file, secs, nanos, content_hash));
+        }
+
+        // Phase 2 (parallel, no SQLite): the freshness check is an independent
+        // stat() + read() + hash per file — exactly the sequential bottleneck on
+        // touched-file cache hits (issue #351). `file_freshness` is pure, so run
+        // it across rayon's pool. One stale file makes the whole cache stale.
+        enum Outcome {
+            Fresh,
+            Refresh(shared_cache::FileFingerprintRefresh),
+            Stale,
+        }
+        let outcomes: Vec<Outcome> = cached_meta
+            .into_par_iter()
+            .map(|(file, secs, nanos, content_hash)| {
+                match shared_cache::file_freshness(
+                    &root.join(&file),
                     secs,
                     nanos,
-                    content_hash,
-                }) => {
-                    fingerprint_refreshes.push(shared_cache::FileFingerprintRefresh {
+                    content_hash.as_deref(),
+                ) {
+                    Some(shared_cache::FileFreshness::Fresh) => Outcome::Fresh,
+                    Some(shared_cache::FileFreshness::FreshWithUpdatedFingerprint {
+                        secs,
+                        nanos,
+                        content_hash,
+                    }) => Outcome::Refresh(shared_cache::FileFingerprintRefresh {
                         path: file,
                         mtime_secs: secs,
                         mtime_nanos: nanos,
                         content_hash,
-                    });
+                    }),
+                    Some(shared_cache::FileFreshness::Stale) | None => Outcome::Stale,
                 }
-                Some(shared_cache::FileFreshness::Stale) | None => return Ok(false),
+            })
+            .collect();
+
+        // Phase 3 (serial): any stale file fails the cache; otherwise persist the
+        // refreshed fingerprints best-effort (same as before, write stays serial).
+        let mut fingerprint_refreshes = Vec::new();
+        for outcome in outcomes {
+            match outcome {
+                Outcome::Fresh => {}
+                Outcome::Refresh(refresh) => fingerprint_refreshes.push(refresh),
+                Outcome::Stale => return Ok(false),
             }
         }
 


### PR DESCRIPTION
Closes #351. Follow-up from #344 (batched fingerprint refreshes).

After #344 landed, touched-file cache hits still spent most of their remaining time in a sequential freshness scan: one `file_freshness()` per source file doing `stat()` + `read()` + xxhash. The #344 benchmark isolated this as roughly 42ms of sequential filesystem/hash work on a 5K-file touched scenario, the dominant remaining cost on that path.

The checks are independent, so this parallelizes them with rayon while keeping SQLite strictly out of the parallel section. `cached_files_are_fresh` now runs in three phases:

1. **Serial (SQLite):** read each file's cached fingerprint. The rusqlite connection isn't shareable across threads, so all DB reads happen here. A file missing from the cache bails immediately, same as before.
2. **Parallel (rayon, no SQLite):** `file_freshness` is a pure `stat`+`read`+hash, so it runs across the pool via `into_par_iter`.
3. **Serial:** one stale file fails the whole cache; otherwise refreshed fingerprints are persisted best-effort (the write stays serial, as before).

Cache-hit validity is unchanged. Adds `rayon` to sem-cli.

### Testing
- Full sem-cli suite passes (99 unit + cache tests, plus the cache-freshness tests).
- The 2 `cwd_resolution` failures are pre-existing on `main` (an unrelated `diff --patch` pathspec test); confirmed by running them on a clean tree. Not introduced here.

### Scope
This addresses #351 only. The other open perf issues, #320 (intern entity IDs) and #322 (share file buffers vs per-entity content), are larger core refactors with a big public-API blast radius that need ~27GB-scale RSS profiling to validate, so they are intentionally out of this PR.

Thanks @Iron-Ham for the issue and the benchmark.