### PR TITLE
docs(skill): stop hardcoding language count in /sem skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to sem are documented in this file.
 
 ### Documentation
 
+- The bundled `/sem` agent skill no longer hardcodes a language count. It said "31 languages", which went stale as grammars were added and disagreed with the README ("32") and the crate description ("28"); it now says "30+ languages" so it can't drift, and an en-dash was replaced with a hyphen.
 - README: documented the optional cloud acceleration flow (`sem login` serves `impact`/`context`/`entities` from a warm pre-built graph for large repos; local is unchanged and `SEM_LOCAL=1` forces local), and added Lua to the supported-languages table.
 
 ### Added

--- a/agent-skill/SKILL.md
+++ b/agent-skill/SKILL.md
@@ -9,9 +9,9 @@ metadata:
 
 # sem — Semantic Version Control
 
-sem extends Git with entity-level operations. Instead of "lines 43–51 changed",
+sem extends Git with entity-level operations. Instead of "lines 43-51 changed",
 it tells you "function `validateToken` was modified in `src/auth.ts`". It parses
-31 languages via tree-sitter and works in any Git repo with no setup.
+30+ languages via tree-sitter and works in any Git repo with no setup.
 
 ## When to reach for sem
 

--- a/skills/sem/SKILL.md
+++ b/skills/sem/SKILL.md
@@ -9,9 +9,9 @@ metadata:
 
 # sem — Semantic Version Control
 
-sem extends Git with entity-level operations. Instead of "lines 43–51 changed",
+sem extends Git with entity-level operations. Instead of "lines 43-51 changed",
 it tells you "function `validateToken` was modified in `src/auth.ts`". It parses
-31 languages via tree-sitter and works in any Git repo with no setup.
+30+ languages via tree-sitter and works in any Git repo with no setup.
 
 ## When to reach for sem
 


### PR DESCRIPTION
The bundled `/sem` agent skill hardcoded "31 languages". That number went stale the moment new grammars landed (Lua, Perl), and it already disagreed with the rest of the repo: the README badge says 31, the README prose says 32, and the crate description says 28 , four different numbers for the same thing.

Rather than reset the same trap by bumping it, this uses **"30+ languages"**, which stays accurate as grammars are added and is never a false claim. Applied to both bundled copies (`agent-skill/` and `skills/sem/`). Also replaced an en-dash with a hyphen.

Note (not fixed here): the README's own badge (31) vs prose (32) inconsistency is still there , worth aligning separately.