### PR TITLE
feat(skill): opt-in live sem statusline badge via installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to sem are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `npx @ataraxy-labs/sem-skill --badge` (opt-in) installs a live sem badge in the Claude Code statusline: it shows how many structural queries ran this session, the last one and its latency, and a sparkline of recent latencies (`⊕ sem ×12  impact 9ms  ▁▂▃▅▂`), fed by a PostToolUse hook that logs each sem MCP call. Non-destructive: it backs up settings and never overwrites an existing statusline (it prints how to add the badge yourself instead).
+
 ### Performance
 
 - Faster graph hydrate on large repos. The public `EntityGraph` maps now use `rustc-hash` (FxHashMap) instead of std SipHash, matching the build's internal maps, and the SQLite cache sets read pragmas (`mmap_size`, `cache_size`, `temp_store=MEMORY`) on every connection. On a 200K-entity / 800K-edge graph this is about 9% faster to hydrate (0.42s to 0.39s, no overlap across repeats); negligible on small repos. Output is byte-identical.

--- a/agent-skill/README.md
+++ b/agent-skill/README.md
@@ -16,6 +16,20 @@ This:
    `sem_impact` / `sem_context` / `sem_entities` / ... tools are available in
    every session.
 
+### Optional: a live sem badge in your statusline
+
+```bash
+npx @ataraxy-labs/sem-skill --badge
+```
+
+Adds a small badge to your Claude Code statusline that shows sem working in real
+time: how many structural queries this session, the last one and its latency,
+and a sparkline of recent latencies (`⊕ sem ×12  impact 9ms  ▁▂▃▅▂`). It is
+opt-in and non-destructive: it backs up your settings, and if you already have a
+statusline it leaves it untouched and just tells you how to add the badge
+yourself. To remove it, delete the `statusLine` key and the `mcp__sem__.*`
+PostToolUse entry from `~/.claude/settings.json`.
+
 It's idempotent, re-run it any time. It needs the sem CLI on PATH
 (`npm i -g @ataraxy-labs/sem` or see the
 [install docs](https://github.com/Ataraxy-Labs/sem#install)); if sem isn't

--- a/agent-skill/badge/sem-activity.py
+++ b/agent-skill/badge/sem-activity.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: log sem MCP tool calls for the statusline badge.
+
+Claude Code passes tool info as JSON on stdin. When the tool is a sem MCP tool
+(mcp__sem__sem_*), append a compact event (session, timestamp, short tool name,
+and latency if the tool returned elapsed_ms) to ~/.claude/sem-activity.jsonl.
+The statusline reads that file to render the live sem badge.
+
+Exit 0 always and print nothing to stdout so we never interfere with the tool.
+"""
+import json
+import os
+import sys
+import time
+
+ACT = os.path.expanduser("~/.claude/sem-activity.jsonl")
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        return
+    tool = data.get("tool_name") or data.get("toolName") or ""
+    if "sem" not in tool.lower():
+        return
+    short = tool.split("__")[-1].replace("sem_", "") or "sem"
+
+    # Pull elapsed_ms out of the tool response if present.
+    ms = None
+    resp = data.get("tool_response") or data.get("toolResponse") or {}
+    if isinstance(resp, str):
+        try:
+            resp = json.loads(resp)
+        except Exception:
+            resp = {}
+    if isinstance(resp, dict):
+        for k in ("elapsed_ms", "elapsedMs", "ms"):
+            if isinstance(resp.get(k), (int, float)):
+                ms = round(resp[k])
+                break
+
+    event = {
+        "session": data.get("session_id") or data.get("sessionId") or "",
+        "ts": int(time.time()),
+        "tool": short,
+    }
+    if ms is not None:
+        event["ms"] = ms
+
+    try:
+        os.makedirs(os.path.dirname(ACT), exist_ok=True)
+        with open(ACT, "a") as f:
+            f.write(json.dumps(event) + "\n")
+    except Exception:
+        pass
+
+if __name__ == "__main__":
+    main()

--- a/agent-skill/badge/statusline-sem.py
+++ b/agent-skill/badge/statusline-sem.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Claude Code statusline with a live sem activity badge.
+
+Reads the session JSON on stdin (Claude Code passes it), plus the sem activity
+log written by the PostToolUse hook, and renders a one-line status showing what
+sem has been doing this session: how many structural queries, the last one, its
+latency, and a sparkline of recent latencies. The point is to make the leverage
+visible in real time, right on the frontend.
+"""
+import json
+import os
+import sys
+import time
+
+ACT = os.path.expanduser("~/.claude/sem-activity.jsonl")
+SPARK = "▁▂▃▄▅▆▇█"
+
+# ANSI
+def c(code):
+    return f"\033[{code}m"
+RESET, GREEN, DIM, BOLD, CYAN, MAGENTA = c("0"), c("32"), c("2"), c("1"), c("36"), c("35")
+
+TAGLINES = [
+    "structural, not textual",
+    "the graph, not the grep",
+    "entities, not lines",
+    "deterministic, not guessed",
+]
+
+def spark(latencies):
+    if not latencies:
+        return ""
+    lo, hi = min(latencies), max(latencies)
+    span = max(hi - lo, 1)
+    return "".join(SPARK[min(int((v - lo) / span * (len(SPARK) - 1)), len(SPARK) - 1)] for v in latencies)
+
+def main():
+    try:
+        sess = json.load(sys.stdin)
+    except Exception:
+        sess = {}
+    session_id = sess.get("session_id") or sess.get("sessionId") or ""
+    cwd = sess.get("workspace", {}).get("current_dir") or sess.get("cwd") or os.getcwd()
+    model = (sess.get("model") or {}).get("display_name") or sess.get("model", "")
+    dirname = os.path.basename(cwd.rstrip("/")) or "/"
+
+    events = []
+    if os.path.exists(ACT):
+        with open(ACT) as f:
+            for line in f:
+                try:
+                    e = json.loads(line)
+                except Exception:
+                    continue
+                if not session_id or e.get("session") == session_id:
+                    events.append(e)
+
+    left = f"{DIM}📁 {dirname}{RESET}"
+    if model:
+        left += f" {DIM}· {model}{RESET}"
+
+    if not events:
+        badge = f"{DIM}⊕ sem idle{RESET}"
+    else:
+        n = len(events)
+        last = events[-1]
+        lat = [e["ms"] for e in events[-12:] if isinstance(e.get("ms"), (int, float))]
+        sp = spark(lat)
+        last_tool = last.get("tool", "sem")
+        last_ms = last.get("ms")
+        ms_str = f" {last_ms}ms" if isinstance(last_ms, (int, float)) else ""
+        tag = TAGLINES[n % len(TAGLINES)]
+        badge = (
+            f"{GREEN}{BOLD}⊕ sem{RESET} {GREEN}×{n}{RESET}"
+            f" {CYAN}{last_tool}{ms_str}{RESET}"
+            + (f" {MAGENTA}{sp}{RESET}" if sp else "")
+            + f" {DIM}· {tag}{RESET}"
+        )
+
+    print(f"{left}  {badge}")
+
+if __name__ == "__main__":
+    main()

--- a/agent-skill/install.mjs
+++ b/agent-skill/install.mjs
@@ -8,13 +8,84 @@
 // registered MCP server).
 
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, copyFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  copyFileSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const log = (m) => process.stdout.write(`${m}\n`);
+const wantBadge = process.argv.slice(2).includes('--badge');
+
+// Opt-in: a live sem activity badge in the Claude Code statusline, fed by a
+// PostToolUse hook that logs each sem MCP call. Only runs with --badge, backs
+// up settings, and never overwrites a statusline you already have.
+function installBadge() {
+  const claudeDir = join(homedir(), '.claude');
+  const hooksDir = join(claudeDir, 'hooks');
+  const slDest = join(claudeDir, 'statusline-sem.py');
+  const hookDest = join(hooksDir, 'sem-activity.py');
+  try {
+    mkdirSync(hooksDir, { recursive: true });
+    copyFileSync(join(here, 'badge', 'statusline-sem.py'), slDest);
+    copyFileSync(join(here, 'badge', 'sem-activity.py'), hookDest);
+    log(`  [ok] installed sem badge scripts -> ${claudeDir}`);
+  } catch (e) {
+    log(`  [!]  could not install badge scripts: ${e.message}`);
+    return;
+  }
+
+  const settingsPath = join(claudeDir, 'settings.json');
+  let settings = {};
+  if (existsSync(settingsPath)) {
+    try {
+      settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    } catch {
+      settings = {};
+    }
+    try {
+      copyFileSync(settingsPath, `${settingsPath}.bak-${Date.now()}`);
+    } catch {}
+  }
+
+  // PostToolUse hook: non-destructive, append only if not already present.
+  settings.hooks = settings.hooks || {};
+  const post = (settings.hooks.PostToolUse = settings.hooks.PostToolUse || []);
+  const hasHook = post.some((e) =>
+    (e.hooks || []).some((h) => (h.command || '').includes('sem-activity.py')),
+  );
+  if (!hasHook) {
+    post.push({
+      matcher: 'mcp__sem__.*',
+      hooks: [{ type: 'command', command: `python3 ${hookDest}` }],
+    });
+  }
+
+  // statusLine: destructive slot, so only set it if you have none (or it is
+  // already ours). Otherwise leave yours alone and print how to add the badge.
+  const slCmd = `python3 ${slDest}`;
+  const existingSl = settings.statusLine && settings.statusLine.command;
+  if (!existingSl || existingSl.includes('statusline-sem.py')) {
+    settings.statusLine = { type: 'command', command: slCmd };
+    log('  [ok] enabled the live sem statusline badge');
+  } else {
+    log('  [i]  you already have a statusline; leaving it untouched.');
+    log(`       to add the sem badge, set your statusline to: ${slCmd}`);
+  }
+
+  try {
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+    log('  [ok] updated ~/.claude/settings.json (backup saved)');
+  } catch (e) {
+    log(`  [!]  could not write settings.json: ${e.message}`);
+  }
+}
 
 function has(cmd) {
   try {
@@ -72,6 +143,17 @@ if (has('claude')) {
   log('       claude mcp add -s user sem -- sem mcp');
 }
 
+// 4. Optional: the live sem statusline badge.
+if (wantBadge) {
+  log('');
+  installBadge();
+} else {
+  log('');
+  log('  [i]  optional: a live sem activity badge for your statusline');
+  log('       (shows structural queries + latency as you work). Enable with:');
+  log('       npx @ataraxy-labs/sem-skill --badge');
+}
+
 log('\nDone. Your agent will now prefer sem (impact / context / orient / diff)');
 log('over grep for structural code questions. Restart the agent session to load');
-log('the MCP tools.\n');
+log('the MCP tools' + (wantBadge ? ' and show the sem badge' : '') + '.\n');

--- a/agent-skill/package.json
+++ b/agent-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ataraxy-labs/sem-skill",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "One-command setup of sem (entity-level code intelligence) for coding agents: installs the sem skill and registers the sem MCP server.",
   "type": "module",
   "bin": {
@@ -9,7 +9,9 @@
   "files": [
     "install.mjs",
     "SKILL.md",
-    "README.md"
+    "README.md",
+    "badge/statusline-sem.py",
+    "badge/sem-activity.py"
   ],
   "keywords": [
     "sem",


### PR DESCRIPTION
## What

`npx @ataraxy-labs/sem-skill --badge` now installs a live sem badge in the Claude Code statusline, so users *see* sem working in real time:

```
📁 sem · Opus 4.8   ⊕ sem ×12  impact 9ms  ▁▂▃▅▂  · the graph, not the grep
```

- green `⊕ sem ×N` , structural queries this session
- last op + latency (pulled from sem's `elapsed_ms`)
- magenta sparkline of recent sem latencies
- clean `⊕ sem idle` before the first sem call

Two small bundled scripts do it: a statusline renderer (`badge/statusline-sem.py`) and a `PostToolUse` hook (`badge/sem-activity.py`) that logs each `mcp__sem__*` call to a per-session activity file.

## Why

The telemetry says the agent/MCP channel is the growth lever, and this makes the leverage visible on the frontend rather than buried in the agent's reasoning , the moment sem runs, the badge ticks up.

## Safety (opt-in, non-destructive)

- Only runs with `--badge`. Without it, the installer just prints a one-line hint and touches nothing.
- Backs up `~/.claude/settings.json` before writing.
- The logging hook is appended without changing any behavior.
- **Never overwrites an existing statusline** , if you have one, it's left untouched and the installer prints how to add the badge yourself.

Verified against a throwaway HOME across all three cases (fresh, existing-statusline, no-flag). Bumps `@ataraxy-labs/sem-skill` to 0.2.0.