### PR TITLE
feat(skill): badge catches sem CLI usage + shows analyzed entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to sem are documented in this file.
 
 ### Added
 
-- `npx @ataraxy-labs/sem-skill --badge` (opt-in) installs a live sem badge in the Claude Code statusline: it shows how many structural queries ran this session, the last one and its latency, and a sparkline of recent latencies (`⊕ sem ×12  impact 9ms  ▁▂▃▅▂`), fed by a PostToolUse hook that logs each sem MCP call. Non-destructive: it backs up settings and never overwrites an existing statusline (it prints how to add the badge yourself instead).
+- `npx @ataraxy-labs/sem-skill --badge` (opt-in) installs a live sem badge in the Claude Code statusline: it shows how many structural queries ran this session, the last command **and the entity it analyzed**, its latency, a sparkline of recent latencies, and a rotating stat (distinct entities analyzed, top command) (`⊕ sem ×12  impact validateToken 9ms  ▁▂▃▅▂  · 7 entities analyzed`). It is fed by a PostToolUse hook that catches sem via **both** the MCP tools and the `sem` CLI (Bash), and falls back to recent activity so the badge never stalls on "idle". Non-destructive: it backs up settings and never overwrites an existing statusline (it prints how to add the badge yourself instead).
 
 ### Performance
 

--- a/agent-skill/README.md
+++ b/agent-skill/README.md
@@ -23,12 +23,16 @@ npx @ataraxy-labs/sem-skill --badge
 ```
 
 Adds a small badge to your Claude Code statusline that shows sem working in real
-time: how many structural queries this session, the last one and its latency,
-and a sparkline of recent latencies (`⊕ sem ×12  impact 9ms  ▁▂▃▅▂`). It is
-opt-in and non-destructive: it backs up your settings, and if you already have a
-statusline it leaves it untouched and just tells you how to add the badge
-yourself. To remove it, delete the `statusLine` key and the `mcp__sem__.*`
-PostToolUse entry from `~/.claude/settings.json`.
+time: how many structural queries this session, the last command **and the
+entity it analyzed**, its latency, a sparkline of recent latencies, and a
+rotating stat (distinct entities analyzed, top command)
+(`⊕ sem ×12  impact validateToken 9ms  ▁▂▃▅▂  · 7 entities analyzed`). It picks
+up sem whether the agent uses the MCP tools or the `sem` CLI, and falls back to
+recent activity so it never gets stuck on "idle". It is opt-in and
+non-destructive: it backs up your settings, and if you already have a statusline
+it leaves it untouched and just tells you how to add the badge yourself. To
+remove it, delete the `statusLine` key and the `mcp__sem__.*` and `Bash`
+PostToolUse entries from `~/.claude/settings.json`.
 
 It's idempotent, re-run it any time. It needs the sem CLI on PATH
 (`npm i -g @ataraxy-labs/sem` or see the

--- a/agent-skill/badge/sem-activity.py
+++ b/agent-skill/badge/sem-activity.py
@@ -1,19 +1,24 @@
 #!/usr/bin/env python3
-"""PostToolUse hook: log sem MCP tool calls for the statusline badge.
+"""PostToolUse hook: log sem usage (command + target entity) for the badge.
 
-Claude Code passes tool info as JSON on stdin. When the tool is a sem MCP tool
-(mcp__sem__sem_*), append a compact event (session, timestamp, short tool name,
-and latency if the tool returned elapsed_ms) to ~/.claude/sem-activity.jsonl.
-The statusline reads that file to render the live sem badge.
+Fires on both paths sem is used:
+  - the sem MCP tools (mcp__sem__sem_*)
+  - the sem CLI run through Bash (e.g. `sem impact foo`, `.../release/sem diff`)
 
-Exit 0 always and print nothing to stdout so we never interfere with the tool.
+Appends {session, ts, tool, target, ms?} to ~/.claude/sem-activity.jsonl, which
+the statusline reads to show a live badge of what sem is doing. Exits 0 and
+prints nothing so it never interferes with the tool.
 """
 import json
 import os
+import re
 import sys
 import time
 
 ACT = os.path.expanduser("~/.claude/sem-activity.jsonl")
+SUBCMDS = "diff|impact|context|entities|graph|blame|log|orient|xref|mcp|whoami"
+CLI_RE = re.compile(r"(?:^|[\s;&|(]|/)sem\s+(" + SUBCMDS + r")\b(.*)")
+
 
 def main():
     try:
@@ -21,29 +26,48 @@ def main():
     except Exception:
         return
     tool = data.get("tool_name") or data.get("toolName") or ""
-    if "sem" not in tool.lower():
-        return
-    short = tool.split("__")[-1].replace("sem_", "") or "sem"
-
-    # Pull elapsed_ms out of the tool response if present.
+    short = target = None
     ms = None
-    resp = data.get("tool_response") or data.get("toolResponse") or {}
-    if isinstance(resp, str):
-        try:
-            resp = json.loads(resp)
-        except Exception:
-            resp = {}
-    if isinstance(resp, dict):
-        for k in ("elapsed_ms", "elapsedMs", "ms"):
-            if isinstance(resp.get(k), (int, float)):
-                ms = round(resp[k])
-                break
+
+    if "mcp__sem__" in tool:
+        short = tool.split("__")[-1].replace("sem_", "") or "sem"
+        ti = data.get("tool_input") or data.get("toolInput") or {}
+        if isinstance(ti, dict):
+            for k in ("targetEntity", "entity_name", "entity", "query", "path"):
+                if ti.get(k):
+                    target = str(ti[k])
+                    break
+        resp = data.get("tool_response") or data.get("toolResponse") or {}
+        if isinstance(resp, str):
+            try:
+                resp = json.loads(resp)
+            except Exception:
+                resp = {}
+        if isinstance(resp, dict):
+            for k in ("elapsed_ms", "elapsedMs", "ms"):
+                if isinstance(resp.get(k), (int, float)):
+                    ms = round(resp[k])
+                    break
+    elif tool == "Bash":
+        cmd = (data.get("tool_input") or data.get("toolInput") or {}).get("command", "")
+        m = CLI_RE.search(cmd or "")
+        if m:
+            short = m.group(1)
+            rest = (m.group(2) or "").strip()
+            tok = rest.split()[0] if rest else ""
+            if tok and not tok.startswith("-"):
+                target = tok.strip("'\"")
+
+    if not short:
+        return
 
     event = {
         "session": data.get("session_id") or data.get("sessionId") or "",
         "ts": int(time.time()),
         "tool": short,
     }
+    if target:
+        event["target"] = target[:40]
     if ms is not None:
         event["ms"] = ms
 
@@ -53,6 +77,7 @@ def main():
             f.write(json.dumps(event) + "\n")
     except Exception:
         pass
+
 
 if __name__ == "__main__":
     main()

--- a/agent-skill/badge/statusline-sem.py
+++ b/agent-skill/badge/statusline-sem.py
@@ -45,6 +45,8 @@ def main():
     dirname = os.path.basename(cwd.rstrip("/")) or "/"
 
     events = []
+    session_events, recent_events = [], []
+    cutoff = time.time() - 3 * 3600  # "recent" = last few hours
     if os.path.exists(ACT):
         with open(ACT) as f:
             for line in f:
@@ -52,8 +54,13 @@ def main():
                     e = json.loads(line)
                 except Exception:
                     continue
-                if not session_id or e.get("session") == session_id:
-                    events.append(e)
+                if session_id and e.get("session") == session_id:
+                    session_events.append(e)
+                if e.get("ts", 0) >= cutoff:
+                    recent_events.append(e)
+    # prefer this session's activity; fall back to recent so a session-id
+    # mismatch between the hook and the statusline can never strand it on "idle"
+    events = (session_events or recent_events)[-40:]
 
     left = f"{DIM}📁 {dirname}{RESET}"
     if model:
@@ -62,19 +69,31 @@ def main():
     if not events:
         badge = f"{DIM}⊕ sem idle{RESET}"
     else:
+        from collections import Counter
         n = len(events)
         last = events[-1]
         lat = [e["ms"] for e in events[-12:] if isinstance(e.get("ms"), (int, float))]
         sp = spark(lat)
         last_tool = last.get("tool", "sem")
+        last_target = last.get("target", "")
+        op = f"{last_tool} {last_target}".strip() if last_target else last_tool
         last_ms = last.get("ms")
         ms_str = f" {last_ms}ms" if isinstance(last_ms, (int, float)) else ""
-        tag = TAGLINES[n % len(TAGLINES)]
+        # rotate the trailing segment through real stats + a tagline
+        tally = Counter(e.get("tool") for e in events)
+        targets = {e.get("target") for e in events if e.get("target")}
+        top_cmd, top_n = tally.most_common(1)[0]
+        insights = [
+            f"{len(targets)} entities analyzed" if targets else TAGLINES[0],
+            f"{top_cmd} ×{top_n} top",
+            TAGLINES[n % len(TAGLINES)],
+        ]
+        insight = insights[n % len(insights)]
         badge = (
             f"{GREEN}{BOLD}⊕ sem{RESET} {GREEN}×{n}{RESET}"
-            f" {CYAN}{last_tool}{ms_str}{RESET}"
+            f" {CYAN}{op}{ms_str}{RESET}"
             + (f" {MAGENTA}{sp}{RESET}" if sp else "")
-            + f" {DIM}· {tag}{RESET}"
+            + f" {DIM}· {insight}{RESET}"
         )
 
     print(f"{left}  {badge}")

--- a/agent-skill/install.mjs
+++ b/agent-skill/install.mjs
@@ -61,10 +61,14 @@ function installBadge() {
     (e.hooks || []).some((h) => (h.command || '').includes('sem-activity.py')),
   );
   if (!hasHook) {
-    post.push({
-      matcher: 'mcp__sem__.*',
-      hooks: [{ type: 'command', command: `python3 ${hookDest}` }],
-    });
+    // sem is used two ways: the MCP tools and the CLI through Bash. Register
+    // both so the badge lights up whichever path the agent takes.
+    for (const matcher of ['mcp__sem__.*', 'Bash']) {
+      post.push({
+        matcher,
+        hooks: [{ type: 'command', command: `python3 ${hookDest}` }],
+      });
+    }
   }
 
   // statusLine: destructive slot, so only set it if you have none (or it is

--- a/agent-skill/package.json
+++ b/agent-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ataraxy-labs/sem-skill",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "One-command setup of sem (entity-level code intelligence) for coding agents: installs the sem skill and registers the sem MCP server.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What

The opt-in `--badge` statusline (PR #402) only logged sem **MCP tool** calls. Agents that drive sem through the **CLI** (Bash) saw the badge sit on \`idle\`. This closes that gap and makes the badge more informative.

## Changes
- **Catch CLI usage:** the installer now registers a \`Bash\` PostToolUse matcher in addition to \`mcp__sem__.*\`, and the hook parses \`sem <subcmd> <entity>\` out of Bash commands.
- **Show the target entity:** the badge now displays *what* sem analyzed, not just the command , \`⊕ sem ×12  impact validateToken 9ms  ▁▂▃▅▂  · 7 entities analyzed\`.
- **Rotating stat:** trailing segment cycles through distinct entities analyzed, top command, and taglines.
- **Never stalls on idle:** falls back to recent activity when a session-id mismatch would otherwise strand the badge.
- Bumps `@ataraxy-labs/sem-skill` 0.2.0 → 0.3.0; README + CHANGELOG updated.

## Verified
Sandbox install (fake `HOME`): preserves an existing user statusline (non-destructive), registers both matchers (`['mcp__sem__.*', 'Bash']`), copies both badge scripts. Hook tested against MCP and CLI payloads; false-positive guard (`sem-old`, `system`) holds.

Users get it with `npx @ataraxy-labs/sem-skill --badge` once published.