### PR TITLE
fix(resolve): resolve type-qualified associated calls (Type::method)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to sem are documented in this file.
 
 - `npx @ataraxy-labs/sem-skill --badge` (opt-in) installs a live sem badge in the Claude Code statusline: it shows how many structural queries ran this session, the last command **and the entity it analyzed**, its latency, a sparkline of recent latencies, and a rotating stat (distinct entities analyzed, top command) (`⊕ sem ×12  impact validateToken 9ms  ▁▂▃▅▂  · 7 entities analyzed`). It is fed by a PostToolUse hook that catches sem via **both** the MCP tools and the `sem` CLI (Bash), and falls back to recent activity so the badge never stalls on "idle". Non-destructive: it backs up settings and never overwrites an existing statusline (it prints how to add the badge yourself instead).
 
+### Fixed
+
+- Impact/dependency resolution now follows type-qualified associated calls (`Type::method()`) when the receiver is a known repo type, so a caller reached only through a static/associated path is no longer dropped from `sem impact`. Previously, e.g., a test helper calling `SemPlugin::detect_changes()` was invisible to the reverse-dependency graph, and its transitive callers were missing from the blast radius. Resolution stays precise: a bare module path (`foo::bar::baz()`) still does not bind to a same-name local function, and common associated names (`Type::new`, `::default`) are not guessed.
+
 ### Performance
 
 - Faster graph hydrate on large repos. The public `EntityGraph` maps now use `rustc-hash` (FxHashMap) instead of std SipHash, matching the build's internal maps, and the SQLite cache sets read pragmas (`mmap_size`, `cache_size`, `temp_store=MEMORY`) on every connection. On a 200K-entity / 800K-edge graph this is about 9% faster to hydrate (0.42s to 0.39s, no overlap across repeats); negligible on small repos. Output is byte-identical.

--- a/crates/sem-core/src/parser/scope_resolve.rs
+++ b/crates/sem-core/src/parser/scope_resolve.rs
@@ -5831,6 +5831,40 @@ fn push_method_call_ref(
 }
 
 /// Resolve a single reference against scopes and symbol tables.
+/// Resolve a qualified callee's final name (`Type::NAME`, `module::path::NAME`) to
+/// an entity id, precisely. An explicit import wins; then, when allowed, a same-file
+/// definition; then a globally UNIQUE definition. The qualifier is the disambiguator,
+/// so we never guess among multiple cross-file candidates for a common name
+/// (`new`, `default`, `from`) — those stay unresolved rather than producing a wrong
+/// edge.
+fn resolve_qualified_callee_name(
+    name: &str,
+    import_table_by_name: &HashMap<&str, &str>,
+    file_lookup: &FileEntityLookup<'_>,
+    symbol_table: &HashMap<String, Vec<String>>,
+    from_entity_id: &str,
+    allow_same_file: bool,
+) -> Option<String> {
+    if let Some(target_id) = import_table_by_name.get(name) {
+        if *target_id != from_entity_id {
+            return Some((*target_id).to_string());
+        }
+    }
+    if allow_same_file {
+        if let Some(same_file) = file_lookup.first_id_by_name(name) {
+            if same_file != from_entity_id {
+                return Some(same_file.to_string());
+            }
+        }
+    }
+    if let Some(ids) = symbol_table.get(name) {
+        if ids.len() == 1 && ids[0] != from_entity_id {
+            return Some(ids[0].clone());
+        }
+    }
+    None
+}
+
 fn resolve_ref(
     ast_ref: &AstRef,
     scope_idx: usize,
@@ -6005,7 +6039,28 @@ fn resolve_ref(
             None
         }
 
-        AstRefKind::ScopedCall { .. } => None,
+        AstRefKind::ScopedCall { path, name } => {
+            // `module::path::fn()` or `Enum::Variant::method()`. Resolve only when it
+            // is precise: the last path segment names a repo type that owns `name`, or
+            // the callee name is explicitly imported. We deliberately do NOT bind to a
+            // same-name repo function for a bare module path (`foo::bar::baz()` must
+            // not resolve to a local `baz`, even a unique one) — sem does not track
+            // full module paths, so guessing there would manufacture false edges.
+            let type_hint = path.rsplit("::").next().unwrap_or(path.as_str());
+            if let Some(members) = class_members.get(type_hint) {
+                if let Some((_, target_id)) = members.iter().find(|(member, _)| member == name) {
+                    if target_id != from_entity_id {
+                        return Some((target_id.clone(), RefType::Calls, "scoped_call"));
+                    }
+                }
+            }
+            if let Some(target_id) = import_table_by_name.get(name.as_str()) {
+                if *target_id != from_entity_id {
+                    return Some(((*target_id).to_string(), RefType::Calls, "scoped_call"));
+                }
+            }
+            None
+        }
 
         AstRefKind::MethodCall {
             receiver: raw_receiver,
@@ -6169,6 +6224,23 @@ fn resolve_ref(
                         swift_call_signatures,
                     ) {
                         return Some((mid, RefType::Calls, "static_call"));
+                    }
+                }
+                // `Type::method()` where the impl block is not keyed under `Type` in
+                // class_members (e.g. `impl Trait for Type`), or a free associated fn.
+                // Only when `Type` is itself a known repo entity: resolve the method by
+                // a same-file or globally unique definition (the `Type::` qualifier is
+                // the disambiguator), so `Vec::new()` and friends stay unresolved.
+                if symbol_table.contains_key(receiver) {
+                    if let Some(hit) = resolve_qualified_callee_name(
+                        method,
+                        import_table_by_name,
+                        file_lookup,
+                        symbol_table,
+                        from_entity_id,
+                        true,
+                    ) {
+                        return Some((hit, RefType::Calls, "static_call"));
                     }
                 }
             }


### PR DESCRIPTION
## The bug

`sem impact` silently dropped any caller reached only through a **type-qualified associated call** like `SemPlugin::detect_changes()`. Two independent gaps in `scope_resolve.rs`:

1. **Static `Type::method()`** resolved against a class-member table keyed by the *impl entity's name*, so `impl Trait for Type { ... }` blocks were never found under `Type`.
2. **Multi-segment `a::b::fn()`** (`ScopedCall`) returned `None` outright.

Found by dogfooding: on the sem repo, `compute_semantic_diff`'s reverse-dependency closure was missing the `roundtrip → SemPlugin::detect_changes` subtree (a test helper and its 4 tests). An ast-grep hand-walk found them; sem didn't.

## The fix

- **Static calls:** when the receiver is a known repo type, resolve `Type::method()` by a same-file or **globally unique** definition (in addition to the existing class-member lookup).
- **Scoped calls:** resolve via a type-qualified member (last path segment names a repo type) or an explicit import.

## Precision preserved (the important part)

- A bare module path `foo::bar::baz()` still does **not** bind to a same-name local `baz` — the existing guard test `test_rust_lowercase_scoped_path_does_not_fallback_to_local_function` passes.
- Common associated names (`Type::new`, `::default`, `::from`) are **not** guessed (only unique or same-file names resolve).
- `Vec::new()` / external types stay unresolved (the receiver isn't a repo entity).

## Verification

- **sem-core: 404 tests pass, 0 failures** (includes the precision guard).
- On the sem repo, `sem impact compute_semantic_diff --depth 0` now returns the full closure including `roundtrip` and the `test_roundtrip_*` callers.
- No public API change.

(Pre-existing, unrelated: `sem-cli/tests/cwd_resolution.rs` has 2 failures on clean `main` in this environment — `sem diff --patch` from a subdir — not touched by this change.)