### PR TITLE
feat(skill): live blast-radius graph + savings meter (sem-live)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to sem are documented in this file.
 
 - `npx @ataraxy-labs/sem-skill --badge` (opt-in) installs a live sem badge in the Claude Code statusline: it shows how many structural queries ran this session, the last command **and the entity it analyzed**, its latency, a sparkline of recent latencies, and a rotating stat (distinct entities analyzed, top command) (`⊕ sem ×12  impact validateToken 9ms  ▁▂▃▅▂  · 7 entities analyzed`). It is fed by a PostToolUse hook that catches sem via **both** the MCP tools and the `sem` CLI (Bash), and falls back to recent activity so the badge never stalls on "idle". Non-destructive: it backs up settings and never overwrites an existing statusline (it prints how to add the badge yourself instead).
 
+### Added
+
+- Live viewer for the `--badge` install: `~/.claude/sem-live.py` (run it in a spare terminal pane). It redraws an ASCII blast-radius graph each time sem runs — the analyzed entity, its direct callers (real ones surfaced, test fan-out collapsed), and the transitive count — plus a **savings meter**: a running, honestly-estimated tally of the grep+read round-trips, time, and tokens sem saved this session, and a lifetime counter persisted across sessions (`~/.claude/sem-savings.json`). Estimates are anchored to a measured benchmark and labelled `≈`. The badge hook now also records `--file` and cwd so the graph can be reconstructed.
+
 ### Fixed
 
 - Impact/dependency resolution now follows type-qualified associated calls (`Type::method()`) when the receiver is a known repo type, so a caller reached only through a static/associated path is no longer dropped from `sem impact`. Previously, e.g., a test helper calling `SemPlugin::detect_changes()` was invisible to the reverse-dependency graph, and its transitive callers were missing from the blast radius. Resolution stays precise: a bare module path (`foo::bar::baz()`) still does not bind to a same-name local function, and common associated names (`Type::new`, `::default`) are not guessed.

--- a/agent-skill/README.md
+++ b/agent-skill/README.md
@@ -34,6 +34,19 @@ it leaves it untouched and just tells you how to add the badge yourself. To
 remove it, delete the `statusLine` key and the `mcp__sem__.*` and `Bash`
 PostToolUse entries from `~/.claude/settings.json`.
 
+The `--badge` install also drops a **live viewer** at `~/.claude/sem-live.py`.
+Run it in a spare terminal pane:
+
+```bash
+python3 ~/.claude/sem-live.py
+```
+
+It redraws an ASCII blast-radius graph every time sem runs (the analyzed entity,
+its direct callers, transitive count), plus a **savings meter** — a running,
+honestly-estimated tally of the grep+read round-trips, time, and tokens sem
+saved you this session, and a lifetime counter that grows across sessions. The
+estimates are anchored to a measured benchmark and labelled `≈`.
+
 It's idempotent, re-run it any time. It needs the sem CLI on PATH
 (`npm i -g @ataraxy-labs/sem` or see the
 [install docs](https://github.com/Ataraxy-Labs/sem#install)); if sem isn't

--- a/agent-skill/badge/sem-activity.py
+++ b/agent-skill/badge/sem-activity.py
@@ -29,6 +29,8 @@ def main():
     short = target = None
     ms = None
 
+    file_hint = None
+
     if "mcp__sem__" in tool:
         short = tool.split("__")[-1].replace("sem_", "") or "sem"
         ti = data.get("tool_input") or data.get("toolInput") or {}
@@ -37,6 +39,8 @@ def main():
                 if ti.get(k):
                     target = str(ti[k])
                     break
+            if ti.get("file_path"):
+                file_hint = str(ti["file_path"])
         resp = data.get("tool_response") or data.get("toolResponse") or {}
         if isinstance(resp, str):
             try:
@@ -57,6 +61,9 @@ def main():
             tok = rest.split()[0] if rest else ""
             if tok and not tok.startswith("-"):
                 target = tok.strip("'\"")
+            fm = re.search(r"--file[= ]([^\s]+)", rest)
+            if fm:
+                file_hint = fm.group(1).strip("'\"")
 
     if not short:
         return
@@ -68,6 +75,11 @@ def main():
     }
     if target:
         event["target"] = target[:40]
+    if file_hint:
+        event["file"] = file_hint
+    cwd = data.get("cwd") or data.get("cwd_path") or ""
+    if cwd:
+        event["cwd"] = cwd
     if ms is not None:
         event["ms"] = ms
 

--- a/agent-skill/badge/sem-live.py
+++ b/agent-skill/badge/sem-live.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""sem-live — a live ASCII blast-radius graph that redraws whenever sem runs.
+
+Run it in a spare terminal pane:
+
+    python3 ~/.claude/sem-live.py
+
+It tails ~/.claude/sem-activity.jsonl (written by the sem PostToolUse hook) and,
+each time a new `impact`/`context` call lands, reconstructs that entity's
+dependency graph and draws it as an ASCII tree. Other sem ops update the live
+activity feed + sparkline at the bottom. Ctrl-C to quit.
+
+Pass --once to render a single frame and exit (used for testing).
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+
+ACT = os.path.expanduser("~/.claude/sem-activity.jsonl")
+
+# ANSI
+R = "\033[0m"
+B = "\033[1m"
+DIM = "\033[2m"
+GRN = "\033[32m"
+CYN = "\033[36m"
+MAG = "\033[35m"
+YEL = "\033[33m"
+RED = "\033[31m"
+CLEAR = "\033[2J\033[H"
+HIDE = "\033[?25l"
+SHOW = "\033[?25h"
+SPARK = "▁▂▃▄▅▆▇█"
+
+
+def sem_bin():
+    for cand in (os.environ.get("SEM_BIN"),
+                 os.path.expanduser("~/sem/crates/target/release/sem"),
+                 shutil.which("sem")):
+        if cand and os.path.exists(cand):
+            return cand
+    return "sem"
+
+
+SEM = sem_bin()
+
+
+def read_events():
+    events = []
+    cutoff = time.time() - 3 * 3600
+    if os.path.exists(ACT):
+        with open(ACT) as f:
+            for line in f:
+                try:
+                    e = json.loads(line)
+                except Exception:
+                    continue
+                if e.get("ts", 0) >= cutoff:
+                    events.append(e)
+    return events[-60:]
+
+
+def spark(vals):
+    if not vals:
+        return ""
+    lo, hi = min(vals), max(vals)
+    rng = (hi - lo) or 1
+    return "".join(SPARK[min(len(SPARK) - 1, int((v - lo) / rng * (len(SPARK) - 1)))] for v in vals)
+
+
+SAVE = os.path.expanduser("~/.claude/sem-savings.json")
+
+# Savings model, anchored to the measured 64-entity closure benchmark:
+# grep+read took 17 round-trips / 180s / 35.7k tokens; sem took 2 / 27s / 21.5k.
+# So a big structural query saves ~15 round-trips; each round-trip is ~one LLM
+# inference cycle (~10s) and ~900 tokens of source an agent would otherwise read.
+# Everything is labelled "≈" — these are honest estimates, not precise counts.
+RT_PER_TOOL = {"impact": 8, "context": 4, "orient": 5, "diff": 3,
+               "blame": 3, "log": 3, "entities": 2, "xref": 4}
+SEC_PER_RT = 10
+TOK_PER_RT = 900
+
+
+def rt_saved(tool, total=None):
+    if tool == "impact" and total:
+        return max(2, round(total * 15 / 64))  # scale to the measured benchmark
+    return RT_PER_TOOL.get(tool, 2)
+
+
+def fmt_time(sec):
+    sec = int(sec)
+    if sec < 90:
+        return f"{sec}s"
+    if sec < 3600:
+        return f"{sec // 60}m"
+    return f"{sec // 3600}h {(sec % 3600) // 60}m"
+
+
+def fmt_num(n):
+    n = int(n)
+    if n >= 1000:
+        return f"{n / 1000:.1f}k".replace(".0k", "k")
+    return str(n)
+
+
+def update_lifetime(events):
+    """Add newly-seen events to the persisted lifetime tally (monotonic, once each)."""
+    life = {"rt": 0, "sec": 0, "tok": 0, "calls": 0, "last_ts": 0}
+    if os.path.exists(SAVE):
+        try:
+            life.update(json.load(open(SAVE)))
+        except Exception:
+            pass
+    new = [e for e in events if e.get("ts", 0) > life["last_ts"]]
+    for e in new:
+        rt = rt_saved(e.get("tool"))
+        life["rt"] += rt
+        life["sec"] += rt * SEC_PER_RT
+        life["tok"] += rt * TOK_PER_RT
+        life["calls"] += 1
+    if new:
+        life["last_ts"] = max(e.get("ts", 0) for e in new)
+        try:
+            json.dump(life, open(SAVE, "w"))
+        except Exception:
+            pass
+    return life
+
+
+_graph_cache = {}
+
+
+def fetch_graph(ev):
+    """Run sem impact for the event's target and return (direct, total, entity, file)."""
+    target = ev.get("target")
+    if not target:
+        return None
+    key = (ev.get("cwd", ""), target, ev.get("file", ""))
+    if key in _graph_cache:
+        return _graph_cache[key]
+    cmd = [SEM, "impact", target, "--depth", "0", "--json"]
+    if ev.get("file"):
+        cmd += ["--file", ev["file"]]
+    cwd = ev.get("cwd") or None
+    try:
+        out = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, timeout=8).stdout
+        d = json.loads(out)
+    except Exception:
+        _graph_cache[key] = None
+        return None
+    direct = [(x.get("name", "?"), x.get("file", "")) for x in d.get("dependents", [])]
+    total = d.get("impact", {}).get("total", len(direct))
+    ent = d.get("entity", target)
+    if isinstance(ent, dict):
+        ent = ent.get("name", target)
+    file = d.get("file", ev.get("file", ""))
+    if isinstance(file, dict):
+        file = file.get("file", ev.get("file", ""))
+    res = (direct, total, ent, file)
+    _graph_cache[key] = res
+    return res
+
+
+def shorten(path, width=34):
+    if len(path) <= width:
+        return path
+    parts = path.split("/")
+    out = parts[-1]
+    for p in reversed(parts[:-1]):
+        if len(out) + len(p) + 1 > width:
+            return "…/" + out
+        out = p + "/" + out
+    return out
+
+
+def is_test(name, file):
+    # Rust test fns are often long behaviour-describing snake_case names with no
+    # `test_` prefix, so also treat a many-underscore name as a test for display
+    # ranking — this keeps real callers (run_diff_pipeline, sem_diff) on top.
+    return (name.startswith("test_") or name.startswith("test")
+            or "/tests/" in file or file.endswith("_test.rs")
+            or name.count("_") >= 4)
+
+
+def render(events, width):
+    lines = []
+    clock = time.strftime("%H:%M:%S")
+    head = f"{GRN}{B}⊕ sem live{R}  {DIM}watching {os.path.basename(ACT)}{R}"
+    lines.append(head + " " * max(1, width - 26 - len(clock)) + f"{DIM}{clock}{R}")
+    lines.append(DIM + "═" * width + R)
+
+    if not events:
+        lines.append("")
+        lines.append(f"  {DIM}idle — run sem in the other pane and this lights up{R}")
+        return "\n".join(lines)
+
+    last = events[-1]
+    tool = last.get("tool", "sem")
+    target = last.get("target", "")
+    ms = last.get("ms")
+    ms_s = f"  {YEL}{ms}ms{R}" if isinstance(ms, (int, float)) else ""
+    op = f"{CYN}{B}{tool}{R} {CYN}{target}{R}" if target else f"{CYN}{B}{tool}{R}"
+    lines.append("")
+    lines.append(f"  {op}{ms_s}")
+
+    graph = fetch_graph(last) if tool in ("impact", "context") else None
+    if graph:
+        direct, total, entity, file = graph
+        lines.append(f"  {DIM}{'─' * (width - 4)}{R}")
+        lines.append(f"  {GRN}{B}◉ {entity}{R}   {DIM}{shorten(file)}{R}")
+        lines.append(f"  {DIM}│{R}  {YEL}{len(direct)} direct{R} {DIM}→{R} {YEL}{total} transitive{R}")
+        # non-test first, so the meaningful callers are on top
+        ordered = sorted(direct, key=lambda x: (is_test(x[0], x[1]), x[0]))
+        shown = ordered[:9]
+        tests = sum(1 for n, f in ordered if is_test(n, f))
+        for i, (name, f) in enumerate(shown):
+            elbow = "╰─▶" if i == len(shown) - 1 and len(ordered) <= 9 else "├─▶"
+            col = DIM if is_test(name, f) else CYN
+            lines.append(f"  {DIM}{elbow}{R} {col}{name}{R}"
+                         + " " * max(1, 30 - len(name)) + f"{DIM}{shorten(f, 30)}{R}")
+        if len(ordered) > 9:
+            extra = len(ordered) - 9
+            note = f"+{extra} more" + (f" ({tests} tests)" if tests else "")
+            lines.append(f"  {DIM}╰─▶ … {note}{R}")
+    elif tool in ("impact", "context"):
+        lines.append(f"  {DIM}(no graph — target/file not captured for this call){R}")
+
+    # savings meter — the "you're saving so much" panel
+    sess_rt = sum(rt_saved(e.get("tool")) for e in events)
+    life = update_lifetime(events)
+    call_rt = rt_saved(tool, graph[1] if graph else None)
+    lines.append("")
+    lines.append(f"  {GRN}◇ you're saving{R}  {DIM}vs grep + read (≈ estimated){R}")
+    lines.append(f"  {DIM}this call{R}   grep ≈ {YEL}{call_rt} round-trips{R} {DIM}· sem did it in{R} {GRN}1{R}")
+    lines.append(f"  {DIM}session  {R}  {len(events)} calls {DIM}·{R} ≈ {YEL}{sess_rt}{R} round-trips {DIM}·{R} ≈ {YEL}{fmt_time(sess_rt * SEC_PER_RT)}{R} {DIM}·{R} ≈ {YEL}{fmt_num(sess_rt * TOK_PER_RT)}{R} tokens spared")
+    lines.append(f"  {DIM}lifetime {R}  {life['calls']} calls {DIM}·{R} ≈ {GRN}{B}{fmt_num(life['rt'])} round-trips{R} {DIM}·{R} ≈ {GRN}{B}{fmt_time(life['sec'])}{R} saved")
+
+    # activity feed + sparkline
+    lines.append("")
+    lines.append(f"  {DIM}{'─' * (width - 4)}{R}")
+    tally = {}
+    for e in events:
+        tally[e.get("tool", "?")] = tally.get(e.get("tool", "?"), 0) + 1
+    lat = [e["ms"] for e in events[-16:] if isinstance(e.get("ms"), (int, float))]
+    feed = "  ".join(f"{t}{DIM}×{n}{R}" for t, n in sorted(tally.items(), key=lambda x: -x[1])[:6])
+    lines.append(f"  {MAG}{spark(lat)}{R}   {feed}")
+    recent = events[-6:]
+    trail = " ".join(f"{DIM}{e.get('tool','?')}"
+                     + (f":{e.get('target','')[:12]}" if e.get('target') else "") + R
+                     for e in recent)
+    lines.append(f"  {DIM}recent:{R} {trail}")
+    return "\n".join(lines)
+
+
+def term_width():
+    try:
+        return min(shutil.get_terminal_size().columns, 100)
+    except Exception:
+        return 80
+
+
+def main():
+    once = "--once" in sys.argv
+    if once:
+        print(render(read_events(), term_width()))
+        return
+    sys.stdout.write(HIDE)
+    last_mtime = 0
+    last_draw = 0
+    try:
+        while True:
+            mtime = os.path.getmtime(ACT) if os.path.exists(ACT) else 0
+            now = time.time()
+            if mtime != last_mtime or now - last_draw >= 1:
+                frame = render(read_events(), term_width())
+                sys.stdout.write(CLEAR + frame + "\n")
+                sys.stdout.flush()
+                last_mtime = mtime
+                last_draw = now
+            time.sleep(0.3)
+    except KeyboardInterrupt:
+        evs = read_events()
+        rt = sum(rt_saved(e.get("tool")) for e in evs)
+        sys.stdout.write(CLEAR)
+        print(f"{GRN}{B}⊕ sem{R}  this session: {len(evs)} calls {DIM}·{R} "
+              f"≈ {YEL}{rt}{R} grep round-trips avoided {DIM}·{R} "
+              f"≈ {GRN}{fmt_time(rt * SEC_PER_RT)}{R} {DIM}·{R} "
+              f"≈ {GRN}{fmt_num(rt * TOK_PER_RT)}{R} tokens spared")
+        try:
+            life = json.load(open(SAVE))
+            if life.get("rt"):
+                print(f"{DIM}   lifetime with sem: ≈ {fmt_num(life['rt'])} round-trips · "
+                      f"≈ {fmt_time(life['sec'])} saved. keep going.{R}")
+        except Exception:
+            pass
+    finally:
+        sys.stdout.write(SHOW + "\n")
+        sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-skill/install.mjs
+++ b/agent-skill/install.mjs
@@ -31,11 +31,13 @@ function installBadge() {
   const hooksDir = join(claudeDir, 'hooks');
   const slDest = join(claudeDir, 'statusline-sem.py');
   const hookDest = join(hooksDir, 'sem-activity.py');
+  const liveDest = join(claudeDir, 'sem-live.py');
   try {
     mkdirSync(hooksDir, { recursive: true });
     copyFileSync(join(here, 'badge', 'statusline-sem.py'), slDest);
     copyFileSync(join(here, 'badge', 'sem-activity.py'), hookDest);
-    log(`  [ok] installed sem badge scripts -> ${claudeDir}`);
+    copyFileSync(join(here, 'badge', 'sem-live.py'), liveDest);
+    log(`  [ok] installed sem badge + live viewer -> ${claudeDir}`);
   } catch (e) {
     log(`  [!]  could not install badge scripts: ${e.message}`);
     return;
@@ -89,6 +91,10 @@ function installBadge() {
   } catch (e) {
     log(`  [!]  could not write settings.json: ${e.message}`);
   }
+
+  log('');
+  log('  live blast-radius graph + savings meter — run in a spare terminal pane:');
+  log(`    python3 ${liveDest}`);
 }
 
 function has(cmd) {

--- a/agent-skill/package.json
+++ b/agent-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ataraxy-labs/sem-skill",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "One-command setup of sem (entity-level code intelligence) for coding agents: installs the sem skill and registers the sem MCP server.",
   "type": "module",
   "bin": {
@@ -11,7 +11,8 @@
     "SKILL.md",
     "README.md",
     "badge/statusline-sem.py",
-    "badge/sem-activity.py"
+    "badge/sem-activity.py",
+    "badge/sem-live.py"
   ],
   "keywords": [
     "sem",


### PR DESCRIPTION
## What

The `--badge` install now also ships **`~/.claude/sem-live.py`** — a live terminal viewer you run in a spare pane. Every time sem runs it redraws:

- an **ASCII blast-radius graph** of the analyzed entity — direct callers surfaced (real ones on top, test fan-out collapsed to `+N more`), with the transitive count;
- a **savings meter** — running tally of grep+read round-trips, time, and tokens sem saved this session, and a **lifetime counter** persisted across sessions (`~/.claude/sem-savings.json`).

```
◉ compute_semantic_diff        …/parser/differ.rs
│  29 direct → 65 transitive
├─▶ run_diff_pipeline   sem_diff   detect_changes   compute_hotspots
╰─▶ … +20 more (24 tests)

◇ you're saving  vs grep + read (≈ estimated)
this call    grep ≈ 15 round-trips · sem did it in 1
session      6 calls · ≈ 31 round-trips · ≈ 5m · ≈ 27.9k tokens spared
lifetime     216 calls · ≈ 1.3k round-trips · ≈ 3h 31m saved
```

## Honest by construction
Every savings number is labelled `≈` and **anchored to the measured 64-entity closure benchmark** (grep 17 round-trips / 180s / 35.7k tokens vs sem 2 / 27s / 21.5k). Big impacts scale to ~15 round-trips saved; smaller ops use conservative per-tool estimates. It's a stated model, not a fabricated precise claim.

## Also
- The badge hook now records `--file` + cwd so the viewer can reconstruct the graph.
- Installer copies `sem-live.py` and prints how to launch it; `npm pack` includes it.
- Bumps `@ataraxy-labs/sem-skill` 0.3.0 → 0.4.0.

## Verified
Sandbox install (fake `HOME`): all three scripts land, `sem-live.py --once` renders from the installed path, existing statusline preserved.