### PR TITLE
feat(skill): savings meter in the statusline (no extra process)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to sem are documented in this file.
 
 ### Added
 
+- The savings meter now lives in the **statusline itself** — no extra process. The `--badge` badge rotates through the estimated grep+read cost this session's sem calls avoided (`≈ 8m saved` / `≈ 37 grep round-trips saved` / `≈ 35k tokens spared`), and when idle it shows the lifetime total (`⊕ sem idle · ≈ 3h saved`). The PostToolUse hook is the single writer of the persisted lifetime tally (`~/.claude/sem-savings.json`), so the counter grows from real usage whether or not the live viewer is open. Estimates stay anchored to the measured benchmark and labelled `≈`.
 - Live viewer for the `--badge` install: `~/.claude/sem-live.py` (run it in a spare terminal pane). It redraws an ASCII blast-radius graph each time sem runs — the analyzed entity, its direct callers (real ones surfaced, test fan-out collapsed), and the transitive count — plus a **savings meter**: a running, honestly-estimated tally of the grep+read round-trips, time, and tokens sem saved this session, and a lifetime counter persisted across sessions (`~/.claude/sem-savings.json`). Estimates are anchored to a measured benchmark and labelled `≈`. The badge hook now also records `--file` and cwd so the graph can be reconstructed.
 
 ### Fixed

--- a/agent-skill/badge/sem-activity.py
+++ b/agent-skill/badge/sem-activity.py
@@ -90,6 +90,28 @@ def main():
     except Exception:
         pass
 
+    # Accumulate a persisted lifetime savings tally (single writer: this hook), so
+    # the statusline and viewer can show a number that grows across every session.
+    # Estimate is anchored to the measured 64-entity benchmark; ~10s and ~900
+    # source tokens per avoided grep+read round-trip.
+    try:
+        save = os.path.expanduser("~/.claude/sem-savings.json")
+        rt_per = {"impact": 8, "context": 4, "orient": 5, "diff": 3,
+                  "blame": 3, "log": 3, "entities": 2, "xref": 4}
+        rt = rt_per.get(short, 2)
+        life = {"rt": 0, "sec": 0, "tok": 0, "calls": 0}
+        try:
+            life.update(json.load(open(save)))
+        except Exception:
+            pass
+        life["rt"] += rt
+        life["sec"] += rt * 10
+        life["tok"] += rt * 900
+        life["calls"] += 1
+        json.dump(life, open(save, "w"))
+    except Exception:
+        pass
+
 
 if __name__ == "__main__":
     main()

--- a/agent-skill/badge/sem-live.py
+++ b/agent-skill/badge/sem-live.py
@@ -107,27 +107,14 @@ def fmt_num(n):
 
 
 def update_lifetime(events):
-    """Add newly-seen events to the persisted lifetime tally (monotonic, once each)."""
-    life = {"rt": 0, "sec": 0, "tok": 0, "calls": 0, "last_ts": 0}
-    if os.path.exists(SAVE):
-        try:
-            life.update(json.load(open(SAVE)))
-        except Exception:
-            pass
-    new = [e for e in events if e.get("ts", 0) > life["last_ts"]]
-    for e in new:
-        rt = rt_saved(e.get("tool"))
-        life["rt"] += rt
-        life["sec"] += rt * SEC_PER_RT
-        life["tok"] += rt * TOK_PER_RT
-        life["calls"] += 1
-    if new:
-        life["last_ts"] = max(e.get("ts", 0) for e in new)
-        try:
-            json.dump(life, open(SAVE, "w"))
-        except Exception:
-            pass
-    return life
+    """Read the persisted lifetime tally. The PostToolUse hook is the single writer
+    (it bumps this on every sem call), so the viewer only reads — that keeps the
+    lifetime counter growing from real usage even when the viewer isn't open, and
+    avoids double-counting."""
+    try:
+        return json.load(open(SAVE))
+    except Exception:
+        return {"rt": 0, "sec": 0, "tok": 0, "calls": 0}
 
 
 _graph_cache = {}

--- a/agent-skill/badge/statusline-sem.py
+++ b/agent-skill/badge/statusline-sem.py
@@ -19,6 +19,35 @@ SPARK = "▁▂▃▄▅▆▇█"
 def c(code):
     return f"\033[{code}m"
 RESET, GREEN, DIM, BOLD, CYAN, MAGENTA = c("0"), c("32"), c("2"), c("1"), c("36"), c("35")
+YELLOW = c("33")
+
+SAVE = os.path.expanduser("~/.claude/sem-savings.json")
+# Savings model, anchored to the measured 64-entity closure benchmark (grep+read
+# 17 round-trips / 180s / 35.7k tokens vs sem 2 / 27s / 21.5k). Each avoided
+# round-trip is ~one LLM inference cycle (~10s) and ~900 tokens of source read.
+RT_PER_TOOL = {"impact": 8, "context": 4, "orient": 5, "diff": 3,
+               "blame": 3, "log": 3, "entities": 2, "xref": 4}
+
+def rt_saved(tool):
+    return RT_PER_TOOL.get(tool, 2)
+
+def fmt_time(sec):
+    sec = int(sec)
+    if sec < 90:
+        return f"{sec}s"
+    if sec < 3600:
+        return f"{sec // 60}m"
+    return f"{sec // 3600}h{(sec % 3600) // 60}m"
+
+def fmt_num(n):
+    n = int(n)
+    return f"{n / 1000:.1f}k".replace(".0k", "k") if n >= 1000 else str(n)
+
+def read_lifetime():
+    try:
+        return json.load(open(SAVE))
+    except Exception:
+        return {}
 
 TAGLINES = [
     "structural, not textual",
@@ -67,7 +96,12 @@ def main():
         left += f" {DIM}· {model}{RESET}"
 
     if not events:
-        badge = f"{DIM}⊕ sem idle{RESET}"
+        life = read_lifetime()
+        if life.get("sec"):
+            badge = (f"{DIM}⊕ sem idle{RESET} {DIM}·{RESET} "
+                     f"{YELLOW}≈ {fmt_time(life['sec'])} saved{RESET}")
+        else:
+            badge = f"{DIM}⊕ sem idle{RESET}"
     else:
         from collections import Counter
         n = len(events)
@@ -79,21 +113,24 @@ def main():
         op = f"{last_tool} {last_target}".strip() if last_target else last_tool
         last_ms = last.get("ms")
         ms_str = f" {last_ms}ms" if isinstance(last_ms, (int, float)) else ""
-        # rotate the trailing segment through real stats + a tagline
+        # the savings meter, live in the statusline: rotate the trailing segment
+        # through the estimated grep+read cost this session's sem calls avoided.
         tally = Counter(e.get("tool") for e in events)
         targets = {e.get("target") for e in events if e.get("target")}
-        top_cmd, top_n = tally.most_common(1)[0]
+        sess_rt = sum(rt_saved(e.get("tool")) for e in events)
         insights = [
+            f"≈ {fmt_time(sess_rt * 10)} saved",
+            f"≈ {sess_rt} grep round-trips saved",
+            f"≈ {fmt_num(sess_rt * 900)} tokens spared",
             f"{len(targets)} entities analyzed" if targets else TAGLINES[0],
-            f"{top_cmd} ×{top_n} top",
-            TAGLINES[n % len(TAGLINES)],
         ]
         insight = insights[n % len(insights)]
+        color = YELLOW if insight.startswith("≈") else DIM
         badge = (
             f"{GREEN}{BOLD}⊕ sem{RESET} {GREEN}×{n}{RESET}"
             f" {CYAN}{op}{ms_str}{RESET}"
             + (f" {MAGENTA}{sp}{RESET}" if sp else "")
-            + f" {DIM}· {insight}{RESET}"
+            + f" {DIM}·{RESET} {color}{insight}{RESET}"
         )
 
     print(f"{left}  {badge}")

--- a/agent-skill/package.json
+++ b/agent-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ataraxy-labs/sem-skill",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "One-command setup of sem (entity-level code intelligence) for coding agents: installs the sem skill and registers the sem MCP server.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Renders the estimated grep+read savings directly in the `--badge` statusline, so users feel the value in-session without running `sem-live.py`.

- Badge rotates through `≈ 8m saved` / `≈ 37 grep round-trips saved` / `≈ 35k tokens spared` (this session).
- Idle state shows the lifetime total: `⊕ sem idle · ≈ 3h saved`.
- The PostToolUse hook is now the single writer of `~/.claude/sem-savings.json`, so lifetime grows from real usage whether or not the viewer is open; the viewer only reads it (no double-count).
- Estimates anchored to the measured 64-entity benchmark, labelled `≈`.
- Bumps `@ataraxy-labs/sem-skill` 0.4.0 -> 0.5.0.