### PR TITLE
fix(cloud): impact/context skip cloud on --no-cache and --file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to sem are documented in this file.
 
 ### Fixed
 
+- Cloud-backed `sem impact` / `sem context` no longer answer queries they can't answer correctly. Two gates added: `--no-cache` now always computes fresh locally (previously the cloud snapshot was served anyway), and **file-hinted queries (`--file`) stay local** — the cloud resolves entities by name with a silent name-only fallback, so for same-named entities (e.g. ten `fn run` command handlers) it could return the *wrong entity's* graph, and a stale cloud index could drop dependents that exist locally. Local resolution disambiguates exactly; the cloud path returns once the server resolves name+file strictly and exposes its indexed commit for a freshness check.
 - Impact/dependency resolution now follows type-qualified associated calls (`Type::method()`) when the receiver is a known repo type, so a caller reached only through a static/associated path is no longer dropped from `sem impact`. Previously, e.g., a test helper calling `SemPlugin::detect_changes()` was invisible to the reverse-dependency graph, and its transitive callers were missing from the blast radius. Resolution stays precise: a bare module path (`foo::bar::baz()`) still does not bind to a same-name local function, and common associated names (`Type::new`, `::default`) are not guessed.
 
 ### Performance

--- a/crates/sem-cli/src/commands/cloud.rs
+++ b/crates/sem-cli/src/commands/cloud.rs
@@ -417,6 +417,19 @@ pub fn try_cloud_impact(opts: &ImpactOptions) -> Option<()> {
     if matches!(opts.mode, super::impact::ImpactMode::Tests) {
         return None;
     }
+    // --no-cache means "compute fresh": serving a remote snapshot would violate it.
+    if opts.no_cache {
+        return None;
+    }
+    // A --file hint exists to disambiguate same-named entities, but the cloud
+    // resolves by name with a silent name-only fallback when the file doesn't
+    // match its index — which returns the WRONG entity's graph (repro: weave's
+    // ten `fn run` command handlers; `--file .../apply.rs` came back with
+    // bench.rs's dependencies). Until the server resolves name+file strictly,
+    // file-hinted queries stay local, where disambiguation is exact.
+    if opts.file_hint.is_some() {
+        return None;
+    }
     let client = CloudClient::from_credentials()?;
     let (git, remote) = cloud_git_context(&opts.cwd)?;
     // Small repos answer graph queries faster from the local cache.
@@ -579,6 +592,11 @@ pub fn try_cloud_impact(opts: &ImpactOptions) -> Option<()> {
 
 /// Try to run `sem context` via cloud.
 pub fn try_cloud_context(opts: &ContextOptions) -> Option<()> {
+    // Same gates as try_cloud_impact: --no-cache means fresh local compute, and
+    // a --file hint needs exact name+file resolution the cloud doesn't do yet.
+    if opts.no_cache || opts.file_path.is_some() {
+        return None;
+    }
     let client = CloudClient::from_credentials()?;
     let (git, remote) = cloud_git_context(&opts.cwd)?;
     // Small repos answer graph queries faster from the local cache.


### PR DESCRIPTION
## Two silent-wrong-answer paths, found by dogfooding on weave

Logged-in CLI routed \`sem impact\`/\`sem context\` to sem-cloud, which:

1. **Ignored \`--no-cache\`** — "compute fresh" served a stale cloud snapshot. Repro: \`find_repo_root\` showed 3 dependents while the local graph has 4 (the cloud index predates weave's \`apply.rs\`).
2. **Ignored \`--file\`** — the server resolves by name with a silent name-only fallback. Among weave's ten \`fn run\` command handlers, \`--file .../apply.rs\` returned **bench.rs's** dependencies; \`--file totally/bogus.rs\` returned data instead of an error.

## Fix
\`try_cloud_impact\` / \`try_cloud_context\` return \`None\` (→ local computation) when \`--no-cache\` is set or a file hint is present. Local resolution disambiguates exactly and errors on a bad file. \`try_cloud_log\` already filters by file server-side + exact name client-side, so it's unaffected; \`entities\` was already gated.

## Verified (weave repo)
- \`impact find_repo_root --no-cache\` → 4/4 dependents including \`apply.rs\` (was 3, stale)
- \`impact run --file .../apply.rs --deps\` → the real deps (\`find_repo_root\`, \`EntityStateDoc::open\`, \`reconstruct_file_from_crdt\`) (was bench's)
- \`impact run --file totally/bogus.rs\` → proper error (was silent wrong data)
- sem-cli tests pass (2 \`cwd_resolution\` failures are pre-existing on main)

## Follow-up (server, sem-cloud)
To re-enable cloud for these cases correctly: strict name+file resolution (404 on miss so the CLI's \`.ok()?\` falls back), and \`lastIndexedCommit\` in the repo response for a freshness gate.