### PR TITLE
docs(action): pin usage examples to v0.15.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Or via Homebrew:
 brew install sem-cli
 ```
 
+Or via winget on Windows:
+
+```powershell
+winget install AtaraxyLabs.sem
+```
+
 Or install the npm wrapper into `node_modules`:
 
 ```bash
@@ -276,7 +282,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: Ataraxy-Labs/sem/action@main
+      - uses: Ataraxy-Labs/sem/action@v0.15.1
 ```
 
 No config, no API keys, never fails your build. See [action/](action/) for details.

--- a/action/README.md
+++ b/action/README.md
@@ -35,10 +35,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: Ataraxy-Labs/sem/action@main
+      - uses: Ataraxy-Labs/sem/action@v0.15.1
 ```
 
-That's it. No config, no API keys. The action installs the prebuilt `sem`
+That's it. No config, no API keys. (Pin the tag for stability, or use
+`@main` to track the latest.) The action installs the prebuilt `sem`
 binary (~2s), diffs the PR's base and head at the entity level across 30+
 languages (tree-sitter), and posts the comment.
 


### PR DESCRIPTION
Now that v0.15.1 is tagged, the action usage examples pin the release tag instead of @main (with a note that @main tracks latest).