### PR TITLE
feat(mcp): render impact/context results as a compact entity tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to sem are documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- `sem_impact` and `sem_context` MCP results now render as a compact entity tree instead of pretty-printed JSON: dependents/dependencies/transitive impact grouped one line per file, every entity name preserved, with the elapsed time and source in a footer. The same information lands in about 15% of the tokens, and the expanded tool widget in agent UIs reads at a glance (`⊕ entity · file`, `← 29 dependents · 10 files`, `⚡ 70 transitively affected`). Context entries keep their verbatim content under a per-entry header.
+
 ## [0.15.1] - 2026-07-01
 
 ### Added

--- a/crates/sem-mcp/src/lib.rs
+++ b/crates/sem-mcp/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cache;
 pub mod cloud;
+pub mod render;
 pub mod server;
 pub mod tools;
 mod transport;

--- a/crates/sem-mcp/src/render.rs
+++ b/crates/sem-mcp/src/render.rs
@@ -1,0 +1,285 @@
+//! Compact text rendering for MCP tool results.
+//!
+//! Tool results are read by models, and by humans expanding the tool widget in
+//! an agent UI. A grouped tree carries the same information as a pretty-printed
+//! JSON dump at a fraction of the tokens (one file path per file instead of per
+//! entity, no repeated keys/braces) and reads at a glance. Nothing is elided:
+//! every entity name is present, grouped under its file.
+
+use serde_json::Value;
+
+fn get_str<'a>(v: &'a Value, key: &str) -> &'a str {
+    v.get(key).and_then(Value::as_str).unwrap_or("")
+}
+
+fn get_u64(v: &Value, key: &str) -> Option<u64> {
+    v.get(key).and_then(Value::as_u64)
+}
+
+fn get_arr<'a>(v: &'a Value, key: &str) -> &'a [Value] {
+    v.get(key)
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[])
+}
+
+/// Entity display name: `name` for functions/methods, `name (type)` otherwise,
+/// so uncommon kinds stay visible without noising the common case.
+fn entity_label(e: &Value) -> String {
+    // impact entities carry `name`; context entries carry `entity`.
+    let name = match get_str(e, "name") {
+        "" => get_str(e, "entity"),
+        n => n,
+    };
+    let ty = get_str(e, "type");
+    match ty {
+        "" | "function" | "method" => name.to_string(),
+        _ => format!("{} ({})", name, ty),
+    }
+}
+
+/// Group entities by file (first-seen order), one line per file:
+/// `  path: name, name (type), name`
+fn push_grouped(out: &mut String, list: &[Value]) {
+    let mut order: Vec<&str> = Vec::new();
+    let mut by_file: std::collections::HashMap<&str, Vec<String>> = std::collections::HashMap::new();
+    for e in list {
+        let file = get_str(e, "file");
+        if !by_file.contains_key(file) {
+            order.push(file);
+        }
+        by_file.entry(file).or_default().push(entity_label(e));
+    }
+    for file in order {
+        let names = by_file[file].join(", ");
+        let file = if file.is_empty() { "(unknown file)" } else { file };
+        out.push_str(&format!("  {}: {}\n", file, names));
+    }
+}
+
+fn file_count(list: &[Value]) -> usize {
+    let mut files: Vec<&str> = list.iter().map(|e| get_str(e, "file")).collect();
+    files.sort_unstable();
+    files.dedup();
+    files.len()
+}
+
+fn footer(v: &Value) -> String {
+    let mut parts = Vec::new();
+    if let Some(ms) = get_u64(v, "elapsed_ms") {
+        parts.push(format!("{}ms", ms));
+    }
+    let source = get_str(v, "source");
+    if !source.is_empty() {
+        parts.push(source.to_string());
+    }
+    if parts.is_empty() {
+        String::new()
+    } else {
+        parts.join(" · ")
+    }
+}
+
+/// Render a sem_impact result (any mode: all, deps, dependents, tests).
+pub fn impact_text(v: &Value) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "⊕ {} · {}\n",
+        get_str(v, "entity"),
+        get_str(v, "file")
+    ));
+
+    let deps = get_arr(v, "dependencies");
+    let dependents = get_arr(v, "dependents");
+    let tests = get_arr(v, "tests");
+
+    if !dependents.is_empty() {
+        out.push_str(&format!(
+            "← {} dependents · {} files\n",
+            dependents.len(),
+            file_count(dependents)
+        ));
+        push_grouped(&mut out, dependents);
+    } else if get_str(v, "mode") == "dependents" || get_str(v, "mode") == "all" {
+        out.push_str("← no dependents\n");
+    }
+
+    if !deps.is_empty() {
+        out.push_str(&format!(
+            "→ {} dependencies · {} files\n",
+            deps.len(),
+            file_count(deps)
+        ));
+        push_grouped(&mut out, deps);
+    } else if get_str(v, "mode") == "deps" || get_str(v, "mode") == "all" {
+        out.push_str("→ no dependencies\n");
+    }
+
+    if let Some(impact) = v.get("impact") {
+        let total = get_u64(impact, "total").unwrap_or(0);
+        let entities = get_arr(impact, "entities");
+        if total > 0 {
+            out.push_str(&format!(
+                "⚡ {} transitively affected · {} files\n",
+                total,
+                file_count(entities)
+            ));
+            // Direct dependents are already listed above; show only the entities
+            // beyond them so the transitive tail is visible without repetition.
+            let direct: std::collections::HashSet<(&str, &str)> = dependents
+                .iter()
+                .map(|e| (get_str(e, "file"), get_str(e, "name")))
+                .collect();
+            let beyond: Vec<Value> = entities
+                .iter()
+                .filter(|e| !direct.contains(&(get_str(e, "file"), get_str(e, "name"))))
+                .cloned()
+                .collect();
+            if !beyond.is_empty() {
+                push_grouped(&mut out, &beyond);
+            }
+        } else {
+            out.push_str("⚡ nothing transitively affected\n");
+        }
+    }
+
+    if !tests.is_empty() {
+        out.push_str(&format!(
+            "✓ {} tests affected · {} files\n",
+            tests.len(),
+            file_count(tests)
+        ));
+        push_grouped(&mut out, tests);
+    }
+    if let Some(n) = get_u64(v, "tests_affected") {
+        if n == 0 {
+            out.push_str("✓ no tests affected\n");
+        }
+    }
+
+    let f = footer(v);
+    if !f.is_empty() {
+        out.push_str(&f);
+        out.push('\n');
+    }
+    out
+}
+
+/// Render a sem_context result: a compact header, then each entry with its
+/// role and verbatim content (the content is the product; never elide it).
+pub fn context_text(v: &Value) -> String {
+    let mut out = String::new();
+    let entries = get_arr(v, "context");
+    let used = get_u64(v, "tokens_used").unwrap_or(0);
+    let budget = get_u64(v, "token_budget").unwrap_or(0);
+    let mut header = format!(
+        "⊕ context · {} entries · {}/{} tokens",
+        entries.len(),
+        used,
+        budget
+    );
+    let f = footer(v);
+    if !f.is_empty() {
+        header.push_str(&format!(" · {}", f));
+    }
+    out.push_str(&header);
+    out.push('\n');
+    if v.get("truncated").and_then(Value::as_bool).unwrap_or(false) {
+        out.push_str("(truncated to fit the token budget)\n");
+    }
+    if v.get("target_omitted")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        out.push_str("(target too large for the budget; showing neighbors)\n");
+    }
+
+    for e in entries {
+        let tokens = get_u64(e, "tokens")
+            .map(|t| format!(" · {} tok", t))
+            .unwrap_or_default();
+        out.push_str(&format!(
+            "\n── {} · {} · {}{}\n",
+            get_str(e, "role"),
+            entity_label(e),
+            get_str(e, "file"),
+            tokens
+        ));
+        let content = get_str(e, "content");
+        if !content.is_empty() {
+            out.push_str(content);
+            if !content.ends_with('\n') {
+                out.push('\n');
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn impact_groups_by_file_and_keeps_every_name() {
+        let v = json!({
+            "entity": "compute", "file": "src/a.rs", "mode": "all",
+            "dependencies": [
+                {"name": "helper", "type": "function", "file": "src/a.rs"},
+                {"name": "Config", "type": "struct", "file": "src/b.rs"},
+            ],
+            "dependents": [
+                {"name": "run", "type": "function", "file": "src/c.rs"},
+                {"name": "run", "type": "function", "file": "src/d.rs"},
+            ],
+            "impact": {"total": 3, "entities": [
+                {"name": "run", "type": "function", "file": "src/c.rs"},
+                {"name": "run", "type": "function", "file": "src/d.rs"},
+                {"name": "main", "type": "function", "file": "src/main.rs"},
+            ]},
+            "tests": [],
+            "elapsed_ms": 12, "source": "local",
+        });
+        let text = impact_text(&v);
+        assert!(text.contains("⊕ compute · src/a.rs"));
+        assert!(text.contains("← 2 dependents · 2 files"));
+        assert!(text.contains("src/c.rs: run"));
+        assert!(text.contains("src/b.rs: Config (struct)"));
+        assert!(text.contains("⚡ 3 transitively affected · 3 files"));
+        // transitive tail shows only what direct dependents didn't already list
+        assert!(text.contains("src/main.rs: main"));
+        assert!(text.contains("12ms · local"));
+    }
+
+    #[test]
+    fn impact_dependents_mode_without_edges_says_so() {
+        let v = json!({
+            "entity": "orphan", "file": "src/a.rs", "mode": "dependents",
+            "dependents": [], "elapsed_ms": 3, "source": "local",
+        });
+        let text = impact_text(&v);
+        assert!(text.contains("← no dependents"));
+    }
+
+    #[test]
+    fn context_renders_entries_with_verbatim_content() {
+        let v = json!({
+            "token_budget": 8000, "tokens_used": 950, "truncated": false,
+            "target_omitted": false,
+            "context": [
+                {"entity": "sync", "type": "function", "file": "src/s.rs",
+                 "role": "target", "tokens": 700, "content": "fn sync() {}\n"},
+                {"entity": "helper", "type": "function", "file": "src/h.rs",
+                 "role": "dependency", "tokens": 250, "content": "fn helper() {}"},
+            ],
+            "entries": 2, "elapsed_ms": 7, "source": "local",
+        });
+        let text = context_text(&v);
+        assert!(text.contains("⊕ context · 2 entries · 950/8000 tokens · 7ms · local"));
+        assert!(text.contains("── target · sync · src/s.rs · 700 tok"));
+        assert!(text.contains("fn sync() {}"));
+        assert!(text.contains("── dependency · helper · src/h.rs · 250 tok"));
+        assert!(text.contains("fn helper() {}"));
+    }
+}

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -1039,7 +1039,7 @@ impl SemServer {
                 out["elapsed_ms"] = serde_json::json!(start.elapsed().as_millis() as u64);
                 out["source"] = serde_json::json!("cloud");
                 return Ok(CallToolResult::success(vec![Content::text(
-                    serde_json::to_string_pretty(&out).unwrap_or_default(),
+                    crate::render::impact_text(&out),
                 )]));
             }
         }
@@ -1109,7 +1109,7 @@ impl SemServer {
             output["elapsed_ms"] = serde_json::json!(start.elapsed().as_millis() as u64);
             output["source"] = serde_json::json!("local");
             return Ok(CallToolResult::success(vec![Content::text(
-                serde_json::to_string_pretty(&output).unwrap(),
+                crate::render::impact_text(&output),
             )]));
         }
 
@@ -1200,7 +1200,7 @@ impl SemServer {
         output["elapsed_ms"] = serde_json::json!(start.elapsed().as_millis() as u64);
         output["source"] = serde_json::json!("local");
         Ok(CallToolResult::success(vec![Content::text(
-            serde_json::to_string_pretty(&output).unwrap_or_default(),
+            crate::render::impact_text(&output),
         )]))
     }
 
@@ -1375,7 +1375,7 @@ impl SemServer {
                 out["elapsed_ms"] = serde_json::json!(start.elapsed().as_millis() as u64);
                 out["source"] = serde_json::json!("cloud");
                 return Ok(CallToolResult::success(vec![Content::text(
-                    serde_json::to_string_pretty(&out).unwrap_or_default(),
+                    crate::render::context_text(&out),
                 )]));
             }
         }
@@ -1424,7 +1424,7 @@ impl SemServer {
             .collect();
 
         Ok(CallToolResult::success(vec![Content::text(
-            serde_json::to_string_pretty(&serde_json::json!({
+            crate::render::context_text(&serde_json::json!({
                 "entity": params.entity_name,
                 "file": rel_path,
                 "token_budget": budget,
@@ -1435,8 +1435,7 @@ impl SemServer {
                 "context": result,
                 "elapsed_ms": start.elapsed().as_millis() as u64,
                 "source": "local",
-            }))
-            .unwrap_or_default(),
+            })),
         )]))
     }
 }


### PR DESCRIPTION
## Why

Expanding a sem tool call in Claude Code showed a ~30KB pretty-printed JSON wall for a 65-entity impact. Correct, but ugly for humans and token-wasteful for models (file paths + keys repeated per entity).

## What

`sem_impact` / `sem_context` MCP results now render as a compact grouped tree — **same data, ~15% of the tokens**:

```
⊕ compute_semantic_diff · crates/sem-core/src/parser/differ.rs
← 29 dependents · 10 files
  crates/sem-cli/src/commands/diff.rs: run_diff_pipeline
  crates/sem-mcp/src/server.rs: sem_diff
  ...
→ 12 dependencies · 5 files
⚡ 70 transitively affected · 11 files
✓ 13 tests affected · 3 files
670ms · local
```

- Every entity name preserved (grouped one line per file; nothing elided)
- Transitive tail deduped against direct dependents (no repetition)
- Non-function kinds annotated (`Config (struct)`); context entries keep verbatim content
- All five return paths covered (cloud + local, every mode)

## Verified
- 58 sem-mcp tests pass (incl. new renderer unit tests)
- End-to-end over real MCP stdio: `tools/call sem_impact` on this repo returns the tree above

Follow-up: same treatment for `sem_log` / `sem_blame` / `sem_diff` / `sem_entities`.