### PR TITLE
feat(log): entity-level history analytics (hotspots + co-change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to sem are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Entity-level history analytics**: `sem log` with no entity now analyzes recent repo history in one pass and reports **hotspots** (the most-changed code entities, with commit counts, distinct authors, and the last commit that touched each) and **co-change pairs** (entities that repeatedly change in the same commits, with a confidence score — "these two never change apart"). Counts are per commit, code entities only (doc headings, config properties, and lockfile chunks are excluded so the signal is about code), and bulk commits touching >50 entities are excluded from pair-counting to keep quadratic noise out. Same via MCP: `sem_log` without `entity_name`. `--file` scopes to one file; `--json` returns everything. This is the time axis a snapshot dependency graph cannot see: which code churns, and which code moves together.
+
 ### Changed
 
 - `sem_impact` and `sem_context` MCP results now render as a compact entity tree instead of pretty-printed JSON: dependents/dependencies/transitive impact grouped one line per file, every entity name preserved, with the elapsed time and source in a footer. The same information lands in about 15% of the tokens, and the expanded tool widget in agent UIs reads at a glance (`⊕ entity · file`, `← 29 dependents · 10 files`, `⚡ 70 transitively affected`). Context entries keep their verbatim content under a per-entry header.

--- a/README.md
+++ b/README.md
@@ -211,6 +211,18 @@ sem log authenticateUser --limit 20
 sem log authenticateUser --json
 ```
 
+With no entity, `sem log` analyzes recent repo history at the entity level:
+**hotspots** (most-changed functions/classes, with author counts) and
+**co-change pairs** (entities that repeatedly change in the same commits —
+"if you touch one, don't forget the other"):
+
+```bash
+sem log                 # repo hotspots + co-change pairs (last 50 commits)
+sem log --limit 200     # deeper history
+sem log --file src/auth.ts   # scoped to one file
+sem log --json          # full data
+```
+
 ### sem entities
 
 List all entities under a file or directory path. No path is the same as `.`.

--- a/crates/sem-cli/src/commands/log.rs
+++ b/crates/sem-cli/src/commands/log.rs
@@ -72,6 +72,159 @@ struct EntityOccurrence {
     entity: SemanticEntity,
 }
 
+pub struct HistoryOptions {
+    pub cwd: String,
+    pub file_path: Option<String>,
+    pub limit: usize,
+    pub json: bool,
+}
+
+/// `sem log` with no entity: repo-level history analytics. The time axis a
+/// snapshot dependency graph can't see — which entities churn (hotspots) and
+/// which change together (co-change pairs).
+pub fn history_command(opts: HistoryOptions) {
+    let root = Path::new(&opts.cwd);
+    let registry = super::create_registry(&opts.cwd);
+    let bridge = match GitBridge::open(root) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("{} {}", "error:".red().bold(), e);
+            std::process::exit(1);
+        }
+    };
+
+    let limit = if opts.limit == 0 { 500 } else { opts.limit };
+    let analytics = sem_core::parser::hotspot::compute_history_analytics(
+        &bridge,
+        &registry,
+        opts.file_path.as_deref(),
+        limit,
+    );
+
+    if opts.json {
+        let hotspots: Vec<serde_json::Value> = analytics
+            .hotspots
+            .iter()
+            .map(|h| {
+                serde_json::json!({
+                    "entity": h.entity_name, "type": h.entity_type,
+                    "file": h.file_path, "commits": h.commits,
+                    "authors": h.authors, "lastSha": h.last_short_sha,
+                })
+            })
+            .collect();
+        let co_changes: Vec<serde_json::Value> = analytics
+            .co_changes
+            .iter()
+            .map(|p| {
+                serde_json::json!({
+                    "a": {"entity": p.a_name, "file": p.a_file, "commits": p.a_commits},
+                    "b": {"entity": p.b_name, "file": p.b_file, "commits": p.b_commits},
+                    "together": p.together, "confidence": p.confidence,
+                })
+            })
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "commitsScanned": analytics.commits_scanned,
+                "hotspots": hotspots,
+                "coChanges": co_changes,
+                "pairCommitsSkipped": analytics.pair_commits_skipped,
+            }))
+            .unwrap_or_default()
+        );
+        return;
+    }
+
+    if analytics.commits_scanned == 0 {
+        println!("{}", "no history to analyze (need at least 2 commits)".dimmed());
+        return;
+    }
+
+    println!(
+        "{} {}",
+        "⊕ repo history".green().bold(),
+        format!("· last {} commits", analytics.commits_scanned).dimmed()
+    );
+
+    if analytics.hotspots.is_empty() {
+        println!("\n  {}", "no entity changes found".dimmed());
+        return;
+    }
+
+    println!("\n  {}", "hotspots — most-changed entities".bold());
+    for h in analytics.hotspots.iter().take(15) {
+        let authors = if h.authors == 1 {
+            "1 author".to_string()
+        } else {
+            format!("{} authors", h.authors)
+        };
+        println!(
+            "  {:>3}  {}  {} {} {}",
+            format!("{}×", h.commits).yellow(),
+            truncate_str(&h.entity_name, 40),
+            authors.dimmed(),
+            truncate_str(&h.file_path, 44).dimmed(),
+            format!("last {}", h.last_short_sha).dimmed(),
+        );
+    }
+    if analytics.hotspots.len() > 15 {
+        println!(
+            "  {}",
+            format!("… {} more (use --json for all)", analytics.hotspots.len() - 15).dimmed()
+        );
+    }
+
+    if !analytics.co_changes.is_empty() {
+        println!(
+            "\n  {}",
+            "co-changes — entities that change together".bold()
+        );
+        for p in analytics.co_changes.iter().take(12) {
+            let cross_file = p.a_file != p.b_file;
+            let files = if cross_file {
+                format!(
+                    "{} ↔ {}",
+                    truncate_str(&p.a_file, 30),
+                    truncate_str(&p.b_file, 30)
+                )
+            } else {
+                truncate_str(&p.a_file, 44).to_string()
+            };
+            println!(
+                "  {:>3}  {} {} {}  {}",
+                format!("{}×", p.together).yellow(),
+                truncate_str(&p.a_name, 28).cyan(),
+                "↔".dimmed(),
+                truncate_str(&p.b_name, 28).cyan(),
+                format!("{:.0}% · {}", p.confidence * 100.0, files).dimmed(),
+            );
+        }
+        if analytics.co_changes.len() > 12 {
+            println!(
+                "  {}",
+                format!(
+                    "… {} more pairs (use --json for all)",
+                    analytics.co_changes.len() - 12
+                )
+                .dimmed()
+            );
+        }
+    }
+
+    if analytics.pair_commits_skipped > 0 {
+        println!(
+            "\n  {}",
+            format!(
+                "note: {} bulk commits (>50 entities) excluded from co-change pairing",
+                analytics.pair_commits_skipped
+            )
+            .dimmed()
+        );
+    }
+}
+
 pub fn log_command(opts: LogOptions) {
     if super::cloud::try_cloud_log(&opts).is_some() {
         return;

--- a/crates/sem-cli/src/main.rs
+++ b/crates/sem-cli/src/main.rs
@@ -20,7 +20,7 @@ use commands::diff::{diff_command, DiffOptions, OutputFormat};
 use commands::entities::{entities_command, EntitiesOptions};
 use commands::graph::{graph_command, GraphOptions};
 use commands::impact::{impact_command, ImpactMode, ImpactOptions};
-use commands::log::{log_command, LogOptions};
+use commands::log::{history_command, log_command, HistoryOptions, LogOptions};
 use commands::orient::{orient_command, OrientOptions};
 
 #[derive(Parser)]
@@ -203,11 +203,12 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
-    /// Show evolution of an entity through git history
+    /// Show evolution of an entity through git history, or, with no entity,
+    /// the repo's history analytics: hotspots and co-change pairs
     Log {
-        /// Name of the entity to trace
+        /// Name of the entity to trace (omit for repo hotspots + co-changes)
         #[arg()]
-        entity: String,
+        entity: Option<String>,
 
         /// File containing the entity (auto-detected if omitted)
         #[arg(long)]
@@ -569,17 +570,27 @@ fn main() {
             json,
             verbose,
         }) => {
-            log_command(LogOptions {
-                cwd: std::env::current_dir()
-                    .unwrap_or_default()
-                    .to_string_lossy()
-                    .to_string(),
-                entity_name: entity,
-                file_path: file,
-                limit,
-                json: resolve_json(format, json),
-                verbose,
-            });
+            let cwd = std::env::current_dir()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
+            match entity {
+                Some(entity) => log_command(LogOptions {
+                    cwd,
+                    entity_name: entity,
+                    file_path: file,
+                    limit,
+                    json: resolve_json(format, json),
+                    verbose,
+                }),
+                // No entity: repo-level history analytics (hotspots + co-changes).
+                None => history_command(HistoryOptions {
+                    cwd,
+                    file_path: file,
+                    limit,
+                    json: resolve_json(format, json),
+                }),
+            }
         }
         Some(Commands::Entities {
             paths,

--- a/crates/sem-core/src/parser/hotspot.rs
+++ b/crates/sem-core/src/parser/hotspot.rs
@@ -16,6 +16,230 @@ pub struct EntityHotspot {
     pub change_count: usize,
 }
 
+/// A hot entity in repo history: how often it changed, by how many people,
+/// and when it last moved. The unit is commits (an entity changing twice in
+/// one commit counts once), so counts compare cleanly across entities.
+#[derive(Debug, Clone)]
+pub struct HotEntity {
+    pub entity_name: String,
+    pub entity_type: String,
+    pub file_path: String,
+    /// Number of scanned commits in which this entity changed.
+    pub commits: usize,
+    /// Distinct commit authors who changed it.
+    pub authors: usize,
+    /// Short SHA of the most recent commit that changed it.
+    pub last_short_sha: String,
+}
+
+/// Two entities that repeatedly change in the same commits. `confidence` is
+/// `together / min(a_commits, b_commits)`: 1.0 means the rarer entity never
+/// changes without the other.
+#[derive(Debug, Clone)]
+pub struct CoChangePair {
+    pub a_name: String,
+    pub a_file: String,
+    pub b_name: String,
+    pub b_file: String,
+    pub together: usize,
+    pub a_commits: usize,
+    pub b_commits: usize,
+    pub confidence: f64,
+}
+
+/// Entity-level history analytics for a repo: hotspots and co-change pairs,
+/// computed in a single walk over recent commits.
+#[derive(Debug, Clone)]
+pub struct HistoryAnalytics {
+    pub commits_scanned: usize,
+    pub hotspots: Vec<HotEntity>,
+    pub co_changes: Vec<CoChangePair>,
+    /// Commits skipped for pair-counting because they touched more entities
+    /// than `MAX_PAIR_ENTITIES` (bulk refactors/imports would otherwise drown
+    /// the signal in quadratic noise). They still count toward hotspots.
+    pub pair_commits_skipped: usize,
+}
+
+/// Commits touching more entities than this don't contribute co-change pairs.
+const MAX_PAIR_ENTITIES: usize = 50;
+
+/// History analytics track code entities only. Doc headings, config properties,
+/// and lockfile chunks churn constantly and would bury the signal the analysis
+/// exists for: which *code* is hot, and which code moves together.
+fn is_code_entity(entity_type: &str) -> bool {
+    matches!(
+        entity_type,
+        "function"
+            | "method"
+            | "constructor"
+            | "init"
+            | "init_declaration"
+            | "class"
+            | "struct"
+            | "enum"
+            | "trait"
+            | "impl"
+            | "interface"
+            | "protocol"
+            | "protocol_declaration"
+            | "extension"
+            | "object_declaration"
+            | "companion_object"
+            | "module"
+            | "namespace"
+            | "component"
+            | "macro_definition"
+            | "type"
+            | "type_alias"
+    )
+}
+
+/// Walk recent git history once and compute entity-level hotspots plus
+/// co-change pairs. This is the "time axis" a snapshot dependency graph can't
+/// see: which entities churn, and which move together.
+pub fn compute_history_analytics(
+    git: &GitBridge,
+    registry: &ParserRegistry,
+    file_path: Option<&str>,
+    max_commits: usize,
+) -> HistoryAnalytics {
+    let commits = match git.get_log(max_commits + 1) {
+        Ok(c) => c,
+        Err(_) => return empty_analytics(),
+    };
+    if commits.len() < 2 {
+        return empty_analytics();
+    }
+
+    type Key = (String, String, String); // (name, type, file)
+    let mut per_entity: HashMap<Key, (usize, std::collections::HashSet<String>, String)> =
+        HashMap::new();
+    let mut pair_counts: HashMap<(Key, Key), usize> = HashMap::new();
+    let mut pair_commits_skipped = 0usize;
+    let pathspecs: Vec<String> = file_path.map(|f| vec![f.to_string()]).unwrap_or_default();
+
+    let windows: Vec<_> = commits.windows(2).collect();
+    let commits_scanned = windows.len();
+    for window in windows {
+        let newer = &window[0];
+        let older = &window[1];
+        let scope = DiffScope::Range {
+            from: older.sha.clone(),
+            to: newer.sha.clone(),
+        };
+        let file_changes = match git.get_changed_files(&scope, &pathspecs) {
+            Ok(fc) => fc,
+            Err(_) => continue,
+        };
+        let diff = compute_semantic_diff(&file_changes, registry, Some(&newer.sha), None);
+
+        // Distinct entities changed in this commit (orphans and file-filtered
+        // changes excluded; a commit counts once per entity).
+        let mut changed: Vec<Key> = diff
+            .changes
+            .iter()
+            .filter(|c| is_code_entity(&c.entity_type))
+            .filter(|c| file_path.map_or(true, |fp| c.file_path == fp))
+            .map(|c| {
+                (
+                    c.entity_name.clone(),
+                    c.entity_type.clone(),
+                    c.file_path.clone(),
+                )
+            })
+            .collect();
+        changed.sort();
+        changed.dedup();
+
+        for key in &changed {
+            let entry = per_entity
+                .entry(key.clone())
+                .or_insert_with(|| (0, std::collections::HashSet::new(), String::new()));
+            entry.0 += 1;
+            entry.1.insert(newer.author.clone());
+            if entry.2.is_empty() {
+                // Commits walk newest-first, so the first sighting is the latest.
+                entry.2 = newer.short_sha.clone();
+            }
+        }
+
+        if changed.len() > MAX_PAIR_ENTITIES {
+            pair_commits_skipped += 1;
+            continue;
+        }
+        for i in 0..changed.len() {
+            for j in (i + 1)..changed.len() {
+                let (a, b) = (changed[i].clone(), changed[j].clone());
+                *pair_counts.entry((a, b)).or_insert(0) += 1;
+            }
+        }
+    }
+
+    let mut hotspots: Vec<HotEntity> = per_entity
+        .iter()
+        .map(|((name, ty, file), (count, authors, last))| HotEntity {
+            entity_name: name.clone(),
+            entity_type: ty.clone(),
+            file_path: file.clone(),
+            commits: *count,
+            authors: authors.len(),
+            last_short_sha: last.clone(),
+        })
+        .collect();
+    hotspots.sort_by(|a, b| {
+        b.commits
+            .cmp(&a.commits)
+            .then_with(|| a.file_path.cmp(&b.file_path))
+            .then_with(|| a.entity_name.cmp(&b.entity_name))
+    });
+
+    let mut co_changes: Vec<CoChangePair> = pair_counts
+        .into_iter()
+        .filter(|(_, together)| *together >= 2)
+        .map(|((a, b), together)| {
+            let a_commits = per_entity.get(&a).map(|e| e.0).unwrap_or(together);
+            let b_commits = per_entity.get(&b).map(|e| e.0).unwrap_or(together);
+            CoChangePair {
+                a_name: a.0,
+                a_file: a.2,
+                b_name: b.0,
+                b_file: b.2,
+                together,
+                a_commits,
+                b_commits,
+                confidence: together as f64 / a_commits.min(b_commits).max(1) as f64,
+            }
+        })
+        .collect();
+    co_changes.sort_by(|a, b| {
+        b.together
+            .cmp(&a.together)
+            .then_with(|| {
+                b.confidence
+                    .partial_cmp(&a.confidence)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| a.a_file.cmp(&b.a_file))
+            .then_with(|| a.a_name.cmp(&b.a_name))
+    });
+
+    HistoryAnalytics {
+        commits_scanned,
+        hotspots,
+        co_changes,
+        pair_commits_skipped,
+    }
+}
+
+fn empty_analytics() -> HistoryAnalytics {
+    HistoryAnalytics {
+        commits_scanned: 0,
+        hotspots: Vec::new(),
+        co_changes: Vec::new(),
+        pair_commits_skipped: 0,
+    }
+}
+
 /// Walk git history and count how often each entity appears in semantic diffs.
 ///
 /// - `file_path`: if Some, only track changes to entities in this file
@@ -91,4 +315,116 @@ pub fn compute_hotspots(
 
     hotspots.sort_by(|a, b| b.change_count.cmp(&a.change_count));
     hotspots
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::plugins::create_default_registry;
+    use git2::{Oid, Repository, Signature};
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn commit_file(repo: &Repository, file_path: &str, contents: &str, message: &str) -> Oid {
+        std::fs::write(repo.workdir().unwrap().join(file_path), contents).unwrap();
+        let mut index = repo.index().unwrap();
+        index.add_path(Path::new(file_path)).unwrap();
+        index.write().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let sig = Signature::now("Test User", "test@example.com").unwrap();
+        match repo.head() {
+            Ok(head) => {
+                let parent = repo.find_commit(head.target().unwrap()).unwrap();
+                repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &[&parent])
+                    .unwrap()
+            }
+            Err(_) => repo
+                .commit(Some("HEAD"), &sig, &sig, message, &tree, &[])
+                .unwrap(),
+        }
+    }
+
+    #[test]
+    fn history_analytics_counts_hotspots_and_co_changes() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path()).unwrap();
+        // c1: create both entities
+        commit_file(
+            &repo,
+            "main.py",
+            "def alpha():\n    return 1\n\ndef beta():\n    return 2\n",
+            "c1",
+        );
+        // c2: modify alpha AND beta (co-change)
+        commit_file(
+            &repo,
+            "main.py",
+            "def alpha():\n    return 10\n\ndef beta():\n    return 20\n",
+            "c2",
+        );
+        // c3: modify alpha only
+        commit_file(
+            &repo,
+            "main.py",
+            "def alpha():\n    return 100\n\ndef beta():\n    return 20\n",
+            "c3",
+        );
+        // c4: modify alpha AND beta again (co-change x2)
+        commit_file(
+            &repo,
+            "main.py",
+            "def alpha():\n    return 1000\n\ndef beta():\n    return 2000\n",
+            "c4",
+        );
+
+        let git = GitBridge::open(temp.path()).unwrap();
+        let registry = create_default_registry();
+        let analytics = compute_history_analytics(&git, &registry, None, 50);
+
+        assert_eq!(analytics.commits_scanned, 3); // c2,c3,c4 diffs
+        let alpha = analytics
+            .hotspots
+            .iter()
+            .find(|h| h.entity_name == "alpha")
+            .expect("alpha hotspot");
+        assert_eq!(alpha.commits, 3);
+        assert_eq!(alpha.authors, 1);
+        assert!(!alpha.last_short_sha.is_empty());
+        let beta = analytics
+            .hotspots
+            .iter()
+            .find(|h| h.entity_name == "beta")
+            .expect("beta hotspot");
+        assert_eq!(beta.commits, 2);
+        // alpha is hotter, so it sorts first
+        assert_eq!(analytics.hotspots[0].entity_name, "alpha");
+
+        let pair = analytics
+            .co_changes
+            .iter()
+            .find(|p| {
+                (p.a_name == "alpha" && p.b_name == "beta")
+                    || (p.a_name == "beta" && p.b_name == "alpha")
+            })
+            .expect("alpha/beta co-change pair");
+        assert_eq!(pair.together, 2);
+        assert!((pair.confidence - 1.0).abs() < f64::EPSILON); // 2 / min(3,2)
+    }
+
+    #[test]
+    fn history_analytics_on_empty_repo_is_empty() {
+        let temp = TempDir::new().unwrap();
+        Repository::init(temp.path()).unwrap();
+        let git = GitBridge::open(temp.path());
+        // A repo with no commits can't even open HEAD in some paths; if open
+        // succeeds, analytics must come back empty rather than erroring.
+        if let Ok(git) = git {
+            let registry = create_default_registry();
+            let analytics = compute_history_analytics(&git, &registry, None, 50);
+            assert_eq!(analytics.commits_scanned, 0);
+            assert!(analytics.hotspots.is_empty());
+            assert!(analytics.co_changes.is_empty());
+        }
+    }
 }

--- a/crates/sem-mcp/src/render.rs
+++ b/crates/sem-mcp/src/render.rs
@@ -216,6 +216,67 @@ pub fn context_text(v: &Value) -> String {
     out
 }
 
+/// Render repo-level history analytics (sem_log with no entity): hotspots and
+/// co-change pairs. Caps mirror the CLI (15 hotspots, 12 pairs) with an
+/// explicit "more" note, so nothing is silently hidden.
+pub fn history_text(a: &sem_core::parser::hotspot::HistoryAnalytics) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "⊕ repo history · last {} commits\n",
+        a.commits_scanned
+    ));
+    if a.hotspots.is_empty() {
+        out.push_str("no entity changes found\n");
+        return out;
+    }
+
+    out.push_str("\nhotspots — most-changed entities\n");
+    for h in a.hotspots.iter().take(15) {
+        out.push_str(&format!(
+            "  {}× {} · {} · {} author{} · last {}\n",
+            h.commits,
+            h.entity_name,
+            h.file_path,
+            h.authors,
+            if h.authors == 1 { "" } else { "s" },
+            h.last_short_sha,
+        ));
+    }
+    if a.hotspots.len() > 15 {
+        out.push_str(&format!("  … {} more\n", a.hotspots.len() - 15));
+    }
+
+    if !a.co_changes.is_empty() {
+        out.push_str("\nco-changes — entities that change together\n");
+        for p in a.co_changes.iter().take(12) {
+            let files = if p.a_file == p.b_file {
+                p.a_file.clone()
+            } else {
+                format!("{} ↔ {}", p.a_file, p.b_file)
+            };
+            out.push_str(&format!(
+                "  {}× {} ↔ {} · {:.0}% · {}\n",
+                p.together,
+                p.a_name,
+                p.b_name,
+                p.confidence * 100.0,
+                files,
+            ));
+        }
+        if a.co_changes.len() > 12 {
+            out.push_str(&format!("  … {} more pairs\n", a.co_changes.len() - 12));
+        }
+    }
+
+    if a.pair_commits_skipped > 0 {
+        out.push_str(&format!(
+            "\nnote: {} bulk commits (>50 entities) excluded from co-change pairing\n",
+            a.pair_commits_skipped
+        ));
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -51,6 +51,14 @@ const MCP_INSTRUCTIONS: &str = "sem: entity-level code intelligence \
 const ENTITY_LOOKUP_CANDIDATE_LIMIT: usize = 10;
 
 /// Lazily-initialized repo context.
+/// sem_log params after the optional entity has been resolved to a concrete
+/// name (the analytics branch handles the None case before this is built).
+struct ResolvedLogParams {
+    entity_name: String,
+    file_path: Option<String>,
+    limit: Option<usize>,
+}
+
 struct RepoContext {
     git: GitBridge,
     repo_root: PathBuf,
@@ -1205,17 +1213,46 @@ impl SemServer {
     }
 
     // ── Tool 5: Log ──
+    // (entity-path params after the optional entity has been resolved)
 
     #[tool(
-        description = "Entity evolution history: trace how a specific entity changed across git commits, distinguishing logic changes from cosmetic ones"
+        description = "Entity evolution history: trace how a specific entity changed across git commits, distinguishing logic changes from cosmetic ones. Omit entity_name for repo-level history analytics: hotspots (most-changed entities, with author counts) and co-change pairs (entities that repeatedly change in the same commits) — the time axis a snapshot dependency graph can't see."
     )]
     async fn sem_log(
         &self,
         Parameters(params): Parameters<LogParams>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let start = Instant::now();
         let ctx = match self.get_context(params.file_path.as_deref()).await {
             Ok(ctx) => ctx,
             Err(err) => return Ok(tool_error(err)),
+        };
+
+        // No entity: repo-level history analytics (hotspots + co-changes).
+        let Some(entity_name) = params.entity_name else {
+            let limit = params.limit.unwrap_or(50);
+            let (rel_file, analytics) = {
+                let rel_file = params.file_path.as_ref().map(|fp| {
+                    let (rel, _) = Self::resolve_file_path(&ctx.repo_root, fp);
+                    rel
+                });
+                let analytics = sem_core::parser::hotspot::compute_history_analytics(
+                    &ctx.git,
+                    &self.registry,
+                    rel_file.as_deref(),
+                    limit,
+                );
+                (rel_file, analytics)
+            };
+            let _ = rel_file;
+            let mut text = crate::render::history_text(&analytics);
+            text.push_str(&format!("{}ms · local\n", start.elapsed().as_millis()));
+            return Ok(CallToolResult::success(vec![Content::text(text)]));
+        };
+        let params = ResolvedLogParams {
+            entity_name,
+            file_path: params.file_path,
+            limit: params.limit,
         };
 
         // Resolve file path: use provided or auto-detect
@@ -2277,7 +2314,7 @@ mod tests {
 
         let result = server
             .sem_log(Parameters(LogParams {
-                entity_name: "old_entity".to_string(),
+                entity_name: Some("old_entity".to_string()),
                 file_path: Some("old.py".to_string()),
                 limit: Some(10),
             }))

--- a/crates/sem-mcp/src/tools.rs
+++ b/crates/sem-mcp/src/tools.rs
@@ -80,8 +80,10 @@ pub struct ImpactAnalysisParams {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct LogParams {
-    #[schemars(description = "Name of the entity to trace history for")]
-    pub entity_name: String,
+    #[schemars(
+        description = "Name of the entity to trace history for. Omit for repo-level history analytics: hotspots (most-changed entities) and co-change pairs (entities that change in the same commits)."
+    )]
+    pub entity_name: Option<String>,
     #[schemars(description = "Path to the file containing the entity. If omitted, auto-detects.")]
     pub file_path: Option<String>,
     #[schemars(description = "Maximum number of commits to analyze. Defaults to 50.")]

--- a/skills/sem/SKILL.md
+++ b/skills/sem/SKILL.md
@@ -66,6 +66,7 @@ Unlike `git blame`, this shows who last modified each *function*, not each line.
 ### sem log — how did this evolve?
 
 ```bash
+sem log                           # repo hotspots + co-change pairs (no entity)
 sem log validateToken             # history of a single entity
 sem log validateToken -v          # with content diffs between versions
 sem log validateToken --limit 20


### PR DESCRIPTION
## The hero feature: the time axis

\`sem log\` with no entity now answers two questions no snapshot code graph can:

**Which code churns?**
```
⊕ repo history · last 40 commits
  hotspots — most-changed entities
   7×  sem_context   1 author  crates/sem-mcp/src/server.rs  last a5874c3
   6×  sem_impact    1 author  crates/sem-mcp/src/server.rs  last a5874c3
```

**Which code moves together?**
```
  co-changes — entities that change together
   4×  Commands ↔ main        100% · crates/sem-cli/src/main.rs
   3×  installBadge ↔ main    100% · install.mjs ↔ sem-activity.py
```

Real output from this repo — and every line checks out (the MCP handlers we churned all week are the hotspots; the installer and its hook really do always change together). Co-change at 100% confidence is a deterministic "if you touch one, don't forget the other" warning.

## Design
- One history walk computes both (extends the existing \`compute_hotspots\` machinery, which finally gets a caller).
- **Per-commit counting** (an entity changing twice in one commit counts once) so counts compare cleanly.
- **Code entities only** — doc headings, config properties, lockfile chunks are excluded; without this the output was 100% Cargo.lock/CHANGELOG noise.
- **Bulk-commit guard**: commits touching >50 entities don't contribute pairs (quadratic noise from mass refactors), with an explicit note — no silent truncation.
- Same via MCP: \`sem_log\` without \`entity_name\`, compact text rendering. \`--file\` scopes, \`--json\` returns everything.
- Additive public API only (new types); existing \`sem log <entity>\` path untouched.

## Verified
- sem-core: hotspot/co-change/confidence/empty-repo unit tests; full suite green.
- sem-mcp: 58 tests pass; end-to-end over MCP stdio on this repo.
- Workspace test-compile clean.