### PR TITLE
docs(skill): put MCP-tools-first guidance at the top of the skill

### DIFF
--- a/skills/sem/SKILL.md
+++ b/skills/sem/SKILL.md
@@ -13,16 +13,40 @@ sem extends Git with entity-level operations. Instead of "lines 43-51 changed",
 it tells you "function `validateToken` was modified in `src/auth.ts`". It parses
 30+ languages via tree-sitter and works in any Git repo with no setup.
 
+## FIRST: use the MCP tools, not the CLI
+
+If the agent has the sem MCP server (tools named `mcp__sem__*` — `sem_diff`,
+`sem_impact`, `sem_context`, `sem_blame`, `sem_log`, `sem_entities`), **always
+call those instead of running `sem` in a shell**. They render as proper tool
+calls in the UI, return compact entity trees, and carry `elapsed_ms`. If they
+are deferred, load them first (e.g. ToolSearch) — do not fall back to Bash just
+because the shell is already open. Map:
+
+| task | MCP tool |
+|------|----------|
+| what changed | `sem_diff` |
+| blast radius / what breaks | `sem_impact` |
+| read/understand an entity + its callers | `sem_context` |
+| find code by intent ("where is X done") | `sem_entities` with `query` |
+| who last touched it | `sem_blame` |
+| how it evolved | `sem_log` with `entity_name` |
+| repo hotspots + co-change pairs | `sem_log` with no `entity_name` |
+
+Use the CLI below only in a real terminal, in scripts, or for commands the MCP
+server doesn't expose (`sem graph`, `sem setup`, exotic flags) — and then as a
+single clean one-liner.
+
 ## When to reach for sem
 
 - User asks "what changed in this commit / PR / branch?"
 - User wants to know what will break if they change a function
 - User asks who last touched a function or class
 - User wants to trace how a function evolved over time
+- User asks what's risky/hot in the repo, or what tends to change together
 - You need structured, token-efficient code context for an LLM subtask
 - You're doing a code review and want entity-level signal, not line noise
 
-## Commands
+## Commands (CLI — for terminals and scripts; in-agent, prefer the MCP tools above)
 
 ### sem diff — what changed?
 


### PR DESCRIPTION
Agents were shelling out `sem ...` via Bash even with the MCP server connected, because the skill leads with bash examples and the MCP note was buried at the bottom. The first section now maps each task to its `mcp__sem__` tool (including the new bare `sem_log` analytics), instructs loading deferred tools instead of falling back to Bash, and scopes the CLI examples to terminals/scripts. This is what makes sem render like Grep/Read in Claude Code instead of raw shell.