### PR TITLE
fix(skill): live viewer draws the graph reliably; hook stops logging prose

### DIFF
--- a/agent-skill/badge/sem-activity.py
+++ b/agent-skill/badge/sem-activity.py
@@ -17,7 +17,20 @@ import time
 
 ACT = os.path.expanduser("~/.claude/sem-activity.jsonl")
 SUBCMDS = "diff|impact|context|entities|graph|blame|log|orient|xref|mcp|whoami"
-CLI_RE = re.compile(r"(?:^|[\s;&|(]|/)sem\s+(" + SUBCMDS + r")\b(.*)")
+# `sem` must be in command position (start of line, or right after a shell
+# separator), not merely after whitespace — otherwise prose inside quoted
+# commit messages ("... sem impact recall, ...") logs garbage events.
+CLI_RE = re.compile(
+    r"(?:^|[;&|(]\s*|&&\s*|\|\|\s*|\n\s*)(?:[\w./~-]*/)?sem\s+(" + SUBCMDS + r")\b([^\n;&|)]*)"
+)
+TARGET_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.:-]*$")
+
+
+def inside_quotes(text, idx):
+    """Cheap heuristic: an odd number of quotes before idx means we're inside
+    a quoted string (a commit message, a PR body), not a real invocation."""
+    prefix = text[:idx]
+    return prefix.count('"') % 2 == 1 or prefix.count("'") % 2 == 1
 
 
 def main():
@@ -53,17 +66,20 @@ def main():
                     ms = round(resp[k])
                     break
     elif tool == "Bash":
-        cmd = (data.get("tool_input") or data.get("toolInput") or {}).get("command", "")
-        m = CLI_RE.search(cmd or "")
-        if m:
+        cmd = (data.get("tool_input") or data.get("toolInput") or {}).get("command", "") or ""
+        for m in CLI_RE.finditer(cmd):
+            if inside_quotes(cmd, m.start()):
+                continue
             short = m.group(1)
             rest = (m.group(2) or "").strip()
             tok = rest.split()[0] if rest else ""
-            if tok and not tok.startswith("-"):
-                target = tok.strip("'\"")
+            tok = tok.strip("'\"")
+            if tok and not tok.startswith("-") and TARGET_RE.match(tok):
+                target = tok
             fm = re.search(r"--file[= ]([^\s]+)", rest)
             if fm:
                 file_hint = fm.group(1).strip("'\"")
+            break
 
     if not short:
         return

--- a/agent-skill/badge/sem-live.py
+++ b/agent-skill/badge/sem-live.py
@@ -193,12 +193,25 @@ def render(events, width):
     lines.append("")
     lines.append(f"  {op}{ms_s}")
 
-    graph = fetch_graph(last) if tool in ("impact", "context") else None
+    # Draw the blast radius of the most recent ANALYZABLE event (impact or
+    # context with a real target), even when later diffs/logs came after it —
+    # otherwise the graph flickers out every time an unrelated command runs.
+    def analyzable(e):
+        return e.get("tool") in ("impact", "context") and e.get("target")
+
+    graph_ev = next((e for e in reversed(events) if analyzable(e)), None)
+    graph = fetch_graph(graph_ev) if graph_ev else None
+    if graph and graph_ev is not last:
+        t = graph_ev.get("tool", "")
+        lines.append(f"  {DIM}last analyzed · {t} {graph_ev.get('target','')}{R}")
     if graph:
         direct, total, entity, file = graph
         lines.append(f"  {DIM}{'─' * (width - 4)}{R}")
         lines.append(f"  {GRN}{B}◉ {entity}{R}   {DIM}{shorten(file)}{R}")
-        lines.append(f"  {DIM}│{R}  {YEL}{len(direct)} direct{R} {DIM}→{R} {YEL}{total} transitive{R}")
+        if not direct:
+            lines.append(f"  {DIM}╰── no callers — nothing in this repo depends on it{R}")
+        else:
+            lines.append(f"  {DIM}│{R}  {YEL}{len(direct)} direct{R} {DIM}→{R} {YEL}{total} transitive{R}")
         # non-test first, so the meaningful callers are on top
         ordered = sorted(direct, key=lambda x: (is_test(x[0], x[1]), x[0]))
         shown = ordered[:9]
@@ -212,8 +225,8 @@ def render(events, width):
             extra = len(ordered) - 9
             note = f"+{extra} more" + (f" ({tests} tests)" if tests else "")
             lines.append(f"  {DIM}╰─▶ … {note}{R}")
-    elif tool in ("impact", "context"):
-        lines.append(f"  {DIM}(no graph — target/file not captured for this call){R}")
+    elif graph_ev:
+        lines.append(f"  {DIM}(no graph — could not resolve {graph_ev.get('target','?')} from {graph_ev.get('cwd','?')}){R}")
 
     # savings meter — the "you're saving so much" panel
     sess_rt = sum(rt_saved(e.get("tool")) for e in events)

--- a/agent-skill/package.json
+++ b/agent-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ataraxy-labs/sem-skill",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "One-command setup of sem (entity-level code intelligence) for coding agents: installs the sem skill and registers the sem MCP server.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Fixes the three bugs that kept sem-live's ASCII blast-radius graph from showing: (1) graph vanished unless the very last event was impact/context — now draws the most recent analyzable event with a 'last analyzed' label; (2) the hook logged sem mentions inside quoted prose (commit messages) as garbage events — command-position anchoring + quote detection + identifier-shaped targets; (3) zero-caller entities looked broken — now say 'no callers' in words. Verified against the real activity log that reproduced the report. Bumps 0.6.0 -> 0.6.1.