### PR TITLE
feat(mcp): session-native blast-radius graph (no extra viewer)

### DIFF
--- a/agent-skill/README.md
+++ b/agent-skill/README.md
@@ -34,8 +34,10 @@ it leaves it untouched and just tells you how to add the badge yourself. To
 remove it, delete the `statusLine` key and the `mcp__sem__.*` and `Bash`
 PostToolUse entries from `~/.claude/settings.json`.
 
-The `--badge` install also drops a **live viewer** at `~/.claude/sem-live.py`.
-Run it in a spare terminal pane:
+Everything renders inside the session: sem MCP calls show as proper tool
+widgets with compact entity trees, and the statusline badge tracks live
+time/token savings. No extra processes needed. Optionally, for a dedicated
+terminal pane, the install also drops `~/.claude/sem-live.py`:
 
 ```bash
 python3 ~/.claude/sem-live.py

--- a/crates/sem-mcp/src/render.rs
+++ b/crates/sem-mcp/src/render.rs
@@ -38,22 +38,38 @@ fn entity_label(e: &Value) -> String {
     }
 }
 
-/// Group entities by file (first-seen order), one line per file:
-/// `  path: name, name (type), name`
+/// True for names/files that look like tests — used only for display ordering
+/// (tests sink to the bottom), never to drop anything.
+fn looks_like_test(e: &Value) -> bool {
+    let name = get_str(e, "name");
+    let file = get_str(e, "file");
+    name.starts_with("test") || file.contains("/tests/") || file.ends_with("_test.rs")
+}
+
+/// Group entities by file (first-seen order), one branch line per file:
+/// `├─▶ path: name, name (type), name` — non-test files first so the callers
+/// that matter are on top; every name is preserved.
 fn push_grouped(out: &mut String, list: &[Value]) {
     let mut order: Vec<&str> = Vec::new();
-    let mut by_file: std::collections::HashMap<&str, Vec<String>> = std::collections::HashMap::new();
+    let mut by_file: std::collections::HashMap<&str, (Vec<String>, bool)> =
+        std::collections::HashMap::new();
     for e in list {
         let file = get_str(e, "file");
         if !by_file.contains_key(file) {
             order.push(file);
         }
-        by_file.entry(file).or_default().push(entity_label(e));
+        let entry = by_file.entry(file).or_insert_with(|| (Vec::new(), true));
+        entry.0.push(entity_label(e));
+        entry.1 = entry.1 && looks_like_test(e);
     }
-    for file in order {
-        let names = by_file[file].join(", ");
+    // Files whose entries are all tests sink to the bottom (stable otherwise).
+    let mut ordered: Vec<&str> = order.clone();
+    ordered.sort_by_key(|f| by_file[f].1);
+    for (idx, file) in ordered.iter().enumerate() {
+        let (names, _) = &by_file[file];
+        let branch = if idx + 1 == ordered.len() { "╰─▶" } else { "├─▶" };
         let file = if file.is_empty() { "(unknown file)" } else { file };
-        out.push_str(&format!("  {}: {}\n", file, names));
+        out.push_str(&format!("{} {}: {}\n", branch, file, names.join(", ")));
     }
 }
 
@@ -84,7 +100,7 @@ fn footer(v: &Value) -> String {
 pub fn impact_text(v: &Value) -> String {
     let mut out = String::new();
     out.push_str(&format!(
-        "⊕ {} · {}\n",
+        "◉ {} · {}\n",
         get_str(v, "entity"),
         get_str(v, "file")
     ));
@@ -303,9 +319,9 @@ mod tests {
             "elapsed_ms": 12, "source": "local",
         });
         let text = impact_text(&v);
-        assert!(text.contains("⊕ compute · src/a.rs"));
+        assert!(text.contains("◉ compute · src/a.rs"));
         assert!(text.contains("← 2 dependents · 2 files"));
-        assert!(text.contains("src/c.rs: run"));
+        assert!(text.contains("├─▶ src/c.rs: run") || text.contains("╰─▶ src/c.rs: run"));
         assert!(text.contains("src/b.rs: Config (struct)"));
         assert!(text.contains("⚡ 3 transitively affected · 3 files"));
         // transitive tail shows only what direct dependents didn't already list

--- a/skills/sem/SKILL.md
+++ b/skills/sem/SKILL.md
@@ -36,6 +36,25 @@ Use the CLI below only in a real terminal, in scripts, or for commands the MCP
 server doesn't expose (`sem graph`, `sem setup`, exotic flags) — and then as a
 single clean one-liner.
 
+## Draw the blast radius in your reply
+
+When an impact result drives your answer (a refactor decision, a "what breaks"
+question), render it as a small ASCII tree in the response — the user should
+see the graph without opening anything:
+
+```
+◉ validateToken · src/auth.ts
+│  8 direct → 23 transitive
+├─▶ refreshToken        src/auth.ts
+├─▶ loginHandler        src/routes/login.ts
+├─▶ SessionMiddleware   src/middleware/session.ts
+╰─▶ … +5 more (12 tests)
+```
+
+Real callers first, tests collapsed into a count, no invented entries — draw
+only what the tool returned. Skip the drawing when impact was incidental to
+the task.
+
 ## When to reach for sem
 
 - User asks "what changed in this commit / PR / branch?"


### PR DESCRIPTION
Kills the separate-process requirement for the live graph. `sem_impact` MCP results now render with tree drawing (◉ header, ├─▶ branch per file, real callers first, all-test files sunk to the bottom, nothing elided) — expanding the widget IS the graph. The skill additionally instructs agents to draw the blast radius as a small ASCII tree inline in their reply when the impact drives the answer. `sem mcp` + `/sem` is now the complete experience; sem-live.py demoted to optional. 58 sem-mcp tests pass.