### PR TITLE
feat(skill): live statusline (spinner at trigger time) + opt-in team presence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to sem are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- The `--badge` statusline is now **live at trigger time**: a PreToolUse hook flips the badge to an animated spinner with the entity name the moment the agent calls sem (`⊕ sem ⠹ impact validateToken…`), and the completed state (count, latency, savings) lands when the call finishes. The render hot path never touches the network (teammates presence refreshes in a detached worker; renders measured at ~20ms).
+- **Team presence (opt-in)**: with `sem login` + `~/.sem/team.json` `{"share": true}`, sessions heartbeat the entity being worked on to sem-cloud (`POST /v1/presence`), and the statusline shows teammates live (`👥 maya → resolve_ref · 2m`). Entity claims API (`/v1/claims`, advisory TTL locks) shipped server-side for agents to route around each other. Off by default; nothing leaves the machine without the opt-in file.
+
 ### Fixed
 
 - The `sem context` / `sem_context` budget packer no longer starves the target while neighbors feast. Previously a target too big for the budget collapsed to its first line (2 tokens) while a single large dependency could consume the entire budget with its full body. The target now degrades gracefully — full body → head-truncated body (docstring, fields, leading code, with an explicit `… truncated: N more lines` marker) using up to ~70% of the budget → bare signature — and no neighbor may cost more tokens than the target itself did (budget/10 floor), oversized neighbors degrading to signatures. On the same query (a large class, budget 2000) the target went from 2 tokens to 1,398 and the answer-relevant attributes are now in the payload.

--- a/agent-skill/README.md
+++ b/agent-skill/README.md
@@ -22,8 +22,10 @@ This:
 npx @ataraxy-labs/sem-skill --badge
 ```
 
-Adds a small badge to your Claude Code statusline that shows sem working in real
-time: how many structural queries this session, the last command **and the
+Adds a live badge to your Claude Code statusline. The moment your agent
+triggers sem you see an animated spinner with the entity being analyzed
+(`⊕ sem ⠹ impact validateToken…`), flipping to the result and running savings
+when it completes. It shows in real time: how many structural queries this session, the last command **and the
 entity it analyzed**, its latency, a sparkline of recent latencies, and a
 rotating stat (distinct entities analyzed, top command)
 (`⊕ sem ×12  impact validateToken 9ms  ▁▂▃▅▂  · 7 entities analyzed`). It picks
@@ -33,6 +35,12 @@ non-destructive: it backs up your settings, and if you already have a statusline
 it leaves it untouched and just tells you how to add the badge yourself. To
 remove it, delete the `statusLine` key and the `mcp__sem__.*` and `Bash`
 PostToolUse entries from `~/.claude/settings.json`.
+
+**Team presence (opt-in):** if you are logged in (`sem login`) and create
+`~/.sem/team.json` with `{"share": true}`, your sessions heartbeat which entity
+your agent is working on, and the statusline shows teammates live
+(`👥 maya → resolve_ref · 2m`) so parallel agents stop colliding. Nothing is
+shared unless you opt in.
 
 Everything renders inside the session: sem MCP calls show as proper tool
 widgets with compact entity trees, and the statusline badge tracks live

--- a/agent-skill/badge/sem-activity.py
+++ b/agent-skill/badge/sem-activity.py
@@ -39,6 +39,7 @@ def main():
     except Exception:
         return
     tool = data.get("tool_name") or data.get("toolName") or ""
+    phase = "start" if (data.get("hook_event_name") or "").startswith("Pre") else "done"
     short = target = None
     ms = None
 
@@ -88,6 +89,7 @@ def main():
         "session": data.get("session_id") or data.get("sessionId") or "",
         "ts": int(time.time()),
         "tool": short,
+        "phase": phase,
     }
     if target:
         event["target"] = target[:40]
@@ -103,6 +105,41 @@ def main():
         os.makedirs(os.path.dirname(ACT), exist_ok=True)
         with open(ACT, "a") as f:
             f.write(json.dumps(event) + "\n")
+    except Exception:
+        pass
+
+    if phase == "start":
+        return
+
+    # Team presence (opt-in): if ~/.sem/team.json has {"share": true} and the
+    # user is logged in, heartbeat this activity to sem-cloud so teammates'
+    # sessions can see who is working on what. Fire-and-forget: a detached
+    # curl with a 2s cap, never blocking the hook or the session.
+    try:
+        import subprocess
+        team = json.load(open(os.path.expanduser("~/.sem/team.json")))
+        creds = json.load(open(os.path.expanduser("~/.sem/credentials.json")))
+        if team.get("share") and creds.get("api_key") and cwd:
+            remote = subprocess.run(
+                ["git", "-C", cwd, "remote", "get-url", "origin"],
+                capture_output=True, text=True, timeout=1,
+            ).stdout.strip()
+            if remote:
+                remote = remote.removesuffix(".git")
+                remote = remote.replace("git@github.com:", "github.com/")
+                remote = remote.replace("https://", "").replace("http://", "")
+                payload = json.dumps({
+                    "repo": remote, "tool": short,
+                    "entity": target or "", "file": file_hint or "",
+                })
+                subprocess.Popen(
+                    ["curl", "-s", "-m", "2", "-X", "POST",
+                     creds.get("endpoint", "https://sem-cloud.fly.dev") + "/v1/presence",
+                     "-H", "Authorization: Bearer " + creds["api_key"],
+                     "-H", "Content-Type: application/json", "-d", payload],
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                    start_new_session=True,
+                )
     except Exception:
         pass
 

--- a/agent-skill/badge/statusline-sem.py
+++ b/agent-skill/badge/statusline-sem.py
@@ -49,6 +49,63 @@ def read_lifetime():
     except Exception:
         return {}
 
+
+TEAM_CACHE = "/tmp/sem-team-presence.json"
+
+def team_presence(cwd):
+    """Teammates active in this repo right now (opt-in via ~/.sem/team.json).
+    Fetch at most every 30s (disk cache), 0.5s timeout, silent on any failure —
+    a statusline must never block."""
+    try:
+        team = json.load(open(os.path.expanduser("~/.sem/team.json")))
+        creds = json.load(open(os.path.expanduser("~/.sem/credentials.json")))
+        if not (team.get("share") and creds.get("api_key")):
+            return []
+        try:
+            cache = json.load(open(TEAM_CACHE))
+            if time.time() - cache.get("ts", 0) < 30 and cache.get("cwd") == cwd:
+                return cache.get("others", [])
+        except Exception:
+            pass
+        # Cache stale: kick a detached refresher and serve the old cache this
+        # tick. The render path never touches the network.
+        import subprocess, sys as _sys
+        subprocess.Popen(
+            [_sys.executable, os.path.abspath(__file__), "--refresh-team", cwd],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        try:
+            return json.load(open(TEAM_CACHE)).get("others", [])
+        except Exception:
+            return []
+    except Exception:
+        return []
+
+
+def refresh_team(cwd):
+    """Background worker: fetch presence and write the cache (called detached)."""
+    try:
+        creds = json.load(open(os.path.expanduser("~/.sem/credentials.json")))
+        import subprocess, urllib.request, urllib.parse
+        remote = subprocess.run(
+            ["git", "-C", cwd, "remote", "get-url", "origin"],
+            capture_output=True, text=True, timeout=2,
+        ).stdout.strip()
+        if not remote:
+            return
+        remote = remote.removesuffix(".git").replace("git@github.com:", "github.com/")
+        remote = remote.replace("https://", "").replace("http://", "")
+        url = (creds.get("endpoint", "https://sem-cloud.fly.dev")
+               + "/v1/presence?repo=" + urllib.parse.quote(remote, safe=""))
+        req = urllib.request.Request(url, headers={"Authorization": "Bearer " + creds["api_key"]})
+        with urllib.request.urlopen(req, timeout=3) as r:
+            data = json.load(r)
+        others = [a for a in data.get("active", []) if not a.get("you")]
+        json.dump({"ts": time.time(), "cwd": cwd, "others": others}, open(TEAM_CACHE, "w"))
+    except Exception:
+        pass
+
 TAGLINES = [
     "structural, not textual",
     "the graph, not the grep",
@@ -103,24 +160,48 @@ def main():
         else:
             badge = f"{DIM}⊕ sem idle{RESET}"
     else:
-        n = len(events)
+        done = [e for e in events if e.get("phase") != "start"]
+        n = len(done)
         last = events[-1]
-        last_tool = last.get("tool", "sem")
-        last_target = last.get("target", "")
-        op = f"{last_tool} {last_target}".strip() if last_target else last_tool
-        last_ms = last.get("ms")
-        ms_str = f" {last_ms}ms" if isinstance(last_ms, (int, float)) else ""
-        # live tokens + time saved this session, always shown (estimated vs
-        # grep+read, anchored to the measured benchmark).
-        sess_rt = sum(rt_saved(e.get("tool")) for e in events)
+        # In-flight: the newest event is a fresh start with no completion yet —
+        # show it the moment the agent triggers sem, with a live spinner.
+        in_flight = last.get("phase") == "start" and time.time() - last.get("ts", 0) < 120
+        SPIN = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+        show = last if (in_flight or not done) else done[-1]
+        tool_name = show.get("tool", "sem")
+        tgt = show.get("target", "")
+        op = f"{tool_name} {tgt}".strip() if tgt else tool_name
+        ms = show.get("ms")
+        ms_str = f" {ms}ms" if isinstance(ms, (int, float)) else ""
+        sess_rt = sum(rt_saved(e.get("tool")) for e in done)
         saved = f"≈ {fmt_time(sess_rt * 10)} · ≈ {fmt_num(sess_rt * 900)} tokens saved"
-        badge = (
-            f"{GREEN}{BOLD}⊕ sem{RESET} {GREEN}×{n}{RESET}"
-            f" {CYAN}{op}{ms_str}{RESET}"
-            f" {DIM}·{RESET} {YELLOW}{saved}{RESET}"
-        )
+        if in_flight:
+            spin = SPIN[int(time.time() * 8) % len(SPIN)]
+            badge = (
+                f"{GREEN}{BOLD}⊕ sem{RESET} {YELLOW}{BOLD}{spin} {op}…{RESET}"
+                + (f" {DIM}·{RESET} {YELLOW}{saved}{RESET}" if n else "")
+            )
+        else:
+            badge = (
+                f"{GREEN}{BOLD}⊕ sem{RESET} {GREEN}×{n}{RESET}"
+                f" {CYAN}{op}{ms_str}{RESET}"
+                f" {DIM}·{RESET} {YELLOW}{saved}{RESET}"
+            )
+
+    others = team_presence(cwd)
+    if others:
+        o = others[0]
+        ago = int(o.get("agoSeconds", 0))
+        ago_s = f"{ago // 60}m" if ago >= 60 else f"{ago}s"
+        who = o.get("user", "teammate")
+        what = o.get("entity") or o.get("tool", "")
+        extra = f" +{len(others) - 1}" if len(others) > 1 else ""
+        badge += f" {DIM}·{RESET} \033[35m👥 {who} → {what} · {ago_s}{extra}{RESET}"
 
     print(f"{left}  {badge}")
 
 if __name__ == "__main__":
-    main()
+    if len(sys.argv) >= 3 and sys.argv[1] == "--refresh-team":
+        refresh_team(sys.argv[2])
+    else:
+        main()

--- a/agent-skill/install.mjs
+++ b/agent-skill/install.mjs
@@ -73,6 +73,21 @@ function installBadge() {
     }
   }
 
+  // PreToolUse: fires the moment the agent TRIGGERS sem, so the statusline
+  // flips to a live spinner before the call even completes.
+  const pre = (settings.hooks.PreToolUse = settings.hooks.PreToolUse || []);
+  const hasPre = pre.some((e) =>
+    (e.hooks || []).some((h) => (h.command || '').includes('sem-activity.py')),
+  );
+  if (!hasPre) {
+    for (const matcher of ['mcp__sem__.*', 'Bash']) {
+      pre.push({
+        matcher,
+        hooks: [{ type: 'command', command: `python3 ${hookDest}` }],
+      });
+    }
+  }
+
   // statusLine: destructive slot, so only set it if you have none (or it is
   // already ours). Otherwise leave yours alone and print how to add the badge.
   const slCmd = `python3 ${slDest}`;

--- a/agent-skill/package.json
+++ b/agent-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ataraxy-labs/sem-skill",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "One-command setup of sem (entity-level code intelligence) for coding agents: installs the sem skill and registers the sem MCP server.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
The badge becomes truly live: PreToolUse hooks flip it to an animated spinner with the entity name the instant the agent calls sem (`⊕ sem ⠹ impact validateToken…`); completion lands count/latency/savings. Render hot path is network-free (~20ms, presence refreshes in a detached worker). Opt-in team presence: `sem login` + `~/.sem/team.json {"share":true}` heartbeats to sem-cloud and shows teammates live (`👥 maya → resolve_ref · 2m`). Off by default. Sandbox-verified fresh install: both hook phases registered, spinner renders. Bumps 0.6.2 -> 0.7.0.