### PR TITLE
chore(skill): pull team presence from the package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ All notable changes to sem are documented in this file.
 ### Added
 
 - The `--badge` statusline is now **live at trigger time**: a PreToolUse hook flips the badge to an animated spinner with the entity name the moment the agent calls sem (`⊕ sem ⠹ impact validateToken…`), and the completed state (count, latency, savings) lands when the call finishes. The render hot path never touches the network (teammates presence refreshes in a detached worker; renders measured at ~20ms).
-- **Team presence (opt-in)**: with `sem login` + `~/.sem/team.json` `{"share": true}`, sessions heartbeat the entity being worked on to sem-cloud (`POST /v1/presence`), and the statusline shows teammates live (`👥 maya → resolve_ref · 2m`). Entity claims API (`/v1/claims`, advisory TTL locks) shipped server-side for agents to route around each other. Off by default; nothing leaves the machine without the opt-in file.
 
 ### Fixed
 

--- a/agent-skill/README.md
+++ b/agent-skill/README.md
@@ -36,12 +36,6 @@ it leaves it untouched and just tells you how to add the badge yourself. To
 remove it, delete the `statusLine` key and the `mcp__sem__.*` and `Bash`
 PostToolUse entries from `~/.claude/settings.json`.
 
-**Team presence (opt-in):** if you are logged in (`sem login`) and create
-`~/.sem/team.json` with `{"share": true}`, your sessions heartbeat which entity
-your agent is working on, and the statusline shows teammates live
-(`👥 maya → resolve_ref · 2m`) so parallel agents stop colliding. Nothing is
-shared unless you opt in.
-
 Everything renders inside the session: sem MCP calls show as proper tool
 widgets with compact entity trees, and the statusline badge tracks live
 time/token savings. No extra processes needed. Optionally, for a dedicated

--- a/agent-skill/badge/sem-activity.py
+++ b/agent-skill/badge/sem-activity.py
@@ -111,38 +111,6 @@ def main():
     if phase == "start":
         return
 
-    # Team presence (opt-in): if ~/.sem/team.json has {"share": true} and the
-    # user is logged in, heartbeat this activity to sem-cloud so teammates'
-    # sessions can see who is working on what. Fire-and-forget: a detached
-    # curl with a 2s cap, never blocking the hook or the session.
-    try:
-        import subprocess
-        team = json.load(open(os.path.expanduser("~/.sem/team.json")))
-        creds = json.load(open(os.path.expanduser("~/.sem/credentials.json")))
-        if team.get("share") and creds.get("api_key") and cwd:
-            remote = subprocess.run(
-                ["git", "-C", cwd, "remote", "get-url", "origin"],
-                capture_output=True, text=True, timeout=1,
-            ).stdout.strip()
-            if remote:
-                remote = remote.removesuffix(".git")
-                remote = remote.replace("git@github.com:", "github.com/")
-                remote = remote.replace("https://", "").replace("http://", "")
-                payload = json.dumps({
-                    "repo": remote, "tool": short,
-                    "entity": target or "", "file": file_hint or "",
-                })
-                subprocess.Popen(
-                    ["curl", "-s", "-m", "2", "-X", "POST",
-                     creds.get("endpoint", "https://sem-cloud.fly.dev") + "/v1/presence",
-                     "-H", "Authorization: Bearer " + creds["api_key"],
-                     "-H", "Content-Type: application/json", "-d", payload],
-                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-                    start_new_session=True,
-                )
-    except Exception:
-        pass
-
     # Accumulate a persisted lifetime savings tally (single writer: this hook), so
     # the statusline and viewer can show a number that grows across every session.
     # Estimate is anchored to the measured 64-entity benchmark; ~10s and ~900

--- a/agent-skill/badge/statusline-sem.py
+++ b/agent-skill/badge/statusline-sem.py
@@ -50,62 +50,6 @@ def read_lifetime():
         return {}
 
 
-TEAM_CACHE = "/tmp/sem-team-presence.json"
-
-def team_presence(cwd):
-    """Teammates active in this repo right now (opt-in via ~/.sem/team.json).
-    Fetch at most every 30s (disk cache), 0.5s timeout, silent on any failure —
-    a statusline must never block."""
-    try:
-        team = json.load(open(os.path.expanduser("~/.sem/team.json")))
-        creds = json.load(open(os.path.expanduser("~/.sem/credentials.json")))
-        if not (team.get("share") and creds.get("api_key")):
-            return []
-        try:
-            cache = json.load(open(TEAM_CACHE))
-            if time.time() - cache.get("ts", 0) < 30 and cache.get("cwd") == cwd:
-                return cache.get("others", [])
-        except Exception:
-            pass
-        # Cache stale: kick a detached refresher and serve the old cache this
-        # tick. The render path never touches the network.
-        import subprocess, sys as _sys
-        subprocess.Popen(
-            [_sys.executable, os.path.abspath(__file__), "--refresh-team", cwd],
-            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-            start_new_session=True,
-        )
-        try:
-            return json.load(open(TEAM_CACHE)).get("others", [])
-        except Exception:
-            return []
-    except Exception:
-        return []
-
-
-def refresh_team(cwd):
-    """Background worker: fetch presence and write the cache (called detached)."""
-    try:
-        creds = json.load(open(os.path.expanduser("~/.sem/credentials.json")))
-        import subprocess, urllib.request, urllib.parse
-        remote = subprocess.run(
-            ["git", "-C", cwd, "remote", "get-url", "origin"],
-            capture_output=True, text=True, timeout=2,
-        ).stdout.strip()
-        if not remote:
-            return
-        remote = remote.removesuffix(".git").replace("git@github.com:", "github.com/")
-        remote = remote.replace("https://", "").replace("http://", "")
-        url = (creds.get("endpoint", "https://sem-cloud.fly.dev")
-               + "/v1/presence?repo=" + urllib.parse.quote(remote, safe=""))
-        req = urllib.request.Request(url, headers={"Authorization": "Bearer " + creds["api_key"]})
-        with urllib.request.urlopen(req, timeout=3) as r:
-            data = json.load(r)
-        others = [a for a in data.get("active", []) if not a.get("you")]
-        json.dump({"ts": time.time(), "cwd": cwd, "others": others}, open(TEAM_CACHE, "w"))
-    except Exception:
-        pass
-
 TAGLINES = [
     "structural, not textual",
     "the graph, not the grep",
@@ -188,20 +132,7 @@ def main():
                 f" {DIM}·{RESET} {YELLOW}{saved}{RESET}"
             )
 
-    others = team_presence(cwd)
-    if others:
-        o = others[0]
-        ago = int(o.get("agoSeconds", 0))
-        ago_s = f"{ago // 60}m" if ago >= 60 else f"{ago}s"
-        who = o.get("user", "teammate")
-        what = o.get("entity") or o.get("tool", "")
-        extra = f" +{len(others) - 1}" if len(others) > 1 else ""
-        badge += f" {DIM}·{RESET} \033[35m👥 {who} → {what} · {ago_s}{extra}{RESET}"
-
     print(f"{left}  {badge}")
 
 if __name__ == "__main__":
-    if len(sys.argv) >= 3 and sys.argv[1] == "--refresh-team":
-        refresh_team(sys.argv[2])
-    else:
-        main()
+    main()

--- a/agent-skill/package.json
+++ b/agent-skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ataraxy-labs/sem-skill",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "One-command setup of sem (entity-level code intelligence) for coding agents: installs the sem skill and registers the sem MCP server.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Product decision: presence is not a feature for now. Strips the presence sensor + teammates display from the badge scripts and README; keeps the live trigger-time spinner and savings meter. Server endpoints stay deployed but dormant/unadvertised. 0.7.0 -> 0.7.1. Verified: spinner renders, zero presence references in shipped scripts, local machine synced to match.