### PR TITLE
docs: changelog entry for the presence removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to sem are documented in this file.
 
 ## [Unreleased]
 
+### Removed
+
+- Team presence was pulled from the `--badge` package before it shipped as a feature (product call: not a feature for now). The statusline no longer shows teammates and the hook sends nothing anywhere; the dormant server endpoints remain unadvertised.
+
 ### Added
 
-- The `--badge` statusline is now **live at trigger time**: a PreToolUse hook flips the badge to an animated spinner with the entity name the moment the agent calls sem (`⊕ sem ⠹ impact validateToken…`), and the completed state (count, latency, savings) lands when the call finishes. The render hot path never touches the network (teammates presence refreshes in a detached worker; renders measured at ~20ms).
+- The `--badge` statusline is now **live at trigger time**: a PreToolUse hook flips the badge to an animated spinner with the entity name the moment the agent calls sem (`⊕ sem ⠹ impact validateToken…`), and the completed state (count, latency, savings) lands when the call finishes. The render hot path never touches the network (renders measured at ~20ms).
 
 ### Fixed
 


### PR DESCRIPTION
Adds the Removed entry the presence-pull PR (#421) merged without (its changelog gate failed), and scrubs a stale reference to the presence refresh worker from the spinner bullet.