### PR TITLE
perf(mcp): local-first tool calls + graph prewarm at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to sem are documented in this file.
 
 ## [Unreleased]
 
+### Performance
+
+- The sem MCP server is now **local-first and prewarmed**. Cloud-first routing on `sem_impact`/`sem_context` cost a network round-trip on every call before the local answer (and carried the same wrong-entity risk gated in the CLI); it is now behind `SEM_MCP_CLOUD=1` until the server resolves name+file strictly. The server also builds the CWD repo's graph in the background at startup, so the agent's first structural query answers from memory. Measured on an 85K-LOC repo: warm `sem_context` runs in under 1ms wall (faster than a ripgrep scan of the same repo), and the first call dropped from 129ms cold to ~0 with prewarm.
+
 ### Removed
 
 - Team presence was pulled from the `--badge` package before it shipped as a feature (product call: not a feature for now). The statusline no longer shows teammates and the hook sends nothing anywhere; the dormant server endpoints remain unadvertised.

--- a/crates/sem-mcp/src/lib.rs
+++ b/crates/sem-mcp/src/lib.rs
@@ -22,6 +22,10 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
             .init();
 
         let server = server::SemServer::new();
+        // Prewarm: build the CWD repo's graph in the background while the
+        // transport handshakes, so the agent's first structural query answers
+        // from memory instead of paying the cold build.
+        server.spawn_prewarm();
         let transport =
             transport::ResilientStdioTransport::new(tokio::io::stdin(), tokio::io::stdout());
         let service = server.serve(transport).await?;

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -694,6 +694,20 @@ impl SemServer {
         Some(file_paths)
     }
 
+    /// Kick a background graph build for the repo discovered from env/CWD, so
+    /// the first real query hits a warm in-memory graph. Fire-and-forget: any
+    /// failure (not a repo, empty dir) is silently ignored and the first query
+    /// simply builds as before.
+    pub fn spawn_prewarm(&self) {
+        let this = self.clone();
+        tokio::spawn(async move {
+            let Ok(repo_root) = Self::discover_repo_root(None) else {
+                return;
+            };
+            let _ = this.live_graph(&repo_root).await;
+        });
+    }
+
     /// Whole-repo (graph, entities), kept hot by the file watcher when active.
     async fn live_graph(&self, repo_root: &Path) -> (Arc<EntityGraph>, Arc<Vec<SemanticEntity>>) {
         if self.ensure_live(repo_root).await.is_some() {
@@ -1040,7 +1054,7 @@ impl SemServer {
         // warm cloud graph instead of a local build. Custom-scope requests
         // (no_default_excludes) stay local since the cloud indexes the default
         // scope; on any miss/error this returns None and the local path runs.
-        if !no_default_excludes {
+        if !no_default_excludes && std::env::var("SEM_MCP_CLOUD").is_ok_and(|v| v == "1") {
             if let Some(mut out) =
                 crate::cloud::try_impact(&ctx.git, &params.entity_name, &rel_path, mode)
             {
@@ -1402,10 +1416,13 @@ impl SemServer {
         let budget = params.token_budget.unwrap_or(8000);
         let hops = params.hops.unwrap_or(0);
 
-        // Cloud-first: a logged-in agent on a large, registered repo gets the
-        // warm cloud context pack. Hop-bounded or custom-scope requests stay
-        // local; on any miss/error this returns None and the local path runs.
-        if !no_default_excludes {
+        // File-hinted queries stay local (same gate as the CLI, #409): the
+        // cloud resolves by name with a silent name-only fallback, so it can
+        // return the wrong same-named entity, and the attempt costs a network
+        // round-trip (~140ms) before the warm in-memory graph answers in
+        // milliseconds. Cloud returns here once the server resolves name+file
+        // strictly. SEM_MCP_CLOUD=1 opts back in for experiments.
+        if !no_default_excludes && std::env::var("SEM_MCP_CLOUD").is_ok_and(|v| v == "1") {
             if let Some(mut out) =
                 crate::cloud::try_context(&ctx.git, &params.entity_name, &rel_path, budget, hops)
             {


### PR DESCRIPTION
Two changes that make warm sem strictly faster than a grep scan: (1) cloud-first routing on MCP impact/context gated behind SEM_MCP_CLOUD=1 (same correctness gate as CLI #409, and it was costing a network round-trip on every call); (2) the server prewarms the CWD repo graph at startup. Measured sequentially (prior numbers were a concurrent-measurement artifact): warm sem_context <1ms wall; first call 129ms -> 27ms with a 1s startup pause, ~0 in real sessions. 58 sem-mcp tests pass.