### PR TITLE
feat(mcp): one-call lookup — sem_context resolves entity_name repo-wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to sem are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **One-call lookup**: `sem_context`'s `file_path` is now optional. With only an `entity_name`, the entity is resolved across the whole repo (unique match proceeds; ambiguity returns a compact candidate list with the files; no match returns near-name suggestions) and the body plus callers/callees comes back in a single round-trip — one agent call where grep needs two (search, then read). Measured 26ms wall on a prewarmed server, name-only, unfamiliar repo.
+
 ### Performance
 
 - The sem MCP server is now **local-first and prewarmed**. Cloud-first routing on `sem_impact`/`sem_context` cost a network round-trip on every call before the local answer (and carried the same wrong-entity risk gated in the CLI); it is now behind `SEM_MCP_CLOUD=1` until the server resolves name+file strictly. The server also builds the CWD repo's graph in the background at startup, so the agent's first structural query answers from memory. Measured on an 85K-LOC repo: warm `sem_context` runs in under 1ms wall (faster than a ripgrep scan of the same repo), and the first call dropped from 129ms cold to ~0 with prewarm.

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -466,6 +466,68 @@ impl SemServer {
         }
     }
 
+    /// Resolve an entity by name across the whole repo (one-call lookup, no
+    /// file hint). Unique match wins; ambiguity returns the candidate files so
+    /// the agent can disambiguate in its next call; no match returns near-name
+    /// suggestions.
+    fn find_entity_repo_wide<'a>(
+        graph: &'a EntityGraph,
+        entity_name: &str,
+    ) -> Result<&'a sem_core::parser::graph::EntityInfo, String> {
+        let qualified = entity_name.rsplit_once('.');
+        let matches = |e: &sem_core::parser::graph::EntityInfo| {
+            e.name == entity_name
+                || qualified.is_some_and(|(parent_part, child_part)| {
+                    e.name == child_part
+                        && e.parent_id
+                            .as_ref()
+                            .and_then(|pid| graph.entities.get(pid))
+                            .is_some_and(|p| p.name == parent_part)
+                })
+        };
+        let mut hits: Vec<&sem_core::parser::graph::EntityInfo> =
+            graph.entities.values().filter(|e| matches(e)).collect();
+        hits.sort_by(|a, b| (&a.file_path, a.start_line).cmp(&(&b.file_path, b.start_line)));
+        match hits.len() {
+            1 => Ok(hits[0]),
+            0 => {
+                let lower = entity_name.to_lowercase();
+                let mut near: Vec<&str> = graph
+                    .entities
+                    .values()
+                    .filter(|e| e.name.to_lowercase().contains(&lower))
+                    .map(|e| e.name.as_str())
+                    .collect();
+                near.sort_unstable();
+                near.dedup();
+                near.truncate(5);
+                if near.is_empty() {
+                    Err(format!("Entity '{}' not found in this repo", entity_name))
+                } else {
+                    Err(format!(
+                        "Entity '{}' not found. Near matches: {}",
+                        entity_name,
+                        near.join(", ")
+                    ))
+                }
+            }
+            _ => {
+                let files: Vec<String> = hits
+                    .iter()
+                    .map(|e| e.file_path.clone())
+                    .collect::<std::collections::BTreeSet<_>>()
+                    .into_iter()
+                    .collect();
+                Err(format!(
+                    "Entity '{}' is ambiguous ({} matches). Pass file_path to pick one: {}",
+                    entity_name,
+                    hits.len(),
+                    files.join(", ")
+                ))
+            }
+        }
+    }
+
     /// Get cached graph or build a new one. Checks: memory cache -> SQLite cache -> fresh build.
     async fn get_or_build_graph(
         &self,
@@ -1401,17 +1463,25 @@ impl SemServer {
         // Time the whole handler so the result carries the real latency the
         // agent waited on — let the speed be felt, not claimed.
         let start = Instant::now();
-        let ctx = match self.get_context(Some(&params.file_path)).await {
+        let ctx = match self.get_context(params.file_path.as_deref()).await {
             Ok(ctx) => ctx,
             Err(err) => return Ok(tool_error(err)),
         };
-        let (rel_path, abs_path) = Self::resolve_file_path(&ctx.repo_root, &params.file_path);
-        if let Some(err) = file_path_error(&params.file_path, &abs_path) {
-            return Ok(tool_error(err));
-        }
-        if self.registry.get_plugin(&rel_path).is_none() {
-            return Ok(tool_error(format!("No parser for file: {}", rel_path)));
-        }
+        // With a file hint, validate it up front; without one, the entity is
+        // resolved repo-wide after the graph is available (one-call lookup).
+        let explicit_rel: Option<String> = match params.file_path.as_deref() {
+            Some(fp) => {
+                let (rel_path, abs_path) = Self::resolve_file_path(&ctx.repo_root, fp);
+                if let Some(err) = file_path_error(fp, &abs_path) {
+                    return Ok(tool_error(err));
+                }
+                if self.registry.get_plugin(&rel_path).is_none() {
+                    return Ok(tool_error(format!("No parser for file: {}", rel_path)));
+                }
+                Some(rel_path)
+            }
+            None => None,
+        };
         let no_default_excludes = params.no_default_excludes.unwrap_or(false);
         let budget = params.token_budget.unwrap_or(8000);
         let hops = params.hops.unwrap_or(0);
@@ -1423,14 +1493,16 @@ impl SemServer {
         // milliseconds. Cloud returns here once the server resolves name+file
         // strictly. SEM_MCP_CLOUD=1 opts back in for experiments.
         if !no_default_excludes && std::env::var("SEM_MCP_CLOUD").is_ok_and(|v| v == "1") {
-            if let Some(mut out) =
-                crate::cloud::try_context(&ctx.git, &params.entity_name, &rel_path, budget, hops)
-            {
+            if let Some(rel_path) = explicit_rel.as_deref() {
+                if let Some(mut out) =
+                    crate::cloud::try_context(&ctx.git, &params.entity_name, rel_path, budget, hops)
+                {
                 out["elapsed_ms"] = serde_json::json!(start.elapsed().as_millis() as u64);
                 out["source"] = serde_json::json!("cloud");
                 return Ok(CallToolResult::success(vec![Content::text(
                     crate::render::context_text(&out),
                 )]));
+                }
             }
         }
 
@@ -1450,10 +1522,19 @@ impl SemServer {
             self.live_graph(&ctx.repo_root).await
         };
 
-        let entity_id = match Self::find_entity_in_graph(&graph, &params.entity_name, &rel_path) {
-            Ok(entity_id) => entity_id,
-            Err(err) => return Ok(tool_error(err)),
+        let (entity_id, rel_path) = match explicit_rel {
+            Some(rel_path) => {
+                match Self::find_entity_in_graph(&graph, &params.entity_name, &rel_path) {
+                    Ok(entity_id) => (entity_id.to_string(), rel_path),
+                    Err(err) => return Ok(tool_error(err)),
+                }
+            }
+            None => match Self::find_entity_repo_wide(&graph, &params.entity_name) {
+                Ok(entity) => (entity.id.clone(), entity.file_path.clone()),
+                Err(err) => return Ok(tool_error(err)),
+            },
         };
+        let entity_id = entity_id.as_str();
         let context_result = sem_core::parser::context::build_context_result_bounded(
             &graph,
             entity_id,
@@ -2200,7 +2281,7 @@ mod tests {
 
         let result = server
             .sem_context(Parameters(ContextParams {
-                file_path: "src/generated/schema.ts".to_string(),
+                file_path: Some("src/generated/schema.ts".to_string()),
                 entity_name: "generatedTarget".to_string(),
                 token_budget: Some(2000),
                 hops: None,
@@ -2227,7 +2308,7 @@ mod tests {
 
         let result = server
             .sem_context(Parameters(ContextParams {
-                file_path: file_path.display().to_string(),
+                file_path: Some(file_path.display().to_string()),
                 entity_name: "known_entity".to_string(),
                 token_budget: None,
                 hops: None,
@@ -2252,7 +2333,7 @@ mod tests {
 
         let result = server
             .sem_context(Parameters(ContextParams {
-                file_path: file_path.display().to_string(),
+                file_path: Some(file_path.display().to_string()),
                 entity_name: "nonexistent_zzz".to_string(),
                 token_budget: None,
                 hops: None,
@@ -2281,7 +2362,7 @@ mod tests {
         // Touch repo A first so it becomes the active repo.
         let a = server
             .sem_context(Parameters(ContextParams {
-                file_path: repo_a.join("a.py").display().to_string(),
+                file_path: Some(repo_a.join("a.py").display().to_string()),
                 entity_name: "alpha_entity".to_string(),
                 token_budget: None,
                 hops: None,
@@ -2294,7 +2375,7 @@ mod tests {
         // A hint into repo B must resolve B's entity, not answer from repo A.
         let b = server
             .sem_context(Parameters(ContextParams {
-                file_path: repo_b.join("b.py").display().to_string(),
+                file_path: Some(repo_b.join("b.py").display().to_string()),
                 entity_name: "beta_entity".to_string(),
                 token_budget: None,
                 hops: None,

--- a/crates/sem-mcp/src/tools.rs
+++ b/crates/sem-mcp/src/tools.rs
@@ -93,8 +93,10 @@ pub struct LogParams {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ContextParams {
-    #[schemars(description = "Path to the file containing the entity")]
-    pub file_path: String,
+    #[schemars(
+        description = "Path to the file containing the entity. OPTIONAL: omit it for one-call lookup — the entity_name is resolved across the whole repo (ambiguity returns a compact candidate list)."
+    )]
+    pub file_path: Option<String>,
     #[schemars(description = "Name of the target entity")]
     pub entity_name: String,
     #[schemars(description = "Maximum token budget. Defaults to 8000.")]

--- a/skills/sem/SKILL.md
+++ b/skills/sem/SKILL.md
@@ -26,11 +26,18 @@ because the shell is already open. Map:
 |------|----------|
 | what changed | `sem_diff` |
 | blast radius / what breaks | `sem_impact` |
-| read/understand an entity + its callers | `sem_context` |
+| read/understand an entity + its callers | `sem_context` with just `entity_name` — ONE call, no file needed |
 | find code by intent ("where is X done") | `sem_entities` with `query` |
 | who last touched it | `sem_blame` |
 | how it evolved | `sem_log` with `entity_name` |
 | repo hotspots + co-change pairs | `sem_log` with no `entity_name` |
+
+**One-call lookup:** when you know (or can guess) the entity name, call
+`sem_context` with only `entity_name` — it resolves across the whole repo and
+returns the body plus callers/callees in one round-trip (grep needs two: search,
+then read). Ambiguous names return a compact candidate list; pass `file_path`
+only then. Do not call `sem_entities` first unless you are searching by intent
+with a free-text `query`.
 
 Use the CLI below only in a real terminal, in scripts, or for commands the MCP
 server doesn't expose (`sem graph`, `sem setup`, exotic flags) — and then as a


### PR DESCRIPTION
Collapses locate+understand into ONE agent round-trip: `sem_context` with just `entity_name` resolves repo-wide (unique match wins; ambiguity returns candidates: `'get' is ambiguous (6 matches). Pass file_path: api.py, cookies.py, …`; misses return near-name suggestions). grep needs two calls (search, then read) for the same outcome. Measured: 26ms wall, name-only, prewarmed server, unfamiliar repo. Skill updated to teach the pattern. 58 tests pass.