### PR TITLE
fix(mcp): gate the socket sidecar behind cfg(unix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to sem are documented in this file.
 
 ### Added
 
+- The socket sidecar is unix-only (`cfg(unix)`): Windows builds skip it with a no-op and the prefetch hook falls back silently — the sidecar is an accelerator, never a requirement. (Fixes the Windows build break the sidecar introduced.)
 - **Socket sidecar**: `sem mcp` now exposes the warm in-memory graph on a per-repo unix socket (`~/.sem/sock/<repo-hash>.sock`, one JSON line in, one out). Short-lived local callers — the prompt-prefetch hook, future CLI fast paths — get one-call entity context in single-digit milliseconds instead of paying a fresh process plus SQLite hydrate (~800ms). Stale sockets from dead servers are detected and taken over; the sidecar is a silent accelerator, never a requirement.
 
 ### Added

--- a/crates/sem-mcp/src/sidecar.rs
+++ b/crates/sem-mcp/src/sidecar.rs
@@ -12,7 +12,9 @@
 
 use std::path::{Path, PathBuf};
 
+#[cfg(unix)]
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+#[cfg(unix)]
 use tokio::net::UnixListener;
 
 use crate::server::SemServer;
@@ -21,6 +23,7 @@ use crate::server::SemServer;
 /// socket's clients are written in (the Python hook implements the same five
 /// lines). Unix socket paths cap out around 104 bytes on macOS, so the repo
 /// root is identified by hash rather than by sanitized path.
+#[cfg(unix)]
 fn fnv1a(bytes: &[u8]) -> u64 {
     let mut h: u64 = 0xcbf29ce484222325;
     for b in bytes {
@@ -31,6 +34,7 @@ fn fnv1a(bytes: &[u8]) -> u64 {
 }
 
 /// Socket path for a repo root: ~/.sem/sock/<fnv1a(canonical_root)>.sock
+#[cfg(unix)]
 pub fn socket_path_for(repo_root: &Path) -> Option<PathBuf> {
     let canonical = repo_root.canonicalize().ok()?;
     let home = dirs_home()?;
@@ -39,6 +43,7 @@ pub fn socket_path_for(repo_root: &Path) -> Option<PathBuf> {
     Some(dir.join(format!("{:016x}.sock", fnv1a(canonical.to_string_lossy().as_bytes()))))
 }
 
+#[cfg(unix)]
 fn dirs_home() -> Option<PathBuf> {
     std::env::var_os("HOME").map(PathBuf::from)
 }
@@ -46,6 +51,7 @@ fn dirs_home() -> Option<PathBuf> {
 /// Bind the sidecar for `repo_root`, stealing a stale socket if a previous
 /// server died without cleanup. Returns None (silently) when binding isn't
 /// possible — the sidecar is an accelerator, never a requirement.
+#[cfg(unix)]
 pub fn spawn(server: SemServer, repo_root: PathBuf) {
     tokio::spawn(async move {
         let Some(path) = socket_path_for(&repo_root) else {
@@ -88,6 +94,13 @@ pub fn spawn(server: SemServer, repo_root: PathBuf) {
     });
 }
 
+/// Windows: no unix sockets — the sidecar is an accelerator, not a
+/// requirement, so it simply doesn't exist there. Callers fall back to the
+/// one-shot CLI path.
+#[cfg(not(unix))]
+pub fn spawn(_server: SemServer, _repo_root: PathBuf) {}
+
+#[cfg(unix)]
 async fn handle(server: &SemServer, repo_root: &Path, req: &str) -> String {
     let parsed: serde_json::Value = match serde_json::from_str(req) {
         Ok(v) => v,
@@ -113,6 +126,7 @@ async fn handle(server: &SemServer, repo_root: &Path, req: &str) -> String {
     }
 }
 
+#[cfg(unix)]
 fn err(msg: &str) -> String {
     serde_json::json!({ "ok": false, "error": msg }).to_string()
 }


### PR DESCRIPTION
Fixes the build-windows failure from #425: unix domain sockets don't exist on Windows. All sidecar socket code is now cfg(unix) with a no-op `spawn` stub elsewhere; the hook client side was already gated. No changelog entry needed beyond the existing sidecar entry (platform note is in code). Waiting on the build-windows check before merge this time.