### PR TITLE
perf(resolve): gate debug log allocation; clone-free edge dedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to sem are documented in this file.
 
 ## [Unreleased]
 
+### Performance
+
+- Graph build: the scope resolver no longer allocates its debug resolution log (several owned strings per reference, discarded by every production path — only a bench consumed it), and edge dedup is index-based instead of cloning both entity IDs per edge into a hash set. Output is byte-identical (proven edge-for-edge on a 139K-entity build); ~1-3% fewer instructions retired. Groundwork toward #320/#322 — the remaining peak-memory work (entity content sharing, ID interning) is tracked there.
+
 ### Added
 
 - **`sem hook prompt-submit`** (hidden plumbing): the prompt-time prefetch, compiled. Reads a Claude Code UserPromptSubmit event, extracts identifier-shaped tokens from the prompt (backticked, snake_case, CamelCase, qualified — never plain words), resolves them against the resident server's socket sidecar, and prints packed entity context for injection. **10ms end-to-end** (was ~40ms as a Python hook — interpreter startup and a git subprocess, both eliminated: repo root is found by walking to `.git` in-process). Silent on conversational prompts, slash commands, unknown names, or when no server is resident.

--- a/crates/sem-core/src/parser/scope_resolve.rs
+++ b/crates/sem-core/src/parser/scope_resolve.rs
@@ -1239,29 +1239,33 @@ fn resolve_with_scopes_full_inner(
 
                                 if !is_parent_child {
                                     let reference = ref_description(ast_ref);
-                                    file_edges.push((
-                                        entity.id.clone(),
-                                        target_id.clone(),
-                                        ref_type,
-                                    ));
                                     add_scope_reference_words(entity_consumed, &reference);
-                                    file_log.push(ResolutionEntry {
-                                        from_entity: entity.id.clone(),
-                                        reference,
-                                        resolved_to: Some(target_id),
-                                        method,
-                                    });
+                                    // The debug log allocates several Strings per
+                                    // reference across the whole repo; production
+                                    // builds discard it, so only populate it when
+                                    // a caller asked for the log.
+                                    if emit_local_binding_log {
+                                        file_log.push(ResolutionEntry {
+                                            from_entity: entity.id.clone(),
+                                            reference,
+                                            resolved_to: Some(target_id.clone()),
+                                            method,
+                                        });
+                                    }
+                                    file_edges.push((entity.id.clone(), target_id, ref_type));
                                 }
                             }
                         } else {
                             let reference = ref_description(ast_ref);
                             add_scope_reference_words(entity_consumed, &reference);
-                            file_log.push(ResolutionEntry {
-                                from_entity: entity.id.clone(),
-                                reference,
-                                resolved_to: None,
-                                method: "unresolved",
-                            });
+                            if emit_local_binding_log {
+                                file_log.push(ResolutionEntry {
+                                    from_entity: entity.id.clone(),
+                                    reference,
+                                    resolved_to: None,
+                                    method: "unresolved",
+                                });
+                            }
                         }
                     }
                 }
@@ -1279,19 +1283,33 @@ fn resolve_with_scopes_full_inner(
         }
     }
 
-    // Deduplicate edges
-    let mut seen: HashSet<(String, String)> =
-        HashSet::with_capacity_and_hasher(all_edges.len(), Default::default());
-    let deduped_edges: Vec<(String, String, RefType)> = {
+    // Deduplicate edges keeping the first-inserted (from, to). Index-based:
+    // sorting indices by borrowed keys avoids the two String clones per edge
+    // the old HashSet key paid — millions of allocations on a monorepo.
+    let all_edges = {
+        let mut order: Vec<usize> = (0..all_edges.len()).collect();
+        order.sort_by(|&a, &b| {
+            (&all_edges[a].0, &all_edges[a].1, a).cmp(&(&all_edges[b].0, &all_edges[b].1, b))
+        });
+        let mut keep = vec![false; all_edges.len()];
+        let mut prev: Option<usize> = None;
+        for &i in &order {
+            let dup = prev.is_some_and(|p: usize| {
+                all_edges[p].0 == all_edges[i].0 && all_edges[p].1 == all_edges[i].1
+            });
+            if !dup {
+                keep[i] = true;
+            }
+            prev = Some(i);
+        }
         let mut result = Vec::with_capacity(all_edges.len());
-        for edge in all_edges {
-            if seen.insert((edge.0.clone(), edge.1.clone())) {
+        for (i, edge) in all_edges.into_iter().enumerate() {
+            if keep[i] {
                 result.push(edge);
             }
         }
         result
     };
-    let all_edges = deduped_edges;
 
     ScopeResultFull {
         edges: all_edges,


### PR DESCRIPTION
First contained cut toward #320/#322. Gates the per-reference debug ResolutionEntry allocation behind the existing emit flag (production discards the log; only a bench reads it) and replaces the clone-per-edge dedup HashSet with index-based dedup over borrowed keys. **Output byte-identical** — proven old-binary-vs-new on deno (139,350 entities / 142,745 edges, frozenset over edges+refTypes+entity IDs). ~1-3% fewer instructions; RSS unchanged within noise (honest: the 2.8GB peak is content+trees per #322, not the log). A more aggressive consumed-words rewrite was attempted and **reverted** because it altered edge output — recall outranks allocation savings. 409 tests pass.