### PR TITLE
feat(mcp): entity-addressed text search (kill grep's last stronghold)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to sem are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Entity-addressed text search**: `sem_entities` takes a `text` parameter — an exact substring searched across entity bodies in the warm in-memory graph (no file reads). Hits come back addressed by the innermost enclosing entity (`file: entity (Lline): matched text`), ready to chain into `sem_context`/`sem_impact`, in ~20-30ms warm on an 85K-LOC repo. This retires the main remaining reason agents fell back to grep (strings, error messages, config keys); misses say honestly that comments between entities and non-code files are not covered.
+
 ### Performance
 
 - Graph build: the scope resolver no longer allocates its debug resolution log (several owned strings per reference, discarded by every production path — only a bench consumed it), and edge dedup is index-based instead of cloning both entity IDs per edge into a hash set. Output is byte-identical (proven edge-for-edge on a 139K-entity build); ~1-3% fewer instructions retired. Groundwork toward #320/#322 — the remaining peak-memory work (entity content sharing, ID interning) is tracked there.

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -802,6 +802,68 @@ impl SemServer {
         })))
     }
 
+    /// Entity-addressed text search over in-memory entity bodies. For each
+    /// matching line, the innermost (smallest-span) enclosing entity wins, so
+    /// a hit inside a method reports the method, not its class.
+    fn render_text_hits(
+        all_entities: &[SemanticEntity],
+        needle: &str,
+        limit: usize,
+    ) -> String {
+        use std::collections::HashMap;
+        // (file, absolute line) -> (span, entity name, entity type, line text)
+        let mut best: HashMap<(&str, usize), (usize, &str, &str, &str)> = HashMap::new();
+        for e in all_entities {
+            if !e.content.contains(needle) {
+                continue;
+            }
+            let span = e.end_line.saturating_sub(e.start_line);
+            for (offset, line) in e.content.lines().enumerate() {
+                if !line.contains(needle) {
+                    continue;
+                }
+                let abs_line = e.start_line + offset;
+                let key = (e.file_path.as_str(), abs_line);
+                match best.get(&key) {
+                    Some((s, ..)) if *s <= span => {}
+                    _ => {
+                        best.insert(key, (span, e.name.as_str(), e.entity_type.as_str(), line));
+                    }
+                }
+            }
+        }
+        if best.is_empty() {
+            return format!(
+                "no entity contains \"{needle}\" (searches code entity bodies; \
+                 comments between entities and non-code files are not covered)"
+            );
+        }
+        let mut hits: Vec<((&str, usize), (usize, &str, &str, &str))> =
+            best.into_iter().collect();
+        hits.sort_by(|a, b| (a.0 .0, a.0 .1).cmp(&(b.0 .0, b.0 .1)));
+        let total = hits.len();
+        let files: std::collections::BTreeSet<&str> = hits.iter().map(|(k, _)| k.0).collect();
+        let mut out = format!(
+            "⊕ text \"{needle}\" · {total} hits · {} files\n",
+            files.len()
+        );
+        for (i, ((file, line), (_, name, ty, text))) in hits.iter().take(limit).enumerate() {
+            let branch = if i + 1 == total.min(limit) { "╰─▶" } else { "├─▶" };
+            let label = if *ty == "function" || *ty == "method" {
+                (*name).to_string()
+            } else {
+                format!("{name} ({ty})")
+            };
+            let text = text.trim();
+            let text: String = text.chars().take(90).collect();
+            out.push_str(&format!("{branch} {file}: {label} (L{line}): {text}\n"));
+        }
+        if total > limit {
+            out.push_str(&format!("… {} more (raise limit)\n", total - limit));
+        }
+        out
+    }
+
     /// Kick a background graph build for the repo discovered from env/CWD, so
     /// the first real query hits a warm in-memory graph. Fire-and-forget: any
     /// failure (not a repo, empty dir) is silently ignored and the first query
@@ -883,6 +945,17 @@ impl SemServer {
             Ok(ctx) => ctx,
             Err(err) => return Ok(tool_error(err)),
         };
+
+        // Text mode: entity-addressed grep. Scan entity bodies in the warm
+        // in-memory graph — no file reads — and return hits addressed by the
+        // innermost enclosing entity, ready for sem_context / sem_impact
+        // chaining. This is the grep killer: same latency class, but hits are
+        // entities, not line numbers in anonymous files.
+        if let Some(needle) = params.text() {
+            let (_, all_entities) = self.live_graph(&ctx.repo_root).await;
+            let text = Self::render_text_hits(&all_entities, needle, params.limit());
+            return Ok(CallToolResult::success(vec![Content::text(text)]));
+        }
 
         // Query mode: rank the whole-repo entity graph by relevance to the
         // query (structural search), instead of listing a path.
@@ -2046,6 +2119,7 @@ mod tests {
                 no_default_excludes: None,
                 query: None,
                 limit: None,
+                text: None,
             }))
             .await
             .unwrap();
@@ -2071,6 +2145,7 @@ mod tests {
                 no_default_excludes: None,
                 query: None,
                 limit: None,
+                text: None,
             }))
             .await
             .unwrap();
@@ -2082,6 +2157,7 @@ mod tests {
                 no_default_excludes: Some(true),
                 query: None,
                 limit: None,
+                text: None,
             }))
             .await
             .unwrap();

--- a/crates/sem-mcp/src/tools.rs
+++ b/crates/sem-mcp/src/tools.rs
@@ -17,6 +17,10 @@ pub struct EntitiesParams {
     pub query: Option<String>,
     #[schemars(description = "Max results for `query` mode (default 10).")]
     pub limit: Option<usize>,
+    #[schemars(
+        description = "Exact substring to search for inside entity bodies across the whole repo (use instead of grep for strings, error messages, config keys). Case-sensitive. Hits come back entity-addressed: file, innermost entity, line, matched line text."
+    )]
+    pub text: Option<String>,
 }
 
 impl EntitiesParams {
@@ -37,6 +41,13 @@ impl EntitiesParams {
 
     pub fn limit(&self) -> usize {
         self.limit.unwrap_or(10).clamp(1, 100)
+    }
+
+    pub fn text(&self) -> Option<&str> {
+        self.text
+            .as_deref()
+            .map(str::trim)
+            .filter(|t| !t.is_empty())
     }
 }
 

--- a/skills/sem/SKILL.md
+++ b/skills/sem/SKILL.md
@@ -28,6 +28,7 @@ because the shell is already open. Map:
 | blast radius / what breaks | `sem_impact` |
 | read/understand an entity + its callers | `sem_context` with just `entity_name` — ONE call, no file needed |
 | find code by intent ("where is X done") | `sem_entities` with `query` |
+| find a string / error message / config key | `sem_entities` with `text` — entity-addressed grep, no files read |
 | who last touched it | `sem_blame` |
 | how it evolved | `sem_log` with `entity_name` |
 | repo hotspots + co-change pairs | `sem_log` with no `entity_name` |
@@ -192,6 +193,13 @@ The `sem_entities` MCP tool also takes a `query` argument for the same ranked
 search, and `sem context <entity> --hops N` bounds the context to N graph hops
 (use 1-2 for just the immediate neighborhood). Prefer these over grep for
 "where is the code that does X".
+
+**Never fall back to grep for strings either**: `sem_entities` with `text`
+searches entity bodies across the repo from the warm in-memory graph and
+returns hits addressed by the innermost enclosing entity (file, entity, line,
+matched text) — ready to chain straight into `sem_context`/`sem_impact`. The
+only remaining text-search cases outside sem are non-code files and comments
+between entities.
 
 ## Make the leverage felt
 


### PR DESCRIPTION
`sem_entities` gains a `text` param: exact-substring search over entity bodies in the warm graph — no file reads, ~20-30ms warm. Hits are entity-addressed (`server.rs: sem_impact (L1220): return Ok(tool_error(...))`), innermost entity wins, chainable straight into context/impact. Misses are honest about the boundary (inter-entity comments, non-code files). Skill updated: string/error-message search now routes to sem, not grep. Consolidation, not proliferation — a param on an existing tool. 58 tests pass; live demo verified on this repo.