### PR TITLE
feat: Fish shell support (.fish files)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to sem are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Fish shell support, via the `tree-sitter-fish` grammar (gated behind the `lang-fish` feature in `grammar-all`). Extracts functions — including the config.fish pattern of definitions inside a top-level `if status is-interactive` block — and resolves fish call edges (a `command`'s name against repo functions, builtins excluded), so `sem impact` sees which fish functions call which. A `function` defined inside another function stays part of the outer entity's content, matching fish's runtime semantics (inner definitions become global, not lexical children). Previously `.fish` files fell back to generic line-based chunking with an unsupported-language warning. Thanks @thalys for the request (#433).
+
 ### Documentation
 
 - **First-principles page on the docs site** (`docs/first-principles.html`, linked from every page's nav): four charts explaining why the recent latency work changes what an agent can afford to do, not just how fast it runs — the scan-vs-index crossover (a text scan pays per byte; residency removes the index's ~800ms hydrate floor, so the constant-time line wins at every repo size), the ~100ms human-perception threshold every new path now sits under, model turns as the real cost unit (3 → 2 → 1 inference turns per structural answer via one-call lookup, then prompt-time prefetch), and tokens per answer (the measured ~15% entity-tree-vs-JSON ratio). Measured numbers come from this changelog; model curves and turn timings are labeled illustrative on the page. Charts are dependency-free inline SVG with hover tooltips and a table view each.

--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ It is fully optional and transparent:
 | Swift | `.swift` | functions, classes, protocols, structs, enums, properties |
 | Elixir | `.ex` `.exs` | modules, functions, macros, guards, protocols |
 | Bash | `.sh` | functions |
+| Fish | `.fish` | functions |
 | Lua | `.lua` | functions (global, local, table, and method forms) |
 | HCL/Terraform | `.hcl` `.tf` `.tfvars` | blocks, attributes (qualified names for nested blocks) |
 | Kotlin | `.kt` `.kts` | classes, interfaces, objects, functions, properties, companion objects |

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1587,6 +1587,7 @@ dependencies = [
  "mimalloc",
  "openssl-sys",
  "rayon",
+ "regex",
  "rusqlite",
  "sem-cloud-client",
  "sem-core",
@@ -1632,6 +1633,7 @@ dependencies = [
  "tree-sitter-elixir",
  "tree-sitter-elm",
  "tree-sitter-embedded-template",
+ "tree-sitter-fish",
  "tree-sitter-fortran",
  "tree-sitter-go",
  "tree-sitter-haskell",
@@ -1678,6 +1680,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "zstd",
 ]
 
 [[package]]
@@ -2204,6 +2207,16 @@ checksum = "833d528e8fcb4e49ddb04d4d6450ddb8ac08f282a58fec94ce981c9c5dbf7e3a"
 dependencies = [
  "cc",
  "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-fish"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "014e3b299f251e9c2e372e3b5e1b0323ef21196e9aa2e90a5bc1f6130cbe8b18"
+dependencies = [
+ "cc",
+ "tree-sitter",
 ]
 
 [[package]]
@@ -3261,3 +3274,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/crates/sem-core/Cargo.toml
+++ b/crates/sem-core/Cargo.toml
@@ -35,6 +35,7 @@ grammar-all = [
     "lang-d",
     "lang-sql",
     "lang-lua",
+    "lang-fish",
 ]
 
 # Individual grammar features
@@ -71,6 +72,7 @@ lang-edn = ["dep:tree-sitter-clojure-orchard"]
 lang-d = ["dep:tree-sitter-d"]
 lang-sql = ["dep:tree-sitter-sequel"]
 lang-lua = ["dep:tree-sitter-lua"]
+lang-fish = ["dep:tree-sitter-fish"]
 
 [dependencies]
 git2 = { version = "0.20", optional = true }
@@ -118,6 +120,7 @@ tree-sitter-elm = { version = "5.9", optional = true }
 tree-sitter-clojure-orchard = { version = "0.2.5", optional = true }
 tree-sitter-d = { version = "0.8.2", optional = true }
 tree-sitter-lua = { version = "0.5.0", optional = true }
+tree-sitter-fish = { version = "3.6", optional = true }
 rustc-hash = "2"
 
 [dev-dependencies]

--- a/crates/sem-core/src/parser/plugins/code/languages.rs
+++ b/crates/sem-core/src/parser/plugins/code/languages.rs
@@ -395,6 +395,11 @@ fn get_lua() -> Option<Language> {
     Some(tree_sitter_lua::LANGUAGE.into())
 }
 
+#[cfg(feature = "lang-fish")]
+fn get_fish() -> Option<Language> {
+    Some(tree_sitter_fish::language())
+}
+
 /// Inside JS/TS function bodies, suppress variable declarations so that local
 /// variables are not extracted as nested entities. Inner function/class
 /// declarations are still extracted for diff granularity.
@@ -1274,6 +1279,26 @@ static LUA_CONFIG: LanguageConfig = LanguageConfig {
     scope_boundary_types: &[],
     get_language: get_lua,
     scope_resolve: None,
+};
+
+#[cfg(feature = "lang-fish")]
+static FISH_CONFIG: LanguageConfig = LanguageConfig {
+    id: "fish",
+    extensions: &[".fish"],
+    // ram02z/tree-sitter-fish: `function_definition` covers `function name ... end`.
+    // Fish function bodies have no wrapper node (statements are direct children),
+    // so there is no container to declare: a `function` defined inside another
+    // stays part of the outer entity's content — consistent with fish semantics,
+    // where inner definitions become global at runtime, not lexical children.
+    // Functions inside top-level `if`/`begin` blocks (the config.fish pattern)
+    // are still extracted via the general recursion.
+    entity_node_types: &["function_definition"],
+    container_node_types: &[],
+    call_entity_identifiers: &[],
+    suppressed_nested_entities: &[],
+    scope_boundary_types: &[],
+    get_language: get_fish,
+    scope_resolve: Some(&FISH_SCOPE_CONFIG),
 };
 
 // ─── Scope Resolve Configs for Supported Languages ────────────────────────────
@@ -2510,6 +2535,45 @@ static BASH_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
     ],
 };
 
+// Fish call edges mirror bash: a `command` node's `name` field is the callee.
+// Unlike bash, fish's control-flow keywords (`if`, `for`, `end`, ...) are real
+// syntax rather than commands, so only genuine builtins need excluding.
+#[cfg(feature = "lang-fish")]
+static FISH_SCOPE_CONFIG: ScopeResolveConfig = ScopeResolveConfig {
+    class_scope_nodes: &[],
+    impl_scope_nodes: &[],
+    function_scope_nodes: &["function_definition"],
+    class_name_field: ClassNameField::Simple("name"),
+
+    assignment_rules: &[],
+    assignment_recurse_into: &[],
+
+    param_rules: &[],
+
+    return_type_field: None,
+
+    call_nodes: &["command"],
+    call_style: CallNodeStyle::FunctionField("name"),
+    new_expr_nodes: &[],
+    new_expr_type_field: "constructor",
+    composite_literal_nodes: &[],
+    member_access: &[],
+    scoped_call_nodes: &[],
+
+    self_keywords: &[],
+
+    init_strategy: InitStrategy::None,
+    import_extractor: None,
+    external_method: false,
+
+    builtins: &[
+        "echo", "printf", "cd", "ls", "cat", "grep", "sed", "awk", "exit", "return", "source",
+        "eval", "set", "test", "string", "math", "status", "read", "argparse", "count", "type",
+        "functions", "abbr", "alias", "complete", "contains", "set_color", "command", "builtin",
+        "emit", "and", "or", "not",
+    ],
+};
+
 macro_rules! all_configs {
     () => {{
         &[
@@ -2579,6 +2643,8 @@ macro_rules! all_configs {
             &D_CONFIG,
             #[cfg(feature = "lang-lua")]
             &LUA_CONFIG,
+            #[cfg(feature = "lang-fish")]
+            &FISH_CONFIG,
         ]
     }};
 }

--- a/crates/sem-core/src/parser/plugins/code/mod.rs
+++ b/crates/sem-core/src/parser/plugins/code/mod.rs
@@ -1474,6 +1474,43 @@ return M
     }
 
     #[test]
+    #[cfg(feature = "lang-fish")]
+    fn test_fish_entity_extraction() {
+        let code = r#"function greet
+    echo "hello $argv[1]"
+end
+
+# the config.fish pattern: definitions wrapped in a top-level guard
+if status is-interactive
+    function fish_prompt
+        set_color green
+        echo -n (prompt_pwd) '> '
+    end
+end
+
+function notify --on-event fish_command_finished --description "ping on done"
+    greet $argv
+end
+"#;
+        let plugin = CodeParserPlugin;
+        let entities = plugin.extract_entities(code, "config.fish");
+        let names: Vec<&str> = entities.iter().map(|e| e.name.as_str()).collect();
+
+        assert!(names.contains(&"greet"), "plain function, got: {:?}", names);
+        assert!(
+            names.contains(&"fish_prompt"),
+            "function inside a top-level if block, got: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"notify"),
+            "function with option flags, got: {:?}",
+            names
+        );
+        assert_eq!(entities.len(), 3, "only functions, got: {:?}", names);
+    }
+
+    #[test]
     fn test_typescript_entity_extraction() {
         // Existing language should still work
         let code = r#"


### PR DESCRIPTION
Fixes #433.

`.fish` files previously fell back to generic line-based chunking with an unsupported-language warning. This adds native Fish support via the maintained [`tree-sitter-fish`](https://crates.io/crates/tree-sitter-fish) grammar (3.6, compatible with our tree-sitter 0.26 pin), behind a `lang-fish` feature included in `grammar-all` (on by default) — same shape as the Lua addition (#393).

What you get:

- **Function extraction**, including the config.fish pattern — definitions wrapped in a top-level `if status is-interactive` block are still found.
- **Call edges**: fish `command` nodes carry a `name` field (same shape as bash), so a `FISH_SCOPE_CONFIG` resolves calls between repo functions (fish builtins excluded). `sem impact` on a fish function finds its callers — verified end-to-end on a sample repo.

One deliberate behavior, documented in the config: fish function bodies have no wrapper node in the grammar (statements are direct children), so a `function` defined inside another function stays part of the outer entity's content rather than becoming a child entity. That matches fish's runtime semantics — inner definitions become global when the outer runs; they aren't lexically scoped children.

Tested: new `test_fish_entity_extraction` unit test (plain function, if-wrapped function, function with option flags); full `sem-core` suite passes (410 tests); manual end-to-end `sem entities` + `sem impact` on a fish file.