### PR TITLE
feat(action): PR-comment footer with an install call-to-action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to sem are documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- The GitHub Action's PR-comment footer now tells the reader what to do next — "add it to your repo in 2 minutes", linking to the action's install snippet — instead of only naming the tool. Every entity-diff comment is seen by all of a repo's collaborators; the footer is the loop that turns viewers into installs.
+
 ### Added
 
 - **`sem repos`** — where your code is stored, in one command. Two inventories side by side: the **cloud account** (authoritative `GET /v1/repos`: every indexed repo with status, entity/file counts, last-indexed time, indexed commit, and any indexing error rendered inline) and **local storage** (every entity cache under the sem cache root with size on disk, entity count, cache kind, and the repo it was built from). `--json` for scripts. Listing the account also reconciles this machine's `~/.sem/repos.json` mirror with server truth — stale entries (a repo registered mid-index stays "pending, 0 entities" forever otherwise) were silently mis-routing the local-vs-cloud decision for impact/context queries. Caches are now stamped with their repo root at save time (`repo_root` in `cache_metadata`); caches built before this show as unlabeled and self-label on their next rebuild.

--- a/action/action.yml
+++ b/action/action.yml
@@ -86,7 +86,7 @@ runs:
             echo "_No entity-level changes — this PR touches no functions, classes, or methods (formatting, comments, or non-code files only)._"
           fi
           echo ""
-          echo "<sub>functions and classes, not lines · <a href=\"https://github.com/Ataraxy-Labs/sem\">sem</a></sub>"
+          echo "<sub>⊕ entity-level diff by <a href=\"https://github.com/Ataraxy-Labs/sem\">sem</a> · <a href=\"https://github.com/Ataraxy-Labs/sem/tree/main/action\">add it to your repo in 2 minutes</a></sub>"
         } > "$BODY_FILE"
 
         # GitHub comments cap at 65536 chars; truncate but keep the summary line.
@@ -102,7 +102,7 @@ runs:
             echo ""
             echo "${SUMMARY:-}"
             echo ""
-            echo "<sub>functions and classes, not lines · <a href=\"https://github.com/Ataraxy-Labs/sem\">sem</a></sub>"
+            echo "<sub>⊕ entity-level diff by <a href=\"https://github.com/Ataraxy-Labs/sem\">sem</a> · <a href=\"https://github.com/Ataraxy-Labs/sem/tree/main/action\">add it to your repo in 2 minutes</a></sub>"
           } > "$BODY_FILE"
           rm -f "$BODY_FILE.tmp"
         fi


### PR DESCRIPTION
Growth loop sharpening: the Action's sticky comment is seen by every collaborator of every repo that installs it, but its footer only named the tool. It now gives the viewer a next step — "add it to your repo in 2 minutes" — linking to the action README's copy-paste install snippet. Applied to both the normal and truncated comment bodies.

Baseline measured today via GitHub code search: zero external repos currently use the action (only sem itself + awesome-rust list mirrors), so the loop hasn't started; this is the cheapest fix to help it spin.