### PR TITLE
fix(docs): workflow-based Pages deploy, replacing the failing legacy builder

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -1,0 +1,42 @@
+# Deploys the docs site (static HTML in /docs) to GitHub Pages via the
+# Actions-based flow, replacing the legacy branch-based Jekyll builder.
+#
+# Why: the legacy builder started failing repo-wide with zero-duration
+# "Page build failed" errors (2026-07-02) on commits that didn't touch docs
+# at all, and direct build requests via the Pages API failed identically.
+# The site is pure static HTML — Jekyll added nothing but a failure mode.
+# This workflow uploads /docs verbatim and deploys it, and only runs when
+# docs actually change.
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs-pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to sem are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- The docs site deploys through workflow-based GitHub Pages (`.github/workflows/docs-pages.yml`: upload `/docs` verbatim, deploy) instead of the legacy branch-based Jekyll builder, which began failing repo-wide with zero-duration "Page build failed" errors on commits that didn't touch docs — including on direct build requests via the Pages API. The site is pure static HTML, so the legacy builder added nothing but a failure mode; deploys now also skip entirely on commits that don't change `docs/`.
+
 ### Added
 
 - **`sem repos`** — where your code is stored, in one command. Two inventories side by side: the **cloud account** (authoritative `GET /v1/repos`: every indexed repo with status, entity/file counts, last-indexed time, indexed commit, and any indexing error rendered inline) and **local storage** (every entity cache under the sem cache root with size on disk, entity count, cache kind, and the repo it was built from). `--json` for scripts. Listing the account also reconciles this machine's `~/.sem/repos.json` mirror with server truth — stale entries (a repo registered mid-index stays "pending, 0 entities" forever otherwise) were silently mis-routing the local-vs-cloud decision for impact/context queries. Caches are now stamped with their repo root at save time (`repo_root` in `cache_metadata`); caches built before this show as unlabeled and self-label on their next rebuild.


### PR DESCRIPTION
The legacy branch-based Jekyll Pages builder started failing repo-wide today: three consecutive zero-duration `Page build failed` errors — on the fish merge (no docs changes), on an Actions re-run, and on a direct `POST /pages/builds` API request. GitHub's status page says Pages is operational, so waiting it out has no ETA. The live site is unaffected (still serving the last good deploy, which is current), but any future docs change is blocked.

This migrates to workflow-based Pages: upload `/docs` verbatim (`actions/upload-pages-artifact`) and deploy (`actions/deploy-pages`). The site is pure static HTML — Jekyll processed nothing and only contributed this failure mode. Bonus: deploys now skip entirely on commits that don't touch `docs/` (the legacy builder ran on every push to main).

Rollout after merge: flip the repo's Pages source from branch to Actions (`PUT /repos/{repo}/pages` with `build_type: workflow`), dispatch the workflow once, verify the site serves.