### PR TITLE
perf(cli): sem impact answers from the resident server's socket — 4.5ms, faster than ripgrep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to sem are documented in this file.
 
 ## [Unreleased]
 
-### Changed
+### Performance
+
+- **CLI sidecar fast path**: `sem impact` now answers from the resident `sem mcp` server's warm graph via its unix socket before doing any local work — measured **4.5ms** end-to-end on a 158K-LOC repo, versus 22.4ms for the local cold path and 7.7ms for a ripgrep scan of the same repo: the full blast radius (callers, dependencies, depth-bounded transitive impact, affected tests) is now cheaper than a raw text match. Output is byte-identical to the local path (the sidecar ships serialized `EntityInfo`s that the CLI feeds to its existing printers; verified across all modes and `--json`). The fast path is an accelerator, never a requirement: bounded socket timeouts and silent fallback mean no resident server (or `SEM_NO_SIDECAR=1`, `--no-cache`, custom scopes, `.semignore`, `--entity-id`) just runs the normal local path. Server-side, the new sidecar `impact` op classifies affected tests only among the entities the impact BFS actually reached, instead of walking the whole corpus per call (6.8ms → 0.1ms on a 4.7K-entity graph).
 
 - The GitHub Action's PR-comment footer now tells the reader what to do next — "add it to your repo in 2 minutes", linking to the action's install snippet — instead of only naming the tool. Every entity-diff comment is seen by all of a repo's collaborators; the footer is the loop that turns viewers into installs.
 

--- a/crates/sem-cli/src/commands/impact.rs
+++ b/crates/sem-cli/src/commands/impact.rs
@@ -50,6 +50,12 @@ fn build_with_spinner<T>(
 }
 
 pub fn impact_command(opts: ImpactOptions) {
+    // A resident server beats the cloud path on both freshness and latency,
+    // so the sidecar goes first.
+    if try_sidecar_impact(&opts) {
+        return;
+    }
+
     if super::cloud::try_cloud_impact(&opts).is_some() {
         return;
     }
@@ -340,6 +346,75 @@ pub fn impact_command(opts: ImpactOptions) {
         }
     }
     timings.finish();
+}
+
+/// The wire shape of the sidecar's `impact` op — real serialized `EntityInfo`s,
+/// so this deserializes into the exact structs the cached-result printers
+/// consume and fast-path output is identical to local output.
+#[derive(serde::Deserialize)]
+struct SidecarImpactResult {
+    entity: EntityInfo,
+    dependencies: Vec<EntityInfo>,
+    dependents: Vec<EntityInfo>,
+    impact: Vec<(EntityInfo, usize)>,
+    tests: Vec<EntityInfo>,
+}
+
+/// Fast path: answer from the resident server's warm graph via its unix
+/// socket, skipping this process's cache open + hydrate. Only for queries the
+/// server can answer with identical semantics: default source scope, resolve
+/// by name. Everything else — and any sidecar miss, error, or ambiguity —
+/// falls back to the normal local path and its richer diagnostics.
+fn try_sidecar_impact(opts: &ImpactOptions) -> bool {
+    if opts.no_cache
+        || opts.no_default_excludes
+        || !opts.file_exts.is_empty()
+        || opts.entity_id.is_some()
+    {
+        return false;
+    }
+    let Some(name) = opts.entity_name.as_deref() else {
+        return false;
+    };
+    let Ok(git) = GitBridge::open(Path::new(&opts.cwd)) else {
+        return false;
+    };
+    let root = git.repo_root().to_path_buf();
+    // A .semignore means this repo's default scope is custom; the resident
+    // server may not share it, so stay local (mirrors cache_source_scope).
+    if root.join(".semignore").exists() {
+        return false;
+    }
+
+    let mut request = serde_json::json!({ "op": "impact", "name": name, "depth": opts.depth });
+    if let Some(file) = opts.file_hint.as_deref() {
+        request["file"] = serde_json::json!(super::normalize_repo_relative_path(
+            Path::new(&opts.cwd),
+            &root,
+            file
+        ));
+    }
+
+    let Some(response) = super::sidecar::query(&root, &request) else {
+        return false;
+    };
+    let Some(result) = response.get("result") else {
+        return false;
+    };
+    let Ok(parsed) = serde_json::from_value::<SidecarImpactResult>(result.clone()) else {
+        return false;
+    };
+
+    let cached = CachedImpactResult {
+        entity: parsed.entity,
+        dependencies: parsed.dependencies,
+        dependents: parsed.dependents,
+        impact: parsed.impact,
+        tests: parsed.tests,
+        tests_truncated: false,
+    };
+    print_cached_result(&cached, opts.mode, opts.json, opts.depth);
+    true
 }
 
 fn try_cached_impact_query(

--- a/crates/sem-cli/src/commands/mod.rs
+++ b/crates/sem-cli/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod log;
 pub mod orient;
 pub mod repos;
 pub mod setup;
+pub mod sidecar;
 pub mod stats;
 
 #[cfg(feature = "self-update")]

--- a/crates/sem-cli/src/commands/sidecar.rs
+++ b/crates/sem-cli/src/commands/sidecar.rs
@@ -1,0 +1,52 @@
+//! CLI fast path over the resident server's unix socket.
+//!
+//! When a `sem mcp` server is resident for this repo, its sidecar socket
+//! answers from the warm in-memory graph in single-digit milliseconds —
+//! skipping this process's cache open + hydrate entirely. The sidecar is an
+//! accelerator, never a requirement: any failure (no socket, no server, slow
+//! reply, protocol mismatch) returns `None` and the caller runs the normal
+//! local path. `SEM_NO_SIDECAR=1` disables it explicitly.
+
+use std::path::Path;
+
+/// Send one JSON request line to the repo's sidecar socket and return the
+/// parsed response if — and only if — it answered `ok: true` in time.
+#[cfg(unix)]
+pub fn query(repo_root: &Path, request: &serde_json::Value) -> Option<serde_json::Value> {
+    use std::io::{BufRead, BufReader, Write};
+    use std::os::unix::net::UnixStream;
+    use std::time::Duration;
+
+    if std::env::var_os("SEM_NO_SIDECAR").is_some() {
+        return None;
+    }
+    let path = sem_mcp::sidecar::socket_path_for(repo_root)?;
+    let mut stream = UnixStream::connect(&path).ok()?;
+    // A warm server replies in milliseconds; a server mid-rebuild might not.
+    // Bound the wait so the fast path can never make the CLI slower than
+    // just doing the local work.
+    stream
+        .set_read_timeout(Some(Duration::from_millis(300)))
+        .ok()?;
+    stream
+        .set_write_timeout(Some(Duration::from_millis(100)))
+        .ok()?;
+
+    let mut line = serde_json::to_string(request).ok()?;
+    line.push('\n');
+    stream.write_all(line.as_bytes()).ok()?;
+
+    let mut response = String::new();
+    BufReader::new(stream).read_line(&mut response).ok()?;
+    let value: serde_json::Value = serde_json::from_str(response.trim()).ok()?;
+    if value.get("ok").and_then(|b| b.as_bool()) == Some(true) {
+        Some(value)
+    } else {
+        None
+    }
+}
+
+#[cfg(not(unix))]
+pub fn query(_repo_root: &Path, _request: &serde_json::Value) -> Option<serde_json::Value> {
+    None
+}

--- a/crates/sem-core/src/parser/graph.rs
+++ b/crates/sem-core/src/parser/graph.rs
@@ -2991,7 +2991,7 @@ fn is_scope_member_container(entity_type: &str) -> bool {
 }
 
 /// Check if an entity looks like a test based on name, file path, and content patterns.
-fn is_test_entity(
+pub fn is_test_entity(
     entity: &crate::model::entity::SemanticEntity,
     custom_test_dirs: &[String],
 ) -> bool {

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -802,6 +802,99 @@ impl SemServer {
         })))
     }
 
+    /// One-call impact for sidecar clients (the CLI fast path): resolve the
+    /// entity by name — file-scoped when a hint is given, repo-wide otherwise —
+    /// then dependencies, dependents, depth-bounded transitive impact (0 =
+    /// unlimited), and affected tests, all from the live in-memory graph.
+    /// Returns typed JSON (serialized `EntityInfo`s) that the CLI deserializes
+    /// straight into its own printer structs, so fast-path output is identical
+    /// to the local compute path. Errors (unknown/ambiguous entity) make the
+    /// caller fall back to local resolution and its richer diagnostics.
+    pub async fn quick_impact(
+        &self,
+        repo_root: &Path,
+        name: &str,
+        file_hint: Option<&str>,
+        max_depth: usize,
+    ) -> Result<serde_json::Value, String> {
+        let (graph, all_entities) = self.live_graph(repo_root).await;
+        let entity = match file_hint {
+            Some(rel_path) => {
+                let entity_id = Self::find_entity_in_graph(&graph, name, rel_path)?;
+                graph
+                    .entities
+                    .get(entity_id)
+                    .ok_or_else(|| format!("Entity '{name}' not found"))?
+            }
+            None => Self::find_entity_repo_wide(&graph, name)?,
+        };
+
+        let dependencies: Vec<_> = graph
+            .get_dependencies(&entity.id)
+            .into_iter()
+            .cloned()
+            .collect();
+        let dependents: Vec<_> = graph
+            .get_dependents(&entity.id)
+            .into_iter()
+            .cloned()
+            .collect();
+
+        // One unbounded BFS over reverse edges (capped like impact_analysis),
+        // recording each entity at its minimum depth. The depth-bounded impact
+        // list and the affected-tests list are both views of this reach set —
+        // classifying only reached entities as tests instead of walking the
+        // whole corpus (`test_impact_with_custom_dirs` clones every test id in
+        // the repo per call, which at sidecar rates was the entire latency
+        // budget: 6.8ms → 0.1ms measured on a 4.7K-entity graph).
+        const BFS_CAP: usize = 10_000;
+        let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        let mut reached: Vec<(&sem_core::parser::graph::EntityInfo, usize)> = Vec::new();
+        let mut queue: std::collections::VecDeque<(&str, usize)> =
+            std::collections::VecDeque::new();
+        seen.insert(entity.id.as_str());
+        queue.push_back((entity.id.as_str(), 0));
+        while let Some((id, depth)) = queue.pop_front() {
+            if reached.len() >= BFS_CAP {
+                break;
+            }
+            for dependent in graph.get_dependents(id) {
+                if seen.insert(dependent.id.as_str()) {
+                    reached.push((dependent, depth + 1));
+                    queue.push_back((dependent.id.as_str(), depth + 1));
+                }
+            }
+        }
+
+        let impact: Vec<(sem_core::parser::graph::EntityInfo, usize)> = reached
+            .iter()
+            .filter(|(_, depth)| max_depth == 0 || *depth <= max_depth)
+            .map(|(info, depth)| ((*info).clone(), *depth))
+            .collect();
+
+        let by_id: std::collections::HashMap<&str, &SemanticEntity> = all_entities
+            .iter()
+            .map(|e| (e.id.as_str(), e))
+            .collect();
+        let tests: Vec<sem_core::parser::graph::EntityInfo> = reached
+            .iter()
+            .filter(|(info, _)| {
+                by_id.get(info.id.as_str()).is_some_and(|e| {
+                    sem_core::parser::graph::is_test_entity(e, &self.registry.custom_test_dirs)
+                })
+            })
+            .map(|(info, _)| (*info).clone())
+            .collect();
+
+        Ok(serde_json::json!({
+            "entity": entity,
+            "dependencies": dependencies,
+            "dependents": dependents,
+            "impact": impact,
+            "tests": tests,
+        }))
+    }
+
     /// Entity-addressed text search over in-memory entity bodies. For each
     /// matching line, the innermost (smallest-span) enclosing entity wins, so
     /// a hit inside a method reports the method, not its class.

--- a/crates/sem-mcp/src/sidecar.rs
+++ b/crates/sem-mcp/src/sidecar.rs
@@ -121,6 +121,17 @@ async fn handle(server: &SemServer, repo_root: &Path, req: &str) -> String {
                 Err(e) => err(&e),
             }
         }
+        Some("impact") => {
+            let Some(name) = parsed.get("name").and_then(|v| v.as_str()) else {
+                return err("missing name");
+            };
+            let file = parsed.get("file").and_then(|v| v.as_str());
+            let depth = parsed.get("depth").and_then(|v| v.as_u64()).unwrap_or(2) as usize;
+            match server.quick_impact(repo_root, name, file, depth).await {
+                Ok(result) => serde_json::json!({ "ok": true, "result": result }).to_string(),
+                Err(e) => err(&e),
+            }
+        }
         Some("ping") => serde_json::json!({ "ok": true, "text": "pong" }).to_string(),
         _ => err("unknown op"),
     }


### PR DESCRIPTION
The benchmark row where traditional infra still won was raw one-shot CLI latency: ripgrep 7.7ms vs cold `sem impact` 22.4ms on this repo. This closes it using infrastructure that already existed — the socket sidecar shipped for the prompt hook, whose changelog listed "future CLI fast paths" as its purpose. This is that path.

## What

- **New sidecar op `impact`** (`quick_impact` on `SemServer`): resolves the entity on the live graph (file-scoped or repo-wide), returns dependencies, dependents, depth-bounded transitive impact (0 = unlimited), and affected tests as **serialized `EntityInfo`s**.
- **CLI fast path** (`try_sidecar_impact`): before any local work, `sem impact` sends one JSON line to the repo's socket and deserializes the reply straight into `CachedImpactResult` — the same struct the existing printers consume, so **fast-path output is byte-identical to the local path** (verified with `diff` across default, `--mode deps/dependents/tests`, and `--json`).
- **Server-side fix that made it fast**: the impact op classifies affected tests only among entities the impact BFS actually reached, instead of `test_impact_with_custom_dirs`'s whole-corpus walk that clones every test id per call — measured 6.8ms → 0.1ms per op on the 4.7K-entity graph (the `context` op was already 0.1ms, which is how the cost was isolated).

## Measured (158K-LOC repo, warm server resident, hyperfine ×10)

| path | wall |
|---|---|
| `sem impact` (sidecar fast path) | **4.5 ms** |
| ripgrep scan of the same repo | 7.7 ms |
| `sem impact` (local, `SEM_NO_SIDECAR=1`) | 22.4 ms |

The full blast radius — callers, deps, transitive impact, affected tests — is now cheaper than a raw text match on the same corpus.

## Safety

The fast path is an accelerator, never a requirement: bounded socket timeouts (300ms read / 100ms write) and silent fallback on any miss, error, or ambiguity. Queries the server can't answer with identical semantics stay local: `--no-cache`, `--entity-id`, `--file-ext`, `--no-default-excludes`, and repos with a `.semignore`. `SEM_NO_SIDECAR=1` disables it. Windows compiles to a no-op (the sidecar is unix-only).

## Testing

Full suites green for sem-core (410), sem-mcp, sem-cli (the two `cwd_resolution` diff-patch failures are pre-existing on this machine, fail identically on untouched main, and are green in CI). Live end-to-end: parity diffs + hyperfine above.