### PR TITLE
fix: pluralize roles correctly in the not-packed summary line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to sem are documented in this file.
 
 ### Fixed
 
+- The context packer's "not packed" summary line pluralizes roles correctly ("transitive dependencies", not "dependencys").
+
 - The docs site deploys through workflow-based GitHub Pages (`.github/workflows/docs-pages.yml`: upload `/docs` verbatim, deploy) instead of the legacy branch-based Jekyll builder, which began failing repo-wide with zero-duration "Page build failed" errors on commits that didn't touch docs — including on direct build requests via the Pages API. The site is pure static HTML, so the legacy builder added nothing but a failure mode; deploys now also skip entirely on commits that don't change `docs/`.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to sem are documented in this file.
 
 - The context packer's "not packed" summary line pluralizes roles correctly ("transitive dependencies", not "dependencys").
 
+- Workspace version bumped to 0.16.0: `ContextResult` gained the public `omitted` field (a breaking change for struct-literal constructors, flagged by cargo-semver-checks), and 0.x semantics put breaking changes in the minor version.
+
 - The docs site deploys through workflow-based GitHub Pages (`.github/workflows/docs-pages.yml`: upload `/docs` verbatim, deploy) instead of the legacy branch-based Jekyll builder, which began failing repo-wide with zero-duration "Page build failed" errors on commits that didn't touch docs — including on direct build requests via the Pages API. The site is pure static HTML, so the legacy builder added nothing but a failure mode; deploys now also skip entirely on commits that don't change `docs/`.
 
 ### Changed

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1576,7 +1576,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sem-cli"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "clap",
  "clap_complete_command",
@@ -1601,7 +1601,7 @@ dependencies = [
 
 [[package]]
 name = "sem-cloud-client"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "sem-core"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "git2",
  "rayon",
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "sem-mcp"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "git2",
  "ignore",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "sem-plugin"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "sem-core",
  "serde",

--- a/crates/sem-cli/Cargo.toml
+++ b/crates/sem-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-cli"
-version = "0.15.1"
+version = "0.16.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Semantic version control CLI. Shows what entities changed (functions, classes, methods) instead of lines."
@@ -15,9 +15,9 @@ name = "sem"
 path = "src/main.rs"
 
 [dependencies]
-sem-core = { path = "../sem-core", version = "0.15.1" }
-sem-mcp = { path = "../sem-mcp", version = "0.15.1" }
-sem-cloud-client = { path = "../sem-cloud-client", version = "0.15.1" }
+sem-core = { path = "../sem-core", version = "0.16.0" }
+sem-mcp = { path = "../sem-mcp", version = "0.16.0" }
+sem-cloud-client = { path = "../sem-cloud-client", version = "0.16.0" }
 serde = { version = "1", features = ["derive"] }
 clap = { version = "4", features = ["derive"] }
 colored = "2"

--- a/crates/sem-cli/src/commands/context.rs
+++ b/crates/sem-cli/src/commands/context.rs
@@ -144,11 +144,11 @@ pub fn context_command(opts: ContextOptions) {
                 .omitted
                 .iter()
                 .map(|t| {
-                    let role = t.role.replace('_', " ");
+                    let role = pluralize_role(&t.role);
                     if t.tests > 0 {
-                        format!("+{} {}s ({} tests)", t.entities, role, t.tests)
+                        format!("+{} {} ({} tests)", t.entities, role, t.tests)
                     } else {
-                        format!("+{} {}s", t.entities, role)
+                        format!("+{} {}", t.entities, role)
                     }
                 })
                 .collect();
@@ -233,4 +233,14 @@ fn find_entity<'a>(
         );
     }
     std::process::exit(1);
+}
+
+/// "direct_dependency" -> "direct dependencies", "direct_dependent" -> "direct dependents".
+fn pluralize_role(role: &str) -> String {
+    let spaced = role.replace('_', " ");
+    if let Some(stem) = spaced.strip_suffix('y') {
+        format!("{stem}ies")
+    } else {
+        format!("{spaced}s")
+    }
 }

--- a/crates/sem-cloud-client/Cargo.toml
+++ b/crates/sem-cloud-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-cloud-client"
-version = "0.15.1"
+version = "0.16.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Shared client for sem-cloud: credentials, repo resolution, caching, and the metered graph API. Used by both the sem CLI and the sem MCP server."

--- a/crates/sem-core/Cargo.toml
+++ b/crates/sem-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-core"
-version = "0.15.1"
+version = "0.16.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Entity-level semantic diff engine. Extracts functions, classes, and methods from 28 languages via tree-sitter and diffs at the entity level."

--- a/crates/sem-mcp/Cargo.toml
+++ b/crates/sem-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-mcp"
-version = "0.15.1"
+version = "0.16.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server for entity-level semantic code intelligence. 6 tools: sem_entities, sem_diff, sem_blame, sem_impact, sem_log, sem_context."
@@ -15,8 +15,8 @@ name = "sem-mcp"
 path = "src/main.rs"
 
 [dependencies]
-sem-core = { path = "../sem-core", version = "0.15.1" }
-sem-cloud-client = { path = "../sem-cloud-client", version = "0.15.1" }
+sem-core = { path = "../sem-core", version = "0.16.0" }
+sem-cloud-client = { path = "../sem-cloud-client", version = "0.16.0" }
 git2 = "0.20"
 lru = "0.16"
 rmcp = { version = "1", features = ["server", "transport-io"] }

--- a/crates/sem-mcp/src/render.rs
+++ b/crates/sem-mcp/src/render.rs
@@ -80,6 +80,16 @@ fn file_count(list: &[Value]) -> usize {
     files.len()
 }
 
+/// "direct_dependency" -> "direct dependencies", "direct_dependent" -> "direct dependents".
+fn pluralize_role(role: &str) -> String {
+    let spaced = role.replace('_', " ");
+    if let Some(stem) = spaced.strip_suffix('y') {
+        format!("{stem}ies")
+    } else {
+        format!("{spaced}s")
+    }
+}
+
 fn footer(v: &Value) -> String {
     let mut parts = Vec::new();
     if let Some(ms) = get_u64(v, "elapsed_ms") {
@@ -234,13 +244,13 @@ pub fn context_text(v: &Value) -> String {
         let parts: Vec<String> = omitted
             .iter()
             .map(|t| {
-                let role = get_str(t, "role").replace('_', " ");
+                let role = pluralize_role(get_str(t, "role"));
                 let n = get_u64(t, "entities").unwrap_or(0);
                 let tests = get_u64(t, "tests").unwrap_or(0);
                 if tests > 0 {
-                    format!("+{} {}s ({} tests)", n, role, tests)
+                    format!("+{} {} ({} tests)", n, role, tests)
                 } else {
-                    format!("+{} {}s", n, role)
+                    format!("+{} {}", n, role)
                 }
             })
             .collect();

--- a/crates/sem-plugin/Cargo.toml
+++ b/crates/sem-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-plugin"
-version = "0.15.1"
+version = "0.16.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "WASI component plugin for semantic entity-level change detection"


### PR DESCRIPTION
"+7 transitive dependencys" -> "+7 transitive dependencies" in the context packer's omitted-tail line, in both the CLI printer and the MCP renderer.