### PR TITLE
feat(mcp): publish sem to the official MCP registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,6 +202,33 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+  publish-mcp-registry:
+    needs: [check-version, publish-npm]
+    if: needs.check-version.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mcp-publisher
+        run: curl -fsSL https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz | tar xz mcp-publisher
+
+      - name: Stamp server.json version
+        run: |
+          jq --arg v "${{ needs.check-version.outputs.version }}" \
+            '.version = $v | .packages[0].version = $v' server.json > server.json.tmp
+          mv server.json.tmp server.json
+
+      - name: Login to MCP registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP registry
+        # Retry once in case the npm publish hasn't propagated when the
+        # registry validates the package's mcpName field.
+        run: ./mcp-publisher publish || (sleep 60 && ./mcp-publisher publish)
+
   publish-crates:
     needs: [check-version, create-tag]
     if: needs.check-version.outputs.should_release == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to sem are documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **sem is published to the official MCP registry** as `io.github.ataraxy-labs/sem`, so MCP clients that browse the registry (VS Code, Cursor, Claude Code, and others) can discover and install the server directly. The release workflow now publishes each release to the registry via `mcp-publisher` (authenticated with GitHub OIDC, no extra secrets), backed by a `server.json` manifest and an `mcpName` field in the npm wrapper.
+
 ### Performance
 
 - **Attention ledger v1: repeated context fills collapse to one line.** The resident server now keeps a per-session ledger of every `context` fill it has emitted (entity id + content fingerprint). When the same session re-asks for an unchanged entity, the answer is a single `≡ unchanged since you read it` line instead of the full packed body — the body is already sitting in the asking model's context window, so re-sending it is pure token waste. Measured through the CLI socket path: 8,586 bytes first fill, 139 bytes on repeat (98.4% suppressed). Opt-in via `SEM_SESSION=<id>` in the environment; `SEM_FRESH=1` bypasses; anonymous calls are never suppressed. Any change to the target entity misses the fingerprint and re-sends in full. This is the first piece of the attention architecture (docs/attention-architecture.md): space (graph), time (commit index), attention (ledger).

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1576,7 +1576,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sem-cli"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "clap",
  "clap_complete_command",
@@ -1601,7 +1601,7 @@ dependencies = [
 
 [[package]]
 name = "sem-cloud-client"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "sem-core"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "git2",
  "rayon",
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "sem-mcp"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "git2",
  "ignore",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "sem-plugin"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "sem-core",
  "serde",

--- a/crates/sem-cli/Cargo.toml
+++ b/crates/sem-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-cli"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Semantic version control CLI. Shows what entities changed (functions, classes, methods) instead of lines."
@@ -15,9 +15,9 @@ name = "sem"
 path = "src/main.rs"
 
 [dependencies]
-sem-core = { path = "../sem-core", version = "0.16.0" }
-sem-mcp = { path = "../sem-mcp", version = "0.16.0" }
-sem-cloud-client = { path = "../sem-cloud-client", version = "0.16.0" }
+sem-core = { path = "../sem-core", version = "0.16.1" }
+sem-mcp = { path = "../sem-mcp", version = "0.16.1" }
+sem-cloud-client = { path = "../sem-cloud-client", version = "0.16.1" }
 serde = { version = "1", features = ["derive"] }
 clap = { version = "4", features = ["derive"] }
 colored = "2"

--- a/crates/sem-cloud-client/Cargo.toml
+++ b/crates/sem-cloud-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-cloud-client"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Shared client for sem-cloud: credentials, repo resolution, caching, and the metered graph API. Used by both the sem CLI and the sem MCP server."

--- a/crates/sem-core/Cargo.toml
+++ b/crates/sem-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-core"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Entity-level semantic diff engine. Extracts functions, classes, and methods from 28 languages via tree-sitter and diffs at the entity level."

--- a/crates/sem-mcp/Cargo.toml
+++ b/crates/sem-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-mcp"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server for entity-level semantic code intelligence. 6 tools: sem_entities, sem_diff, sem_blame, sem_impact, sem_log, sem_context."
@@ -15,8 +15,8 @@ name = "sem-mcp"
 path = "src/main.rs"
 
 [dependencies]
-sem-core = { path = "../sem-core", version = "0.16.0" }
-sem-cloud-client = { path = "../sem-cloud-client", version = "0.16.0" }
+sem-core = { path = "../sem-core", version = "0.16.1" }
+sem-cloud-client = { path = "../sem-cloud-client", version = "0.16.1" }
 git2 = "0.20"
 lru = "0.16"
 rmcp = { version = "1", features = ["server", "transport-io"] }

--- a/crates/sem-plugin/Cargo.toml
+++ b/crates/sem-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-plugin"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "WASI component plugin for semantic entity-level change detection"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ataraxy-labs/sem",
-  "version": "0.7.0",
+  "mcpName": "io.github.ataraxy-labs/sem",
+  "version": "0.16.1",
   "description": "npm wrapper for the sem CLI. Downloads the matching release binary and exposes the sem command in node_modules/.bin.",
   "license": "MIT OR Apache-2.0",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.ataraxy-labs/sem",
+  "description": "Entity-level code intelligence: semantic diff, impact analysis, blame, and context for AI agents",
+  "websiteUrl": "https://ataraxy-labs.com",
+  "repository": {
+    "url": "https://github.com/Ataraxy-Labs/sem",
+    "source": "github"
+  },
+  "version": "0.16.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@ataraxy-labs/sem",
+      "version": "0.16.1",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Publishes sem to the [official MCP registry](https://github.com/modelcontextprotocol/registry) as `io.github.ataraxy-labs/sem`, so MCP clients that browse the registry (VS Code, Cursor, Claude Code, and others) can discover and install the server directly.

## What's in here

- **`server.json`** — registry manifest: npm package `@ataraxy-labs/sem`, stdio transport, launched as `sem mcp` via npx. Validated against the official `2025-12-11` server schema.
- **`package.json`** — adds the `mcpName` field the registry checks against the published npm package, and syncs the long-stale wrapper version (0.7.0 → 0.16.1; CI re-syncs at publish anyway).
- **`release.yml`** — new `publish-mcp-registry` job after the npm publish: stamps the release version into `server.json` with jq, logs in with GitHub OIDC (`id-token: write`, no new repo secrets), and publishes with `mcp-publisher`. Retries once after 60s in case the npm publish hasn't propagated when the registry validates `mcpName`.
- **Version bump 0.16.0 → 0.16.1** across the workspace crates + lockfile. Patch is safe: no `sem-core` public API changes since v0.16.0 (only an internal `parser/context.rs` fix). Merging this triggers the release workflow, which cuts v0.16.1 and publishes the first registry entry.

## Verification done

- `server.json` validated against the official registry JSON schema (ajv)
- npm wrapper tests pass; `sync-package-version.mjs` preserves `mcpName`
- jq stamp command tested locally; workflow YAML parses
- `mcp-publisher` release asset name (`mcp-publisher_linux_amd64.tar.gz`) confirmed against the registry's latest release
- Registry API confirmed no existing `io.github.ataraxy-labs/*` entries