### PR TITLE
style: rustfmt sidecar quick_context call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to sem are documented in this file.
 
 ### Fixed
 
+- Internal: rustfmt line-wrap missed in the #445 sidecar change; no behavior change.
+
 - The context packer's token estimator was undercounting real tokens 2-3x on dense code (words x 1.3 vs the ~4 chars/token reality: a context reported as 661 tokens measured ~2,400 real tokens), silently overshooting every budget. It now takes the max of the word- and character-based estimates, so nominal budgets match what the consuming model actually pays.
 
 - The context packer's "not packed" summary line pluralizes roles correctly ("transitive dependencies", not "dependencys").

--- a/crates/sem-mcp/src/sidecar.rs
+++ b/crates/sem-mcp/src/sidecar.rs
@@ -155,7 +155,10 @@ async fn handle(server: &SemServer, repo_root: &Path, req: &str) -> String {
             let budget = parsed.get("budget").and_then(|v| v.as_u64()).unwrap_or(900) as usize;
             let hops = parsed.get("hops").and_then(|v| v.as_u64()).unwrap_or(1) as usize;
             let session = parsed.get("session").and_then(|v| v.as_str());
-            match server.quick_context(repo_root, name, budget, hops, session).await {
+            match server
+                .quick_context(repo_root, name, budget, hops, session)
+                .await
+            {
                 Ok(text) => serde_json::json!({ "ok": true, "text": text }).to_string(),
                 Err(e) => err(&e),
             }


### PR DESCRIPTION
cargo fmt line-wrap missed in #445; no behavior change.