### PR TITLE
fix(release): match the MCP registry namespace casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to sem are documented in this file.
 
 ### Added
 
-- **sem is published to the official MCP registry** as `io.github.ataraxy-labs/sem`, so MCP clients that browse the registry (VS Code, Cursor, Claude Code, and others) can discover and install the server directly. The release workflow now publishes each release to the registry via `mcp-publisher` (authenticated with GitHub OIDC, no extra secrets), backed by a `server.json` manifest and an `mcpName` field in the npm wrapper.
+- **sem is published to the official MCP registry** as `io.github.Ataraxy-Labs/sem`, so MCP clients that browse the registry (VS Code, Cursor, Claude Code, and others) can discover and install the server directly. The release workflow now publishes each release to the registry via `mcp-publisher` (authenticated with GitHub OIDC, no extra secrets), backed by a `server.json` manifest and an `mcpName` field in the npm wrapper.
 
 ### Performance
 

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1576,7 +1576,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sem-cli"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "clap",
  "clap_complete_command",
@@ -1601,7 +1601,7 @@ dependencies = [
 
 [[package]]
 name = "sem-cloud-client"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "sem-core"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "git2",
  "rayon",
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "sem-mcp"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "git2",
  "ignore",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "sem-plugin"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "sem-core",
  "serde",

--- a/crates/sem-cli/Cargo.toml
+++ b/crates/sem-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-cli"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Semantic version control CLI. Shows what entities changed (functions, classes, methods) instead of lines."
@@ -15,9 +15,9 @@ name = "sem"
 path = "src/main.rs"
 
 [dependencies]
-sem-core = { path = "../sem-core", version = "0.16.1" }
-sem-mcp = { path = "../sem-mcp", version = "0.16.1" }
-sem-cloud-client = { path = "../sem-cloud-client", version = "0.16.1" }
+sem-core = { path = "../sem-core", version = "0.16.2" }
+sem-mcp = { path = "../sem-mcp", version = "0.16.2" }
+sem-cloud-client = { path = "../sem-cloud-client", version = "0.16.2" }
 serde = { version = "1", features = ["derive"] }
 clap = { version = "4", features = ["derive"] }
 colored = "2"

--- a/crates/sem-cloud-client/Cargo.toml
+++ b/crates/sem-cloud-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-cloud-client"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Shared client for sem-cloud: credentials, repo resolution, caching, and the metered graph API. Used by both the sem CLI and the sem MCP server."

--- a/crates/sem-core/Cargo.toml
+++ b/crates/sem-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-core"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Entity-level semantic diff engine. Extracts functions, classes, and methods from 28 languages via tree-sitter and diffs at the entity level."

--- a/crates/sem-mcp/Cargo.toml
+++ b/crates/sem-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-mcp"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server for entity-level semantic code intelligence. 6 tools: sem_entities, sem_diff, sem_blame, sem_impact, sem_log, sem_context."
@@ -15,8 +15,8 @@ name = "sem-mcp"
 path = "src/main.rs"
 
 [dependencies]
-sem-core = { path = "../sem-core", version = "0.16.1" }
-sem-cloud-client = { path = "../sem-cloud-client", version = "0.16.1" }
+sem-core = { path = "../sem-core", version = "0.16.2" }
+sem-cloud-client = { path = "../sem-cloud-client", version = "0.16.2" }
 git2 = "0.20"
 lru = "0.16"
 rmcp = { version = "1", features = ["server", "transport-io"] }

--- a/crates/sem-plugin/Cargo.toml
+++ b/crates/sem-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-plugin"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "WASI component plugin for semantic entity-level change detection"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ataraxy-labs/sem",
-  "mcpName": "io.github.ataraxy-labs/sem",
-  "version": "0.16.1",
+  "mcpName": "io.github.Ataraxy-Labs/sem",
+  "version": "0.16.2",
   "description": "npm wrapper for the sem CLI. Downloads the matching release binary and exposes the sem command in node_modules/.bin.",
   "license": "MIT OR Apache-2.0",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -1,19 +1,19 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.ataraxy-labs/sem",
+  "name": "io.github.Ataraxy-Labs/sem",
   "description": "Entity-level code intelligence: semantic diff, impact analysis, blame, and context for AI agents",
   "websiteUrl": "https://ataraxy-labs.com",
   "repository": {
     "url": "https://github.com/Ataraxy-Labs/sem",
     "source": "github"
   },
-  "version": "0.16.1",
+  "version": "0.16.2",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@ataraxy-labs/sem",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Follow-up to #446. The v0.16.1 `publish-mcp-registry` job failed with a 403: the registry's GitHub OIDC grant is case-sensitive (`io.github.Ataraxy-Labs/*`, the org's exact casing) while we published as `io.github.ataraxy-labs/sem`. The registry also compares the npm package's `mcpName` to the server name with exact equality, so the already-published 0.16.1 wrapper (lowercase `mcpName`) can't be reused.

- Renames the server to `io.github.Ataraxy-Labs/sem` in `server.json`, `package.json` (`mcpName`), and the CHANGELOG entry
- Bumps 0.16.1 → 0.16.2 (no code changes) so merging republishes npm with the corrected `mcpName` and reruns the registry publish

`server.json` re-validated against the registry schema (the name pattern allows uppercase).