### PR TITLE
feat(git): support reftable repos via CLI ref resolution (#451)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to sem are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Repos using git's **reftable** ref storage (`git init --ref-format=reftable`, git 2.45+) now fail with a clear, actionable error instead of libgit2's cryptic `unsupported extension name extensions.refstorage`. The message names the incompatibility and gives the safe workaround (`git refs migrate --ref-format=files`) plus the tracking issue. sem deliberately refuses rather than force-opening the repo: libgit2 cannot read reftable refs, so proceeding would produce silently wrong diffs. Real reftable support lands when libgit2 ships it. Thanks @bengry for the report and repro (#451).
+
 ### Added
 
 - **`sem orient --pack <tokens>`: turn-zero briefings from task text.** Feed orient a whole issue or task description and it returns a packed briefing — the top matching functions' bodies plus their immediate callers/callees — sized to the token budget. Ranking is body-term convergence: code-ish terms are extracted from the task text (flags, dotted names, identifiers) and entities are ranked by how many distinct terms their bodies contain, since issue vocabulary lives in bodies, not names. Built for prompt-time injection (the agent-side analog of the prompt-submit prefetch hook): the code an agent would spend its first turns foraging for arrives at turn zero. Honest calibration: on three ground-truth issues it put the exact target function first on two; issues that quote the tool's own output can still poison term extraction.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to sem are documented in this file.
 
 ### Fixed
 
-- Repos using git's **reftable** ref storage (`git init --ref-format=reftable`, git 2.45+) now fail with a clear, actionable error instead of libgit2's cryptic `unsupported extension name extensions.refstorage`. The message names the incompatibility and gives the safe workaround (`git refs migrate --ref-format=files`) plus the tracking issue. sem deliberately refuses rather than force-opening the repo: libgit2 cannot read reftable refs, so proceeding would produce silently wrong diffs. Real reftable support lands when libgit2 ships it. Thanks @bengry for the report and repro (#451).
+- **sem now works on repos using git's reftable ref storage** (`git init --ref-format=reftable`, git 2.45+). Previously every command died with libgit2's cryptic `unsupported extension name extensions.refstorage`. libgit2 can't read reftable refs, but the object database and index are unchanged, so GitBridge now tolerates the extension and routes just the ref resolutions (`HEAD`, refspecs, revwalk starts) through the git CLI while libgit2 keeps doing everything else by OID. Verified end to end on a real reftable repo: working/staged/commit/range diffs, blame, and per-file history all produce identical results to a files-backend repo. One residual gap: the cache freshness oracle's direct `git2::Repository::open` is `.ok()`-guarded, so on reftable repos it just skips the acceleration (correctness unaffected). Requires `git` on PATH for the ref lookups. Thanks @bengry for the report and clean repro (#451).
 
 ### Added
 

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1576,7 +1576,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sem-cli"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "clap",
  "clap_complete_command",
@@ -1601,7 +1601,7 @@ dependencies = [
 
 [[package]]
 name = "sem-cloud-client"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "sem-core"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "git2",
  "rayon",
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "sem-mcp"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "git2",
  "ignore",
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "sem-plugin"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "sem-core",
  "serde",

--- a/crates/sem-cli/Cargo.toml
+++ b/crates/sem-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-cli"
-version = "0.16.2"
+version = "0.17.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Semantic version control CLI. Shows what entities changed (functions, classes, methods) instead of lines."
@@ -15,9 +15,9 @@ name = "sem"
 path = "src/main.rs"
 
 [dependencies]
-sem-core = { path = "../sem-core", version = "0.16.2" }
-sem-mcp = { path = "../sem-mcp", version = "0.16.2" }
-sem-cloud-client = { path = "../sem-cloud-client", version = "0.16.2" }
+sem-core = { path = "../sem-core", version = "0.17.0" }
+sem-mcp = { path = "../sem-mcp", version = "0.17.0" }
+sem-cloud-client = { path = "../sem-cloud-client", version = "0.17.0" }
 serde = { version = "1", features = ["derive"] }
 clap = { version = "4", features = ["derive"] }
 colored = "2"

--- a/crates/sem-cloud-client/Cargo.toml
+++ b/crates/sem-cloud-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-cloud-client"
-version = "0.16.2"
+version = "0.17.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Shared client for sem-cloud: credentials, repo resolution, caching, and the metered graph API. Used by both the sem CLI and the sem MCP server."

--- a/crates/sem-core/Cargo.toml
+++ b/crates/sem-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-core"
-version = "0.16.2"
+version = "0.17.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Entity-level semantic diff engine. Extracts functions, classes, and methods from 28 languages via tree-sitter and diffs at the entity level."

--- a/crates/sem-core/src/git/bridge.rs
+++ b/crates/sem-core/src/git/bridge.rs
@@ -31,12 +31,17 @@ pub struct GitBridge {
     repo: Repository,
     repo_root: PathBuf,
     cwd: PathBuf,
+    /// True when the repo's refs live outside libgit2's reach (git's reftable
+    /// backend, `extensions.refstorage`). Objects, trees, and the index are
+    /// unaffected, so libgit2 keeps doing everything except ref resolution,
+    /// which routes through the git CLI instead.
+    cli_refs: bool,
 }
 
 impl GitBridge {
     pub fn open(path: &Path) -> Result<Self, GitError> {
         let cwd = normalize_open_path(path)?;
-        ensure_relative_worktrees_extension_supported()?;
+        ensure_git_extensions_supported()?;
         let repo = match Repository::discover(path) {
             Ok(repo) => repo,
             Err(error) if should_retry_with_command_line_safe_directory(&error, path) => {
@@ -51,11 +56,83 @@ impl GitBridge {
         };
         let repo_root = repo.workdir().ok_or(GitError::NotARepo)?;
         let repo_root = fs::canonicalize(repo_root)?;
+        let cli_refs = repo
+            .config()
+            .ok()
+            .and_then(|cfg| cfg.get_string("extensions.refstorage").ok())
+            .is_some_and(|value| !value.is_empty() && value != "files");
         Ok(Self {
             repo,
             repo_root,
             cwd,
+            cli_refs,
         })
+    }
+
+    /// Resolve a refspec to an object id via the git CLI. Used when refs live
+    /// in a backend libgit2 can't read (reftable): real git resolves the ref,
+    /// then everything downstream proceeds through libgit2's ODB by OID.
+    fn cli_rev_parse(&self, refspec: &str) -> Result<Oid, GitError> {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(&self.repo_root)
+            .args(["rev-parse", "--verify", "--quiet", "--end-of-options"])
+            .arg(format!("{refspec}^{{object}}"))
+            .output()?;
+        if !output.status.success() {
+            return Err(git_command_error(format!(
+                "cannot resolve '{refspec}' via git rev-parse"
+            )));
+        }
+        let text = String::from_utf8_lossy(&output.stdout);
+        Ok(Oid::from_str(text.trim())?)
+    }
+
+    /// revparse_single that works on reftable repos (CLI resolves the ref,
+    /// libgit2 loads the object).
+    fn resolve_object(&self, refspec: &str) -> Result<git2::Object<'_>, GitError> {
+        if self.cli_refs {
+            let oid = self.cli_rev_parse(refspec)?;
+            Ok(self.repo.find_object(oid, None)?)
+        } else {
+            Ok(self.repo.revparse_single(refspec)?)
+        }
+    }
+
+    /// HEAD's commit, reftable-safe.
+    fn head_commit(&self) -> Result<git2::Commit<'_>, GitError> {
+        if self.cli_refs {
+            let oid = self.cli_rev_parse("HEAD")?;
+            Ok(self.repo.find_commit(oid)?)
+        } else {
+            let head = self.repo.head()?;
+            let oid = head
+                .target()
+                .ok_or_else(|| git2::Error::from_str("HEAD has no target"))?;
+            Ok(self.repo.find_commit(oid)?)
+        }
+    }
+
+    /// Whether HEAD resolves to a commit (false in unborn repos), reftable-safe.
+    fn has_head(&self) -> bool {
+        if self.cli_refs {
+            self.cli_rev_parse("HEAD").is_ok()
+        } else {
+            self.repo.head().is_ok()
+        }
+    }
+
+    /// A revwalk starting at HEAD, reftable-safe (`push_head` needs libgit2 to
+    /// read the ref; pushing HEAD's OID walks the identical history).
+    fn revwalk_from_head(&self) -> Result<git2::Revwalk<'_>, GitError> {
+        let mut revwalk = self.repo.revwalk()?;
+        if self.cli_refs {
+            revwalk.push(self.head_commit()?.id())?;
+        } else {
+            revwalk.push_head()?;
+        }
+        revwalk.set_sorting(git2::Sort::TOPOLOGICAL | git2::Sort::TIME)?;
+        Ok(revwalk)
     }
 
     pub fn repo_root(&self) -> &Path {
@@ -72,8 +149,7 @@ impl GitBridge {
 
     /// Resolve a refspec to its full commit SHA, if valid.
     pub fn resolve_ref_sha(&self, refspec: &str) -> Option<String> {
-        self.repo
-            .revparse_single(refspec)
+        self.resolve_object(refspec)
             .ok()
             .and_then(|obj| obj.peel_to_commit().ok())
             .map(|c| c.id().to_string())
@@ -120,11 +196,7 @@ impl GitBridge {
     }
 
     pub fn get_head_sha(&self) -> Result<String, GitError> {
-        let head = self.repo.head()?;
-        let oid = head
-            .target()
-            .ok_or_else(|| git2::Error::from_str("HEAD has no target"))?;
-        Ok(oid.to_string())
+        Ok(self.head_commit()?.id().to_string())
     }
 
     /// Combined detect scope + get files in one call (fast path).
@@ -192,7 +264,7 @@ impl GitBridge {
         staged: bool,
         pathspecs: &[String],
     ) -> Result<Vec<FileChange>, GitError> {
-        let has_head = self.repo.head().is_ok();
+        let has_head = self.has_head();
         let mut command = Command::new("git");
         command
             .arg("-C")
@@ -252,15 +324,15 @@ impl GitBridge {
 
     /// Resolve the merge base between two refs
     pub fn resolve_merge_base(&self, ref1: &str, ref2: &str) -> Result<String, GitError> {
-        let obj1 = self.repo.revparse_single(ref1)?;
-        let obj2 = self.repo.revparse_single(ref2)?;
+        let obj1 = self.resolve_object(ref1)?;
+        let obj2 = self.resolve_object(ref2)?;
         let oid = self.repo.merge_base(obj1.id(), obj2.id())?;
         Ok(oid.to_string())
     }
 
     /// Check if a string resolves to a valid git revision
     pub fn is_valid_rev(&self, refspec: &str) -> bool {
-        self.repo.revparse_single(refspec).is_ok()
+        self.resolve_object(refspec).is_ok()
     }
 
     fn make_diff_opts(&self, pathspecs: &[String]) -> Result<DiffOptions, GitError> {
@@ -310,11 +382,8 @@ impl GitBridge {
             return self.changed_files_via_cli(true, pathspecs);
         }
 
-        let head_tree = match self.repo.head() {
-            Ok(head) => {
-                let commit = head.peel_to_commit()?;
-                Some(commit.tree()?)
-            }
+        let head_tree = match self.head_commit() {
+            Ok(commit) => Some(commit.tree()?),
             Err(_) => None, // No commits yet
         };
 
@@ -458,7 +527,7 @@ impl GitBridge {
 
     /// Number of parents of a commit (0 = root, >1 = merge).
     pub fn commit_parent_count(&self, sha: &str) -> Result<usize, GitError> {
-        let obj = self.repo.revparse_single(sha)?;
+        let obj = self.resolve_object(sha)?;
         Ok(obj.peel_to_commit()?.parent_count())
     }
 
@@ -467,7 +536,7 @@ impl GitBridge {
         sha: &str,
         pathspecs: &[String],
     ) -> Result<Vec<FileChange>, GitError> {
-        let obj = self.repo.revparse_single(sha)?;
+        let obj = self.resolve_object(sha)?;
         let commit = obj.peel_to_commit()?;
         let tree = commit.tree()?;
 
@@ -492,8 +561,8 @@ impl GitBridge {
         to: &str,
         pathspecs: &[String],
     ) -> Result<Vec<FileChange>, GitError> {
-        let from_obj = self.repo.revparse_single(from)?;
-        let to_obj = self.repo.revparse_single(to)?;
+        let from_obj = self.resolve_object(from)?;
+        let to_obj = self.resolve_object(to)?;
 
         let from_tree = from_obj.peel_to_commit()?.tree()?;
         let to_tree = to_obj.peel_to_commit()?.tree()?;
@@ -686,7 +755,7 @@ impl GitBridge {
     }
 
     fn resolve_tree(&self, refspec: &str) -> Result<git2::Tree<'_>, GitError> {
-        let obj = self.repo.revparse_single(refspec)?;
+        let obj = self.resolve_object(refspec)?;
         let commit = obj.peel_to_commit()?;
         Ok(commit.tree()?)
     }
@@ -773,9 +842,7 @@ impl GitBridge {
         file_path: &str,
         limit: usize,
     ) -> Result<Vec<CommitInfo>, GitError> {
-        let mut revwalk = self.repo.revwalk()?;
-        revwalk.push_head()?;
-        revwalk.set_sorting(git2::Sort::TOPOLOGICAL | git2::Sort::TIME)?;
+        let revwalk = self.revwalk_from_head()?;
 
         let mut commits = Vec::new();
         let path = Path::new(file_path);
@@ -842,9 +909,7 @@ impl GitBridge {
             Err(error) => return Err(error),
         }
 
-        let mut revwalk = self.repo.revwalk()?;
-        revwalk.push_head()?;
-        revwalk.set_sorting(git2::Sort::TOPOLOGICAL | git2::Sort::TIME)?;
+        let revwalk = self.revwalk_from_head()?;
 
         let mut results = Vec::new();
         let mut tracked_path = file_path.to_string();
@@ -1023,7 +1088,7 @@ impl GitBridge {
     /// Get all file paths changed in a single commit (vs its parent).
     /// Returns file paths from the new side of each delta.
     pub fn get_commit_changed_files(&self, sha: &str) -> Result<Vec<String>, GitError> {
-        let obj = self.repo.revparse_single(sha)?;
+        let obj = self.resolve_object(sha)?;
         let commit = obj.peel_to_commit()?;
         let tree = commit.tree()?;
         let parent_tree = if commit.parent_count() > 0 {
@@ -1206,15 +1271,21 @@ fn git_command_error(message: String) -> GitError {
     GitError::Git2(git2::Error::from_str(&message))
 }
 
-fn ensure_relative_worktrees_extension_supported() -> Result<(), GitError> {
+fn ensure_git_extensions_supported() -> Result<(), GitError> {
     static EXTENSIONS: OnceLock<Result<(), String>> = OnceLock::new();
 
     EXTENSIONS
         .get_or_init(|| {
-            // Git 2.48 introduced extensions.relativeWorktrees. libgit2 1.9.x
-            // can operate on these repositories, but rejects unknown extension
-            // names while opening the repo unless callers opt in first.
-            unsafe { git2::opts::set_extensions(&["relativeworktrees"]) }
+            // libgit2 rejects unknown extension names while opening a repo
+            // unless callers opt in first. set_extensions REPLACES the custom
+            // list, so every tolerated extension must be registered here, in
+            // one place:
+            // - relativeworktrees (git 2.48): libgit2 1.9.x operates on these
+            //   repos fine once the name is tolerated.
+            // - refstorage (git 2.45, reftable): libgit2 can't read reftable
+            //   refs, so GitBridge routes ref resolution through the git CLI
+            //   (see `cli_refs`); objects and the index work unchanged.
+            unsafe { git2::opts::set_extensions(&["relativeworktrees", "refstorage"]) }
                 .map_err(|error| error.message().to_string())
         })
         .as_ref()
@@ -1498,12 +1569,10 @@ mod tests {
     }
 
     #[test]
-    fn open_reports_reftable_repos_with_actionable_error() {
-        // Regression for #451: repos using git's reftable ref storage
-        // (git 2.45+, `git init --ref-format=reftable`) carry
-        // extensions.refstorage, which libgit2 rejects with a cryptic
-        // "unsupported extension name" error. sem should refuse clearly,
-        // with the workaround in the message.
+    fn open_tolerates_refstorage_extension() {
+        // Regression for #451: the extensions.refstorage key made libgit2
+        // refuse to open the repo outright. The extension is tolerated now,
+        // and ref resolution routes through the git CLI (`cli_refs`).
         let temp = TempDir::new().unwrap();
         let repo = Repository::init(temp.path()).unwrap();
         drop(repo);
@@ -1518,17 +1587,81 @@ mod tests {
         )
         .unwrap();
 
-        let error = match GitBridge::open(temp.path()) {
-            Ok(_) => panic!("open should refuse a reftable repo"),
-            Err(error) => error,
+        let bridge = GitBridge::open(temp.path()).expect("open should tolerate refstorage");
+        assert!(bridge.cli_refs);
+    }
+
+    /// End-to-end on a REAL reftable repo. Skips (with a note) when the
+    /// installed git predates `git init --ref-format=reftable` (2.45).
+    #[test]
+    fn reftable_repo_diff_blame_and_head_work_via_cli_refs() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        let git = |args: &[&str]| {
+            Command::new("git")
+                .arg("-C")
+                .arg(root)
+                .args(args)
+                .output()
+                .unwrap()
         };
-        assert!(matches!(error, GitError::UnsupportedRefStorage));
-        let message = error.to_string();
-        assert!(message.contains("reftable"), "message: {message}");
-        assert!(
-            message.contains("git refs migrate --ref-format=files"),
-            "message should carry the workaround: {message}"
-        );
+
+        let init = git(&["init", "-q", "--ref-format=reftable"]);
+        if !init.status.success() {
+            eprintln!("git lacks reftable support; skipping");
+            return;
+        }
+        git(&["config", "user.email", "t@example.com"]);
+        git(&["config", "user.name", "Test"]);
+        fs::write(root.join("file.py"), "def hello():\n    return 1\n").unwrap();
+        git(&["add", "file.py"]);
+        git(&["commit", "-q", "-m", "init"]);
+        fs::write(root.join("file.py"), "def hello():\n    return 2\n").unwrap();
+
+        let bridge = GitBridge::open(root).expect("open real reftable repo");
+        assert!(bridge.cli_refs);
+
+        // HEAD resolution matches real git.
+        let cli_head = String::from_utf8_lossy(&git(&["rev-parse", "HEAD"]).stdout)
+            .trim()
+            .to_string();
+        assert_eq!(bridge.get_head_sha().unwrap(), cli_head);
+        assert!(bridge.is_valid_rev("HEAD"));
+        assert_eq!(bridge.resolve_ref_sha("HEAD").as_deref(), Some(cli_head.as_str()));
+
+        // Working-tree diff sees the modification with correct before/after.
+        let (_, files) = bridge.detect_and_get_files(&[]).unwrap();
+        assert_eq!(files.len(), 1, "files: {files:?}");
+        assert_eq!(files[0].file_path, "file.py");
+        assert!(files[0]
+            .before_content
+            .as_deref()
+            .unwrap_or("")
+            .contains("return 1"));
+        assert!(files[0]
+            .after_content
+            .as_deref()
+            .unwrap_or("")
+            .contains("return 2"));
+
+        // Commit and range diffs resolve refs via the CLI too.
+        git(&["add", "file.py"]);
+        git(&["commit", "-q", "-m", "second"]);
+        let range = bridge
+            .get_changed_files(
+                &DiffScope::Range {
+                    from: "HEAD~1".to_string(),
+                    to: "HEAD".to_string(),
+                },
+                &[],
+            )
+            .unwrap();
+        assert_eq!(range.len(), 1);
+        assert_eq!(range[0].file_path, "file.py");
+
+        // History walk starts from CLI-resolved HEAD.
+        let commits = bridge.get_file_commits("file.py", 0).unwrap();
+        assert_eq!(commits.len(), 2, "commits: {commits:?}");
     }
 
     #[test]

--- a/crates/sem-core/src/git/bridge.rs
+++ b/crates/sem-core/src/git/bridge.rs
@@ -14,6 +14,13 @@ use super::types::{CommitInfo, DiffScope, FileChange, FileCommitInfo, FileStatus
 pub enum GitError {
     #[error("not a git repository")]
     NotARepo,
+    #[error(
+        "this repository uses git's reftable ref storage (extensions.refstorage), which sem's \
+         git backend (libgit2) can't read yet. Workaround: convert the repo's refs back with \
+         `git refs migrate --ref-format=files` (safe and reversible). Tracking: \
+         https://github.com/Ataraxy-Labs/sem/issues/451"
+    )]
+    UnsupportedRefStorage,
     #[error("git error: {0}")]
     Git2(#[from] git2::Error),
     #[error("io error: {0}")]
@@ -1218,6 +1225,13 @@ fn ensure_relative_worktrees_extension_supported() -> Result<(), GitError> {
 fn map_git_error(error: git2::Error) -> GitError {
     if error.code() == ErrorCode::NotFound {
         GitError::NotARepo
+    } else if error.message().contains("extensions.refstorage") {
+        // The repo uses git's reftable ref-storage backend (git 2.45+,
+        // `git init --ref-format=reftable`). libgit2 cannot read reftable refs
+        // at all, so registering the extension would open the repo and then
+        // silently misread it; a clear refusal is the only safe answer until
+        // libgit2 ships reftable support.
+        GitError::UnsupportedRefStorage
     } else {
         GitError::Git2(error)
     }
@@ -1481,6 +1495,40 @@ mod tests {
 
         let bridge = GitBridge::open(temp.path()).unwrap();
         assert_eq!(bridge.repo_root(), fs::canonicalize(temp.path()).unwrap());
+    }
+
+    #[test]
+    fn open_reports_reftable_repos_with_actionable_error() {
+        // Regression for #451: repos using git's reftable ref storage
+        // (git 2.45+, `git init --ref-format=reftable`) carry
+        // extensions.refstorage, which libgit2 rejects with a cryptic
+        // "unsupported extension name" error. sem should refuse clearly,
+        // with the workaround in the message.
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init(temp.path()).unwrap();
+        drop(repo);
+
+        let config = temp.path().join(".git/config");
+        let contents = fs::read_to_string(&config).unwrap();
+        assert!(contents.contains("repositoryformatversion = 0"));
+        fs::write(
+            &config,
+            contents.replace("repositoryformatversion = 0", "repositoryformatversion = 1")
+                + "\n[extensions]\n\trefstorage = reftable\n",
+        )
+        .unwrap();
+
+        let error = match GitBridge::open(temp.path()) {
+            Ok(_) => panic!("open should refuse a reftable repo"),
+            Err(error) => error,
+        };
+        assert!(matches!(error, GitError::UnsupportedRefStorage));
+        let message = error.to_string();
+        assert!(message.contains("reftable"), "message: {message}");
+        assert!(
+            message.contains("git refs migrate --ref-format=files"),
+            "message should carry the workaround: {message}"
+        );
     }
 
     #[test]

--- a/crates/sem-mcp/Cargo.toml
+++ b/crates/sem-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-mcp"
-version = "0.16.2"
+version = "0.17.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server for entity-level semantic code intelligence. 6 tools: sem_entities, sem_diff, sem_blame, sem_impact, sem_log, sem_context."
@@ -15,8 +15,8 @@ name = "sem-mcp"
 path = "src/main.rs"
 
 [dependencies]
-sem-core = { path = "../sem-core", version = "0.16.2" }
-sem-cloud-client = { path = "../sem-cloud-client", version = "0.16.2" }
+sem-core = { path = "../sem-core", version = "0.17.0" }
+sem-cloud-client = { path = "../sem-cloud-client", version = "0.17.0" }
 git2 = "0.20"
 lru = "0.16"
 rmcp = { version = "1", features = ["server", "transport-io"] }

--- a/crates/sem-plugin/Cargo.toml
+++ b/crates/sem-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-plugin"
-version = "0.16.2"
+version = "0.17.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "WASI component plugin for semantic entity-level change detection"


### PR DESCRIPTION
Fixes #451 , and goes further than the first commit: sem now **works** on reftable repos instead of erroring clearly.

## Approach
libgit2 can't read reftable refs, but reftable changes nothing else , the object DB and index are standard. So:
- tolerate `extensions.refstorage` (registered alongside `relativeworktrees`, one place);
- detect it per-repo (`cli_refs` flag on GitBridge);
- route **only ref resolution** through the git CLI (`git rev-parse --verify`), via one `cli_rev_parse` helper and four thin wrappers (`resolve_object`, `head_commit`, `has_head`, `revwalk_from_head`) swapped into the 12 ref-touching call sites;
- everything downstream (trees, blobs, diffs, revwalks) stays libgit2, addressed by OID.

Same pattern as the existing sparse-checkout CLI fallback.

## Probed before building
With the extension registered, libgit2 empirically: opens the repo ✅, reads objects/trees/blobs by OID ✅, walks revs from a pushed OID ✅, and **fails loudly** (InvalidSpec) on every ref-touching call ✅ , so a missed path produces an error, never a silently wrong answer.

## Verified
- New end-to-end test on a **real** reftable repo (git 2.55): HEAD sha identical to `git rev-parse`, working diff with correct before/after contents, `HEAD~1..HEAD` range diff, per-file history walk. Skips gracefully when git predates reftable (2.45).
- `sem diff` and `sem blame` verified via the release binary on a real reftable repo.
- sem-core: 412 passed, 0 failed.

## Residual gap (documented)
The cache freshness oracle's direct `git2::Repository::open` is `.ok()`-guarded , on reftable repos it skips the acceleration; correctness unaffected. Ref lookups need `git` on PATH (already required by blame/log paths).

Thanks @bengry for the report and clean repro.