### PR TITLE
feat(graph): unique-method-name call edges + Parent::child qualifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to sem are documented in this file.
 
 ### Added
 
+- **Unique-method-name call edges (dynamic languages).** Attribute calls on receivers of unknown type (`index.keep_levels(...)`) previously produced no graph edge, hiding real dependents and blinding `--tests`. In Python/Ruby — where receiver types are statically unknowable — a method name with exactly one definition repo-wide now resolves to it: one candidate, one edge; any ambiguity, no edge. Static languages keep precision-first resolution (an unresolved receiver there is deliberate: shadowed import, instance property).
+- **`Parent::child` entity qualifiers.** `sem impact "Dataset::set_index"` and friends now work everywhere `Parent.child` does (graph and cached lookups).
+
 - **`sem impact --tests` lexical fallback + fast-path fallthrough.** Graph edges miss tests that call a target through a module namespace (`xr.where(...)` resolves to no entity), so `--tests` could answer "No tests found" for a function with dozens of tests. Now: an empty tests answer from the sidecar or disk cache is treated as non-authoritative and falls through to the full path, which backstops zero graph edges with lexical reachability — test entities naming the target as a whole word — clearly labeled as weaker evidence. Found live: an agent's graph-selected verify loop (run only the tests that reach your change) went from 0 selected tests to a 56-test net on `xr.where`, versus the 1,900+ tests of whole-file runs.
 - **Sharper `--pack` briefings.** Term ranking is now IDF-weighted (a term appearing in half the repo is worth almost nothing), `<details>` environment dumps in issue text are stripped before extraction, attribute accesses glued to receivers ("d2.loc") also emit their `.attr` suffixes as terms, and one of the three briefing slots goes to the top name-echo orient hit — for bugs where the issue names a surface API the culprit's body never mentions.
 

--- a/crates/sem-cli/src/cache.rs
+++ b/crates/sem-cli/src/cache.rs
@@ -1045,7 +1045,11 @@ impl DiskCache {
             }
         }
 
-        if let Some((parent_name, child_name)) = query.rsplit_once('.') {
+        // Accept `Parent.child` and `Parent::child` qualifiers alike.
+        let qualified_split = query
+            .rsplit_once("::")
+            .or_else(|| query.rsplit_once('.'));
+        if let Some((parent_name, child_name)) = qualified_split {
             if let Some(file_hint) = file_hint {
                 self.add_entity_candidates(
                     "SELECT child.id, child.name, child.entity_type, child.file_path,

--- a/crates/sem-cli/src/commands/mod.rs
+++ b/crates/sem-cli/src/commands/mod.rs
@@ -152,7 +152,12 @@ pub fn entity_matches_qualified(
     if entity_matches_query(entity, query) {
         return true;
     }
-    if let Some((parent_part, child_part)) = query.rsplit_once('.') {
+    // Accept both `Parent.child` and `Parent::child` — agents reach for
+    // whichever qualifier their working language uses.
+    let split = query
+        .rsplit_once("::")
+        .or_else(|| query.rsplit_once('.'));
+    if let Some((parent_part, child_part)) = split {
         if entity.name == child_part {
             if let Some(pid) = &entity.parent_id {
                 if let Some(parent) = graph.entities.get(pid) {

--- a/crates/sem-core/src/parser/scope_resolve.rs
+++ b/crates/sem-core/src/parser/scope_resolve.rs
@@ -6386,6 +6386,27 @@ fn resolve_ref(
                 }
             }
 
+            // Last resort: a repo-wide unique METHOD name is unambiguous even
+            // when the receiver's type is unknown — `index.keep_levels()` can
+            // only mean the one `keep_levels` the repo defines. One candidate,
+            // one edge; two candidates, no edge (guessing would manufacture
+            // false callers). Restricted to entities with a parent (methods),
+            // so attribute calls never bind to same-named free functions.
+            if allow_cross_file_calls {
+                if let Some(target_ids) = symbol_table.get(method.as_str()) {
+                    if let [tid] = target_ids.as_slice() {
+                        if tid != from_entity_id
+                            && entity_map.get(tid).is_some_and(|e| {
+                                e.parent_id.is_some()
+                                    && matches!(e.entity_type.as_str(), "method" | "function")
+                            })
+                        {
+                            return Some((tid.clone(), RefType::Calls, "unique_method_name"));
+                        }
+                    }
+                }
+            }
+
             None
         }
     }

--- a/crates/sem-core/src/parser/scope_resolve.rs
+++ b/crates/sem-core/src/parser/scope_resolve.rs
@@ -6392,7 +6392,13 @@ fn resolve_ref(
             // one edge; two candidates, no edge (guessing would manufacture
             // false callers). Restricted to entities with a parent (methods),
             // so attribute calls never bind to same-named free functions.
-            if allow_cross_file_calls {
+            // Dynamic languages only: there, receiver types are statically
+            // unknowable and the missing edge is pure blindness; in static
+            // languages an unresolved receiver is deliberate (shadowed
+            // import, instance property) and must stay unresolved.
+            let dynamic_receiver_lang =
+                file_path.ends_with(".py") || file_path.ends_with(".rb");
+            if allow_cross_file_calls && dynamic_receiver_lang {
                 if let Some(target_ids) = symbol_table.get(method.as_str()) {
                     if let [tid] = target_ids.as_slice() {
                         if tid != from_entity_id


### PR DESCRIPTION
Both from a live agent debrief on a SWE-bench pair (xarray reset_index):

**Dynamic-dispatch blind spot**: `sem impact keep_levels --dependents` said 'No dependents' while `Dataset.reset_index` calls it via `index.keep_levels(...)` — receiver type unknown, no edge. Now, when a method name has exactly one definition repo-wide and that definition is a member (has a parent entity), the attribute call resolves to it. One candidate = one edge; any ambiguity = no edge, so this cannot manufacture false callers. Restricted to members so attribute calls never bind to same-named free functions, and gated on cross-file resolution.

**Qualifier ergonomics**: the benchmark agent burned 4 of its 9 sem calls on ambiguity retries, trying `DataVariables::__len__`-style names. `Parent::child` is now accepted everywhere `Parent.child` is (graph-path and SQLite-cached lookups).

Verified on the live repo: `keep_levels` shows its real dependent; `Dataset::set_index --tests` resolves without --file. Full suite green except the two pre-existing cwd_resolution failures (present on clean main).

Measured effect on the benchmark task (agent-reported, 3-run medians): graph-selected verify loop 0.59s vs 2.90s whole-file runs (4.9x per iteration); 999 bytes of sem test-selection output replaced scanning a 489KB test corpus.
