### PR TITLE
release: v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to sem are documented in this file.
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-07-03
+
 ### Fixed
 
 - **sem now works on repos using git's reftable ref storage** (`git init --ref-format=reftable`, git 2.45+). Previously every command died with libgit2's cryptic `unsupported extension name extensions.refstorage`. libgit2 can't read reftable refs, but the object database and index are unchanged, so GitBridge now tolerates the extension and routes just the ref resolutions (`HEAD`, refspecs, revwalk starts) through the git CLI while libgit2 keeps doing everything else by OID. Verified end to end on a real reftable repo: working/staged/commit/range diffs, blame, and per-file history all produce identical results to a files-backend repo. One residual gap: the cache freshness oracle's direct `git2::Repository::open` is `.ok()`-guarded, so on reftable repos it just skips the acceleration (correctness unaffected). Requires `git` on PATH for the ref lookups. Thanks @bengry for the report and clean repro (#451).

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1576,7 +1576,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sem-cli"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "clap",
  "clap_complete_command",
@@ -1601,7 +1601,7 @@ dependencies = [
 
 [[package]]
 name = "sem-cloud-client"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "sem-core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "git2",
  "rayon",
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "sem-mcp"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "git2",
  "ignore",
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "sem-plugin"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "sem-core",
  "serde",

--- a/crates/sem-cli/Cargo.toml
+++ b/crates/sem-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-cli"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Semantic version control CLI. Shows what entities changed (functions, classes, methods) instead of lines."
@@ -15,9 +15,9 @@ name = "sem"
 path = "src/main.rs"
 
 [dependencies]
-sem-core = { path = "../sem-core", version = "0.17.0" }
-sem-mcp = { path = "../sem-mcp", version = "0.17.0" }
-sem-cloud-client = { path = "../sem-cloud-client", version = "0.17.0" }
+sem-core = { path = "../sem-core", version = "0.18.0" }
+sem-mcp = { path = "../sem-mcp", version = "0.18.0" }
+sem-cloud-client = { path = "../sem-cloud-client", version = "0.18.0" }
 serde = { version = "1", features = ["derive"] }
 clap = { version = "4", features = ["derive"] }
 colored = "2"

--- a/crates/sem-cloud-client/Cargo.toml
+++ b/crates/sem-cloud-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-cloud-client"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Shared client for sem-cloud: credentials, repo resolution, caching, and the metered graph API. Used by both the sem CLI and the sem MCP server."

--- a/crates/sem-core/Cargo.toml
+++ b/crates/sem-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-core"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Entity-level semantic diff engine. Extracts functions, classes, and methods from 28 languages via tree-sitter and diffs at the entity level."

--- a/crates/sem-mcp/Cargo.toml
+++ b/crates/sem-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-mcp"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server for entity-level semantic code intelligence. 6 tools: sem_entities, sem_diff, sem_blame, sem_impact, sem_log, sem_context."
@@ -15,8 +15,8 @@ name = "sem-mcp"
 path = "src/main.rs"
 
 [dependencies]
-sem-core = { path = "../sem-core", version = "0.17.0" }
-sem-cloud-client = { path = "../sem-cloud-client", version = "0.17.0" }
+sem-core = { path = "../sem-core", version = "0.18.0" }
+sem-cloud-client = { path = "../sem-cloud-client", version = "0.18.0" }
 git2 = "0.20"
 lru = "0.16"
 rmcp = { version = "1", features = ["server", "transport-io"] }

--- a/crates/sem-plugin/Cargo.toml
+++ b/crates/sem-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-plugin"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "WASI component plugin for semantic entity-level change detection"


### PR DESCRIPTION
Version bump + changelog heading for v0.18.0. Ships the verify-phase stack measured in today's agent benchmarks: impact --tests lexical fallback and fast-path fallthrough, IDF-weighted pack briefings, unique-method-name call edges (dynamic languages), Parent::child qualifiers, plus the earlier unreleased items accumulated under [Unreleased].