### PR TITLE
perf(hash): zero-alloc structural hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to sem are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Structural hashing no longer allocates a Vec per AST node.** The two structural-hash walkers (`hash_structural_tokens` and its name-excluding variant) collected every internal node's children into a fresh heap `Vec` (plus a fresh tree-sitter cursor) just to push them in reverse, despite a comment claiming zero allocations. They now reuse a single cursor and push children in place, reversing the appended slice, which is byte-for-byte identical output. On a cold graph build this removes roughly 300k allocations (structural hashing alone dropped from about 319k allocations to 13.5k, measured with dhat on deno). Peak RSS is unchanged and wall time is within noise under mimalloc, but the churn reduction helps memory-constrained and non-mimalloc builds. Hashes are verified identical across 3,337 entities, so rename detection and existing caches are unaffected.
+
 ### Added
 
 - **`sem setup` now makes sem a Claude Code session default (macOS/Linux).** Beyond the `git diff` alias, it installs two session hooks into `~/.claude/settings.json`: a warm resident graph (SessionStart runs `sem mcp --resident` detached, so structural queries answer in single-digit ms instead of rebuilding) and prompt-time context injection (`sem hook prompt-submit`). The JSON edit is idempotent, backs up `settings.json` first, refuses to touch a file it can't parse, and preserves every existing user hook and key; `sem unsetup` removes exactly the sem hooks and cleans up empty arrays. Local warmth is free and login-free — cloud (`sem login`) is repositioned in the README as the scale/team/CI upgrade, not the way to get warmth.

--- a/crates/sem-core/src/utils/hash.rs
+++ b/crates/sem-core/src/utils/hash.rs
@@ -45,6 +45,10 @@ pub fn structural_hash_excluding_range(
 /// Zero allocations: hashes directly from source byte slices.
 fn hash_structural_tokens(root: Node, source: &[u8], hasher: &mut Xxh3) {
     let mut worklist = vec![root];
+    // One cursor reused for the whole traversal instead of `node.walk()` per
+    // internal node, and children are pushed in place instead of collected into
+    // a fresh Vec per node — the two per-node allocations the old code paid.
+    let mut cursor = root.walk();
     while let Some(node) = worklist.pop() {
         let kind = node.kind();
 
@@ -70,11 +74,10 @@ fn hash_structural_tokens(root: Node, source: &[u8], hasher: &mut Xxh3) {
             // e.g. `x = foo(bar)` vs `foo(bar) = x` have same leaves but different structure.
             hasher.write(kind.as_bytes());
             hasher.write(b":");
-            let mut cursor = node.walk();
-            let children: Vec<_> = node.children(&mut cursor).collect();
-            for child in children.into_iter().rev() {
-                worklist.push(child);
-            }
+            // Push children in source order, then reverse just the appended
+            // slice so `pop()` yields them in source order — identical traversal
+            // (and identical hash) to the previous `children.rev()` push.
+            push_children_reversed(&mut cursor, node, &mut worklist);
         }
     }
 }
@@ -89,6 +92,7 @@ fn hash_structural_tokens_excluding(
     exclude_end: usize,
 ) {
     let mut worklist = vec![root];
+    let mut cursor = root.walk();
     while let Some(node) = worklist.pop() {
         let kind = node.kind();
 
@@ -114,13 +118,33 @@ fn hash_structural_tokens_excluding(
         } else {
             hasher.write(kind.as_bytes());
             hasher.write(b":");
-            let mut cursor = node.walk();
-            let children: Vec<_> = node.children(&mut cursor).collect();
-            for child in children.into_iter().rev() {
-                worklist.push(child);
+            push_children_reversed(&mut cursor, node, &mut worklist);
+        }
+    }
+}
+
+/// Push `node`'s children onto `worklist` such that a subsequent `pop()`
+/// sequence yields them in source (first-to-last) order, without allocating a
+/// per-node Vec. Children are appended in source order, then the appended tail
+/// is reversed in place. Equivalent to the previous
+/// `node.children(&mut cursor).collect::<Vec<_>>().into_iter().rev()`.
+#[inline]
+fn push_children_reversed<'a>(
+    cursor: &mut tree_sitter::TreeCursor<'a>,
+    node: Node<'a>,
+    worklist: &mut Vec<Node<'a>>,
+) {
+    let base = worklist.len();
+    cursor.reset(node);
+    if cursor.goto_first_child() {
+        loop {
+            worklist.push(cursor.node());
+            if !cursor.goto_next_sibling() {
+                break;
             }
         }
     }
+    worklist[base..].reverse();
 }
 
 /// Trim leading/trailing ASCII whitespace from a byte slice without allocating.


### PR DESCRIPTION
Surfaced while profiling #322 with dhat.

`hash_structural_tokens` and its name-excluding variant collected every internal AST node's children into a fresh `Vec` (plus a fresh tree-sitter cursor) just to push them in reverse, despite a comment claiming zero allocations. They now reuse a single cursor and push children in place, reversing the appended slice.

**Correctness (the non-negotiable):** output is byte-for-byte identical, so rename detection and every existing user cache are unaffected. Verified by capturing structural hashes on a real repo before and after: **3,337 entities, zero differences.** 412 core tests pass, fmt + clippy clean.

**Impact:** removes ~300k allocations per cold graph build (dhat on deno: structural hashing dropped from ~319k allocations to 13.5k). Peak RSS is unchanged and wall time is within noise under mimalloc, so this does **not** close #322 (peak RSS is genuinely spread across many sites). The win is allocator churn, which matters on memory-constrained and non-mimalloc builds, and it fixes two functions whose 'zero allocations' comment was false.