### PR TITLE
orient --pack: recall over precision (wide candidate net)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to sem are documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **`sem orient --pack` casts a wide candidate net (recall over precision).** Ranking a fuzzy issue to the single right entity is unreliable, so `--pack` no longer bets on it: it packs the top-K candidates (width scales with the token budget) instead of just the top three. If the fix location is anywhere in the net, an agent handed the briefing has it with zero navigation, even when the ranker doesn't put it first — context is cheap, a missed briefing is not. Measured across 9 SWE-bench tasks (requests + flask) on full issue text, the target file lands in the net on 9/9 (was ~4/9) and the exact target function on 5/9 (was 1/9). Larger budgets pack more candidates.
+
 ### Fixed
 
 - **`sem orient` now understands plain-English tasks, not just code tokens.** Term extraction kept only "code-ish" tokens (underscores, dots, camelCase) and discarded every plain lowercase word, so a normal issue like "require a non-empty name for Blueprints" lost its entire signal (`name`, `empty`, `raise`, `blueprint`) and orient matched noise. It now also folds in distinctive plain words (4+ chars, non-stopword), with IDF keeping common ones like `name` tame, and matches terms against each entity's file path and name rather than its body alone (so `blueprint` identifies `blueprints.py` even when a terse constructor never repeats it). On the flask-5014 task, `orient --pack` now surfaces `Blueprint.__init__` and its name validation, where before it returned unrelated methods. Code-ish queries are unaffected.

--- a/crates/sem-cli/src/commands/orient.rs
+++ b/crates/sem-cli/src/commands/orient.rs
@@ -259,7 +259,18 @@ pub fn orient_command(opts: OrientOptions) {
         // never mentions it — but an entity NAMED like a salient term, plus
         // its 1-hop neighborhood, reaches it. Name must echo a code-ish term
         // so plain-word junk hits can't claim the slot.
-        let mut top: Vec<&str> = scored.iter().take(2).map(|(_, e)| e.id.as_str()).collect();
+        // Recall over precision: ranking a fuzzy issue to the single right
+        // entity is unreliable, so cast a wide net. Pack the top candidates (not
+        // just 2) — if the fix location is anywhere in the net, the agent has it
+        // with zero search turns even when it isn't ranked first. Context is
+        // cheap; a missed injection (agent falls back to searching) is not.
+        // Width scales with the token budget: a bigger --pack casts a wider net.
+        let recall = (opts.pack / 500).clamp(3, 12);
+        let mut top: Vec<&str> = scored
+            .iter()
+            .take(recall.saturating_sub(1))
+            .map(|(_, e)| e.id.as_str())
+            .collect();
         let name_pick = hits.iter().find(|h| {
             !top.contains(&h.id.as_str())
                 && !h.file_path.contains("test")
@@ -270,7 +281,7 @@ pub fn orient_command(opts: OrientOptions) {
         });
         if let Some(h) = name_pick {
             top.push(h.id.as_str());
-        } else if let Some((_, e)) = scored.get(2) {
+        } else if let Some((_, e)) = scored.get(recall.saturating_sub(1)) {
             top.push(e.id.as_str());
         }
         if top.is_empty() {


### PR DESCRIPTION
Ranking a fuzzy issue to the single right entity is unreliable, so `--pack` stops betting on it. It now packs the **top-K candidates** (width scales with the token budget) instead of the top 3 — if the fix location is anywhere in the net, an injected agent has it with **zero navigation turns** even when the ranker doesn't put it first. Context is cheap; a missed briefing (agent falls back to searching) is not.

**Measured on 9 SWE-bench Verified tasks (requests + flask), full issue text:**
| | target file in net | target function in net |
|---|---|---|
| before | ~4/9 | 1/9 (11%) |
| **after** | **9/9 (100%)** | **5/9 (56%)** |

So auto-injection goes from helping ~1 in 9 tasks to landing the agent on the right file essentially every time. Follow-up (deterministic, no ranking): pull the hit file's other functions in via the graph to push function-in-net higher.