### PR TITLE
entities --text: fuse find + comprehend (call-graph neighbourhood per hit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to sem are documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **Entity-addressed text search now carries each hit's call-graph neighbourhood — find and comprehend in one call.** `sem entities --text` (and the MCP `sem_entities text=`) already returned the enclosing entity for each substring match instead of a bare `file:line`. Now each hit also shows what that entity calls and who calls it, pulled from the graph (deduped, capped with a `+N` overflow so hub functions stay compact). This is the deterministic answer to "beat grep+read": grep gives you a line and leaves you to chase callers across files by hand; this gives you the location *and* the cross-file relationships in a single call. The lookup is O(1) per hit regardless of repo size, so the advantage over grep+read grows on large codebases — you narrow by relationships, not by opening dozens of files. No ranking, no fuzziness; the same exact matches, now comprehension-ready.
+
 ## [0.19.0] - 2026-07-05
 
 ### Removed

--- a/crates/sem-cli/src/commands/entities.rs
+++ b/crates/sem-cli/src/commands/entities.rs
@@ -419,11 +419,16 @@ fn text_search(opts: &EntitiesOptions, needle: &str) {
         &ext_filter,
         opts.no_default_excludes,
     );
-    let (_, all_entities) =
+    let (graph, all_entities) =
         super::graph::get_or_build_graph(&root, &file_paths, &registry, false, source_scope);
     print!(
         "{}",
-        sem_mcp::server::SemServer::render_text_hits(&all_entities, needle, TEXT_SEARCH_LIMIT)
+        sem_mcp::server::SemServer::render_text_hits(
+            &graph,
+            &all_entities,
+            needle,
+            TEXT_SEARCH_LIMIT
+        )
     );
 }
 

--- a/crates/sem-cli/src/main.rs
+++ b/crates/sem-cli/src/main.rs
@@ -267,9 +267,10 @@ enum Commands {
         #[arg(long = "except", value_name = "KIND", conflicts_with = "only_kinds")]
         except_kinds: Vec<String>,
 
-        /// Search entity bodies for an exact substring instead of listing:
-        /// hits come back entity-addressed (file, innermost entity, line,
-        /// matched text). Use instead of grep for strings in code.
+        /// Search entity bodies for an exact substring instead of listing.
+        /// Each hit is its enclosing entity WITH its call-graph neighbourhood
+        /// (what it calls, who calls it) — find and comprehend in one call.
+        /// Use instead of grep for strings in code, especially on large repos.
         #[arg(long, value_name = "SUBSTRING")]
         text: Option<String>,
     },

--- a/crates/sem-mcp/src/server.rs
+++ b/crates/sem-mcp/src/server.rs
@@ -842,8 +842,8 @@ impl SemServer {
         needle: &str,
         limit: usize,
     ) -> Result<String, String> {
-        let (_, all_entities) = self.live_graph(repo_root).await;
-        Ok(Self::render_text_hits(&all_entities, needle, limit))
+        let (graph, all_entities) = self.live_graph(repo_root).await;
+        Ok(Self::render_text_hits(&graph, &all_entities, needle, limit))
     }
 
     pub async fn quick_context(
@@ -1014,10 +1014,22 @@ impl SemServer {
     /// Entity-addressed text search over in-memory entity bodies. For each
     /// matching line, the innermost (smallest-span) enclosing entity wins, so
     /// a hit inside a method reports the method, not its class.
-    pub fn render_text_hits(all_entities: &[SemanticEntity], needle: &str, limit: usize) -> String {
+    /// Entity-addressed text search that also carries each hit's graph
+    /// neighbourhood — who calls it, what it calls. This fuses *find* and
+    /// *comprehend* into one call: grep gives you `file:line`, this gives you
+    /// the enclosing entity plus the cross-file relationships that would
+    /// otherwise take a read-chain to reconstruct. The lookup is O(1) per hit
+    /// regardless of repo size, so the advantage over grep+read grows on large
+    /// codebases (narrow by relationships, not by reading dozens of files).
+    pub fn render_text_hits(
+        graph: &EntityGraph,
+        all_entities: &[SemanticEntity],
+        needle: &str,
+        limit: usize,
+    ) -> String {
         use std::collections::HashMap;
-        // (file, absolute line) -> (span, entity name, entity type, line text)
-        let mut best: HashMap<(&str, usize), (usize, &str, &str, &str)> = HashMap::new();
+        // (file, absolute line) -> (span, entity, line text)
+        let mut best: HashMap<(&str, usize), (usize, &SemanticEntity, &str)> = HashMap::new();
         for e in all_entities {
             if !e.content.contains(needle) {
                 continue;
@@ -1032,7 +1044,7 @@ impl SemServer {
                 match best.get(&key) {
                     Some((s, ..)) if *s <= span => {}
                     _ => {
-                        best.insert(key, (span, e.name.as_str(), e.entity_type.as_str(), line));
+                        best.insert(key, (span, e, line));
                     }
                 }
             }
@@ -1043,7 +1055,8 @@ impl SemServer {
                  comments between entities and non-code files are not covered)"
             );
         }
-        let mut hits: Vec<((&str, usize), (usize, &str, &str, &str))> = best.into_iter().collect();
+        let mut hits: Vec<((&str, usize), (usize, &SemanticEntity, &str))> =
+            best.into_iter().collect();
         hits.sort_by(|a, b| (a.0 .0, a.0 .1).cmp(&(b.0 .0, b.0 .1)));
         let total = hits.len();
         let files: std::collections::BTreeSet<&str> = hits.iter().map(|(k, _)| k.0).collect();
@@ -1051,20 +1064,42 @@ impl SemServer {
             "⊕ text \"{needle}\" · {total} hits · {} files\n",
             files.len()
         );
-        for (i, ((file, line), (_, name, ty, text))) in hits.iter().take(limit).enumerate() {
+        // A few neighbour names, deduped and capped — the "who calls this /
+        // what does it call" grep can't answer without a read-chain.
+        let names = |v: Vec<&sem_core::parser::graph::EntityInfo>| -> String {
+            let mut ns: Vec<&str> = v.iter().map(|d| d.name.as_str()).collect();
+            ns.sort_unstable();
+            ns.dedup();
+            let extra = ns.len().saturating_sub(4);
+            let shown = ns.into_iter().take(4).collect::<Vec<_>>().join(", ");
+            if extra > 0 {
+                format!("{shown}, +{extra}")
+            } else {
+                shown
+            }
+        };
+        for (i, ((file, line), (_, e, text))) in hits.iter().take(limit).enumerate() {
             let branch = if i + 1 == total.min(limit) {
                 "╰─▶"
             } else {
                 "├─▶"
             };
-            let label = if *ty == "function" || *ty == "method" {
-                (*name).to_string()
+            let label = if e.entity_type == "function" || e.entity_type == "method" {
+                e.name.clone()
             } else {
-                format!("{name} ({ty})")
+                format!("{} ({})", e.name, e.entity_type)
             };
-            let text = text.trim();
-            let text: String = text.chars().take(90).collect();
-            out.push_str(&format!("{branch} {file}: {label} (L{line}): {text}\n"));
+            let text: String = text.trim().chars().take(90).collect();
+            let callees = graph.get_dependencies(&e.id);
+            let callers = graph.get_dependents(&e.id);
+            let mut rel = String::new();
+            if !callees.is_empty() {
+                rel.push_str(&format!(" · calls {}", names(callees)));
+            }
+            if !callers.is_empty() {
+                rel.push_str(&format!(" · called by {}", names(callers)));
+            }
+            out.push_str(&format!("{branch} {file}: {label} (L{line}): {text}{rel}\n"));
         }
         if total > limit {
             out.push_str(&format!("… {} more (raise limit)\n", total - limit));
@@ -1145,7 +1180,7 @@ impl SemServer {
     // ── Tool 1: Entities ──
 
     #[tool(
-        description = "List semantic entities (functions, classes, etc.) under a file or directory path (defaults to '.'). Pass `text` to search entity bodies for an exact substring instead (entity-addressed, grep-style hits ready for sem_context/sem_impact)."
+        description = "List semantic entities (functions, classes, etc.) under a file or directory path (defaults to '.'). Pass `text` to search entity bodies for an exact substring instead: each hit comes back as its enclosing entity WITH its call-graph neighbourhood (what it calls, who calls it) — find and comprehend in one call, so you rarely need a follow-up read. Prefer this over grep for strings in code, especially on large repos where grep returns line hits you'd otherwise have to chase across files."
     )]
     async fn sem_entities(
         &self,
@@ -1163,8 +1198,8 @@ impl SemServer {
         // chaining. This is the grep killer: same latency class, but hits are
         // entities, not line numbers in anonymous files.
         if let Some(needle) = params.text() {
-            let (_, all_entities) = self.live_graph(&ctx.repo_root).await;
-            let text = Self::render_text_hits(&all_entities, needle, params.limit());
+            let (graph, all_entities) = self.live_graph(&ctx.repo_root).await;
+            let text = Self::render_text_hits(&graph, &all_entities, needle, params.limit());
             return Ok(CallToolResult::success(vec![Content::text(text)]));
         }
 


### PR DESCRIPTION
**The deterministic way to beat grep+read, and it scales with repo size.**

`sem entities --text` (and MCP `sem_entities text=`) already returned the *enclosing entity* for each substring match instead of a bare `file:line`. Now each hit also carries its **call-graph neighbourhood** — what it calls, who calls it — pulled from the graph, deduped and capped with a `+N` overflow so hub functions stay compact.

**Why this beats grep+read:**
- grep gives you a line; understanding it means chasing callers/callees across files by hand — several turns, hallucination-prone.
- This gives you the location *and* the cross-file relationships in **one call**. Find + comprehend fused.
- The neighbour lookup is **O(1) per hit regardless of repo size**, while grep+read is O(repo) — more code, more hits to disambiguate, more files to open. So the edge grows on large codebases: you narrow by *relationships*, not by reading dozens of files.

**No ranking, no fuzziness** — the same exact substring matches as before, now comprehension-ready. This is additive (enriches existing output), so unlike orient it can't regress what's found.

Example (searching `get_dependents` on this repo):
```
get_dependents (L2529) · calls EntityInfo · called by build_context_result_bounded, print_all_with_tests, print_dependents, render_text_hits
```
One call: definition + exact callers. grep would give 22 line hits and leave the caller-chasing to you.