### PR TITLE
Bump sem-cli and related crates to 0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to sem are documented in this file.
 
 ### Fixed
 
+- **`sem --version` now reports the correct version.** The `v0.21.1` tag only bumped `sem-core`, leaving `sem-cli`, `sem-mcp`, `sem-plugin`, and `sem-cloud-client` at `0.21.0`, so the binary still reported `0.21.0`. Bumped those crates (and their internal path dependencies) to `0.21.1` to match the tag. Thanks @chenrui333 (#480).
 - **Building a graph over Svelte components no longer crashes (SIGSEGV) on Linux/glibc.** `sem graph`/`context`/`orient` over `.svelte` files deterministically exited 139 from an invalid free in the `tree-sitter-htmlx-svelte` 0.1.8 grammar's scanner, hit during parallel graph construction (macOS's allocator tolerated the bad free, so it only showed on Linux). Bumped the grammar to 0.1.16, which carries the scanner fixes; the existing version constraint already permitted it, so this is a lock-only dependency update. Added a parallel-Svelte-graph regression test. Thanks @XF-FW for the exhaustive isolation and the verified fix (#471).
 
 ## [0.21.0] - 2026-07-10

--- a/crates/sem-cli/Cargo.toml
+++ b/crates/sem-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-cli"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Semantic version control CLI. Shows what entities changed (functions, classes, methods) instead of lines."
@@ -15,9 +15,9 @@ name = "sem"
 path = "src/main.rs"
 
 [dependencies]
-sem-core = { path = "../sem-core", version = "0.21.0" }
-sem-mcp = { path = "../sem-mcp", version = "0.21.0" }
-sem-cloud-client = { path = "../sem-cloud-client", version = "0.21.0" }
+sem-core = { path = "../sem-core", version = "0.21.1" }
+sem-mcp = { path = "../sem-mcp", version = "0.21.1" }
+sem-cloud-client = { path = "../sem-cloud-client", version = "0.21.1" }
 serde = { version = "1", features = ["derive"] }
 clap = { version = "4", features = ["derive"] }
 colored = "2"

--- a/crates/sem-cloud-client/Cargo.toml
+++ b/crates/sem-cloud-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-cloud-client"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Shared client for sem-cloud: credentials, repo resolution, caching, and the metered graph API. Used by both the sem CLI and the sem MCP server."

--- a/crates/sem-mcp/Cargo.toml
+++ b/crates/sem-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-mcp"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server for entity-level semantic code intelligence. 6 tools: sem_entities, sem_diff, sem_blame, sem_impact, sem_log, sem_context."
@@ -15,8 +15,8 @@ name = "sem-mcp"
 path = "src/main.rs"
 
 [dependencies]
-sem-core = { path = "../sem-core", version = "0.21.0" }
-sem-cloud-client = { path = "../sem-cloud-client", version = "0.21.0" }
+sem-core = { path = "../sem-core", version = "0.21.1" }
+sem-cloud-client = { path = "../sem-cloud-client", version = "0.21.1" }
 git2 = "0.20"
 lru = "0.16"
 rmcp = { version = "1", features = ["server", "transport-io"] }

--- a/crates/sem-plugin/Cargo.toml
+++ b/crates/sem-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sem-plugin"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "WASI component plugin for semantic entity-level change detection"


### PR DESCRIPTION
The `v0.21.1` tag only bumped `sem-core`; `sem-cli`, `sem-mcp`, `sem-plugin`, and `sem-cloud-client` were left at 0.21.0, so `sem --version` reports `0.21.0`. Bump them to match the tag.

- https://github.com/Homebrew/homebrew-core/pull/298592