### PR TITLE
Surface added and deleted containers in semantic diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to sem are documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **Semantic diffs now retain added and deleted containers alongside their changed children.** Adding or removing a whole JSON section surfaces the structural parent instead of only its leaves; unchanged parent declarations modified solely through child edits remain suppressed to avoid redundant output.
+
 ## [0.22.1] - 2026-08-16
 
 ### Added

--- a/crates/sem-core/src/parser/differ.rs
+++ b/crates/sem-core/src/parser/differ.rs
@@ -321,9 +321,9 @@ fn suppress_redundant_parents(
             continue;
         }
 
-        // Added/Deleted: suppress unconditionally; the children carry the detail.
-        // Modified: only suppress if the container's own declaration is unchanged
-        // and the value type didn't transition.
+        // Modified containers are redundant when only their children changed.
+        // Added/Deleted containers carry structural information of their own,
+        // so retain them alongside their changed children.
         let should_suppress = if change.change_type == ChangeType::Modified {
             match (before_by_id.get(eid), after_by_id.get(eid)) {
                 (Some(bp), Some(ap)) if bp.entity_type == ap.entity_type => {
@@ -334,7 +334,7 @@ fn suppress_redundant_parents(
                 _ => false,
             }
         } else {
-            true
+            false
         };
 
         if should_suppress {
@@ -342,13 +342,17 @@ fn suppress_redundant_parents(
         }
     }
 
-    // Suppress an old parent that a Moved child left behind when the old
-    // parent itself appears as a change — handles the parent-rename case
-    // where the parent itself failed to match.
+    // A moved child already explains a Modified old parent. An Added or
+    // Deleted parent represents a structural replacement and must remain.
+    let modified_ids: HashSet<&str> = changes
+        .iter()
+        .filter(|change| change.change_type == ChangeType::Modified)
+        .map(|change| change.entity_id.as_str())
+        .collect();
     for change in changes.iter() {
         if change.change_type == ChangeType::Moved {
             if let Some(ref old_pid) = change.old_parent_id {
-                if changed_ids.contains(old_pid.as_str()) {
+                if modified_ids.contains(old_pid.as_str()) {
                     suppress.insert(old_pid.clone());
                 }
             }

--- a/crates/sem-core/src/parser/plugins/json.rs
+++ b/crates/sem-core/src/parser/plugins/json.rs
@@ -854,25 +854,17 @@ mod tests {
     }
 
     #[test]
-    fn whole_object_added_only_leaf_children_reported() {
+    fn whole_new_container_surfaces_as_added() {
         let changes = json_diff("{}", "{\n  \"scripts\": {\n    \"build\": \"tsc\"\n  }\n}");
-        assert!(
-            !changes.iter().any(|c| c.entity_name == "scripts"),
-            "scripts (container) should be suppressed; got: {:?}",
-            names(&changes)
-        );
+        find_change(&changes, "scripts", ChangeType::Added);
         let build = find_change(&changes, "build", ChangeType::Added);
         assert_eq!(build.parent_name.as_deref(), Some("scripts"));
     }
 
     #[test]
-    fn whole_object_deleted_only_leaf_children_reported() {
+    fn whole_deleted_container_surfaces_as_deleted() {
         let changes = json_diff("{\n  \"scripts\": {\n    \"build\": \"tsc\"\n  }\n}", "{}");
-        assert!(
-            !changes.iter().any(|c| c.entity_name == "scripts"),
-            "scripts (container) should be suppressed; got: {:?}",
-            names(&changes)
-        );
+        find_change(&changes, "scripts", ChangeType::Deleted);
         find_change(&changes, "build", ChangeType::Deleted);
     }
 
@@ -979,22 +971,18 @@ mod tests {
     }
 
     #[test]
-    fn parent_object_renamed_and_child_renamed_only_child_surfaces() {
-        // scripts → tasks AND dev → develop. Parent rename cannot be detected
-        // because the renamed child key changes the parent's structural_hash.
-        // The child move alone conveys the move + rename via:
-        //   parent_name="tasks", old_entity_name="dev", old_parent_id=<scripts>
+    fn parent_object_and_child_renamed_surfaces_container_swap_and_move() {
+        // The child rename prevents confidently matching the parent rename,
+        // so preserve the Deleted/Added container pair alongside the move.
         let before = "{\n  \"scripts\": {\n    \"dev\": \"vite\"\n  }\n}\n";
         let after = "{\n  \"tasks\": {\n    \"develop\": \"vite\"\n  }\n}\n";
         let changes = json_diff(before, after);
-        assert_eq!(names(&changes), vec![("develop".into(), ChangeType::Moved)]);
-        let develop = &changes[0];
+        find_change(&changes, "scripts", ChangeType::Deleted);
+        find_change(&changes, "tasks", ChangeType::Added);
+        let develop = find_change(&changes, "develop", ChangeType::Moved);
         assert_eq!(develop.old_entity_name.as_deref(), Some("dev"));
         assert_eq!(develop.parent_name.as_deref(), Some("tasks"));
-        assert!(
-            develop.old_parent_id.is_some(),
-            "child Moved should carry old_parent_id"
-        );
+        assert!(develop.old_parent_id.is_some());
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -1295,11 +1283,10 @@ mod tests {
     // ─────────────────────────────────────────────────────────────────────────
 
     #[test]
-    fn parent_rename_with_sibling_added_surfaces_leaf_moves() {
+    fn parent_rename_with_sibling_added_surfaces_container_swap_plus_moves() {
         // Parent renamed AND a new sibling appears: structural_hash diverges,
-        // Phase 2 misses the parent rename. The unchanged child still matches
-        // by structural_hash and surfaces as Moved; the parent Deleted/Added
-        // entries are container-suppressed.
+        // so the structural replacement must remain visible alongside the
+        // child move and addition.
         let before = r#"{
   "scripts": {
     "build": "tsc"
@@ -1312,17 +1299,12 @@ mod tests {
   }
 }"#;
         let changes = json_diff(before, after);
+        find_change(&changes, "scripts", ChangeType::Deleted);
+        find_change(&changes, "tasks", ChangeType::Added);
         let build = find_change(&changes, "build", ChangeType::Moved);
         assert_eq!(build.parent_name.as_deref(), Some("tasks"));
         assert!(build.old_parent_id.is_some());
         find_change(&changes, "test", ChangeType::Added);
-        assert!(
-            !changes
-                .iter()
-                .any(|c| c.entity_name == "scripts" || c.entity_name == "tasks"),
-            "parent Deleted/Added should be suppressed; got: {:?}",
-            names(&changes)
-        );
     }
 
     #[test]
@@ -1372,20 +1354,15 @@ mod tests {
     }
 
     #[test]
-    fn deep_whole_section_deleted_only_leaf_reported() {
+    fn deep_whole_section_deleted_surfaces_intermediate_containers() {
         let changes = json_diff(
             "{\n  \"jest\": {\n    \"config\": {\n      \"testTimeout\": 5000\n    }\n  }\n}",
             "{}",
         );
+        find_change(&changes, "jest", ChangeType::Deleted);
+        find_change(&changes, "config", ChangeType::Deleted);
         let timeout = find_change(&changes, "testTimeout", ChangeType::Deleted);
         assert_eq!(timeout.parent_name.as_deref(), Some("jest::config"));
-        assert!(
-            !changes
-                .iter()
-                .any(|c| c.entity_name == "jest" || c.entity_name == "config"),
-            "intermediate containers should be suppressed; got: {:?}",
-            names(&changes)
-        );
     }
 
     #[test]

--- a/crates/sem-core/src/parser/plugins/svelte.rs
+++ b/crates/sem-core/src/parser/plugins/svelte.rs
@@ -2028,13 +2028,12 @@ function hello() {}
                 .collect::<Vec<_>>()
         );
 
-        // script parent is suppressed because its child (count) is also Added
         assert!(
-            !result
+            result
                 .changes
                 .iter()
                 .any(|c| c.entity_name == "script" && c.entity_type == "svelte_instance_script"),
-            "script parent should be suppressed when children are also added"
+            "script parent should surface as Added alongside its children"
         );
         assert!(
             result


### PR DESCRIPTION
## Summary

Preserve added and deleted container entities in semantic diff output, even when their changed children are also reported.

Modified containers are still suppressed when their own declaration did not change and only their children changed, so ordinary nested edits remain concise.

## Why

Given this JSON change:

```json
{}
```

```json
{
  "defaults": {
    "retries": 3
  }
}
```

Current behavior reports only the leaf:

```text
defaults::retries added
```

That hides the structural fact that an entire `defaults` section was introduced. With this change, the diff reports both levels:

```text
defaults added
defaults::retries added
```

The corresponding deletion likewise reports both `defaults deleted` and `defaults::retries deleted`.

This also makes structural replacements complete. When `scripts` becomes `tasks` but simultaneous child changes prevent a confident parent rename match, the diff now preserves the full story:

```text
scripts deleted
tasks added
scripts::build → tasks::build
tasks::test added
```

Previously the parent deletion and addition could be suppressed, leaving only the child move and addition.

## Implementation

- Restrict redundant-parent suppression to `Modified` containers.
- Keep `Added` and `Deleted` containers because they carry structural information independent of their children.
- When a child moves, suppress only a redundant `Modified` old parent; retain `Added` or `Deleted` parents that describe a structural replacement.
- Update behavior tests for whole JSON sections, deep deletion, parent replacement, and Svelte new-file containers.

## Verification

- `cargo test --workspace --quiet`
- All workspace tests pass; one pre-existing test remains ignored.