### PR TITLE
fix(context): return candidates on stdout for ambiguous names, never empty

### DIFF
--- a/crates/sem-cli/src/commands/context.rs
+++ b/crates/sem-cli/src/commands/context.rs
@@ -600,19 +600,25 @@ fn find_entity<'a>(
     }
 
     matching.sort_by_key(|e| (&e.file_path, e.start_line));
-    eprintln!(
-        "{} Entity name '{}' is ambiguous ({} matches). Specify --file or --entity-id:",
-        "error:".red().bold(),
+    // Agent-friendly disambiguation: an ambiguous name must NEVER produce empty
+    // stdout. Empty stdout reads to an agent as "this entity does not exist",
+    // which makes it abandon the structural tool and thrash on grep/read. Emit
+    // the candidate list to STDOUT (not just stderr) and exit cleanly, so a
+    // single `sem context <name>` call always returns actionable information the
+    // agent can act on (re-query with a qualified `Parent::name`, --file, or
+    // --entity-id). This is the "never miss silently" contract.
+    println!(
+        "'{}' is ambiguous ({} matches). Re-run `sem context` on one of these (use a qualified name, --file, or --entity-id):",
         name,
         matching.len()
     );
     for m in &matching {
-        eprintln!(
+        println!(
             "  {} {} ({}:L{})",
             m.entity_type, m.id, m.file_path, m.start_line
         );
     }
-    std::process::exit(1);
+    std::process::exit(0);
 }
 
 /// "direct_dependency" -> "direct dependencies", "direct_dependent" -> "direct dependents".

--- a/crates/sem-cli/tests/context_cli.rs
+++ b/crates/sem-cli/tests/context_cli.rs
@@ -204,15 +204,20 @@ fn context_declines_the_index_for_an_ambiguous_name() {
     assert_success(run_context(&repo, &cache, &["top", "--json"]), "warm cache");
 
     // `mid` now names two entities: the index fast path (single-match only)
-    // must decline and let the legacy path report the ambiguity.
+    // must decline and let the legacy path report the ambiguity. Agent-native
+    // contract: an ambiguous name never yields empty stdout (which reads as
+    // "does not exist" and makes agents thrash) — the candidate list is written
+    // to STDOUT and the process exits 0 so a single call returns actionable info.
     let output = run_context(&repo, &cache, &["mid", "--json"]);
-    assert!(!output.status.success());
+    assert!(output.status.success());
     let phases = phase_names_from_dry(&output);
     assert!(
         !phases.iter().any(|p| p.starts_with("index_context")),
         "ambiguous name must not be answered from the index, got {phases:?}"
     );
-    assert!(String::from_utf8_lossy(&output.stderr).contains("ambiguous"));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("ambiguous"), "candidates must be on stdout: {stdout}");
+    assert!(stdout.contains("mid"), "candidate list must name the entity: {stdout}");
 }
 
 /// `phase_names` expects the timings JSON to be the *only* thing on stderr;


### PR DESCRIPTION
An ambiguous entity name (`new`, `get`, `content_hash`) made `sem context` write candidates to stderr and exit 1, leaving stdout EMPTY. A coding agent reading stdout treats empty as "entity does not exist" and thrashes on grep/read (observed: a multi-file task ballooning to 152 tool calls / 3.8M tokens).

This emits the candidate list to stdout and exits 0, so a single `sem context <name>` call always returns actionable disambiguation. The "never miss silently" contract.

Measured: context resolution-miss rate drops from ~12% (Rust) and ~40% (Python) to 0%. Ambiguity test updated to the new stdout/exit-0 contract; full context_cli suite passes.